### PR TITLE
missed_hashes = hashes without a Change, unsummarized_hashes = Changes without own_summary

### DIFF
--- a/apps/native/src-tauri/src/get_history.rs
+++ b/apps/native/src-tauri/src/get_history.rs
@@ -37,21 +37,21 @@ pub async fn get_history<R: Runtime>(app: &AppHandle<R>) -> Result<Vec<crate::sh
             unique.len()
         };
 
-        let (change_map, missed_hashes) = if let Some(ref parent) = parent_db {
+        let (change_map, unsummarized_hashes) = if let Some(ref parent) = parent_db {
             let diff_hashes: Vec<String> = raw_changes.iter()
             .filter(|c| !crate::changes_from_diff::is_sensitive_or_opaque(c))
             .map(|c| c.hash.clone())
             .collect();
             match crate::summarize::find_existing::by_base_with_hashes(&db_path, parent.id, &diff_hashes) {
                 Ok(found) => {
-                    let missed = found.missed_hashes.clone();
                     let grouped = crate::summarize::group_existing::from_change_sets(vec![found]);
+                    let unsummarized = grouped.unsummarized_hashes.clone();
                     let map = if grouped.groups.is_empty() && grouped.singles.is_empty() {
                         None
                     } else {
                         Some(grouped)
                     };
-                    (map, missed)
+                    (map, unsummarized)
                 }
                 Err(_) => (None, vec![]),
             }
@@ -89,7 +89,7 @@ pub async fn get_history<R: Runtime>(app: &AppHandle<R>) -> Result<Vec<crate::sh
             file_count,
             commit: db_commit,
             change_map,
-            missed_hashes,
+            unsummarized_hashes,
             raw_changes,
             origin_message: None,
             origin_hash: None,
@@ -132,7 +132,7 @@ fn populate_restore_history_items(
                         entries[ultimate_idx].message.clone(),
                         entries[ultimate_idx].change_map.clone(),
                         entries[ultimate_idx].raw_changes.clone(),
-                        entries[ultimate_idx].missed_hashes.clone(),
+                        entries[ultimate_idx].unsummarized_hashes.clone(),
                         entries[ultimate_idx].file_count,
                     ));
                 }
@@ -160,14 +160,14 @@ fn populate_restore_history_items(
         entries[k].is_undone = true;
     }
 
-    for (i, origin_hash, origin_message, change_map, raw_changes, missed_hashes, file_count) in inherited {
+    for (i, origin_hash, origin_message, change_map, raw_changes, unsummarized_hashes, file_count) in inherited {
         let short_hash = &origin_hash[..origin_hash.len().min(8)];
         entries[i].message = Some(format!("Restore commit {short_hash}"));
         entries[i].origin_message = origin_message;
         entries[i].origin_hash = Some(origin_hash);
         entries[i].change_map = change_map;
         entries[i].raw_changes = raw_changes;
-        entries[i].missed_hashes = missed_hashes;
+        entries[i].unsummarized_hashes = unsummarized_hashes;
         entries[i].file_count = file_count;
     }
 

--- a/apps/native/src-tauri/src/shared_types.rs
+++ b/apps/native/src-tauri/src/shared_types.rs
@@ -82,7 +82,7 @@ pub struct SemanticChangeGroup {
 pub struct SemanticChangeMap {
     pub groups: Vec<SemanticChangeGroup>,
     pub singles: Vec<ChangeWithSummary>,
-    pub missed_hashes: Vec<String>,
+    pub unsummarized_hashes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -114,7 +114,7 @@ pub struct HistoryItem {
     pub file_count: usize,
     pub commit: Option<crate::sqlite_types::Commit>,
     pub change_map: Option<SemanticChangeMap>,
-    pub missed_hashes: Vec<String>,
+    pub unsummarized_hashes: Vec<String>,
     pub raw_changes: Vec<crate::sqlite_types::Change>,
     pub origin_message: Option<String>,
     pub origin_hash: Option<String>,

--- a/apps/native/src-tauri/src/summarize/group_existing.rs
+++ b/apps/native/src-tauri/src/summarize/group_existing.rs
@@ -12,14 +12,21 @@ use crate::sqlite_types::ChangeSummary;
 pub fn from_change_sets(change_sets: Vec<FoundSetForCurrent>) -> SemanticChangeMap {
     let mut groups: HashMap<i64, (ChangeSummary, Vec<ChangeWithSummary>)> = HashMap::new();
     let mut singles: Vec<ChangeWithSummary> = vec![];
-    let mut missed_hashes: Vec<String> = vec![];
+    let mut unsummarized_hashes: Vec<String> = vec![];
     // true = placed in a group, false = placed in singles
     let mut seen: HashMap<i64, bool> = HashMap::new();
 
     for cs in change_sets {
-        missed_hashes.extend(cs.missed_hashes);
+        unsummarized_hashes.extend(cs.missed_hashes);
         for sc in cs.changes {
             let change_id = sc.change.id;
+            if sc.own_summary.is_none() {
+                if !seen.contains_key(&change_id) {
+                    unsummarized_hashes.push(sc.change.hash.clone());
+                    seen.insert(change_id, false);
+                }
+                continue;
+            }
             match seen.get(&change_id).copied() {
                 Some(true) => continue, // already in a group, nothing better to do
                 Some(false) => {
@@ -54,7 +61,7 @@ pub fn from_change_sets(change_sets: Vec<FoundSetForCurrent>) -> SemanticChangeM
             .map(|(summary, changes)| SemanticChangeGroup { summary, changes })
             .collect(),
         singles,
-        missed_hashes,
+        unsummarized_hashes,
     };
     dbg::group_log_result(&map);
     map

--- a/apps/native/src-tauri/src/summarize/mod.rs
+++ b/apps/native/src-tauri/src/summarize/mod.rs
@@ -54,7 +54,7 @@ pub async fn new_changeset<R: Runtime>(
 
     let semantic_map = group_existing::from_change_sets(existing);
     let (missed_changes, unfound) =
-        crate::changes_from_diff::filter_by_hashes(all_changes, &semantic_map.missed_hashes);
+        crate::changes_from_diff::filter_by_hashes(all_changes, &semantic_map.unsummarized_hashes);
     if let Some(unfound_hashes) = unfound {
         log::warn!(
             "[new_changeset] {} missed hash(es) not found in current diff: {:?}",

--- a/apps/native/src-tauri/src/summarize/simplify_grouped.rs
+++ b/apps/native/src-tauri/src/summarize/simplify_grouped.rs
@@ -36,7 +36,7 @@ fn simplify(map: &SemanticChangeMap) -> SimplifiedMap {
     SimplifiedMap {
         groups: map.groups.iter().map(simplify_group).collect(),
         singles: map.singles.iter().map(simplify_change).collect(),
-        missed_hashes: Some(map.missed_hashes.clone()),
+        missed_hashes: Some(map.unsummarized_hashes.clone()),
     }
 }
 
@@ -48,7 +48,7 @@ pub fn full(map: &SemanticChangeMap) -> SimplifiedMap {
 
 pub fn for_hash_placement(map: &SemanticChangeMap) -> SimplifiedMap {
     let mut result = simplify(map);
-    // model sees this for existing, missed hashes are analyzed in full
+    // model sees this for existing, unsummarized hashes are analyzed in full
     result.missed_hashes = None;
     for group in &mut result.groups {
         for change in &mut group.changes {

--- a/apps/native/src-tauri/src/summarize/sumlog.rs
+++ b/apps/native/src-tauri/src/summarize/sumlog.rs
@@ -126,7 +126,7 @@ pub fn group_log_result(map: &SemanticChangeMap) {
         &serde_json::json!({
             "groups": groups,
             "singles": singles,
-            "missed_hashes": map.missed_hashes,
+            "unsummarized_hashes": map.unsummarized_hashes,
         }),
     );
 }
@@ -220,7 +220,7 @@ pub fn grouped_log_semantic_map(map: &SemanticChangeMap) {
         &serde_json::json!({
             "groups": groups,
             "singles": singles,
-            "missed_hashes": map.missed_hashes,
+            "unsummarized_hashes": map.unsummarized_hashes,
         }),
     );
 }

--- a/apps/native/src/components/widget/analyze-history-button.tsx
+++ b/apps/native/src/components/widget/analyze-history-button.tsx
@@ -13,7 +13,7 @@ export function AnalyzeHistoryButton() {
   const recentUnsummarizedHashes = history
     .filter((item) => !item.isBase)
     .slice(0, 5)
-    .filter((item) => !item.changeMap || item.missedHashes.length > 0)
+    .filter((item) => !item.changeMap || item.unsummarizedHashes.length > 0)
     .map((item) => item.hash);
 
   //stop only works for queued items

--- a/apps/native/src/components/widget/history/history-item-meta.tsx
+++ b/apps/native/src/components/widget/history/history-item-meta.tsx
@@ -6,7 +6,7 @@ import { ExternalBadge } from "@/components/widget/badges/external-badge";
 import { AnalyzeHistoryItemButton } from "@/components/widget/analyze-history-item-button";
 
 export function HistoryItemMeta({ item, isPreview }: { item: HistoryItem; isPreview?: boolean }) {
-  const showAnalyze = (!item.changeMap || item.missedHashes.length > 0) && !item.isBase;
+  const showAnalyze = (!item.changeMap || item.unsummarizedHashes.length > 0) && !item.isBase;
   return (
     <div className="mt-[6px] flex w-fit flex-wrap items-center gap-2">
       <CommitHashBadge hash={item.hash} />
@@ -16,7 +16,7 @@ export function HistoryItemMeta({ item, isPreview }: { item: HistoryItem; isPrev
       {showAnalyze && (
         <AnalyzeHistoryItemButton
           hash={item.hash}
-          isPartial={!!(item.changeMap && item.missedHashes.length > 0)}
+          isPartial={!!(item.changeMap && item.unsummarizedHashes.length > 0)}
         />
       )}
     </div>

--- a/apps/native/src/components/widget/unsummarized-changes-detected.tsx
+++ b/apps/native/src/components/widget/unsummarized-changes-detected.tsx
@@ -12,7 +12,7 @@ export function UnsummarizedChangesDetected() {
   const configDir = useWidgetStore((s) => s.configDir);
   const { generateCurrentSummary } = useSummary();
   const [isSummarizing, setIsSummarizing] = useState(false);
-  const hasUnsummarized = !changeMap || changeMap.missedHashes.length > 0;
+  const hasUnsummarized = !changeMap || changeMap.unsummarizedHashes.length > 0;
 
   useEffect(() => {
     setIsSummarizing(false);

--- a/apps/native/src/components/widget/widget.stories.tsx
+++ b/apps/native/src/components/widget/widget.stories.tsx
@@ -174,7 +174,7 @@ const mockChangeMap: SemanticChangeMap = {
       description: "KeyRepeat = 2",
     },
   ],
-  missedHashes: [],
+  unsummarizedHashes: [],
 };
 
 // =============================================================================

--- a/apps/native/src/hooks/use-history-restore.ts
+++ b/apps/native/src/hooks/use-history-restore.ts
@@ -158,7 +158,7 @@ function makePreviewItem(target: HistoryItem): HistoryItem {
     fileCount: target.fileCount,
     commit: null,
     changeMap: target.changeMap,
-    missedHashes: target.missedHashes,
+    unsummarizedHashes: target.unsummarizedHashes,
     rawChanges: target.rawChanges,
     originMessage: target.message,
     originHash: target.hash,

--- a/apps/native/src/hooks/use-history.ts
+++ b/apps/native/src/hooks/use-history.ts
@@ -41,7 +41,7 @@ export function useHistory() {
       for (const hash of hashes) {
         if (!useWidgetStore.getState().analyzingHistoryForHashes.has(hash)) break;
         const item = useWidgetStore.getState().history.find((h) => h.hash === hash);
-        if (item?.changeMap && item.missedHashes.length === 0) {
+        if (item?.changeMap && item.unsummarizedHashes.length === 0) {
           removeAnalyzingHistoryHash(hash);
           continue;
         }

--- a/apps/native/src/types/shared.ts
+++ b/apps/native/src/types/shared.ts
@@ -98,11 +98,11 @@ export type GitStatus = { files: GitFileStatus[]; branch: string | null; headIsB
 /**
  * A commit entry combining git log data, tag-derived flags, optional DB metadata, and raw diff changes.
  */
-export type HistoryItem = { hash: string; message: string | null; createdAt: number; isBuilt: boolean; isBase: boolean; isExternal: boolean; fileCount: number; commit: Commit | null; changeMap: SemanticChangeMap | null; missedHashes: string[]; rawChanges: Change[]; originMessage: string | null; originHash: string | null; isOrphanedRestore: boolean; isUndone: boolean }
+export type HistoryItem = { hash: string; message: string | null; createdAt: number; isBuilt: boolean; isBase: boolean; isExternal: boolean; fileCount: number; commit: Commit | null; changeMap: SemanticChangeMap | null; unsummarizedHashes: string[]; rawChanges: Change[]; originMessage: string | null; originHash: string | null; isOrphanedRestore: boolean; isUndone: boolean }
 
 export type SemanticChangeGroup = { summary: ChangeSummary; changes: ChangeWithSummary[] }
 
-export type SemanticChangeMap = { groups: SemanticChangeGroup[]; singles: ChangeWithSummary[]; missedHashes: string[] }
+export type SemanticChangeMap = { groups: SemanticChangeGroup[]; singles: ChangeWithSummary[]; unsummarizedHashes: string[] }
 
 export type SummarizedChange = { change: Change; ownSummary: ChangeSummary | null; groupSummary: ChangeSummary | null }
 


### PR DESCRIPTION
`find_existing.rs` tracks missed_hashes for which no change exists. 
`group_existing.rs` tracks unsummarized_hashes for changes without an own_summary_id.

This means summarization pipelines will pick up Changes that exist but have no summary, meaning we can create Changes for other purposes ahead of time without summarization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the internal field used to track unsummarized changes across the app (backend, API output, and UI). UI behavior and controls remain the same; components that indicate or analyze unsummarized changes will continue to work with identical functionality, now referencing the updated field name for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->