### PR TITLE
feat(validation): add syntax validation for .nix and .yaml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,6 +3136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,7 +3561,6 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2",
  "similar",
  "specta",
@@ -3590,6 +3595,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "uuid",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -5670,19 +5676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.13.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7693,12 +7686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8874,6 +8861,19 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "similar",
  "specta",
@@ -5669,6 +5670,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7677,6 +7691,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ specta = { version = "=2.0.0-rc.22", features = ["derive"] }
 specta-typescript = "0.0.9"
 tauri-specta = { version = "2.0.0-rc.21", features = ["derive", "typescript"] }
 rnix = "0.14.0"
+serde_yaml = "0.9"
 rowan = "0.16.1"
 fuzzy-matcher = "0.3.7"
 rusqlite_migration = "1.2"

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -68,7 +68,7 @@ specta = { version = "=2.0.0-rc.22", features = ["derive"] }
 specta-typescript = "0.0.9"
 tauri-specta = { version = "2.0.0-rc.21", features = ["derive", "typescript"] }
 rnix = "0.14.0"
-serde_yaml = "0.9"
+yaml_serde = "0.10.4"
 rowan = "0.16.1"
 fuzzy-matcher = "0.3.7"
 rusqlite_migration = "1.2"

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -8,6 +8,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::Context;
+use log::debug;
 
 const PATH_SCOPE_ERROR_CODE: &str = "E_PATH_OUTSIDE_CONFIG_DIR";
 
@@ -187,6 +188,156 @@ fn path_scope_error(input: &str, base: &Path, resolved: &Path, operation: &str) 
     )
 }
 
+/// Validate basic syntax of a .nix file using the rnix parser.
+/// We can't use rnix because it is error-tolerant and will produce an AST
+/// even for complete junk, which isn't helpful for our use case of validating AI-generated edits.
+/// Instead, we check basic structural validity: balanced braces/brackets/parens, closed strings.
+fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
+    // Simple validation: track bracket/brace/paren balance across the content,
+    // respecting string contexts. This catches obvious errors like unmatched braces.
+
+    let mut brace_depth = 0;
+    let mut bracket_depth = 0;
+    let mut paren_depth = 0;
+    let mut in_string = false;
+    let mut in_multiline_string = false;
+    let mut escape_next = false;
+
+    let chars: Vec<char> = content.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let ch = chars[i];
+
+        if escape_next {
+            escape_next = false;
+            i += 1;
+            continue;
+        }
+
+        // Check for multiline strings: '' ... ''
+        if !in_string && i + 1 < chars.len() && ch == '\'' && chars[i + 1] == '\'' {
+            in_multiline_string = !in_multiline_string;
+            i += 2;
+            continue;
+        }
+
+        if in_multiline_string {
+            i += 1;
+            continue;
+        }
+
+        match ch {
+            '\\' if in_string => escape_next = true,
+            '"' => in_string = !in_string,
+            '{' if !in_string => brace_depth += 1,
+            '}' if !in_string => {
+                brace_depth -= 1;
+                if brace_depth < 0 {
+                    return Err(anyhow::anyhow!(
+                        "Syntax error in {}: unmatched closing brace '}}'",
+                        file_path
+                    ));
+                }
+            }
+            '[' if !in_string => bracket_depth += 1,
+            ']' if !in_string => {
+                bracket_depth -= 1;
+                if bracket_depth < 0 {
+                    return Err(anyhow::anyhow!(
+                        "Syntax error in {}: unmatched closing bracket ']'",
+                        file_path
+                    ));
+                }
+            }
+            '(' if !in_string => paren_depth += 1,
+            ')' if !in_string => {
+                paren_depth -= 1;
+                if paren_depth < 0 {
+                    return Err(anyhow::anyhow!(
+                        "Syntax error in {}: unmatched closing parenthesis ')'",
+                        file_path
+                    ));
+                }
+            }
+            _ => {}
+        }
+
+        i += 1;
+    }
+
+    if in_string {
+        return Err(anyhow::anyhow!(
+            "Syntax error in {}: unclosed string literal",
+            file_path
+        ));
+    }
+
+    if in_multiline_string {
+        return Err(anyhow::anyhow!(
+            "Syntax error in {}: unclosed multiline string ''...''",
+            file_path
+        ));
+    }
+
+    if brace_depth != 0 {
+        return Err(anyhow::anyhow!(
+            "Syntax error in {}: {} unmatched opening brace(s)",
+            file_path,
+            brace_depth
+        ));
+    }
+
+    if bracket_depth != 0 {
+        return Err(anyhow::anyhow!(
+            "Syntax error in {}: {} unmatched opening bracket(s)",
+            file_path,
+            bracket_depth
+        ));
+    }
+
+    if paren_depth != 0 {
+        return Err(anyhow::anyhow!(
+            "Syntax error in {}: {} unmatched opening parenthesis/parentheses",
+            file_path,
+            paren_depth
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate basic syntax of a .yaml or .yml file using serde_yaml.
+fn validate_yaml_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
+    // Try to parse the YAML content. serde_yaml will catch syntax errors
+    // like unmatched quotes, braces, brackets, etc.
+    serde_yaml::from_str::<serde_yaml::Value>(content)
+        .map_err(|e| anyhow::anyhow!("Syntax error in {}: {}", file_path, e))?;
+
+    Ok(())
+}
+
+/// Validate file content based on extension before writing.
+fn validate_file_content(file_path: &str, content: &str) -> anyhow::Result<()> {
+    if file_path.ends_with(".nix") {
+        if let Err(e) = validate_nix_syntax(content, file_path) {
+            debug!("Nix syntax validation failed for {}: {}", file_path, e);
+            return Err(e);
+        } else {
+            debug!("Nix syntax validation succeeded for {}", file_path);
+        }
+    } else if file_path.ends_with(".yaml") || file_path.ends_with(".yml") {
+        if let Err(e) = validate_yaml_syntax(content, file_path) {
+            debug!("YAML syntax validation failed for {}: {}", file_path, e);
+            return Err(e);
+        } else {
+            debug!("YAML syntax validation succeeded for {}", file_path);
+        }
+    }
+
+    Ok(())
+}
+
 /// Apply an evolution's edits to the filesystem.
 ///
 pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::Result<()> {
@@ -201,6 +352,7 @@ pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::R
                     full_path.display()
                 ));
             }
+            validate_file_content(&edit.path, &edit.replace)?;
             std::fs::write(&full_path, &edit.replace)?;
             return Ok(());
         }
@@ -214,6 +366,7 @@ pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::R
             }
             std::fs::create_dir_all(parent)?;
         }
+        validate_file_content(&edit.path, &edit.replace)?;
         std::fs::write(&full_path, &edit.replace)?;
     } else {
         rewrite_existing_file_in_dir(base, &edit.path, "edit existing file", |content| {
@@ -234,7 +387,9 @@ pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::R
                 ));
             }
 
-            Ok(content.replace(&edit.search, &edit.replace))
+            let new_content = content.replace(&edit.search, &edit.replace);
+            validate_file_content(&edit.path, &new_content)?;
+            Ok(new_content)
         })?;
     }
 
@@ -315,5 +470,156 @@ mod tests {
 
         let err = apply_file_edits(base, &edit).expect_err("expected parent-not-dir error");
         assert!(err.to_string().contains("Parent path is not a directory"));
+    }
+
+    #[test]
+    fn validate_nix_syntax_accepts_valid_nix() {
+        let valid_nix = r#"
+{
+  config,
+  pkgs,
+  ...
+}:
+{
+  environment.systemPackages = [ pkgs.git pkgs.vim ];
+  system.stateVersion = "24.05";
+}
+"#;
+
+        super::validate_nix_syntax(valid_nix, "test.nix").expect("should parse valid nix syntax");
+    }
+
+    #[test]
+    fn validate_nix_syntax_rejects_unmatched_braces() {
+        let invalid_nix = r#"
+{
+  environment.systemPackages = [ pkgs.git ];
+  # Missing closing brace
+"#;
+
+        let err = super::validate_nix_syntax(invalid_nix, "test.nix")
+            .expect_err("should reject unmatched braces");
+        assert!(err.to_string().contains("Syntax error"));
+    }
+
+    #[test]
+    fn validate_nix_syntax_rejects_unmatched_brackets() {
+        let invalid_nix = r#"
+{
+  environment.systemPackages = [ pkgs.git pkgs.vim;
+}
+"#;
+
+        let err = super::validate_nix_syntax(invalid_nix, "test.nix")
+            .expect_err("should reject unmatched brackets");
+        assert!(err.to_string().contains("Syntax error"));
+    }
+
+    #[test]
+    fn validate_nix_syntax_rejects_unclosed_string() {
+        let invalid_nix = r#"
+{
+  description = "My config;
+}
+"#;
+
+        let err = super::validate_nix_syntax(invalid_nix, "test.nix")
+            .expect_err("should reject unclosed string");
+        assert!(err.to_string().contains("Syntax error"));
+    }
+
+    #[test]
+    fn validate_yaml_syntax_accepts_valid_yaml() {
+        let valid_yaml = r#"
+name: test
+config:
+  enable: true
+  items:
+    - first
+    - second
+"#;
+
+        super::validate_yaml_syntax(valid_yaml, "test.yaml")
+            .expect("should parse valid yaml syntax");
+    }
+
+    #[test]
+    fn validate_yaml_syntax_rejects_unmatched_braces() {
+        let invalid_yaml = r#"
+config: { unclosed: value
+"#;
+
+        let err = super::validate_yaml_syntax(invalid_yaml, "test.yaml")
+            .expect_err("should reject unmatched braces");
+        assert!(err.to_string().contains("Syntax error"));
+    }
+
+    #[test]
+    fn validate_yaml_syntax_rejects_unclosed_string() {
+        let invalid_yaml = r#"
+key: "unclosed string value
+"#;
+
+        let err = super::validate_yaml_syntax(invalid_yaml, "test.yaml")
+            .expect_err("should reject unclosed string");
+        assert!(err.to_string().contains("Syntax error"));
+    }
+
+    #[test]
+    fn validate_file_content_delegates_by_extension() {
+        // Test .nix file
+        let valid_nix = "{ }";
+        super::validate_file_content("modules/test.nix", valid_nix).expect("should validate .nix");
+
+        // Test .yaml file
+        let valid_yaml = "key: value";
+        super::validate_file_content("config.yaml", valid_yaml).expect("should validate .yaml");
+
+        // Test .yml file
+        super::validate_file_content("config.yml", valid_yaml).expect("should validate .yml");
+
+        // Test non-validated file (should always pass)
+        super::validate_file_content("readme.md", "anything here")
+            .expect("should accept non-validated file types");
+    }
+
+    #[test]
+    fn file_edit_rejects_invalid_nix() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let base = temp.path();
+        let file_path = base.join("test.nix");
+        fs::write(&file_path, "{ }").expect("seed file");
+
+        let edit = FileEdit {
+            path: "test.nix".to_string(),
+            search: "".to_string(),
+            replace: "{ broken".to_string(), // Unmatched brace
+        };
+
+        let err = apply_file_edits(base, &edit).expect_err("should reject invalid nix");
+        assert!(err.to_string().contains("Syntax error"));
+        // Verify file was NOT written
+        let content = fs::read_to_string(&file_path).expect("read file");
+        assert_eq!(content, "{ }"); // Original content unchanged
+    }
+
+    #[test]
+    fn file_edit_rejects_invalid_yaml() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let base = temp.path();
+        let file_path = base.join("config.yaml");
+        fs::write(&file_path, "key: value").expect("seed file");
+
+        let edit = FileEdit {
+            path: "config.yaml".to_string(),
+            search: "".to_string(),
+            replace: "key: [unclosed".to_string(), // Unmatched bracket
+        };
+
+        let err = apply_file_edits(base, &edit).expect_err("should reject invalid yaml");
+        assert!(err.to_string().contains("Syntax error"));
+        // Verify file was NOT written
+        let content = fs::read_to_string(&file_path).expect("read file");
+        assert_eq!(content, "key: value"); // Original content unchanged
     }
 }

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -188,7 +188,8 @@ fn path_scope_error(input: &str, base: &Path, resolved: &Path, operation: &str) 
     )
 }
 
-/// Validate basic syntax of a .nix file using the rnix parser.
+/// Validate basic syntax of a .nix file using a simple custom validator that checks for balanced braces, brackets
+/// parens, and closed strings.
 /// We can't use rnix because it is error-tolerant and will produce an AST
 /// even for complete junk, which isn't helpful for our use case of validating AI-generated edits.
 /// Instead, we check basic structural validity: balanced braces/brackets/parens, closed strings.
@@ -201,6 +202,8 @@ fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
     let mut paren_depth = 0;
     let mut in_string = false;
     let mut in_multiline_string = false;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
     let mut escape_next = false;
 
     let chars: Vec<char> = content.chars().collect();
@@ -208,6 +211,24 @@ fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
 
     while i < chars.len() {
         let ch = chars[i];
+
+        if in_line_comment {
+            if ch == '\n' {
+                in_line_comment = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if in_block_comment {
+            if i + 1 < chars.len() && ch == '*' && chars[i + 1] == '/' {
+                in_block_comment = false;
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
 
         if escape_next {
             escape_next = false;
@@ -217,6 +238,18 @@ fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
 
         // Check for multiline strings: '' ... ''
         if !in_string && i + 1 < chars.len() && ch == '\'' && chars[i + 1] == '\'' {
+            if in_multiline_string {
+                // In an indented string, '' introduces either an escape sequence
+                // (e.g. ''', ''$, ''\) or the closing delimiter.
+                // Only treat it as closing when it is not an escape prefix.
+                if i + 2 < chars.len()
+                    && (chars[i + 2] == '\'' || chars[i + 2] == '$' || chars[i + 2] == '\\')
+                {
+                    i += 3;
+                    continue;
+                }
+            }
+
             in_multiline_string = !in_multiline_string;
             i += 2;
             continue;
@@ -225,6 +258,19 @@ fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
         if in_multiline_string {
             i += 1;
             continue;
+        }
+
+        if !in_string {
+            if ch == '#' {
+                in_line_comment = true;
+                i += 1;
+                continue;
+            }
+            if i + 1 < chars.len() && ch == '/' && chars[i + 1] == '*' {
+                in_block_comment = true;
+                i += 2;
+                continue;
+            }
         }
 
         match ch {
@@ -280,6 +326,13 @@ fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
         ));
     }
 
+    if in_block_comment {
+        return Err(anyhow::anyhow!(
+            "Syntax error in {}: unclosed block comment /*...*/",
+            file_path
+        ));
+    }
+
     if brace_depth != 0 {
         return Err(anyhow::anyhow!(
             "Syntax error in {}: {} unmatched opening brace(s)",
@@ -309,9 +362,9 @@ fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
 
 /// Validate basic syntax of a .yaml or .yml file using serde_yaml.
 fn validate_yaml_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
-    // Try to parse the YAML content. serde_yaml will catch syntax errors
+    // Try to parse the YAML content. yaml_serde will catch syntax errors
     // like unmatched quotes, braces, brackets, etc.
-    serde_yaml::from_str::<serde_yaml::Value>(content)
+    yaml_serde::from_str::<yaml_serde::Value>(content)
         .map_err(|e| anyhow::anyhow!("Syntax error in {}: {}", file_path, e))?;
 
     Ok(())
@@ -526,6 +579,62 @@ mod tests {
         let err = super::validate_nix_syntax(invalid_nix, "test.nix")
             .expect_err("should reject unclosed string");
         assert!(err.to_string().contains("Syntax error"));
+    }
+
+    #[test]
+    fn validate_nix_syntax_accepts_multiline_string_escapes() {
+        let valid_nix = r#"
+{
+    script = ''
+        echo "It'''s working"
+        echo ''$HOME
+        echo ''\n
+    '';
+}
+"#;
+
+        super::validate_nix_syntax(valid_nix, "test.nix")
+            .expect("should accept multiline string escapes without closing early");
+    }
+
+    #[test]
+    fn validate_nix_syntax_ignores_hash_comments() {
+        let nix_with_comment = r#"
+{
+  # this unmatched stuff should be ignored: } ] )
+  environment.systemPackages = [ pkgs.git ];
+}
+"#;
+
+        super::validate_nix_syntax(nix_with_comment, "test.nix")
+            .expect("should ignore delimiters inside hash comments");
+    }
+
+    #[test]
+    fn validate_nix_syntax_ignores_block_comments() {
+        let nix_with_block_comment = r#"
+{
+  /* unmatched delimiters in comment should be ignored: } ] ) */
+  environment.systemPackages = [ pkgs.git ];
+}
+"#;
+
+        super::validate_nix_syntax(nix_with_block_comment, "test.nix")
+            .expect("should ignore delimiters inside block comments");
+    }
+
+    #[test]
+    fn validate_nix_syntax_rejects_unclosed_block_comment() {
+        let invalid_nix = r#"
+{
+  /* block comment never closes
+  environment.systemPackages = [ pkgs.git ];
+}
+"#;
+
+        let err = super::validate_nix_syntax(invalid_nix, "test.nix")
+            .expect_err("should reject unclosed block comment");
+        assert!(err.to_string().contains("unclosed block comment"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -70,7 +70,9 @@ pub fn create_tools() -> Vec<Tool> {
                          unique in the file. For creating a new file or replacing an entire file, \
                          use empty search string. \
                          IMPORTANT: Always provide complete, production-ready code - never use \
-                         placeholders, TODOs, or abbreviated implementations.".to_string(),
+                         placeholders, TODOs, or abbreviated implementations. \
+                         NOTE: For .nix, .yaml, and .yml files, the edit will be rejected if syntax is invalid \
+                         (e.g., unmatched braces/brackets, unclosed strings). Ensure edits maintain valid syntax.".to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -92,7 +94,10 @@ pub fn create_tools() -> Vec<Tool> {
         },
         Tool {
             name: "edit_nix_file".to_string(),
-            description: "Edit a Nix file with semantic operations using attribute-path Add/Remove/Set/SetAttrs actions.\n\nUse this tool whenever you need the agent to make structured edits to Nix config. `add` and `remove` operate on list-valued attributes such as `home.packages` or `environment.systemPackages`. `set` assigns a scalar value such as a boolean, string, number, or null to an attribute path like `services.tailscale.enable`. `set_attrs` creates or updates a Nix attribute set (object) at a given path and sets key-value pairs inside it, including nested JSON objects/arrays that map to nested Nix attrsets/lists. Use this for options like `system.defaults.dock` that take an attrset value. The tool understands Nix syntax and will modify existing assignments when possible, or insert a new assignment into the module body if missing.\n\nAlways: provide an `action` object with exactly one of `add`, `remove`, `set`, or `set_attrs`. After calling this tool, run `build_check` to verify changes.".to_string(),            parameters: serde_json::json!({
+            description: r#"Edit a Nix file with semantic operations using attribute-path Add/Remove/Set/SetAttrs actions.
+Use this tool whenever you need the agent to make structured edits to Nix config. `add` and `remove` operate on list-valued attributes such as `home.packages` or `environment.systemPackages`. `set` assigns a scalar value such as a boolean, string, number, or `null` to an attribute path like `services.tailscale.enable`. `set_attrs` creates or updates a Nix attribute set (object) at a given path and sets key-value pairs inside it, including nested JSON objects/arrays that map to nested Nix attrsets/lists. Use this for options like `system.defaults.dock` that take an attrset value. The tool understands Nix syntax and will modify existing assignments when possible, or insert a new assignment into the module body if missing.
+Always: provide an `action` object with exactly one of `add`, `remove`, `set`, or `set_attrs`. After calling this tool, run `build_check` to verify changes.
+IMPORTANT: The generated Nix code is syntax-validated before writing. Edits with syntax errors (unmatched braces/brackets, unclosed strings, etc) will be rejected. Ensure all generated code is syntactically complete and correct."#.to_string(),            parameters: serde_json::json!({
                 "type": "object",
                 "$defs": {
                     "jsonValue": {


### PR DESCRIPTION
This change adds simple syntax validation prior to applying edits to 1) .nix and 2) .yaml/.yml files, and the edit tools will fail back to the agent if these don't succeed.

Previously we would blindly apply an edit, then wait for a build check to catch any syntax errors, and require the agent to attempt to patch it back up and iterate. Unfortunately, I observed this as frequently being unsuccessful, and in fact as often as not subsequent edits would just make the state of the file worse, not better.

Most likely we'll have better luck if all edits are required to be atomic -- this is what I believe most-always if not always to be the case -- and only allow subsequent edits to operate on files that are either correct or at least in their initial state.

I ran through some of the automated tests and was able to observe this approach being successful in practice, e.g. a validation check failed, the agent followed up with a different edit, and that one (and the subsequent build check) succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added syntax validation for .nix, .yaml, and .yml content so invalid edits (replacements, creations, and search/replace) are rejected before writing.

* **Documentation**
  * Updated tool descriptions and notes to clarify that edits with invalid syntax will be rejected and generated Nix/YAML is validated prior to write.

* **Tests**
  * Extended tests to cover validators and integration behavior preventing invalid overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->