### PR TITLE
chore: realign versions with nixmac-web release history

### DIFF
--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native",
-  "version": "0.18.1",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "imports": {

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nixmac"
-version = "0.18.1"
+version = "0.22.0"
 description = "Nixmac - macOS nix-darwin configuration manager"
 authors = ["you"]
 edition = "2021"

--- a/apps/native/src-tauri/tauri.conf.json
+++ b/apps/native/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "nixmac",
-  "version": "0.18.1",
+  "version": "0.22.0",
   "identifier": "com.darkmatter.nixmac",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -31,9 +31,18 @@
       "frameworks": [],
       "dmg": {
         "background": "icons/dmg-background.png",
-        "windowSize": { "width": 660, "height": 400 },
-        "appPosition": { "x": 180, "y": 170 },
-        "applicationFolderPosition": { "x": 480, "y": 170 }
+        "windowSize": {
+          "width": 660,
+          "height": 400
+        },
+        "appPosition": {
+          "x": 180,
+          "y": 170
+        },
+        "applicationFolderPosition": {
+          "x": 480,
+          "y": 170
+        }
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
     "ultracite": "6.4.0"
   },
   "packageManager": "bun@1.3.2",
-  "version": "0.18.1"
+  "version": "0.22.0"
 }


### PR DESCRIPTION
## Summary
- The pruned desktop repo kept a stale root \`package.json\` at 0.18.1 after the split, while real shipping history (now on \`darkmatter/nixmac-web\`) had already reached **v0.22.0**.
- The first auto-release run in this repo saw no tags and bumped to \`v0.18.2\` — older than what users actually run. Deleted the bogus \`v0.18.2\` GitHub release + tag.
- This PR resets all four version files to \`0.22.0\` so the next merge cuts \`v0.22.1\` as a clean continuation of the real release line and overwrites \`releases.nixmac.com/latest.json\`.

## Test plan
- [ ] PR build passes in branch mode
- [ ] After merge: main-push run tags \`v0.22.1\`, creates GitHub Release, updates \`releases.nixmac.com/latest.json\` to 0.22.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.22.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->