### PR TITLE
chore: sync Cargo.lock to v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "nixmac"
-version = "0.18.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-openai",


### PR DESCRIPTION
Missed in #8 — `sync-versions.mjs` only rewrites `Cargo.toml`'s `[package]` version, not the lockfile's corresponding `name = "nixmac" version = "..."` entry. Harmless to builds (cargo rewrites it on next run) but it drifts from main otherwise.