### PR TITLE
feat(gitignore): implement gitignore support for file operations and searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,6 +3549,7 @@ dependencies = [
  "fuzzy-matcher",
  "glob",
  "hex",
+ "ignore",
  "log",
  "objc",
  "once_cell",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <img width="256" height="256" alt="icon" src="https://github.com/user-attachments/assets/31313c7d-e83b-43a7-b668-6d6d8ac687d4" />
 </p>

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ tempfile = "3.23.0"
 async-openai = "0.30.1"
 async-trait = "0.1"
 glob = "0.3"
+ignore = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 similar = "2.7.0"

--- a/apps/native/src-tauri/src/evolve/config_dir_context.rs
+++ b/apps/native/src-tauri/src/evolve/config_dir_context.rs
@@ -1,7 +1,9 @@
 // Builds a picture of the config_dir for the evolve provider to use as context.
 // This is used to DRAMATICALLY cut down on the amount of file system exploration
 // that the agent needs to do using the `list_files` tool.
+use super::gitignore::{is_ignored_by_matcher, load_gitignore_matcher};
 use anyhow::{Context, Result};
+use ignore::gitignore::Gitignore;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -56,21 +58,33 @@ pub fn format_config_dir_context_with_max_depth(
         ));
     }
 
+    let gitignore = load_gitignore_matcher(root)?;
     let mut output = String::from("CONFIG_DIR/\n");
     let mut rendered_entries = 0usize;
-    render_dir(root, "", 0, max_depth, &mut output, &mut rendered_entries)?;
+    render_dir(
+        root,
+        root,
+        gitignore.as_ref(),
+        "",
+        0,
+        max_depth,
+        &mut output,
+        &mut rendered_entries,
+    )?;
     Ok(output.trim_end().to_string())
 }
 
 fn render_dir(
+    root: &Path,
     dir: &Path,
+    gitignore: Option<&Gitignore>,
     prefix: &str,
     depth: usize,
     max_depth: usize,
     output: &mut String,
     rendered_entries: &mut usize,
 ) -> Result<()> {
-    let mut entries = collect_filtered_entries(dir)?;
+    let mut entries = collect_filtered_entries(root, dir, gitignore)?;
 
     entries.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -107,7 +121,9 @@ fn render_dir(
                 format!("{}│   ", prefix)
             };
             render_dir(
+                root,
                 &entry.path,
+                gitignore,
                 &child_prefix,
                 depth + 1,
                 max_depth,
@@ -120,7 +136,11 @@ fn render_dir(
     Ok(())
 }
 
-fn collect_filtered_entries(dir: &Path) -> Result<Vec<EntryView>> {
+fn collect_filtered_entries(
+    root: &Path,
+    dir: &Path,
+    gitignore: Option<&Gitignore>,
+) -> Result<Vec<EntryView>> {
     let mut out = Vec::new();
     for entry in
         fs::read_dir(dir).with_context(|| format!("failed to read directory: {}", dir.display()))?
@@ -131,18 +151,27 @@ fn collect_filtered_entries(dir: &Path) -> Result<Vec<EntryView>> {
             .file_type()
             .with_context(|| format!("failed to read file type for {}", entry.path().display()))?;
         let name = entry.file_name().to_string_lossy().to_string();
+        let path = entry.path();
+
+        let relative = path
+            .strip_prefix(root)
+            .with_context(|| format!("failed to strip root prefix from {}", path.display()))?;
 
         if should_skip_name(&name) {
             continue;
         }
 
-        if !file_type.is_dir() && !is_allowed_file(&name, &entry.path()) {
+        if is_ignored_by_matcher(gitignore, relative, file_type.is_dir()) {
+            continue;
+        }
+
+        if !file_type.is_dir() && !is_allowed_file(&name, &path) {
             continue;
         }
 
         out.push(EntryView {
             name,
-            path: entry.path(),
+            path,
             is_dir: file_type.is_dir(),
         });
     }
@@ -172,6 +201,7 @@ fn is_allowed_file(name: &str, path: &Path) -> bool {
 mod tests {
     use super::*;
     use std::path::Path;
+    use tempfile::tempdir;
 
     #[test]
     fn prints_config_dir_context_for_inspection() -> Result<()> {
@@ -193,6 +223,36 @@ mod tests {
             context.starts_with("CONFIG_DIR/"),
             "context should start with CONFIG_DIR/"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn excludes_files_ignored_by_root_gitignore() -> Result<()> {
+        let tmp = tempdir()?;
+        fs::write(tmp.path().join(".gitignore"), "secret.txt\n")?;
+        fs::write(tmp.path().join("visible.txt"), "hello")?;
+        fs::write(tmp.path().join("secret.txt"), "hidden")?;
+
+        let context = format_config_dir_context(tmp.path().to_str().context("utf-8 path")?)?;
+
+        assert!(context.contains("visible.txt"), "context: {context}");
+        assert!(!context.contains("secret.txt"), "context: {context}");
+        Ok(())
+    }
+
+    #[test]
+    fn excludes_files_ignored_by_subdir_gitignore() -> Result<()> {
+        let tmp = tempdir()?;
+        fs::create_dir_all(tmp.path().join("nested"))?;
+        fs::write(tmp.path().join("nested/.gitignore"), "secret.txt\n")?;
+        fs::write(tmp.path().join("nested/visible.txt"), "hello")?;
+        fs::write(tmp.path().join("nested/secret.txt"), "hidden")?;
+
+        let context = format_config_dir_context(tmp.path().to_str().context("utf-8 path")?)?;
+
+        assert!(context.contains("nested/"), "context: {context}");
+        assert!(context.contains("visible.txt"), "context: {context}");
+        assert!(!context.contains("secret.txt"), "context: {context}");
         Ok(())
     }
 }

--- a/apps/native/src-tauri/src/evolve/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/edit_nix_file.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 
 use crate::evolve::file_ops::rewrite_existing_file_in_dir;
 use crate::evolve::types::FileEditAction;
+use ignore::gitignore::Gitignore;
 
 /// Internal marker key used in JSON edit payloads to request a raw Nix path literal.
 ///
@@ -237,8 +238,17 @@ fn render_nix_expression_literal(
 }
 
 /// Apply a semantic file edit to the filesystem, with Nix-aware handling for specific edit types.
-pub fn apply_semantic_edit(base: &Path, edit: &SemanticFileEdit) -> anyhow::Result<()> {
-    rewrite_existing_file_in_dir(base, &edit.path, "apply semantic nix edit", |content| {
+pub fn apply_semantic_edit(
+    base: &Path,
+    edit: &SemanticFileEdit,
+    gitignore_matcher: Option<&Gitignore>,
+) -> anyhow::Result<()> {
+    rewrite_existing_file_in_dir(
+        base,
+        &edit.path,
+        "apply semantic nix edit",
+        gitignore_matcher,
+        |content| {
         info!(
             "apply_semantic_edit: path={} | action={:?}",
             edit.path, edit.action
@@ -262,7 +272,8 @@ pub fn apply_semantic_edit(base: &Path, edit: &SemanticFileEdit) -> anyhow::Resu
                 set_attrs(content, path, attrs)
             }
         }
-    })?;
+    },
+    )?;
 
     Ok(())
 }

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -7,7 +7,8 @@
 
 use super::gitignore::{is_ignored_by_matcher, load_gitignore_matcher};
 use super::utils::normalize_relative_path;
-use std::path::{Component, Path, PathBuf};
+use ignore::gitignore::Gitignore;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use log::debug;
@@ -17,34 +18,7 @@ const PATH_SCOPE_ERROR_CODE: &str = "E_PATH_OUTSIDE_CONFIG_DIR";
 /// Join a relative path into `base`, rejecting absolute paths and any path
 /// that would escape `base` using `..` components.
 pub(crate) fn join_in_dir(base: &Path, rel: &str) -> anyhow::Result<PathBuf> {
-    let rel_path = Path::new(rel);
-
-    if rel_path.is_absolute() {
-        return Err(anyhow::anyhow!("Absolute paths are not allowed"));
-    }
-
-    // Build a normalized relative path while validating components. This
-    // prevents inputs like `a/../b` from leaving `..` components present
-    // and avoids creating unnecessary intermediate directories.
-    // In other words, base="base" and rel="a/../b" will yield "base/b", not "base/a/../b".
-    let mut normalized = PathBuf::new();
-    for comp in rel_path.components() {
-        match comp {
-            Component::Normal(s) => normalized.push(s),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                if !normalized.pop() {
-                    return Err(anyhow::anyhow!("Path escapes the config directory"));
-                }
-            }
-            Component::Prefix(_) | Component::RootDir => {
-                return Err(anyhow::anyhow!(
-                    "Path prefixes or root components are not allowed in relative paths"
-                ));
-            }
-        }
-    }
-
+    let normalized = normalize_relative_path(Path::new(rel))?;
     Ok(base.join(normalized))
 }
 
@@ -117,12 +91,13 @@ pub(crate) fn rewrite_existing_file_in_dir<F>(
     base: &Path,
     rel: &str,
     operation: &str,
+    gitignore_matcher: Option<&Gitignore>,
     edit: F,
 ) -> anyhow::Result<()>
 where
     F: FnOnce(&str) -> anyhow::Result<String>,
 {
-    reject_gitignored_edit_path(base, rel, operation)?;
+    reject_gitignored_edit_path(base, rel, operation, gitignore_matcher)?;
     let full_path = resolve_existing_path_in_dir(base, rel)?;
     let fail = |kind: &str| format!("Failed to {} {} for {}", kind, rel, operation);
 
@@ -394,10 +369,12 @@ fn validate_file_content(file_path: &str, content: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Apply an evolution's edits to the filesystem.
-///
-pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::Result<()> {
-    reject_gitignored_edit_path(base, &edit.path, "apply file edit")?;
+pub fn apply_file_edits(
+    base: &Path,
+    edit: &super::types::FileEdit,
+    gitignore_matcher: Option<&Gitignore>,
+) -> anyhow::Result<()> {
+    reject_gitignored_edit_path(base, &edit.path, "apply file edit", gitignore_matcher)?;
 
     if edit.search.is_empty() {
         // Empty search means full-file replace. If the file already exists,
@@ -427,37 +404,54 @@ pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::R
         validate_file_content(&edit.path, &edit.replace)?;
         std::fs::write(&full_path, &edit.replace)?;
     } else {
-        rewrite_existing_file_in_dir(base, &edit.path, "edit existing file", |content| {
-            // Verify search string exists and is unique.
-            let count = content.matches(&edit.search).count();
-            if count == 0 {
-                return Err(anyhow::anyhow!(
-                    "Search string not found in {}: {:?}",
-                    edit.path,
-                    edit.search.chars().take(50).collect::<String>()
-                ));
-            }
-            if count > 1 {
-                return Err(anyhow::anyhow!(
-                    "Search string found {} times in {} (must be unique)",
-                    count,
-                    edit.path
-                ));
-            }
+        rewrite_existing_file_in_dir(
+            base,
+            &edit.path,
+            "edit existing file",
+            gitignore_matcher,
+            |content| {
+                // Verify search string exists and is unique.
+                let count = content.matches(&edit.search).count();
+                if count == 0 {
+                    return Err(anyhow::anyhow!(
+                        "Search string not found in {}: {:?}",
+                        edit.path,
+                        edit.search.chars().take(50).collect::<String>()
+                    ));
+                }
+                if count > 1 {
+                    return Err(anyhow::anyhow!(
+                        "Search string found {} times in {} (must be unique)",
+                        count,
+                        edit.path
+                    ));
+                }
 
-            let new_content = content.replace(&edit.search, &edit.replace);
-            validate_file_content(&edit.path, &new_content)?;
-            Ok(new_content)
-        })?;
+                let new_content = content.replace(&edit.search, &edit.replace);
+                validate_file_content(&edit.path, &new_content)?;
+                Ok(new_content)
+            },
+        )?;
     }
 
     Ok(())
 }
 
-fn reject_gitignored_edit_path(base: &Path, rel: &str, operation: &str) -> anyhow::Result<()> {
+fn reject_gitignored_edit_path(
+    base: &Path,
+    rel: &str,
+    operation: &str,
+    gitignore_matcher: Option<&Gitignore>,
+) -> anyhow::Result<()> {
     let normalized_rel = normalize_relative_path(Path::new(rel))?;
-    let gitignore = load_gitignore_matcher(base)?;
-    if is_ignored_by_matcher(gitignore.as_ref(), &normalized_rel, false) {
+    let is_ignored = if let Some(matcher) = gitignore_matcher {
+        is_ignored_by_matcher(Some(matcher), &normalized_rel, false)
+    } else {
+        let gitignore = load_gitignore_matcher(base)?;
+        is_ignored_by_matcher(gitignore.as_ref(), &normalized_rel, false)
+    };
+
+    if is_ignored {
         return Err(anyhow::anyhow!(
             "{}: '{}' is ignored by .gitignore in config_dir; refusing to edit",
             operation,
@@ -487,7 +481,7 @@ mod tests {
             replace: "new".to_string(),
         };
 
-        apply_file_edits(base, &edit).expect("apply edit");
+        apply_file_edits(base, &edit, None).expect("apply edit");
 
         let updated = fs::read_to_string(&file_path).expect("read updated file");
         assert_eq!(updated, "new");
@@ -505,7 +499,7 @@ mod tests {
             replace: "{}\n".to_string(),
         };
 
-        apply_file_edits(base, &edit).expect("apply create edit");
+        apply_file_edits(base, &edit, None).expect("apply create edit");
 
         let created = fs::read_to_string(&file_path).expect("read created file");
         assert_eq!(created, "{}\n");
@@ -524,7 +518,7 @@ mod tests {
             replace: "new".to_string(),
         };
 
-        let err = apply_file_edits(base, &edit).expect_err("expected directory-path error");
+        let err = apply_file_edits(base, &edit, None).expect_err("expected directory-path error");
         assert!(err.to_string().contains("Path is a directory, not a file"));
     }
 
@@ -540,7 +534,7 @@ mod tests {
             replace: "new".to_string(),
         };
 
-        let err = apply_file_edits(base, &edit).expect_err("expected parent-not-dir error");
+        let err = apply_file_edits(base, &edit, None).expect_err("expected parent-not-dir error");
         assert!(err.to_string().contains("Parent path is not a directory"));
     }
 
@@ -556,7 +550,7 @@ mod tests {
             replace: "new".to_string(),
         };
 
-        let err = apply_file_edits(base, &edit).expect_err("expected gitignored-path error");
+        let err = apply_file_edits(base, &edit, None).expect_err("expected gitignored-path error");
         assert!(err.to_string().contains("ignored by .gitignore"));
     }
 
@@ -567,10 +561,11 @@ mod tests {
         fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(base.join("secret.txt"), "old").expect("seed file");
 
-        let err = rewrite_existing_file_in_dir(base, "secret.txt", "test rewrite", |content| {
-            Ok(content.replace("old", "new"))
-        })
-        .expect_err("expected gitignored-path error");
+        let err =
+            rewrite_existing_file_in_dir(base, "secret.txt", "test rewrite", None, |content| {
+                Ok(content.replace("old", "new"))
+            })
+            .expect_err("expected gitignored-path error");
         assert!(err.to_string().contains("ignored by .gitignore"));
     }
 
@@ -754,7 +749,7 @@ key: "unclosed string value
             replace: "{ broken".to_string(), // Unmatched brace
         };
 
-        let err = apply_file_edits(base, &edit).expect_err("should reject invalid nix");
+        let err = apply_file_edits(base, &edit, None).expect_err("should reject invalid nix");
         assert!(err.to_string().contains("Syntax error"));
         // Verify file was NOT written
         let content = fs::read_to_string(&file_path).expect("read file");
@@ -774,7 +769,7 @@ key: "unclosed string value
             replace: "key: [unclosed".to_string(), // Unmatched bracket
         };
 
-        let err = apply_file_edits(base, &edit).expect_err("should reject invalid yaml");
+        let err = apply_file_edits(base, &edit, None).expect_err("should reject invalid yaml");
         assert!(err.to_string().contains("Syntax error"));
         // Verify file was NOT written
         let content = fs::read_to_string(&file_path).expect("read file");

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -5,6 +5,8 @@
 //!
 //! Uses OpenAI function calling to generate structured file edits.
 
+use super::gitignore::{is_ignored_by_matcher, load_gitignore_matcher};
+use super::utils::normalize_relative_path;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::Context;
@@ -120,6 +122,7 @@ pub(crate) fn rewrite_existing_file_in_dir<F>(
 where
     F: FnOnce(&str) -> anyhow::Result<String>,
 {
+    reject_gitignored_edit_path(base, rel, operation)?;
     let full_path = resolve_existing_path_in_dir(base, rel)?;
     let fail = |kind: &str| format!("Failed to {} {} for {}", kind, rel, operation);
 
@@ -394,6 +397,8 @@ fn validate_file_content(file_path: &str, content: &str) -> anyhow::Result<()> {
 /// Apply an evolution's edits to the filesystem.
 ///
 pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::Result<()> {
+    reject_gitignored_edit_path(base, &edit.path, "apply file edit")?;
+
     if edit.search.is_empty() {
         // Empty search means full-file replace. If the file already exists,
         // treat this as an existing-file rewrite (not a create path).
@@ -449,9 +454,23 @@ pub fn apply_file_edits(base: &Path, edit: &super::types::FileEdit) -> anyhow::R
     Ok(())
 }
 
+fn reject_gitignored_edit_path(base: &Path, rel: &str, operation: &str) -> anyhow::Result<()> {
+    let normalized_rel = normalize_relative_path(Path::new(rel))?;
+    let gitignore = load_gitignore_matcher(base)?;
+    if is_ignored_by_matcher(gitignore.as_ref(), &normalized_rel, false) {
+        return Err(anyhow::anyhow!(
+            "{}: '{}' is ignored by .gitignore in config_dir; refusing to edit",
+            operation,
+            rel
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::apply_file_edits;
+    use super::{apply_file_edits, rewrite_existing_file_in_dir};
     use crate::evolve::types::FileEdit;
     use std::fs;
 
@@ -523,6 +542,36 @@ mod tests {
 
         let err = apply_file_edits(base, &edit).expect_err("expected parent-not-dir error");
         assert!(err.to_string().contains("Parent path is not a directory"));
+    }
+
+    #[test]
+    fn apply_file_edits_rejects_gitignored_target() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let base = temp.path();
+        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+
+        let edit = FileEdit {
+            path: "secret.txt".to_string(),
+            search: "".to_string(),
+            replace: "new".to_string(),
+        };
+
+        let err = apply_file_edits(base, &edit).expect_err("expected gitignored-path error");
+        assert!(err.to_string().contains("ignored by .gitignore"));
+    }
+
+    #[test]
+    fn rewrite_existing_file_in_dir_rejects_gitignored_target() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let base = temp.path();
+        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        fs::write(base.join("secret.txt"), "old").expect("seed file");
+
+        let err = rewrite_existing_file_in_dir(base, "secret.txt", "test rewrite", |content| {
+            Ok(content.replace("old", "new"))
+        })
+        .expect_err("expected gitignored-path error");
+        assert!(err.to_string().contains("ignored by .gitignore"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -5,7 +5,7 @@
 //!
 //! Uses OpenAI function calling to generate structured file edits.
 
-use super::gitignore::{is_ignored_by_matcher, load_gitignore_matcher};
+use super::gitignore::is_ignored_by_matcher;
 use super::utils::normalize_relative_path;
 use ignore::gitignore::Gitignore;
 use std::path::{Path, PathBuf};
@@ -438,18 +438,13 @@ pub fn apply_file_edits(
 }
 
 fn reject_gitignored_edit_path(
-    base: &Path,
+    _base: &Path,
     rel: &str,
     operation: &str,
     gitignore_matcher: Option<&Gitignore>,
 ) -> anyhow::Result<()> {
     let normalized_rel = normalize_relative_path(Path::new(rel))?;
-    let is_ignored = if let Some(matcher) = gitignore_matcher {
-        is_ignored_by_matcher(Some(matcher), &normalized_rel, false)
-    } else {
-        let gitignore = load_gitignore_matcher(base)?;
-        is_ignored_by_matcher(gitignore.as_ref(), &normalized_rel, false)
-    };
+    let is_ignored = is_ignored_by_matcher(gitignore_matcher, &normalized_rel, false);
 
     if is_ignored {
         return Err(anyhow::anyhow!(
@@ -465,6 +460,7 @@ fn reject_gitignored_edit_path(
 #[cfg(test)]
 mod tests {
     use super::{apply_file_edits, rewrite_existing_file_in_dir};
+    use crate::evolve::gitignore::load_gitignore_matcher;
     use crate::evolve::types::FileEdit;
     use std::fs;
 
@@ -543,6 +539,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("create temp dir");
         let base = temp.path();
         fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        let gitignore_matcher = load_gitignore_matcher(base).expect("load matcher");
 
         let edit = FileEdit {
             path: "secret.txt".to_string(),
@@ -550,7 +547,8 @@ mod tests {
             replace: "new".to_string(),
         };
 
-        let err = apply_file_edits(base, &edit, None).expect_err("expected gitignored-path error");
+        let err = apply_file_edits(base, &edit, gitignore_matcher.as_ref())
+            .expect_err("expected gitignored-path error");
         assert!(err.to_string().contains("ignored by .gitignore"));
     }
 
@@ -560,11 +558,16 @@ mod tests {
         let base = temp.path();
         fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(base.join("secret.txt"), "old").expect("seed file");
+        let gitignore_matcher = load_gitignore_matcher(base).expect("load matcher");
 
         let err =
-            rewrite_existing_file_in_dir(base, "secret.txt", "test rewrite", None, |content| {
-                Ok(content.replace("old", "new"))
-            })
+            rewrite_existing_file_in_dir(
+                base,
+                "secret.txt",
+                "test rewrite",
+                gitignore_matcher.as_ref(),
+                |content| Ok(content.replace("old", "new")),
+            )
             .expect_err("expected gitignored-path error");
         assert!(err.to_string().contains("ignored by .gitignore"));
     }

--- a/apps/native/src-tauri/src/evolve/gitignore.rs
+++ b/apps/native/src-tauri/src/evolve/gitignore.rs
@@ -1,0 +1,73 @@
+use anyhow::{anyhow, Result};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Load all `.gitignore` files under the base config directory.
+pub(crate) fn load_gitignore_matcher(base: &Path) -> Result<Option<Gitignore>> {
+    let mut gitignore_paths = Vec::new();
+    collect_gitignore_files(base, &mut gitignore_paths)?;
+
+    if gitignore_paths.is_empty() {
+        return Ok(None);
+    }
+
+    gitignore_paths.sort();
+
+    let mut builder = GitignoreBuilder::new(base);
+    for gitignore_path in gitignore_paths {
+        builder.add(gitignore_path);
+    }
+
+    let matcher = builder.build().map_err(|e| {
+        anyhow!(
+            "Failed to parse one or more .gitignore files in {}: {}",
+            base.display(),
+            e
+        )
+    })?;
+
+    Ok(Some(matcher))
+}
+
+/// Returns true when `relative_path` is ignored by the provided gitignore matcher.
+pub(crate) fn is_ignored_by_matcher(
+    matcher: Option<&Gitignore>,
+    relative_path: &Path,
+    is_dir: bool,
+) -> bool {
+    matcher
+        .map(|m| m.matched_path_or_any_parents(relative_path, is_dir).is_ignore())
+        .unwrap_or(false)
+}
+
+fn collect_gitignore_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir)
+        .map_err(|e| anyhow!("Failed to read directory {}: {}", dir.display(), e))?
+    {
+        let entry = entry
+            .map_err(|e| anyhow!("Failed to read directory entry in {}: {}", dir.display(), e))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| anyhow!("Failed to get file type for {}: {}", entry.path().display(), e))?;
+        let path = entry.path();
+        let name = entry.file_name();
+
+        if file_type.is_file() && name == ".gitignore" {
+            out.push(path);
+            continue;
+        }
+
+        if !file_type.is_dir() || file_type.is_symlink() {
+            continue;
+        }
+
+        if super::IGNORED_DIRS.contains(&name.to_string_lossy().as_ref()) {
+            continue;
+        }
+
+        collect_gitignore_files(&path, out)?;
+    }
+
+    Ok(())
+}

--- a/apps/native/src-tauri/src/evolve/gitignore.rs
+++ b/apps/native/src-tauri/src/evolve/gitignore.rs
@@ -1,12 +1,13 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use log::warn;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Load all `.gitignore` files under the base config directory.
 pub(crate) fn load_gitignore_matcher(base: &Path) -> Result<Option<Gitignore>> {
     let mut gitignore_paths = Vec::new();
-    collect_gitignore_files(base, &mut gitignore_paths)?;
+    collect_gitignore_files(base, &mut gitignore_paths);
 
     if gitignore_paths.is_empty() {
         return Ok(None);
@@ -14,20 +15,7 @@ pub(crate) fn load_gitignore_matcher(base: &Path) -> Result<Option<Gitignore>> {
 
     gitignore_paths.sort();
 
-    let mut builder = GitignoreBuilder::new(base);
-    for gitignore_path in gitignore_paths {
-        builder.add(gitignore_path);
-    }
-
-    let matcher = builder.build().map_err(|e| {
-        anyhow!(
-            "Failed to parse one or more .gitignore files in {}: {}",
-            base.display(),
-            e
-        )
-    })?;
-
-    Ok(Some(matcher))
+    Ok(build_matcher(base, &gitignore_paths))
 }
 
 /// Returns true when `relative_path` is ignored by the provided gitignore matcher.
@@ -37,19 +25,51 @@ pub(crate) fn is_ignored_by_matcher(
     is_dir: bool,
 ) -> bool {
     matcher
-        .map(|m| m.matched_path_or_any_parents(relative_path, is_dir).is_ignore())
+        .map(|m| {
+            m.matched_path_or_any_parents(relative_path, is_dir)
+                .is_ignore()
+        })
         .unwrap_or(false)
 }
 
-fn collect_gitignore_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in fs::read_dir(dir)
-        .map_err(|e| anyhow!("Failed to read directory {}: {}", dir.display(), e))?
-    {
-        let entry = entry
-            .map_err(|e| anyhow!("Failed to read directory entry in {}: {}", dir.display(), e))?;
-        let file_type = entry
-            .file_type()
-            .map_err(|e| anyhow!("Failed to get file type for {}: {}", entry.path().display(), e))?;
+fn collect_gitignore_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!(
+                "Unable to read directory {} while collecting .gitignore files: {}",
+                dir.display(),
+                e
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(
+                    "Unable to read directory entry in {} while collecting .gitignore files: {}",
+                    dir.display(),
+                    e
+                );
+                continue;
+            }
+        };
+
+        let file_type = match entry.file_type() {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(
+                    "Unable to get file type for {} while collecting .gitignore files: {}",
+                    entry.path().display(),
+                    e
+                );
+                continue;
+            }
+        };
+
         let path = entry.path();
         let name = entry.file_name();
 
@@ -66,8 +86,154 @@ fn collect_gitignore_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
             continue;
         }
 
-        collect_gitignore_files(&path, out)?;
+        collect_gitignore_files(&path, out);
+    }
+}
+
+/// Build a Gitignore matcher from the provided .gitignore paths, skipping any that are invalid or unreadable.
+/// There is a fallback that attempts to salvage as many valid .gitignore files as possible in the case
+/// where the initial build fails, but if none can be loaded then this returns None.
+fn build_matcher(base: &Path, gitignore_paths: &[PathBuf]) -> Option<Gitignore> {
+    let mut full_builder = GitignoreBuilder::new(base);
+    for path in gitignore_paths {
+        full_builder.add(path);
     }
 
-    Ok(())
+    if let Ok(matcher) = full_builder.build() {
+        return Some(matcher);
+    }
+
+    // Fallback: keep as many valid .gitignore files as possible.
+    let mut accepted_paths: Vec<PathBuf> = Vec::new();
+    for path in gitignore_paths {
+        let mut trial_builder = GitignoreBuilder::new(base);
+        for accepted in &accepted_paths {
+            trial_builder.add(accepted);
+        }
+        trial_builder.add(path);
+
+        match trial_builder.build() {
+            Ok(_) => accepted_paths.push(path.clone()),
+            Err(e) => warn!(
+                "Skipping invalid or unreadable .gitignore file {}: {}",
+                path.display(),
+                e
+            ),
+        }
+    }
+
+    if accepted_paths.is_empty() {
+        warn!(
+            "Failed to build gitignore matcher for {}: no valid .gitignore files could be loaded; continuing without matcher",
+            base.display()
+        );
+        return None;
+    }
+
+    let mut final_builder = GitignoreBuilder::new(base);
+    for accepted in &accepted_paths {
+        final_builder.add(accepted);
+    }
+
+    match final_builder.build() {
+        Ok(matcher) => Some(matcher),
+        Err(e) => {
+            warn!(
+                "Failed to build final gitignore matcher for {}: {}; continuing without matcher",
+                base.display(),
+                e
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_ignored_by_matcher, load_gitignore_matcher};
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn loads_matcher_when_subdir_is_unreadable() {
+        let temp = tempdir().expect("create temp dir");
+        let base = temp.path();
+        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write root .gitignore");
+
+        let blocked = base.join("blocked");
+        fs::create_dir_all(&blocked).expect("create blocked dir");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&blocked).expect("metadata").permissions();
+            perms.set_mode(0o000);
+            fs::set_permissions(&blocked, perms).expect("make blocked dir unreadable");
+        }
+
+        let matcher = load_gitignore_matcher(base).expect("load matcher should not fail");
+        assert!(matcher.is_some(), "expected matcher from root .gitignore");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&blocked).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&blocked, perms).expect("restore permissions for cleanup");
+        }
+    }
+
+    #[test]
+    fn malformed_gitignore_does_not_error() {
+        let temp = tempdir().expect("create temp dir");
+        let base = temp.path();
+        fs::write(base.join(".gitignore"), "[unterminated").expect("write malformed .gitignore");
+
+        let _matcher = load_gitignore_matcher(base).expect("load matcher should not fail");
+    }
+
+    #[test]
+    fn preserves_valid_rules_when_some_gitignore_files_unreadable() {
+        let temp = tempdir().expect("create temp dir");
+        let base = temp.path();
+        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write root .gitignore");
+
+        let nested = base.join("nested");
+        fs::create_dir_all(&nested).expect("create nested dir");
+        let nested_gitignore = nested.join(".gitignore");
+        fs::write(&nested_gitignore, "ignored-in-nested.txt\n").expect("write nested .gitignore");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&nested_gitignore)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o000);
+            fs::set_permissions(&nested_gitignore, perms)
+                .expect("make nested .gitignore unreadable");
+        }
+
+        let matcher = load_gitignore_matcher(base).expect("matcher load should not fail");
+        assert!(
+            matcher.is_some(),
+            "expected matcher from readable .gitignore files"
+        );
+
+        assert!(
+            is_ignored_by_matcher(matcher.as_ref(), Path::new("secret.txt"), false),
+            "expected root rule to still apply"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&nested_gitignore)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o644);
+            fs::set_permissions(&nested_gitignore, perms).expect("restore permissions for cleanup");
+        }
+    }
 }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -27,6 +27,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Runtime};
@@ -577,6 +578,8 @@ pub async fn generate_evolution<R: Runtime>(
         ),
     });
 
+    let gitignore_matcher = gitignore::load_gitignore_matcher(Path::new(config_dir))?;
+
     // Track whether we've made any actual edits or build checks
     let mut made_edit_or_build_check = false;
 
@@ -780,7 +783,13 @@ pub async fn generate_evolution<R: Runtime>(
                         EvolveEvent::tool_call(start_time, iteration, tool_name, &args_summary),
                     );
 
-                    let result = execute_tool(config_dir, host_attr.as_str(), tool_name, &args);
+                    let result = execute_tool(
+                        config_dir,
+                        host_attr.as_str(),
+                        tool_name,
+                        &args,
+                        gitignore_matcher.as_ref(),
+                    );
 
                     match result {
                         Ok(ref res) => {

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -4,6 +4,7 @@ mod chat_memory;
 mod config_dir_context;
 mod edit_nix_file;
 mod file_ops;
+mod gitignore;
 pub mod messages;
 pub mod providers;
 mod search_code;

--- a/apps/native/src-tauri/src/evolve/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/search_code.rs
@@ -16,14 +16,6 @@ pub fn execute_search_code(
     file_pattern: Option<&str>,
     gitignore: Option<&Gitignore>,
 ) -> Result<String> {
-    let gitignore_owned;
-    let gitignore = if let Some(m) = gitignore {
-        Some(m)
-    } else {
-        gitignore_owned = super::gitignore::load_gitignore_matcher(Path::new(config_dir))?;
-        gitignore_owned.as_ref()
-    };
-
     info!("Searching for pattern: {}", pattern);
 
     let mut cmd = Command::new("rg");
@@ -209,6 +201,7 @@ fn normalize_match_path(path: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{execute_search_code, filter_grep_matches};
+    use crate::evolve::gitignore::load_gitignore_matcher;
     use std::fs;
     use tempfile::tempdir;
 
@@ -218,12 +211,13 @@ mod tests {
         fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(tmp.path().join("visible.txt"), "NEEDLE").expect("write visible file");
         fs::write(tmp.path().join("secret.txt"), "NEEDLE").expect("write secret file");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let output = execute_search_code(
             tmp.path().to_str().expect("utf-8 path"),
             "NEEDLE",
             None,
-            None,
+            gitignore_matcher.as_ref(),
         )
         .expect("search should succeed");
 
@@ -236,12 +230,13 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(tmp.path().join("secret.txt"), "NEEDLE").expect("write secret file");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let output = execute_search_code(
             tmp.path().to_str().expect("utf-8 path"),
             "NEEDLE",
             Some("secret.txt"),
-            None,
+            gitignore_matcher.as_ref(),
         )
         .expect("search should succeed");
 
@@ -258,12 +253,13 @@ mod tests {
             .expect("write nested visible file");
         fs::write(tmp.path().join("nested/secret.txt"), "NEEDLE")
             .expect("write nested secret file");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let output = execute_search_code(
             tmp.path().to_str().expect("utf-8 path"),
             "NEEDLE",
             None,
-            None,
+            gitignore_matcher.as_ref(),
         )
         .expect("search should succeed");
 

--- a/apps/native/src-tauri/src/evolve/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/search_code.rs
@@ -1,8 +1,9 @@
 use super::utils::truncate_error;
 use anyhow::{anyhow, Result};
+use ignore::gitignore::Gitignore;
 use log::info;
 use serde_json::Value;
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 // Maximum number of rg search results to return.
@@ -15,6 +16,7 @@ pub fn execute_search_code(
     file_pattern: Option<&str>,
 ) -> Result<String> {
     info!("Searching for pattern: {}", pattern);
+    let gitignore = super::gitignore::load_gitignore_matcher(Path::new(config_dir))?;
 
     let mut cmd = Command::new("rg");
     cmd.args([
@@ -57,7 +59,7 @@ pub fn execute_search_code(
         Ok(out) => {
             let status = out.status;
             if status.success() {
-                let formatted = format_rg_json_matches(&out.stdout);
+                let formatted = format_rg_json_matches(&out.stdout, gitignore.as_ref());
                 if formatted.is_empty() {
                     Ok("No matches found.".to_string())
                 } else {
@@ -99,12 +101,17 @@ pub fn execute_search_code(
                 .current_dir(config_dir)
                 .output()?;
             let stdout = String::from_utf8_lossy(&output.stdout);
-            Ok(truncate_error(&stdout, 8000))
+            let filtered = filter_grep_matches(&stdout, gitignore.as_ref());
+            if filtered.trim().is_empty() {
+                Ok("No matches found.".to_string())
+            } else {
+                Ok(truncate_error(&filtered, 8000))
+            }
         }
     }
 }
 
-fn format_rg_json_matches(stdout: &[u8]) -> String {
+fn format_rg_json_matches(stdout: &[u8], gitignore: Option<&Gitignore>) -> String {
     let mut lines: Vec<String> = Vec::new();
 
     for json_line in String::from_utf8_lossy(stdout).lines() {
@@ -126,6 +133,10 @@ fn format_rg_json_matches(stdout: &[u8]) -> String {
             continue;
         };
 
+        if is_ignored_match(path, false, gitignore) {
+            continue;
+        }
+
         let line_number = data["line_number"].as_u64().unwrap_or(0);
         let match_text = data["lines"]["text"]
             .as_str()
@@ -136,4 +147,97 @@ fn format_rg_json_matches(stdout: &[u8]) -> String {
     }
 
     lines.join("\n")
+}
+
+fn filter_grep_matches(stdout: &str, gitignore: Option<&Gitignore>) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    for line in stdout.lines() {
+        if lines.len() >= MAX_SEARCH_RESULTS {
+            break;
+        }
+
+        let Some((path, _rest)) = line.split_once(':') else {
+            continue;
+        };
+
+        if is_ignored_match(path, false, gitignore) {
+            continue;
+        }
+
+        lines.push(line.to_string());
+    }
+
+    lines.join("\n")
+}
+
+fn is_ignored_match(path: &str, is_dir: bool, gitignore: Option<&Gitignore>) -> bool {
+    let rel = normalize_match_path(path);
+    super::gitignore::is_ignored_by_matcher(gitignore, &rel, is_dir)
+}
+
+fn normalize_match_path(path: &str) -> PathBuf {
+    let raw = Path::new(path);
+    let rel = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        PathBuf::from(path.trim_start_matches("./"))
+    };
+
+    super::utils::normalize_relative_path(&rel).unwrap_or(rel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::execute_search_code;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn search_code_skips_files_ignored_by_base_gitignore() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        fs::write(tmp.path().join("visible.txt"), "NEEDLE").expect("write visible file");
+        fs::write(tmp.path().join("secret.txt"), "NEEDLE").expect("write secret file");
+
+        let output = execute_search_code(tmp.path().to_str().expect("utf-8 path"), "NEEDLE", None)
+            .expect("search should succeed");
+
+        assert!(output.contains("visible.txt"), "output: {output}");
+        assert!(!output.contains("secret.txt"), "output: {output}");
+    }
+
+    #[test]
+    fn search_code_respects_gitignore_even_with_file_pattern() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        fs::write(tmp.path().join("secret.txt"), "NEEDLE").expect("write secret file");
+
+        let output = execute_search_code(
+            tmp.path().to_str().expect("utf-8 path"),
+            "NEEDLE",
+            Some("secret.txt"),
+        )
+        .expect("search should succeed");
+
+        assert_eq!(output, "No matches found.");
+    }
+
+    #[test]
+    fn search_code_skips_files_ignored_by_subdir_gitignore() {
+        let tmp = tempdir().expect("tempdir");
+        fs::create_dir_all(tmp.path().join("nested")).expect("make nested dir");
+        fs::write(tmp.path().join("nested/.gitignore"), "secret.txt\n")
+            .expect("write nested .gitignore");
+        fs::write(tmp.path().join("nested/visible.txt"), "NEEDLE")
+            .expect("write nested visible file");
+        fs::write(tmp.path().join("nested/secret.txt"), "NEEDLE")
+            .expect("write nested secret file");
+
+        let output = execute_search_code(tmp.path().to_str().expect("utf-8 path"), "NEEDLE", None)
+            .expect("search should succeed");
+
+        assert!(output.contains("nested/visible.txt"), "output: {output}");
+        assert!(!output.contains("nested/secret.txt"), "output: {output}");
+    }
 }

--- a/apps/native/src-tauri/src/evolve/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/search_code.rs
@@ -14,9 +14,17 @@ pub fn execute_search_code(
     config_dir: &str,
     pattern: &str,
     file_pattern: Option<&str>,
+    gitignore: Option<&Gitignore>,
 ) -> Result<String> {
+    let gitignore_owned;
+    let gitignore = if let Some(m) = gitignore {
+        Some(m)
+    } else {
+        gitignore_owned = super::gitignore::load_gitignore_matcher(Path::new(config_dir))?;
+        gitignore_owned.as_ref()
+    };
+
     info!("Searching for pattern: {}", pattern);
-    let gitignore = super::gitignore::load_gitignore_matcher(Path::new(config_dir))?;
 
     let mut cmd = Command::new("rg");
     cmd.args([
@@ -59,7 +67,7 @@ pub fn execute_search_code(
         Ok(out) => {
             let status = out.status;
             if status.success() {
-                let formatted = format_rg_json_matches(&out.stdout, gitignore.as_ref());
+                let formatted = format_rg_json_matches(&out.stdout, gitignore);
                 if formatted.is_empty() {
                     Ok("No matches found.".to_string())
                 } else {
@@ -101,7 +109,7 @@ pub fn execute_search_code(
                 .current_dir(config_dir)
                 .output()?;
             let stdout = String::from_utf8_lossy(&output.stdout);
-            let filtered = filter_grep_matches(&stdout, gitignore.as_ref());
+            let filtered = filter_grep_matches(&stdout, gitignore);
             if filtered.trim().is_empty() {
                 Ok("No matches found.".to_string())
             } else {
@@ -157,9 +165,20 @@ fn filter_grep_matches(stdout: &str, gitignore: Option<&Gitignore>) -> String {
             break;
         }
 
-        let Some((path, _rest)) = line.split_once(':') else {
+        let mut parts = line.rsplitn(3, ':');
+        let Some(_text) = parts.next() else {
             continue;
         };
+        let Some(line_no) = parts.next() else {
+            continue;
+        };
+        let Some(path) = parts.next() else {
+            continue;
+        };
+
+        if line_no.parse::<u64>().is_err() {
+            continue;
+        }
 
         if is_ignored_match(path, false, gitignore) {
             continue;
@@ -189,7 +208,7 @@ fn normalize_match_path(path: &str) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::execute_search_code;
+    use super::{execute_search_code, filter_grep_matches};
     use std::fs;
     use tempfile::tempdir;
 
@@ -200,8 +219,13 @@ mod tests {
         fs::write(tmp.path().join("visible.txt"), "NEEDLE").expect("write visible file");
         fs::write(tmp.path().join("secret.txt"), "NEEDLE").expect("write secret file");
 
-        let output = execute_search_code(tmp.path().to_str().expect("utf-8 path"), "NEEDLE", None)
-            .expect("search should succeed");
+        let output = execute_search_code(
+            tmp.path().to_str().expect("utf-8 path"),
+            "NEEDLE",
+            None,
+            None,
+        )
+        .expect("search should succeed");
 
         assert!(output.contains("visible.txt"), "output: {output}");
         assert!(!output.contains("secret.txt"), "output: {output}");
@@ -217,6 +241,7 @@ mod tests {
             tmp.path().to_str().expect("utf-8 path"),
             "NEEDLE",
             Some("secret.txt"),
+            None,
         )
         .expect("search should succeed");
 
@@ -234,10 +259,31 @@ mod tests {
         fs::write(tmp.path().join("nested/secret.txt"), "NEEDLE")
             .expect("write nested secret file");
 
-        let output = execute_search_code(tmp.path().to_str().expect("utf-8 path"), "NEEDLE", None)
-            .expect("search should succeed");
+        let output = execute_search_code(
+            tmp.path().to_str().expect("utf-8 path"),
+            "NEEDLE",
+            None,
+            None,
+        )
+        .expect("search should succeed");
 
         assert!(output.contains("nested/visible.txt"), "output: {output}");
         assert!(!output.contains("nested/secret.txt"), "output: {output}");
+    }
+
+    #[test]
+    fn grep_fallback_parser_handles_colons_in_filename() {
+        let stdout = "dir:with:colon/file.txt:12:match text\ndir/file.txt:not-a-line:ignored\n";
+
+        let output = filter_grep_matches(stdout, None);
+
+        assert!(
+            output.contains("dir:with:colon/file.txt:12:match text"),
+            "output: {output}"
+        );
+        assert!(
+            !output.contains("dir/file.txt:not-a-line:ignored"),
+            "output: {output}"
+        );
     }
 }

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -6,6 +6,7 @@ use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 use super::file_ops::{
     apply_file_edits, ensure_path_under_base, join_in_dir, resolve_existing_path_in_dir,
 };
+use super::gitignore::{is_ignored_by_matcher, load_gitignore_matcher};
 use super::messages::Tool;
 use super::search_code::execute_search_code;
 use super::search_docs::{
@@ -13,6 +14,7 @@ use super::search_docs::{
 };
 use super::search_packages::execute_search_packages;
 use super::types::FileEdit;
+use super::utils::normalize_relative_path;
 
 use anyhow::{anyhow, Context, Result};
 use log::{debug, error, info};
@@ -440,6 +442,15 @@ pub fn execute_tool(
             let path = args["path"]
                 .as_str()
                 .ok_or_else(|| anyhow!("read_file: missing path"))?;
+            let normalized_rel = normalize_relative_path(Path::new(path))?;
+            let gitignore = load_gitignore_matcher(base)?;
+            if is_ignored_by_matcher(gitignore.as_ref(), &normalized_rel, false) {
+                return Err(anyhow!(
+                    "read_file: '{}' is ignored by .gitignore in config_dir",
+                    path
+                ));
+            }
+
             let full_path = resolve_existing_path_in_dir(base, path)?;
             info!("Reading file: {}", full_path.display());
             let content = std::fs::read_to_string(&full_path)
@@ -456,6 +467,7 @@ pub fn execute_tool(
             info!("Listing files matching: {}", full_pattern.display());
 
             let ignored_dirs = super::IGNORED_DIRS;
+            let gitignore = load_gitignore_matcher(base)?;
             let matched_files = glob::glob(full_pattern.to_str().unwrap())
                 .map_err(|e| anyhow!("Invalid glob pattern: {}", e))?
                 .filter_map(|p| p.ok())
@@ -481,6 +493,10 @@ pub fn execute_tool(
                     if ignored_dirs.contains(&name.to_string_lossy().as_ref()) {
                         continue;
                     }
+                }
+
+                if is_ignored_by_matcher(gitignore.as_ref(), rel, false) {
+                    continue;
                 }
 
                 files.push(rel.to_string_lossy().to_string());
@@ -786,7 +802,10 @@ fn truncate_for_log(s: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::is_editing_tool;
+    use super::{execute_tool, is_editing_tool, ToolResult};
+    use serde_json::json;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn returns_true_for_editing_tools() {
@@ -801,5 +820,153 @@ mod tests {
         assert!(!is_editing_tool("build_check"));
         assert!(!is_editing_tool("done"));
         assert!(!is_editing_tool(""));
+    }
+
+    #[test]
+    fn read_file_rejects_base_gitignored_files() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        fs::write(tmp.path().join("secret.txt"), "top secret").expect("write secret file");
+
+        let result = execute_tool(
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "read_file",
+            &json!({ "path": "secret.txt" }),
+        );
+
+        let err = result.expect_err("ignored file should be rejected");
+        assert!(
+            err.to_string().contains("ignored by .gitignore"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn read_file_rejects_subdir_gitignored_files() {
+        let tmp = tempdir().expect("tempdir");
+        fs::create_dir_all(tmp.path().join("nested")).expect("make nested dir");
+        fs::write(tmp.path().join("nested/.gitignore"), "secret.txt\n")
+            .expect("write nested .gitignore");
+        fs::write(tmp.path().join("nested/secret.txt"), "top secret")
+            .expect("write nested secret file");
+
+        let result = execute_tool(
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "read_file",
+            &json!({ "path": "nested/secret.txt" }),
+        );
+
+        let err = result.expect_err("nested gitignored file should be rejected");
+        assert!(
+            err.to_string().contains("ignored by .gitignore"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn list_files_skips_base_gitignored_files() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join(".gitignore"), "secret.txt\nignored-dir/\n")
+            .expect("write .gitignore");
+        fs::write(tmp.path().join("visible.txt"), "visible").expect("write visible file");
+        fs::write(tmp.path().join("secret.txt"), "secret").expect("write secret file");
+        fs::create_dir_all(tmp.path().join("ignored-dir")).expect("make ignored dir");
+        fs::write(tmp.path().join("ignored-dir/file.txt"), "ignored").expect("write ignored file");
+
+        let result = execute_tool(
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "list_files",
+            &json!({ "pattern": "**/*.txt" }),
+        )
+        .expect("list_files should succeed");
+
+        let ToolResult::Continue(output) = result else {
+            panic!("expected ToolResult::Continue");
+        };
+
+        assert!(output.contains("visible.txt"), "output: {output}");
+        assert!(!output.contains("secret.txt"), "output: {output}");
+        assert!(!output.contains("ignored-dir/file.txt"), "output: {output}");
+    }
+
+    #[test]
+    fn edit_file_rejects_base_gitignored_paths() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+
+        let result = execute_tool(
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_file",
+            &json!({
+                "path": "secret.txt",
+                "search": "",
+                "replace": "hello"
+            }),
+        );
+
+        let err = result.expect_err("edit_file should reject gitignored paths");
+        let err_chain = format!("{err:#}");
+        assert!(
+            err_chain.contains("ignored by .gitignore"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn edit_nix_file_rejects_base_gitignored_paths() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join(".gitignore"), "ignored.nix\n").expect("write .gitignore");
+        fs::write(tmp.path().join("ignored.nix"), "{ ... }: { }\n").expect("write nix file");
+
+        let result = execute_tool(
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_nix_file",
+            &json!({
+                "path": "ignored.nix",
+                "action": {
+                    "set": {
+                        "path": "services.tailscale.enable",
+                        "value": true
+                    }
+                }
+            }),
+        );
+
+        let err = result.expect_err("edit_nix_file should reject gitignored paths");
+        assert!(
+            err.to_string().contains("ignored by .gitignore"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn edit_file_rejects_subdir_gitignored_paths() {
+        let tmp = tempdir().expect("tempdir");
+        fs::create_dir_all(tmp.path().join("nested")).expect("make nested dir");
+        fs::write(tmp.path().join("nested/.gitignore"), "secret.txt\n")
+            .expect("write nested .gitignore");
+
+        let result = execute_tool(
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_file",
+            &json!({
+                "path": "nested/secret.txt",
+                "search": "",
+                "replace": "hello"
+            }),
+        );
+
+        let err = result.expect_err("edit_file should reject nested gitignored paths");
+        let err_chain = format!("{err:#}");
+        assert!(
+            err_chain.contains("ignored by .gitignore"),
+            "unexpected error: {err:#}"
+        );
     }
 }

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -6,7 +6,7 @@ use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 use super::file_ops::{
     apply_file_edits, ensure_path_under_base, join_in_dir, resolve_existing_path_in_dir,
 };
-use super::gitignore::{is_ignored_by_matcher, load_gitignore_matcher};
+use super::gitignore::is_ignored_by_matcher;
 use super::messages::Tool;
 use super::search_code::execute_search_code;
 use super::search_docs::{
@@ -17,6 +17,7 @@ use super::types::FileEdit;
 use super::utils::normalize_relative_path;
 
 use anyhow::{anyhow, Context, Result};
+use ignore::gitignore::Gitignore;
 use log::{debug, error, info};
 use std::path::{Component, Path};
 
@@ -418,9 +419,9 @@ pub fn execute_tool(
     host_attr: &str,
     name: &str,
     args: &serde_json::Value,
+    gitignore_matcher: Option<&Gitignore>,
 ) -> Result<ToolResult> {
     let base = Path::new(config_dir);
-    let gitignore_matcher = load_gitignore_matcher(base)?;
     match name {
         "think" => {
             let category = args["category"].as_str().unwrap_or("other").to_string();
@@ -444,7 +445,7 @@ pub fn execute_tool(
                 .as_str()
                 .ok_or_else(|| anyhow!("read_file: missing path"))?;
             let normalized_rel = normalize_relative_path(Path::new(path))?;
-            if is_ignored_by_matcher(gitignore_matcher.as_ref(), &normalized_rel, false) {
+            if is_ignored_by_matcher(gitignore_matcher, &normalized_rel, false) {
                 return Err(anyhow!(
                     "read_file: '{}' is ignored by .gitignore in config_dir",
                     path
@@ -494,7 +495,7 @@ pub fn execute_tool(
                     }
                 }
 
-                if is_ignored_by_matcher(gitignore_matcher.as_ref(), rel, false) {
+                if is_ignored_by_matcher(gitignore_matcher, rel, false) {
                     continue;
                 }
 
@@ -540,7 +541,7 @@ pub fn execute_tool(
                     search: search.to_string(),
                     replace: replace.to_string(),
                 },
-                gitignore_matcher.as_ref(),
+                gitignore_matcher,
             )
             .with_context(|| {
                 format!(
@@ -675,7 +676,7 @@ pub fn execute_tool(
                     path: path.to_string(),
                     action: action.clone(),
                 },
-                gitignore_matcher.as_ref(),
+                gitignore_matcher,
             )?;
 
             Ok(ToolResult::EditSemantic(SemanticFileEdit {
@@ -721,12 +722,7 @@ pub fn execute_tool(
                 .as_str()
                 .ok_or_else(|| anyhow!("search_code: missing pattern"))?;
             let file_pattern = args["file_pattern"].as_str();
-            let output = execute_search_code(
-                config_dir,
-                pattern,
-                file_pattern,
-                gitignore_matcher.as_ref(),
-            )?;
+            let output = execute_search_code(config_dir, pattern, file_pattern, gitignore_matcher)?;
             Ok(ToolResult::Continue(output))
         }
 
@@ -809,6 +805,7 @@ fn truncate_for_log(s: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{execute_tool, is_editing_tool, ToolResult};
+    use crate::evolve::gitignore::load_gitignore_matcher;
     use serde_json::json;
     use std::fs;
     use tempfile::tempdir;
@@ -833,12 +830,14 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(tmp.path().join("secret.txt"), "top secret").expect("write secret file");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path().to_str().expect("utf-8 path"),
             "dummy-host",
             "read_file",
             &json!({ "path": "secret.txt" }),
+            gitignore_matcher.as_ref(),
         );
 
         let err = result.expect_err("ignored file should be rejected");
@@ -856,12 +855,14 @@ mod tests {
             .expect("write nested .gitignore");
         fs::write(tmp.path().join("nested/secret.txt"), "top secret")
             .expect("write nested secret file");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path().to_str().expect("utf-8 path"),
             "dummy-host",
             "read_file",
             &json!({ "path": "nested/secret.txt" }),
+            gitignore_matcher.as_ref(),
         );
 
         let err = result.expect_err("nested gitignored file should be rejected");
@@ -880,12 +881,14 @@ mod tests {
         fs::write(tmp.path().join("secret.txt"), "secret").expect("write secret file");
         fs::create_dir_all(tmp.path().join("ignored-dir")).expect("make ignored dir");
         fs::write(tmp.path().join("ignored-dir/file.txt"), "ignored").expect("write ignored file");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path().to_str().expect("utf-8 path"),
             "dummy-host",
             "list_files",
             &json!({ "pattern": "**/*.txt" }),
+            gitignore_matcher.as_ref(),
         )
         .expect("list_files should succeed");
 
@@ -902,6 +905,7 @@ mod tests {
     fn edit_file_rejects_base_gitignored_paths() {
         let tmp = tempdir().expect("tempdir");
         fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path().to_str().expect("utf-8 path"),
@@ -912,6 +916,7 @@ mod tests {
                 "search": "",
                 "replace": "hello"
             }),
+            gitignore_matcher.as_ref(),
         );
 
         let err = result.expect_err("edit_file should reject gitignored paths");
@@ -927,6 +932,7 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         fs::write(tmp.path().join(".gitignore"), "ignored.nix\n").expect("write .gitignore");
         fs::write(tmp.path().join("ignored.nix"), "{ ... }: { }\n").expect("write nix file");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path().to_str().expect("utf-8 path"),
@@ -941,6 +947,7 @@ mod tests {
                     }
                 }
             }),
+            gitignore_matcher.as_ref(),
         );
 
         let err = result.expect_err("edit_nix_file should reject gitignored paths");
@@ -956,6 +963,7 @@ mod tests {
         fs::create_dir_all(tmp.path().join("nested")).expect("make nested dir");
         fs::write(tmp.path().join("nested/.gitignore"), "secret.txt\n")
             .expect("write nested .gitignore");
+        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path().to_str().expect("utf-8 path"),
@@ -966,6 +974,7 @@ mod tests {
                 "search": "",
                 "replace": "hello"
             }),
+            gitignore_matcher.as_ref(),
         );
 
         let err = result.expect_err("edit_file should reject nested gitignored paths");

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -420,6 +420,7 @@ pub fn execute_tool(
     args: &serde_json::Value,
 ) -> Result<ToolResult> {
     let base = Path::new(config_dir);
+    let gitignore_matcher = load_gitignore_matcher(base)?;
     match name {
         "think" => {
             let category = args["category"].as_str().unwrap_or("other").to_string();
@@ -443,8 +444,7 @@ pub fn execute_tool(
                 .as_str()
                 .ok_or_else(|| anyhow!("read_file: missing path"))?;
             let normalized_rel = normalize_relative_path(Path::new(path))?;
-            let gitignore = load_gitignore_matcher(base)?;
-            if is_ignored_by_matcher(gitignore.as_ref(), &normalized_rel, false) {
+            if is_ignored_by_matcher(gitignore_matcher.as_ref(), &normalized_rel, false) {
                 return Err(anyhow!(
                     "read_file: '{}' is ignored by .gitignore in config_dir",
                     path
@@ -467,7 +467,6 @@ pub fn execute_tool(
             info!("Listing files matching: {}", full_pattern.display());
 
             let ignored_dirs = super::IGNORED_DIRS;
-            let gitignore = load_gitignore_matcher(base)?;
             let matched_files = glob::glob(full_pattern.to_str().unwrap())
                 .map_err(|e| anyhow!("Invalid glob pattern: {}", e))?
                 .filter_map(|p| p.ok())
@@ -495,7 +494,7 @@ pub fn execute_tool(
                     }
                 }
 
-                if is_ignored_by_matcher(gitignore.as_ref(), rel, false) {
+                if is_ignored_by_matcher(gitignore_matcher.as_ref(), rel, false) {
                     continue;
                 }
 
@@ -541,6 +540,7 @@ pub fn execute_tool(
                     search: search.to_string(),
                     replace: replace.to_string(),
                 },
+                gitignore_matcher.as_ref(),
             )
             .with_context(|| {
                 format!(
@@ -675,6 +675,7 @@ pub fn execute_tool(
                     path: path.to_string(),
                     action: action.clone(),
                 },
+                gitignore_matcher.as_ref(),
             )?;
 
             Ok(ToolResult::EditSemantic(SemanticFileEdit {
@@ -720,7 +721,12 @@ pub fn execute_tool(
                 .as_str()
                 .ok_or_else(|| anyhow!("search_code: missing pattern"))?;
             let file_pattern = args["file_pattern"].as_str();
-            let output = execute_search_code(config_dir, pattern, file_pattern)?;
+            let output = execute_search_code(
+                config_dir,
+                pattern,
+                file_pattern,
+                gitignore_matcher.as_ref(),
+            )?;
             Ok(ToolResult::Continue(output))
         }
 

--- a/apps/native/src-tauri/src/evolve/utils.rs
+++ b/apps/native/src-tauri/src/evolve/utils.rs
@@ -1,5 +1,8 @@
 //! Common utilities for the evolve module
 
+use anyhow::{anyhow, Result};
+use std::path::{Component, Path, PathBuf};
+
 /// Truncate error output to a maximum length, keeping the most relevant parts
 pub fn truncate_error(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
@@ -17,4 +20,73 @@ pub fn truncate_error(s: &str, max_len: usize) -> String {
         s.len() - max_len,
         end
     )
+}
+
+/// Normalize a relative path by collapsing `.` and resolving internal `..` components.
+///
+/// Rejects absolute/prefixed paths and parent traversals that escape the root.
+pub(crate) fn normalize_relative_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Err(anyhow!("Absolute paths are not allowed"));
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(seg) => normalized.push(seg),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(anyhow!("Path escapes the config directory"));
+                }
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(anyhow!(
+                    "Path prefixes or root components are not allowed in relative paths"
+                ));
+            }
+        }
+    }
+
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_relative_path;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn normalizes_simple_relative_path() {
+        let got = normalize_relative_path(Path::new("modules/darwin/default.nix"))
+            .expect("normalize should succeed");
+        assert_eq!(got, PathBuf::from("modules/darwin/default.nix"));
+    }
+
+    #[test]
+    fn normalizes_dots_and_internal_parents() {
+        let got = normalize_relative_path(Path::new("./modules/./darwin/../home.nix"))
+            .expect("normalize should succeed");
+        assert_eq!(got, PathBuf::from("modules/home.nix"));
+    }
+
+    #[test]
+    fn rejects_escape_outside_root() {
+        let err = normalize_relative_path(Path::new("../secrets.nix"))
+            .expect_err("normalize should reject escaping path");
+        assert!(
+            err.to_string().contains("escapes the config directory"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn rejects_absolute_path() {
+        let err = normalize_relative_path(Path::new("/etc/passwd"))
+            .expect_err("normalize should reject absolute path");
+        assert!(
+            err.to_string().contains("Absolute paths are not allowed"),
+            "unexpected error: {err:#}"
+        );
+    }
 }


### PR DESCRIPTION
Keep .gitignored files out of the agent's line of fire. This includes:

- directory structure context
- relevant agent actions (read/list/edit/search)
- ???

Also add some unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The application now respects `.gitignore` files across all operations—files matched by gitignore rules are excluded from reads, edits, searches, and file listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->