### PR TITLE
fix(lints): correct lint configuration from warnings to unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <img width="256" height="256" alt="icon" src="https://github.com/user-attachments/assets/31313c7d-e83b-43a7-b668-6d6d8ac687d4" />
 </p>

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["you"]
 edition = "2021"
 
 [lints.rust]
-warnings = "deny"
+unused = "deny"
 unexpected_cfgs = "allow"
 
 [build-dependencies]


### PR DESCRIPTION
In the current toolchain warnings was being flagged as a "problem" by better-toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened Rust linting rules in the native build configuration to enforce denial of unused items, improving code quality checks during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->