### PR TITLE
Track builds with nix store path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <img width="256" height="256" alt="icon" src="https://github.com/user-attachments/assets/31313c7d-e83b-43a7-b668-6d6d8ac687d4" />
 </p>

--- a/apps/native/.storybook/mocks/tauri-runtime.ts
+++ b/apps/native/.storybook/mocks/tauri-runtime.ts
@@ -71,7 +71,6 @@ const baseGitStatus = () => ({
   files: [],
   branch: "main",
   branchCommitMessages: [],
-  headIsBuilt: false,
   isMainBranch: true,
   branchHasBuiltCommit: false,
   diff: "",
@@ -189,7 +188,6 @@ export const storybookDarwinAPI = {
     checkoutNewBranch: async (branchName: string) => ({ ok: true, branch: branchName }),
     checkoutBranch: async () => undefined,
     checkoutMainBranch: async () => undefined,
-    tagAsBuilt: async () => undefined,
     mergeBranch: async () => undefined,
   },
   darwin: {

--- a/apps/native/src-tauri/src/apply_system_defaults.rs
+++ b/apps/native/src-tauri/src/apply_system_defaults.rs
@@ -99,7 +99,10 @@ pub async fn apply_system_defaults(
         backup_branch: None,
         step: shared_types::EvolveStep::Evolve,
     };
-    let mut evolve_state = evolve_state::set(app, initial_state).context("Failed to set evolve state")?;
+    let working_tree_status =
+        git::status(&dir).context("Failed to get working tree status for evolve state")?;
+    let mut evolve_state = evolve_state::set(app, initial_state, &working_tree_status.changes)
+        .context("Failed to set evolve state")?;
 
     // Run the summarization pipeline against the working tree diff.
     // `new_changeset` reads `git::status().diff` which includes untracked files,
@@ -112,7 +115,8 @@ pub async fn apply_system_defaults(
             );
             evolve_state.current_changeset_id = Some(changeset_id);
             evolve_state =
-                evolve_state::set(app, evolve_state).context("Failed to update evolve state with changeset")?;
+                evolve_state::set(app, evolve_state, &working_tree_status.changes)
+                    .context("Failed to update evolve state with changeset")?;
         }
         Ok(None) => {
             log::warn!("[apply_system_defaults] Summarizer returned None — diff may be empty");

--- a/apps/native/src-tauri/src/build_state.rs
+++ b/apps/native/src-tauri/src/build_state.rs
@@ -1,0 +1,166 @@
+//! Persisted build state — tracks the last successful nix-darwin build.
+//!
+//! Intentionally separate from `evolve-state.json` so that build records
+//! survive evolution discards and resets.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_store::StoreExt;
+
+use crate::sqlite_types::Change;
+use crate::types::GitStatus;
+
+const BUILD_STATE_PATH: &str = "build-state.json";
+const BUILD_STATE_KEY: &str = "buildState";
+
+/// The last successful nix-darwin build recorded by nixmac.
+/// And the current nix store path for validation
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildState {
+    pub nixmac_built_store_path: Option<String>,
+    pub changeset_id: Option<i64>,
+    pub head_commit_hash: Option<String>,
+    pub built_at: Option<i64>,
+    pub current_nix_store_path: Option<String>,
+}
+
+impl BuildState {
+    pub fn unknown_build(&self) -> bool {
+        self.current_nix_store_path.is_none()
+            || self.current_nix_store_path != self.nixmac_built_store_path
+    }
+}
+
+/// Resolve the nix store path for the currently active system profile.
+pub fn read_current_store_path() -> Option<String> {
+    std::fs::canonicalize("/nix/var/nix/profiles/system")
+        .ok()
+        .and_then(|p| p.to_str().map(String::from))
+}
+
+/// Load the persisted build state. Returns `BuildState::default()` if absent or corrupt.
+pub fn get<R: Runtime>(app: &AppHandle<R>) -> Result<BuildState> {
+    let store = app.store(BUILD_STATE_PATH)?;
+    if let Some(val) = store.get(BUILD_STATE_KEY) {
+        if let Ok(state) = serde_json::from_value::<BuildState>(val.clone()) {
+            return Ok(state);
+        }
+    }
+    Ok(BuildState::default())
+}
+
+/// Persist build state to `build-state.json`.
+pub fn set<R: Runtime>(app: &AppHandle<R>, state: BuildState) -> Result<BuildState> {
+    let store = app.store(BUILD_STATE_PATH)?;
+    store.set(BUILD_STATE_KEY, serde_json::to_value(&state)?);
+    store.save()?;
+    Ok(state)
+}
+
+/// Returns true if the current working tree state was actually built.
+///
+/// 1. Fast-fail: live nix store path must match `nixmac_built_store_path`.
+/// 2. No changes is not committable.
+/// 3. If `changeset_id` is Some: the stored change hashes must exactly match
+///    the hashes in `current_changes` (from git status).
+pub fn current_state_built<R: Runtime>(app: &AppHandle<R>, current_changes: &[Change]) -> bool {
+    let Ok(state) = get(app) else { return false };
+
+    // Fast-fail: if the live store path doesn't match what nixmac last built, not built.
+    let live = read_current_store_path();
+    if live.is_none() || live != state.nixmac_built_store_path {
+        return false;
+    }
+
+    match state.changeset_id {
+        None => current_changes.is_empty(),
+        Some(id) => {
+            let Ok(db_path) = crate::db::get_db_path(app) else { return false };
+            let Ok(conn) = rusqlite::Connection::open(&db_path) else { return false };
+            let Ok(stored_hashes) =
+                crate::db::changesets::fetch_hashes_for_changeset(&conn, id)
+            else {
+                return false;
+            };
+            let current_hashes: std::collections::HashSet<&str> =
+                current_changes.iter().map(|c| c.hash.as_str()).collect();
+            let stored_set: std::collections::HashSet<&str> =
+                stored_hashes.iter().map(|h| h.as_str()).collect();
+            current_hashes == stored_set
+        }
+    }
+}
+
+/// Shared post-build write used by all build paths.
+///
+/// Post-build write the nix store path, HEAD commit, and optional changeset.
+pub fn record_build<R: Runtime>(app: &AppHandle<R>, git_status: &GitStatus) -> Result<()> {
+    let db_path = crate::db::get_db_path(app)?;
+    let config_dir = crate::store::get_config_dir(app)?;
+
+    let build_changeset_id = if !git_status.changes.is_empty() {
+        let base_id = crate::db::commits::store_head_commit(&db_path, &config_dir, None)?
+            .ok_or_else(|| anyhow::anyhow!("missing HEAD commit while recording build state"))?;
+        Some(crate::db::store_bare_changeset::store(
+            &db_path,
+            base_id,
+            &git_status.changes,
+        )?)
+    } else {
+        None
+    };
+
+    let current = read_current_store_path();
+    set(
+        app,
+        BuildState {
+            nixmac_built_store_path: current.clone(),
+            changeset_id: build_changeset_id,
+            head_commit_hash: git_status.head_commit_hash.clone(),
+            built_at: Some(crate::utils::unix_now()),
+            current_nix_store_path: current,
+        },
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(nixmac: Option<&str>, current: Option<&str>) -> BuildState {
+        BuildState {
+            nixmac_built_store_path: nixmac.map(str::to_owned),
+            current_nix_store_path: current.map(str::to_owned),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn unknown_build_when_current_is_none() {
+        assert!(state(Some("/nix/store/abc"), None).unknown_build());
+    }
+
+    #[test]
+    fn unknown_build_when_paths_differ() {
+        assert!(state(Some("/nix/store/abc"), Some("/nix/store/xyz")).unknown_build());
+    }
+
+    #[test]
+    fn known_build_when_paths_match() {
+        assert!(!state(Some("/nix/store/abc"), Some("/nix/store/abc")).unknown_build());
+    }
+
+    #[test]
+    fn unknown_build_when_nixmac_path_is_none() {
+        assert!(state(None, Some("/nix/store/abc")).unknown_build());
+    }
+
+    #[test]
+    fn both_none_is_unknown() {
+        assert!(state(None, None).unknown_build());
+    }
+}

--- a/apps/native/src-tauri/src/commands.rs
+++ b/apps/native/src-tauri/src/commands.rs
@@ -8,8 +8,8 @@
 //! preview mode, etc.) is computed and managed entirely by the client.
 
 use crate::{
-    darwin, db, default_config, evolution, evolve_state, feedback, git, nix, peek, permissions,
-    rollback, scanner, store, types, utils,
+    darwin, db, default_config, evolution, evolve_state, feedback, finalize_restore, git, nix,
+    peek, permissions, rollback, scanner, store, types, utils,
 };
 use std::path::Path;
 use std::process::Command;
@@ -266,6 +266,18 @@ pub async fn git_commit(app: AppHandle, message: String) -> Result<CommitResult,
         }
     }
 
+    // Update build state: new HEAD hash, no changeset (working tree is now clean).
+    if let Ok(current_build_state) = crate::build_state::get(&app) {
+        let updated = crate::build_state::BuildState {
+            head_commit_hash: Some(commit_info.hash.clone()),
+            changeset_id: None,
+            ..current_build_state
+        };
+        if let Err(e) = crate::build_state::set(&app, updated) {
+            log::warn!("[git_commit] Failed to update build state: {}", e);
+        }
+    }
+
     // Evolution complete — reset state back to idle.
     let evolve_state = evolve_state::clear(&app).unwrap_or_else(|e| {
         log::error!("[git_commit] Failed to clear evolve state: {}", e);
@@ -290,15 +302,6 @@ pub struct CommitResult {
 pub async fn git_stash(app: AppHandle, message: String) -> Result<serde_json::Value, String> {
     let dir = store::ensure_config_dir_exists(&app).map_err(|e| capture_err("git_stash", e))?;
     git::stash(&dir, &message).map_err(|e| capture_err("git_stash", e))?;
-    Ok(serde_json::json!({"ok": true}))
-}
-
-/// Adds the nixmac-built tag to HEAD
-#[tauri::command]
-pub async fn git_tag_as_built(app: AppHandle) -> Result<serde_json::Value, String> {
-    let dir =
-        store::ensure_config_dir_exists(&app).map_err(|e| capture_err("git_tag_as_built", e))?;
-    git::tag_as_built(&dir).map_err(|e| capture_err("git_tag_as_built", e))?;
     Ok(serde_json::json!({"ok": true}))
 }
 
@@ -438,7 +441,6 @@ pub async fn darwin_apply(
 pub async fn darwin_apply_stream_start(
     app: AppHandle,
     host_override: Option<String>,
-    defer_built_tag: Option<bool>,
 ) -> Result<serde_json::Value, String> {
     let dir = store::ensure_config_dir_exists(&app)
         .map_err(|e| capture_err("darwin_apply_stream_start", e))?;
@@ -464,7 +466,7 @@ pub async fn darwin_apply_stream_start(
             "Host attribute not found. Set a host in Settings or ensure your flake defines exactly one darwinConfiguration.".to_string()
         })?;
 
-    darwin::apply_stream(&app, &dir, &host, !defer_built_tag.unwrap_or(false))
+    darwin::apply_stream(&app, &dir, &host)
         .map_err(|e| capture_err("darwin_apply_stream_start", e))?;
     Ok(serde_json::json!({"ok": true}))
 }
@@ -679,47 +681,15 @@ pub async fn abort_restore(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Commits, tags and stored on succesful history restore
+/// Commits, tags and stores on successful history restore, then records build state.
 #[tauri::command]
 pub async fn finalize_restore(
     app: AppHandle,
     target_hash: String,
 ) -> Result<crate::types::GitStatus, String> {
-    let config_dir =
-        store::get_config_dir(&app).map_err(|e| capture_err("finalize_restore", e))?;
-    let label = &target_hash[..target_hash.len().min(8)];
-    let info = git::commit_all(&config_dir, &format!("Restore commit {label}"))
-        .map_err(|e| capture_err("finalize_restore", e))?;
-    crate::historelog::log_finalize(&info.hash);
-    if let Err(e) = git::tag_commit(
-        &config_dir,
-        &format!("nixmac-commit-{}", &info.hash[..8]),
-        &info.hash,
-        false,
-    ) {
-        log::warn!("[finalize_restore] Failed to tag commit: {}", e);
-    }
-    if let Err(e) = git::tag_as_built(&config_dir) {
-        log::warn!("[finalize_restore] Failed to tag as built: {}", e);
-    }
-    // Link the commit to its origin for metadata
-    if let Ok(db_path) = db::get_db_path(&app) {
-        let commit_hash = info.hash.clone();
-        let origin = target_hash.clone();
-        match tokio::task::spawn_blocking(move || {
-            db::restore_commits::insert(&db_path, &commit_hash, &origin)
-        })
+    finalize_restore::finalize_restore(&app, target_hash)
         .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => log::warn!("[finalize_restore] Failed to record restore origin: {}", e),
-            Err(e) => log::warn!("[finalize_restore] Failed to record restore origin (panic): {}", e),
-        }
-    }
-    let git_status =
-        git::status(&config_dir).map_err(|e| capture_err("finalize_restore", e))?;
-    let _ = store::set_cached_git_status(&app, &git_status);
-    Ok(git_status)
+        .map_err(|e| capture_err("finalize_restore", e))
 }
 
 /// Generates a commit message from the current semantic change map via the pipeline.
@@ -1095,6 +1065,7 @@ pub async fn darwin_adopt_manual_changes(app: AppHandle) -> Result<i64, String> 
             current_changeset_id: None,
             ..Default::default()
         },
+        &git_status.changes,
     )
     .map_err(|e| capture_err("darwin_adopt_manual_changes", e))?;
 

--- a/apps/native/src-tauri/src/darwin.rs
+++ b/apps/native/src-tauri/src/darwin.rs
@@ -84,7 +84,6 @@ pub fn apply_stream(
     app: &AppHandle,
     config_dir: &str,
     host_attr: &str,
-    tag_head_as_built: bool,
 ) -> Result<(), anyhow::Error> {
     info!(
         "[darwin] apply_stream: config_dir={}, host_attr={}",
@@ -96,7 +95,7 @@ pub fn apply_stream(
     let app_handle = app.clone();
 
     std::thread::spawn(move || {
-        match run_darwin_rebuild(&app_handle, &config_dir_owned, &host_attr_owned, tag_head_as_built) {
+        match run_darwin_rebuild(&app_handle, &config_dir_owned, &host_attr_owned) {
             Ok(payload) => {
                 info!("[darwin] darwin-rebuild completed successfully");
                 let _ = app_handle.emit("darwin:apply:end", payload);
@@ -441,7 +440,6 @@ fn run_darwin_rebuild(
     app: &AppHandle,
     config_dir: &str,
     host_attr: &str,
-    tag_head_as_built: bool,
 ) -> Result<serde_json::Value, serde_json::Value> {
     let (log_file, log_path) = create_log_file().map_err(|e| {
         serde_json::json!({
@@ -628,12 +626,6 @@ fn run_darwin_rebuild(
     }
 
     summarizer.complete(true);
-
-    if tag_head_as_built {
-        if let Err(e) = crate::git::tag_as_built(config_dir) {
-            error!("[darwin] Failed to tag HEAD as built: {}", e);
-        }
-    }
 
     // Log completion
     {

--- a/apps/native/src-tauri/src/db/changesets.rs
+++ b/apps/native/src-tauri/src/db/changesets.rs
@@ -45,12 +45,11 @@ pub fn upsert_change(
     Ok(())
 }
 
-#[allow(dead_code)]
 pub fn insert_change_or_ignore(
     tx: &Transaction,
     change: &Change,
     own_summary_id: Option<i64>,
-) -> Result<()> {
+) -> Result<i64> {
     tx.execute(
         "INSERT OR IGNORE INTO changes \
          (hash, filename, diff, line_count, created_at, own_summary_id) \
@@ -60,7 +59,11 @@ pub fn insert_change_or_ignore(
             own_summary_id,
         ],
     )?;
-    Ok(())
+    Ok(tx.query_row(
+        "SELECT id FROM changes WHERE hash = ?1",
+        [&change.hash],
+        |row| row.get(0),
+    )?)
 }
 
 pub fn link_change_to_group_summary(
@@ -420,6 +423,19 @@ pub fn mark_change_summary_failed(tx: &Transaction, summary_id: i64) -> Result<(
         [summary_id],
     )?;
     Ok(())
+}
+
+/// Fetch the change hashes stored in a changeset.
+pub fn fetch_hashes_for_changeset(conn: &Connection, changeset_id: i64) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT c.hash FROM changes c \
+         JOIN set_changes sc ON sc.change_id = c.id \
+         WHERE sc.change_set_id = ?1",
+    )?;
+    let hashes = stmt
+        .query_map([changeset_id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
+    Ok(hashes)
 }
 
 /// Builds a JSON array of hash-summary_id pairs for the queue summarizer.

--- a/apps/native/src-tauri/src/db/mod.rs
+++ b/apps/native/src-tauri/src/db/mod.rs
@@ -5,6 +5,7 @@ pub mod commits;
 pub mod evolutions;
 pub mod restore_commits;
 mod schema;
+pub mod store_bare_changeset;
 pub mod store_evolved_changeset;
 pub mod store_new_changeset;
 

--- a/apps/native/src-tauri/src/db/store_bare_changeset.rs
+++ b/apps/native/src-tauri/src/db/store_bare_changeset.rs
@@ -1,0 +1,30 @@
+//! Lightweight changeset persistence — no AI, no queued summaries.
+
+use anyhow::Result;
+use std::path::Path;
+
+use crate::db::changesets::{insert_change_or_ignore, insert_change_set, link_change_to_set};
+use crate::sqlite_types::Change;
+use crate::utils::unix_now;
+
+/// Insert `changes` as bare rows where absent, create a new changeset.
+pub fn store(db_path: &Path, base_commit_id: i64, changes: &[Change]) -> Result<i64> {
+    let mut conn = rusqlite::Connection::open(db_path)?;
+    let now = unix_now();
+    let tx = conn.transaction()?;
+
+    let mut change_ids = Vec::with_capacity(changes.len());
+    for change in changes {
+        let id = insert_change_or_ignore(&tx, change, None)?;
+        change_ids.push(id);
+    }
+
+    let change_set_id = insert_change_set(&tx, None, base_commit_id, None, None, now, None)?;
+
+    for id in change_ids {
+        link_change_to_set(&tx, change_set_id, id)?;
+    }
+
+    tx.commit()?;
+    Ok(change_set_id)
+}

--- a/apps/native/src-tauri/src/evolution.rs
+++ b/apps/native/src-tauri/src/evolution.rs
@@ -168,7 +168,7 @@ pub async fn backup_evolve_and_record_changeset(
             backup_branch: Some(branch.clone()),
             ..pre_evolve_state.clone()
         };
-        let _ = evolve_state::set(app, updated);
+        let _ = evolve_state::set(app, updated, &initial_status.changes);
     }
 
     // Step 2: Run AI evolution
@@ -240,6 +240,7 @@ pub async fn backup_evolve_and_record_changeset(
             backup_branch,
             ..Default::default()
         },
+        &final_status.changes,
     )
     .unwrap_or_default();
 
@@ -282,6 +283,7 @@ fn restore_after_failure(app: &AppHandle, config_dir: &str, backup_branch: &Opti
                     backup_branch: None,
                     ..evolve_state::get(app).unwrap_or_default()
                 },
+                &[],
             );
         }
         None => {

--- a/apps/native/src-tauri/src/evolve_state.rs
+++ b/apps/native/src-tauri/src/evolve_state.rs
@@ -4,7 +4,20 @@ use anyhow::Result;
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_store::StoreExt;
 
-pub use crate::shared_types::EvolveState;
+use crate::sqlite_types::Change;
+
+pub use crate::shared_types::{EvolveState, EvolveStep};
+
+impl EvolveState {
+    pub fn recompute_step(&mut self, is_built: bool) {
+        self.committable = self.evolution_id.is_some() && is_built;
+        self.step = match (self.evolution_id, is_built) {
+            (None, _) => EvolveStep::Begin,
+            (Some(_), false) => EvolveStep::Evolve,
+            (Some(_), true) => EvolveStep::Merge,
+        };
+    }
+}
 
 const EVOLVE_STATE_PATH: &str = "evolve-state.json";
 const EVOLVE_STATE_KEY: &str = "evolveState";
@@ -20,9 +33,16 @@ pub fn get<R: Runtime>(app: &AppHandle<R>) -> Result<EvolveState> {
     Ok(EvolveState::default())
 }
 
-/// Recompute `step`, persist, and return the updated state.
-pub fn set<R: Runtime>(app: &AppHandle<R>, mut state: EvolveState) -> Result<EvolveState> {
-    state.recompute_step();
+/// Recompute `step` and `committable` from build and git states.
+///
+/// Status is used to compare working tree to that at time of known build
+pub fn set<R: Runtime>(
+    app: &AppHandle<R>,
+    mut state: EvolveState,
+    current_changes: &[Change],
+) -> Result<EvolveState> {
+    let is_built = crate::build_state::current_state_built(app, current_changes);
+    state.recompute_step(is_built);
     let store = app.store(EVOLVE_STATE_PATH)?;
     store.set(EVOLVE_STATE_KEY, serde_json::to_value(&state)?);
     store.save()?;
@@ -31,5 +51,5 @@ pub fn set<R: Runtime>(app: &AppHandle<R>, mut state: EvolveState) -> Result<Evo
 
 /// Reset to idle and persist.
 pub fn clear<R: Runtime>(app: &AppHandle<R>) -> Result<EvolveState> {
-    set(app, EvolveState::default())
+    set(app, EvolveState::default(), &[])
 }

--- a/apps/native/src-tauri/src/finalize_apply.rs
+++ b/apps/native/src-tauri/src/finalize_apply.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 
-use crate::{evolve_state, git, store, types::GitStatus};
+use crate::{build_state, evolve_state, git, store, types::GitStatus};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,10 +21,10 @@ pub async fn finalize_apply(app: &AppHandle) -> Result<ApplyResult> {
     let final_status = git::status(&config_dir).context("Failed to get final git status")?;
     let _ = store::set_cached_git_status(app, &final_status);
 
-    let mut es = evolve_state::get(app).unwrap_or_default();
-    es.changeset_at_build = es.current_changeset_id;
-    es.committable = true;
-    let evolve_state = evolve_state::set(app, es)?;
+    build_state::record_build(app, &final_status).context("Failed to record build state")?;
+
+    let evolve_state =
+        evolve_state::set(app, evolve_state::get(app).unwrap_or_default(), &final_status.changes)?;
 
     Ok(ApplyResult {
         git_status: final_status,

--- a/apps/native/src-tauri/src/finalize_restore.rs
+++ b/apps/native/src-tauri/src/finalize_restore.rs
@@ -1,0 +1,52 @@
+//! Post-restore finalization: commit, tag, record in DB, then record build state.
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+
+use crate::{build_state, db, git, store, types::GitStatus};
+
+/// Finalize a successful history restore.
+///
+/// Commits the restored files, tags the commit, links it to its origin in the
+/// DB, and records build state (replaces the old `git::tag_as_built` call).
+pub async fn finalize_restore(app: &AppHandle, target_hash: String) -> Result<GitStatus> {
+    let config_dir = store::get_config_dir(app).context("Failed to get config directory")?;
+
+    let label = &target_hash[..target_hash.len().min(8)];
+    let info = git::commit_all(&config_dir, &format!("Restore commit {label}"))
+        .context("Failed to commit restored files")?;
+
+    crate::historelog::log_finalize(&info.hash);
+
+    if let Err(e) = git::tag_commit(
+        &config_dir,
+        &format!("nixmac-commit-{}", &info.hash[..8]),
+        &info.hash,
+        false,
+    ) {
+        log::warn!("[finalize_restore] Failed to tag commit: {}", e);
+    }
+
+    // Record restore origin in DB
+    if let Ok(db_path) = db::get_db_path(app) {
+        let commit_hash = info.hash.clone();
+        let origin = target_hash.clone();
+        match tokio::task::spawn_blocking(move || {
+            db::restore_commits::insert(&db_path, &commit_hash, &origin)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => log::warn!("[finalize_restore] Failed to record restore origin: {}", e),
+            Err(e) => log::warn!("[finalize_restore] Failed to record restore origin (panic): {}", e),
+        }
+    }
+
+    let git_status = git::status(&config_dir).context("Failed to get git status after restore")?;
+    let _ = store::set_cached_git_status(app, &git_status);
+
+    build_state::record_build(app, &git_status)
+        .context("Failed to record build state after restore")?;
+
+    Ok(git_status)
+}

--- a/apps/native/src-tauri/src/get_history.rs
+++ b/apps/native/src-tauri/src/get_history.rs
@@ -11,7 +11,12 @@ pub async fn get_history<R: Runtime>(app: &AppHandle<R>) -> Result<Vec<crate::sh
 
     let git_commits = crate::git::log(&config_dir, "HEAD", None)?;
 
-    let last_built_sha = crate::git::get_last_built_commit_sha(&config_dir);
+    let build_state = crate::build_state::get(app).unwrap_or_default();
+    let last_built_sha = if build_state.unknown_build() {
+        None
+    } else {
+        build_state.head_commit_hash
+    };
 
     let mut entries = Vec::with_capacity(git_commits.len());
     let mut origin_hashes: Vec<Option<String>> = Vec::with_capacity(git_commits.len());

--- a/apps/native/src-tauri/src/git.rs
+++ b/apps/native/src-tauri/src/git.rs
@@ -270,17 +270,6 @@ pub fn parse_files_from_diff(diff: &str) -> Vec<GitFileStatus> {
     files
 }
 
-/// Returns the SHA of the commit with the nixmac-last-build tag or None
-pub fn get_last_built_commit_sha(dir: &str) -> Option<String> {
-    let output = git_command()
-        .args(["rev-parse", "--verify", "refs/tags/nixmac-last-build"])
-        .current_dir(dir)
-        .output()
-        .ok()?;
-
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
 /// Gets the SHA of any ref (branch name, tag, or symbolic ref like HEAD).
 pub fn get_ref_sha(dir: &str, ref_name: &str) -> Option<String> {
     let output = git_command()
@@ -295,17 +284,6 @@ pub fn get_ref_sha(dir: &str, ref_name: &str) -> Option<String> {
 /// Gets the SHA of the current HEAD commit.
 fn get_head_sha(dir: &str) -> Option<String> {
     get_ref_sha(dir, "HEAD")
-}
-
-/// True if HEAD has the nixmac-last-build tag
-pub fn head_is_built(dir: &str) -> bool {
-    let Some(built_sha) = get_last_built_commit_sha(dir) else {
-        return false;
-    };
-    let Some(head_sha) = get_head_sha(dir) else {
-        return false;
-    };
-    built_sha == head_sha
 }
 
 /// Returns the current branch name (None if detached HEAD)
@@ -334,8 +312,6 @@ pub fn status(dir: &str) -> Result<GitStatus> {
 
     let files = parse_files_from_diff(&diff);
 
-    let head_is_built = head_is_built(dir);
-
     let head_commit_hash = get_head_sha(dir);
 
     let clean_head = diff.is_empty();
@@ -345,7 +321,6 @@ pub fn status(dir: &str) -> Result<GitStatus> {
     Ok(GitStatus {
         files,
         branch,
-        head_is_built,
         diff,
         additions,
         deletions,
@@ -569,14 +544,6 @@ pub fn tag_commit(dir: &str, tag: &str, target: &str, force: bool) -> Result<()>
         .current_dir(dir)
         .output()
         .with_context(|| format!("failed to create tag `{}`", tag))?;
-    Ok(())
-}
-
-/// Git tags `nixmac-last-build` & `nixmac-built-<timestamp>`
-pub fn tag_as_built(dir: &str) -> Result<()> {
-    let timestamped_tag = format!("nixmac-built-{}", crate::utils::unix_now());
-    tag_commit(dir, &timestamped_tag, "HEAD", false)?;
-    tag_commit(dir, "nixmac-last-build", "HEAD", true)?;
     Ok(())
 }
 

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod apply_system_defaults;
+mod build_state;
 mod changes_from_diff;
 mod cli;
 mod commands;
@@ -19,6 +20,7 @@ mod evolve;
 mod evolve_state;
 mod feedback;
 mod finalize_apply;
+mod finalize_restore;
 mod get_history;
 mod git;
 mod historelog;
@@ -315,7 +317,6 @@ fn run_gui_mode(
             commands::git_cached,
             commands::git_commit,
             commands::git_stash,
-            commands::git_tag_as_built,
             // Darwin/Nix
             commands::darwin_evolve,
             commands::darwin_evolve_cancel,

--- a/apps/native/src-tauri/src/shared_types.rs
+++ b/apps/native/src-tauri/src/shared_types.rs
@@ -33,7 +33,6 @@ pub struct GitFileStatus {
 pub struct GitStatus {
     pub files: Vec<GitFileStatus>,
     pub branch: Option<String>,
-    pub head_is_built: bool,
     pub diff: String,
     pub additions: usize,
     pub deletions: usize,
@@ -50,6 +49,7 @@ pub struct WatcherEvent {
     pub change_map: Option<SemanticChangeMap>,
     pub evolve_state: Option<EvolveState>,
     pub error: Option<String>,
+    pub external_build_detected: bool,
 }
 
 // =============================================================================
@@ -142,7 +142,11 @@ pub enum EvolveStep {
 pub struct EvolveState {
     pub evolution_id: Option<i64>,
     pub current_changeset_id: Option<i64>,
+    /// Maintained for compatibility
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
     pub changeset_at_build: Option<i64>,
+    /// current state verifyably built
     pub committable: bool,
     pub backup_branch: Option<String>,
     /// Computed from the other fields — always kept in sync by `set`.
@@ -162,16 +166,6 @@ impl Default for EvolveState {
     }
 }
 
-impl EvolveState {
-    #[allow(dead_code)]
-    pub fn recompute_step(&mut self) {
-        self.step = match (self.evolution_id, self.committable) {
-            (None, _) => EvolveStep::Begin,
-            (Some(_), false) => EvolveStep::Evolve,
-            (Some(_), true) => EvolveStep::Merge,
-        };
-    }
-}
 
 // =============================================================================
 // Evolution command result types

--- a/apps/native/src-tauri/src/summarize/group_existing.rs
+++ b/apps/native/src-tauri/src/summarize/group_existing.rs
@@ -21,9 +21,9 @@ pub fn from_change_sets(change_sets: Vec<FoundSetForCurrent>) -> SemanticChangeM
         for sc in cs.changes {
             let change_id = sc.change.id;
             if sc.own_summary.is_none() {
-                if !seen.contains_key(&change_id) {
+                if let std::collections::hash_map::Entry::Vacant(e) = seen.entry(change_id) {
                     unsummarized_hashes.push(sc.change.hash.clone());
-                    seen.insert(change_id, false);
+                    e.insert(false);
                 }
                 continue;
             }

--- a/apps/native/src-tauri/src/summarize/pipelines/history.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/history.rs
@@ -54,20 +54,22 @@ pub async fn from_commit_times_number<R: Runtime>(
             &diff_hashes,
         )?;
 
-        if found.change_set.is_some() && found.missed_hashes.is_empty() {
-            // fully covered — nothing to do
+        let has_changeset = found.change_set.is_some();
+        let semantic_map = crate::summarize::group_existing::from_change_sets(vec![found]);
+
+        if has_changeset && semantic_map.unsummarized_hashes.is_empty() {
+            // fully covered — all changes have summaries
             continue;
         }
 
-        if found.change_set.is_some() {
-            // partially covered — evolve with missed changes
-            let missed_set: std::collections::HashSet<&str> =
-                found.missed_hashes.iter().map(String::as_str).collect();
+        if has_changeset {
+            // partially covered — evolve with unsummarized changes
+            let unsummarized_set: std::collections::HashSet<&str> =
+                semantic_map.unsummarized_hashes.iter().map(String::as_str).collect();
             let missed_changes: Vec<_> = changes
                 .into_iter()
-                .filter(|c| missed_set.contains(c.hash.as_str()))
+                .filter(|c| unsummarized_set.contains(c.hash.as_str()))
                 .collect();
-            let semantic_map = crate::summarize::group_existing::from_change_sets(vec![found]);
             if let Err(e) = super::evolved_changeset::analyze(
                 semantic_map,
                 missed_changes,

--- a/apps/native/src-tauri/src/watcher.rs
+++ b/apps/native/src-tauri/src/watcher.rs
@@ -5,7 +5,7 @@
 //! which is kept in sync by both this watcher and the evolution/summarize handlers.
 
 use crate::shared_types::WatcherEvent;
-use crate::{db, evolve_state, git, store, summarize};
+use crate::{build_state, db, evolve_state, git, store, summarize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
@@ -49,6 +49,12 @@ where
     // Step 3: Signal that a watcher is now active and spawn the new thread.
     WATCHER_ACTIVE.store(true, Ordering::SeqCst);
     let new_thread = std::thread::spawn(move || {
+        // Seed the in-memory store path or read the live value.
+        let mut last_known_store_path: Option<String> = build_state::get(&app_handle)
+            .ok()
+            .and_then(|bs| bs.current_nix_store_path)
+            .or_else(build_state::read_current_store_path);
+
         loop {
             // Check if we should stop (set by a new call to start_watching)
             if !WATCHER_ACTIVE.load(Ordering::SeqCst) {
@@ -61,6 +67,25 @@ where
                 watch_dir.clone()
             };
 
+            // Detect external builds
+            let mut external_build_detected = false;
+            let live_store_path = build_state::read_current_store_path();
+            if live_store_path != last_known_store_path {
+                last_known_store_path = live_store_path.clone();
+                // Persist so the next app start initialises correctly.
+                if let Ok(mut bs) = build_state::get(&app_handle) {
+                    bs.current_nix_store_path = live_store_path.clone();
+                    let _ = build_state::set(&app_handle, bs);
+                }
+                // If the new path differs from what nixmac built, it's an external build.
+                let nixmac_built = build_state::get(&app_handle)
+                    .ok()
+                    .and_then(|bs| bs.nixmac_built_store_path);
+                if live_store_path.is_some() && live_store_path != nixmac_built {
+                    external_build_detected = true;
+                }
+            }
+
             if let Some(ref dir) = current_dir {
                 match git::status(dir) {
                     Ok(status) => {
@@ -72,7 +97,7 @@ where
                             .and_then(|s| serde_json::to_string(&s).ok());
                         let current_json = serde_json::to_string(&status).ok();
 
-                        if current_json != cached_json {
+                        if current_json != cached_json || external_build_detected {
                             let change_map = db::get_db_path(&app_handle)
                                 .ok()
                                 .and_then(|db_path| {
@@ -80,20 +105,23 @@ where
                                 })
                                 .map(summarize::group_existing::from_change_sets)
                                 .unwrap_or_default();
-                            let evolve_state_non_committable = evolve_state::get(&app_handle)
+                            let evolve_state_updated = evolve_state::get(&app_handle)
                                 .ok()
-                                .filter(|es| es.committable)
+                                .filter(|es| es.committable || external_build_detected)
                                 .and_then(|mut es| {
-                                    es.committable = false;
-                                    evolve_state::set(&app_handle, es).ok()
+                                    if !external_build_detected {
+                                        es.committable = false;
+                                    }
+                                    evolve_state::set(&app_handle, es, &status.changes).ok()
                                 });
                             let _ = app_handle.emit(
                                 "git:status-changed",
                                 WatcherEvent {
                                     git_status: Some(status.clone()),
                                     change_map: Some(change_map),
-                                    evolve_state: evolve_state_non_committable,
+                                    evolve_state: evolve_state_updated,
                                     error: None,
+                                    external_build_detected,
                                 },
                             );
                             let _ = store::set_cached_git_status(&app_handle, &status);
@@ -107,6 +135,7 @@ where
                                 change_map: None,
                                 evolve_state: None,
                                 error: Some(e.to_string()),
+                                external_build_detected: false,
                             },
                         );
                     }

--- a/apps/native/src/components/widget/external-build-detected.stories.tsx
+++ b/apps/native/src/components/widget/external-build-detected.stories.tsx
@@ -1,0 +1,88 @@
+// @ts-nocheck - Storybook 10 alpha types have inference issues (resolves to `never`)
+import preview from "#storybook/preview";
+import type { EvolveState } from "@/stores/widget-store";
+import { useWidgetStore } from "@/stores/widget-store";
+import { fn } from "@storybook/test";
+import { useEffect } from "react";
+import { ExternalBuildDetected } from "./external-build-detected";
+
+// Mock Tauri API for Storybook
+if (typeof window !== "undefined") {
+  (window as any).__TAURI_INTERNALS__ = {
+    invoke: async (cmd: string) => {
+      console.log("Mock Tauri invoke:", cmd);
+      return null;
+    },
+  };
+}
+
+const meta = preview.meta({
+  title: "Widget/ExternalBuildDetected",
+  component: ExternalBuildDetected,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+});
+
+export default meta;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const mockEvolveState: EvolveState = {
+  evolutionId: 42,
+  currentChangesetId: null,
+  committable: false,
+  backupBranch: null,
+  step: "evolve",
+};
+
+function setup({
+  externalBuildDetected,
+  evolveState,
+}: {
+  externalBuildDetected: boolean;
+  evolveState: EvolveState | null;
+}) {
+  useEffect(() => {
+    const store = useWidgetStore.getState();
+    store.setExternalBuildDetected(externalBuildDetected);
+    store.setEvolveState(evolveState);
+  }, [externalBuildDetected, evolveState]);
+
+  return (
+    <div className="w-[400px] border border-border rounded">
+      <ExternalBuildDetected />
+    </div>
+  );
+}
+
+// =============================================================================
+// Stories
+// =============================================================================
+
+/**
+ * Default — banner is visible: external build detected during an active evolution.
+ */
+export const Visible = meta.story({
+  render: () =>
+    setup({ externalBuildDetected: true, evolveState: mockEvolveState }),
+});
+
+/**
+ * Hidden — no external build detected, component renders nothing.
+ */
+export const HiddenNoBuild = meta.story({
+  render: () =>
+    setup({ externalBuildDetected: false, evolveState: mockEvolveState }),
+});
+
+/**
+ * Hidden — external build detected but no active evolution, component renders nothing.
+ */
+export const HiddenNoEvolution = meta.story({
+  render: () =>
+    setup({ externalBuildDetected: true, evolveState: null }),
+});

--- a/apps/native/src/components/widget/external-build-detected.tsx
+++ b/apps/native/src/components/widget/external-build-detected.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Hammer } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { useWidgetStore } from "@/stores/widget-store";
+import { useApply } from "@/hooks/use-apply";
+
+export function ExternalBuildDetected() {
+  const externalBuildDetected = useWidgetStore((s) => s.externalBuildDetected);
+  const evolveState = useWidgetStore((s) => s.evolveState);
+  const { handleManualBuildConfirm } = useApply();
+  const [isPending, setIsPending] = useState(false);
+
+  if (!externalBuildDetected || !evolveState?.evolutionId) return null;
+
+  const handleProceed = async () => {
+    setIsPending(true);
+    try {
+      await handleManualBuildConfirm();
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div className="flex w-full shrink-0 items-center justify-between gap-2 border-teal-300/20 border-b px-2 py-1.5 text-muted-foreground text-xs">
+      <span className="flex items-center gap-1.5">
+        <Hammer className="h-3 w-3 shrink-0" />
+        A nix build was detected outside nixmac.
+      </span>
+      <button
+        type="button"
+        onClick={handleProceed}
+        disabled={isPending}
+        className="flex items-center gap-1 text-teal-300 hover:text-teal-200 disabled:opacity-60 shrink-0"
+      >
+        {isPending ? (
+          <>
+            <Spinner className="h-3 w-3" />
+            loading…
+          </>
+        ) : (
+          "Proceed to commit"
+        )}
+      </button>
+    </div>
+  );
+}

--- a/apps/native/src/components/widget/merge-section.tsx
+++ b/apps/native/src/components/widget/merge-section.tsx
@@ -23,7 +23,7 @@ export function MergeSection() {
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const msg = new FormData(e.currentTarget).get("commitMsg")?.toString() ?? "";
-    await handleCommit({ message: msg, tagAsBuilt: true });
+    await handleCommit({ message: msg });
     useWidgetStore.getState().setEvolvePrompt("");
   }
 

--- a/apps/native/src/components/widget/steps/evolve-step.tsx
+++ b/apps/native/src/components/widget/steps/evolve-step.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ConfirmButton } from "@/components/widget/confirm-button";
+import { ExternalBuildDetected } from "@/components/widget/external-build-detected";
 import { GetStartedMessage } from "@/components/widget/get-started-message";
 import { PromptInputSection } from "@/components/widget/prompt-input-section";
 import { StepActionsHeader } from "@/components/widget/step-actions-header";
@@ -23,7 +24,7 @@ export function EvolveStep() {
 
   const isBegin = step === "begin";
 
-  const needsRebuild = evolveState != null && evolveState.changesetAtBuild !== null;
+  const needsRebuild = evolveState != null && evolveState.committable;
 
   const clearIcon = needsRebuild ? <Undo2 className="h-3.5 w-3.5" /> : <Eraser className="h-3.5 w-3.5" />;
   const clearLabel = needsRebuild ? "Undo All" : "Discard";
@@ -62,6 +63,7 @@ export function EvolveStep() {
 
   return (
     <>
+      <ExternalBuildDetected />
       {header()}
       <SummaryOrDiff />
       <PromptInputSection />

--- a/apps/native/src/components/widget/summaries/summary-or-diff.tsx
+++ b/apps/native/src/components/widget/summaries/summary-or-diff.tsx
@@ -35,8 +35,8 @@ export function SummaryOrDiff({ variant = "default" }: SummaryOrDiffProps) {
     >
       <div className="flex shrink-0 items-center justify-between gap-2 border-border/50 border-b py-2">
         <div className="flex items-center gap-2">
-          {evolveState.committable ? <Wrench className="h-4 w-4 text-primary" /> : <Dna className="h-4 w-4 text-primary" />}
-          <h2 className="font-medium text-sm">{evolveState.committable ? "Active Changes" : "What's changed"}</h2>
+          {evolveState.step === "merge" ? <Wrench className="h-4 w-4 text-primary" /> : <Dna className="h-4 w-4 text-primary" />}
+          <h2 className="font-medium text-sm">{evolveState.step === "merge" ? "Active Changes" : "What's changed"}</h2>
         </div>
         <AnimatedTabsList defaultValue="summary">
           <AnimatedTabsTrigger value="summary">Summary</AnimatedTabsTrigger>

--- a/apps/native/src/components/widget/widget.stories.tsx
+++ b/apps/native/src/components/widget/widget.stories.tsx
@@ -77,7 +77,6 @@ const mockGitStatusAllStaged: GitStatus = {
   diff: "diff --git a/modules/darwin/default.nix b/modules/darwin/default.nix\n...",
   additions: 25,
   deletions: 3,
-  headIsBuilt: true,
 };
 
 const mockEvolveEvents: EvolveEvent[] = [

--- a/apps/native/src/components/widget/widget.test.tsx
+++ b/apps/native/src/components/widget/widget.test.tsx
@@ -81,7 +81,6 @@ describe("DarwinWidget", () => {
     store.setGitStatus({
       files: [{ path: "test.nix", changeType: "edited" }],
       branch: null,
-      headIsBuilt: false,
       diff: "",
       additions: 0,
       deletions: 0,

--- a/apps/native/src/hooks/use-apply.ts
+++ b/apps/native/src/hooks/use-apply.ts
@@ -20,6 +20,7 @@ export function useApply() {
       onSuccess: async () => {
         try {
           const result = await darwinAPI.darwin.finalizeApply();
+          useWidgetStore.getState().setExternalBuildDetected(false);
           if (result?.gitStatus) {
             useWidgetStore.getState().setGitStatus(result.gitStatus);
           }
@@ -36,8 +37,28 @@ export function useApply() {
   const handleHistoryBuild = useCallback(async () => {
     const store = useWidgetStore.getState();
     store.setProcessing(true, "apply");
-    await triggerRebuild({ context: "apply" });
+    await triggerRebuild({
+      context: "apply",
+      onSuccess: async () => {
+        await darwinAPI.darwin.finalizeApply();
+      },
+    });
   }, [triggerRebuild]);
 
-  return { handleApply, handleHistoryBuild };
+  const handleManualBuildConfirm = useCallback(async () => {
+    try {
+      const result = await darwinAPI.darwin.finalizeApply();
+      useWidgetStore.getState().setExternalBuildDetected(false);
+      if (result?.gitStatus) {
+        useWidgetStore.getState().setGitStatus(result.gitStatus);
+      }
+      if (result?.evolveState) {
+        useWidgetStore.getState().setEvolveState(result.evolveState);
+      }
+    } catch (e) {
+      console.error("Failed to finalize manual build:", e);
+    }
+  }, []);
+
+  return { handleApply, handleHistoryBuild, handleManualBuildConfirm };
 }

--- a/apps/native/src/hooks/use-evolve.ts
+++ b/apps/native/src/hooks/use-evolve.ts
@@ -42,6 +42,7 @@ export function useEvolve() {
     store.setProcessing(true, "evolve");
     store.setGenerating(true);
     store.setError(null);
+    store.setExternalBuildDetected(false);
     store.clearEvolveEvents();
     store.clearLogs();
     store.clearPreview();

--- a/apps/native/src/hooks/use-git-operations.ts
+++ b/apps/native/src/hooks/use-git-operations.ts
@@ -65,7 +65,7 @@ export function useGitOperations() {
   );
 
   const handleCommit = useCallback(
-    async ({ message, tagAsBuilt = false }: { message: string; tagAsBuilt?: boolean }) => {
+    async ({ message }: { message: string }) => {
       const store = useWidgetStore.getState();
       store.setProcessing(true, "merge");
       store.appendLog(`\n> Committing changes...\n`);
@@ -77,9 +77,6 @@ export function useGitOperations() {
         toast.success("Committed successfully");
         useWidgetStore.getState().clearPreview();
         useWidgetStore.getState().setEvolveState(result.evolveState);
-        if (tagAsBuilt) {
-          await darwinAPI.git.tagAsBuilt();
-        }
         await refreshGitStatus();
       } catch (e: unknown) {
         const msg = (e as Error)?.message || String(e);

--- a/apps/native/src/hooks/use-history-restore.ts
+++ b/apps/native/src/hooks/use-history-restore.ts
@@ -245,7 +245,6 @@ export function useHistoryRestore(
         await darwinAPI.darwin.prepareRestore(hash);
         await triggerRebuild({
           context: "rollback",
-          deferBuiltTag: true,
           onSuccess: async () => {
             const result = await darwinAPI.darwin.finalizeRestore(hash);
             setGitStatus(result);

--- a/apps/native/src/hooks/use-rebuild-stream.ts
+++ b/apps/native/src/hooks/use-rebuild-stream.ts
@@ -7,7 +7,6 @@ interface RebuildOptions {
   context: RebuildContext;
   onSuccess?: () => Promise<void>;
   onFailure?: () => Promise<void>;
-  deferBuiltTag?: boolean;
 }
 
 /**
@@ -133,7 +132,7 @@ export function useRebuildStream() {
       });
 
       try {
-        await darwinAPI.darwin.applyStreamStart(undefined, options.deferBuiltTag);
+        await darwinAPI.darwin.applyStreamStart();
       } catch (e: unknown) {
         const msg = (e as Error)?.message || String(e);
         useWidgetStore.getState().setRebuildError("generic_error", msg);

--- a/apps/native/src/hooks/use-rollback.ts
+++ b/apps/native/src/hooks/use-rollback.ts
@@ -5,8 +5,8 @@ import { useRebuildStream } from "@/hooks/use-rebuild-stream";
 
 /**
  * Hook for discarding changes and restoring the working tree to HEAD.
- * If the AI's changes were applied (committable === true), rebuilds after
- * discarding to sync the running system with the restored HEAD files.
+ * If the last build matches the running system, rebuilds after discarding
+ * to sync the running system with the restored HEAD files.
  */
 export function useRollback() {
   const { triggerRebuild } = useRebuildStream();
@@ -27,7 +27,12 @@ export function useRollback() {
       store.appendLog("✓ Changes discarded\n");
 
       if (wasCommittable) {
-        await triggerRebuild({ context: "rollback" });
+        await triggerRebuild({
+          context: "rollback",
+          onSuccess: async () => {
+            await darwinAPI.darwin.finalizeApply();
+          },
+        });
       } else {
         useWidgetStore.getState().setProcessing(false);
       }

--- a/apps/native/src/hooks/use-watcher.ts
+++ b/apps/native/src/hooks/use-watcher.ts
@@ -21,7 +21,7 @@ export function useWatcher() {
     const gitStatusSub = ipcRenderer.on<WatcherEvent>(
       "git:status-changed",
       (event) => {
-        const { error, gitStatus, changeMap, evolveState } = event.payload;
+        const { error, gitStatus, changeMap, evolveState, externalBuildDetected } = event.payload;
 
         if (error) {
           useWidgetStore.getState().setError(error);
@@ -41,6 +41,7 @@ export function useWatcher() {
           if (evolveState) {
             store.setEvolveState(evolveState);
           }
+          store.setExternalBuildDetected(externalBuildDetected);
           if (store.showHistory) {
             loadHistory();
           }

--- a/apps/native/src/stores/widget-store.ts
+++ b/apps/native/src/stores/widget-store.ts
@@ -83,6 +83,7 @@ export interface WidgetState {
 
   // Evolve state derived from backend source of truth
   evolveState: EvolveState | null;
+  externalBuildDetected: boolean;
 
   // Git (from backend)
   gitStatus: GitStatus | null;
@@ -154,6 +155,7 @@ export interface WidgetActions {
   setDarwinRebuildAvailable: (available: boolean | null) => void;
   setDarwinRebuildPrefetching: (prefetching: boolean) => void;
   setEvolveState: (state: EvolveState | null) => void;
+  setExternalBuildDetected: (detected: boolean) => void;
   setGitStatus: (status: GitStatus | null) => void;
   setEvolvePrompt: (prompt: string) => void;
   setProcessing: (isProcessing: boolean, action?: ProcessingAction) => void;
@@ -246,6 +248,7 @@ export const initialWidgetState: WidgetState = {
 
   // Routing state
   evolveState: null,
+  externalBuildDetected: false,
 
   // Git
   gitStatus: null,
@@ -316,6 +319,7 @@ export function createWidgetStore(initialState?: Partial<WidgetState>) {
     setHosts: (hosts) => set({ hosts }),
     setHost: (host) => set({ host }),
     setEvolveState: (evolveState) => set({ evolveState: evolveState }),
+    setExternalBuildDetected: (externalBuildDetected) => set({ externalBuildDetected }),
     setGitStatus: (gitStatus) => set({ gitStatus }),
     setEvolvePrompt: (evolvePrompt) => set({ evolvePrompt }),
     setProcessing: (isProcessing, action = null) =>

--- a/apps/native/src/tauri-api.ts
+++ b/apps/native/src/tauri-api.ts
@@ -250,7 +250,6 @@ export const darwinAPI = {
     cached: () => invoke<GitStatus | null>("git_cached"),
     commit: (message: string) => invoke<CommitResult>("git_commit", { message }),
     stash: (message: string) => invoke("git_stash", { message }),
-    tagAsBuilt: () => invoke("git_tag_as_built"),
   },
   darwin: {
     evolve: (description: string) => invoke<EvolutionResult>("darwin_evolve", { description }),
@@ -259,8 +258,8 @@ export const darwinAPI = {
     evolveFromManual: () => invoke<number>("darwin_adopt_manual_changes"),
     evolveCancel: () => invoke("darwin_evolve_cancel"),
     apply: (hostOverride?: string) => invoke("darwin_apply", { hostOverride }),
-    applyStreamStart: (hostOverride?: string, deferBuiltTag?: boolean) =>
-      invoke("darwin_apply_stream_start", { hostOverride, deferBuiltTag }),
+    applyStreamStart: (hostOverride?: string) =>
+      invoke("darwin_apply_stream_start", { hostOverride }),
     applyStreamCancel: () => invoke("darwin_apply_stream_cancel"),
     finalizeApply: () => invoke<ApplyResult>("finalize_apply"),
     rollbackErase: () => invoke<RollbackResult>("rollback_erase"),

--- a/apps/native/src/types/shared.ts
+++ b/apps/native/src/types/shared.ts
@@ -74,7 +74,11 @@ export type EvolutionTelemetry = { state: EvolutionState; iterations: number; bu
 /**
  * Persisted evolve state stored in `evolve-state.json`.
  */
-export type EvolveState = { evolutionId: number | null; currentChangesetId: number | null; changesetAtBuild: number | null; committable: boolean; backupBranch: string | null; 
+export type EvolveState = { evolutionId: number | null; currentChangesetId: number | null; 
+/**
+ * current state verifyably built
+ */
+committable: boolean; backupBranch: string | null; 
 /**
  * Computed from the other fields — always kept in sync by `set`.
  */
@@ -93,7 +97,7 @@ export type GitFileStatus = { path: string; changeType: ChangeType }
 /**
  * Comprehensive git repository status.
  */
-export type GitStatus = { files: GitFileStatus[]; branch: string | null; headIsBuilt: boolean; diff: string; additions: number; deletions: number; headCommitHash: string | null; cleanHead: boolean; changes: Change[] }
+export type GitStatus = { files: GitFileStatus[]; branch: string | null; diff: string; additions: number; deletions: number; headCommitHash: string | null; cleanHead: boolean; changes: Change[] }
 
 /**
  * A commit entry combining git log data, tag-derived flags, optional DB metadata, and raw diff changes.
@@ -111,5 +115,5 @@ export type SummarizedChangeSet = { changeSet: ChangeSet; changes: SummarizedCha
 /**
  * Event payload emitted by the git status watcher.
  */
-export type WatcherEvent = { gitStatus: GitStatus | null; changeMap: SemanticChangeMap | null; evolveState: EvolveState | null; error: string | null }
+export type WatcherEvent = { gitStatus: GitStatus | null; changeMap: SemanticChangeMap | null; evolveState: EvolveState | null; error: string | null; externalBuildDetected: boolean }
 


### PR DESCRIPTION
Replace Git Tags with Nix Store Path Tracking

- Nix store path replaces git tags as the build source of truth
- External builds are detected by the watcher and surfaced to the user
- Builds on uncommitted changes are tracked and verified via changeset hashes (allowing for manual edits path entirely separate from AI) 
- history reflects this accurately


**Follow-up:**
- Smarter rollback using a combination of evolution backup / restore and nix native rollback.
- Manual changes resurfaced as flow mirroring that of AI edits

**Test this by:** 
_Happy path_
Evolve, build, commit — history should show that commit as built
Restart the app after building — built state should persist, history still shows correct commit

_External build detection_
Run darwin-rebuild switch mid-evolve — banner should appear
Dismiss/acknowledge the banner — build state should update, routing should reflect new build

_Build state after commit_
Commit something, verify history shows it as built with [CURRENT] badge

**Check the build state store:**
`code ~/Library/Application\ Support/com.darkmatter.nixmac/build-state.json`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect externally-built system profiles and surface a confirmable "External Build Detected" status with a CTA to proceed to commit.
  * Show external-build indicator in the watcher and widget UI.

* **Refactor**
  * Replaced Git-tag–based build tracking with persistent internal build state.
  * Removed "tag as built" flow and related controls from commit/rebuild workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->