### PR TITLE
fix(dev): remove unreachable sops keyservice, add dev secrets fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ process-compose.yaml
 
 # bv (beads viewer) local config and caches
 .bv/
+
+# Local dev sops secrets (encrypted with local &dev key per .sops.yaml)
+/ops/secrets/secrets.dev.yaml

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -4,6 +4,19 @@
   config,
   ...
 }:
+let
+  # Run a command under `sops exec-env`, preferring a gitignored
+  # ops/secrets/secrets.dev.yaml (encrypted with the local &dev key per
+  # .sops.yaml's \.dev\.yaml rule) and falling back to prod
+  # ops/secrets/secrets.yaml. Selection runs at shell time, not Nix eval time.
+  sopsExecEnv = command: ''
+    SECRETS="${config.git.root}/ops/secrets/secrets.yaml"
+    if [ -f "${config.git.root}/ops/secrets/secrets.dev.yaml" ]; then
+      SECRETS="${config.git.root}/ops/secrets/secrets.dev.yaml"
+    fi
+    exec ${pkgs.sops}/bin/sops exec-env "$SECRETS" ${command}
+  '';
+in
 lib.mkIf (!(config.container.isBuilding or false)) {
   # Dev-only packages (excluded from container builds by conditional import).
   packages = [
@@ -85,7 +98,13 @@ lib.mkIf (!(config.container.isBuilding or false)) {
   languages.javascript.bun.install.enable = true;
   languages.javascript.bun.enable = true;
 
-  env.SOPS_KEYSERVICE = "tcp://100.116.189.36:5000";
+  # Secrets selection: prefer a gitignored ops/secrets/secrets.dev.yaml
+  # (encrypted with your local &dev key per .sops.yaml's \.dev\.yaml rule),
+  # else fall back to the prod-encrypted ops/secrets/secrets.yaml. The check
+  # runs at shell time inside exec, not at Nix eval — builtins.pathExists
+  # under pure flake eval can't verify files created after the devenv shell
+  # is built. To opt in to the remote sops keyservice, set
+  # env.SOPS_KEYSERVICE in your gitignored devenv.local.nix.
 
   # https://devenv.sh/processes/
   # Use process-compose as the process manager for the TUI
@@ -93,7 +112,7 @@ lib.mkIf (!(config.container.isBuilding or false)) {
 
   processes.tauri = {
     cwd = "${config.git.root}/apps/native";
-    exec = "${pkgs.sops}/bin/sops exec-env ${config.git.root}/ops/secrets/secrets.yaml '${config.git.root}/apps/native/src-tauri/scripts/tauri-dev.sh'";
+    exec = sopsExecEnv "'${config.git.root}/apps/native/src-tauri/scripts/tauri-dev.sh'";
   };
 
   # processes.server = {
@@ -112,7 +131,7 @@ lib.mkIf (!(config.container.isBuilding or false)) {
 
   processes.test = {
     cwd = "${config.git.root}/apps/native";
-    exec = "sops exec-env ${config.git.root}/ops/secrets/secrets.yaml 'bun run test:watch'";
+    exec = sopsExecEnv "'bun run test:watch'";
   };
 
   # Formatting


### PR DESCRIPTION
## Summary
- Remove hardcoded `env.SOPS_KEYSERVICE = "tcp://100.116.189.36:5000"` — that Tailscale endpoint is unreachable from off-Tailnet and causes ~20s sops hangs + decrypt failures when the runner is down
- Extract a `sopsExecEnv` helper in `nix/dev.nix` that prefers a gitignored `ops/secrets/secrets.dev.yaml` (encrypted with the local `&dev` key per the existing `\.dev\.yaml` rule in `.sops.yaml`) and falls back to `ops/secrets/secrets.yaml`
- Add `/ops/secrets/secrets.dev.yaml` to `.gitignore`

## Why this approach
`builtins.pathExists` under pure flake eval can't see files created after the devenv shell is built, so the dev/prod selection has to happen at shell time inside the `exec` string, not at Nix eval time. The helper is a simple `command: ''...''` binding so `processes.tauri` and `processes.test` share one implementation instead of duplicating the bash check.

The `\.dev\.yaml` rule already exists in `.sops.yaml` and already routes to `&dev`. This PR uses policy that's already encoded in the repo.

## Opt-in for keyservice users
Anyone who still wants the remote sops keyservice can set `env.SOPS_KEYSERVICE = "tcp://100.116.189.36:5000";` in a gitignored `devenv.local.nix` (this repo's devenv bootstrap auto-loads it).

## CI impact: none
GitHub Actions workflows invoke `sops exec-env ops/secrets/secrets.yaml` directly, not through `nix/dev.nix`. This PR only affects local `devenv up` / `devenv shell` flows.

## Test plan
- [x] `rm -rf .devenv && devenv shell -- true` — eval clean
- [x] Inspect generated `/nix/store/*-devenv-processes-{tauri,test}` wrappers — both contain the runtime `if [ -f secrets.dev.yaml ]; then ... fi` selection and use `${pkgs.sops}/bin/sops` (fixes a pre-existing inconsistency where only `processes.tauri` used the store-pinned binary)
- [x] With no `secrets.dev.yaml`: falls back to `secrets.yaml` (verified)
- [x] With a local encrypted `secrets.dev.yaml` present: `sops -d` in <100ms (down from 20s+ timeout against the unreachable keyservice)
- [ ] `devenv up` start-to-tauri-window on Cooper's machine (you can opt back in via `devenv.local.nix` — please confirm no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)