### PR TITLE
feat(native): close settings and history panels with Esc

### DIFF
--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -68,9 +68,10 @@ export function DarwinWidget() {
 
   // Esc closes the settings modal or history panel (settings takes priority since it overlays history).
   // Respects defaultPrevented so nested Radix layers (Select/Popover/inner dialogs) handle Esc first.
+  // Skips during IME composition — Esc cancels the candidate, not the modal.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== "Escape" || e.defaultPrevented) return;
+      if (e.key !== "Escape" || e.defaultPrevented || e.isComposing || e.keyCode === 229) return;
       const { settingsOpen, showHistory, isProcessing, isGenerating, setSettingsOpen, setShowHistory } =
         useWidgetStore.getState();
       if (settingsOpen) {

--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -66,6 +66,25 @@ export function DarwinWidget() {
     }
   }, []);
 
+  // Esc closes the settings modal or history panel (settings takes priority since it overlays history).
+  // Respects defaultPrevented so nested Radix layers (Select/Popover/inner dialogs) handle Esc first.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      const { settingsOpen, showHistory, isProcessing, isGenerating, setSettingsOpen, setShowHistory } =
+        useWidgetStore.getState();
+      if (settingsOpen) {
+        e.preventDefault();
+        setSettingsOpen(false);
+      } else if (showHistory && !(isProcessing || isGenerating)) {
+        e.preventDefault();
+        setShowHistory(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   // Load initial data once on mount, then start watching for changes
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Summary
Adds a window-level keydown handler in `widget.tsx` that closes the settings modal or history panel on Escape.

- **Settings takes priority** when both are open (settings visually overlays history)
- **History close is gated** on `!(isProcessing || isGenerating)` so an in-flight run can't be cancelled by a stray keystroke
- **Respects `e.defaultPrevented`** so nested Radix layers (Select, Popover, inner dialogs) get first shot at Esc before the panel handler runs

19 lines, one file touched.

## Test plan
- [ ] Open settings → press Esc → settings closes
- [ ] Open history → press Esc → history closes
- [ ] Open settings over history → press Esc → settings closes (history stays)
- [ ] Open a Select or inner dialog inside settings → press Esc → inner layer closes first; settings stays until the next Esc
- [ ] History open during a run (`isProcessing` / `isGenerating`) → press Esc → history does NOT close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Escape key support for improved widget navigation.
  * Press Escape closes the settings panel first when open.
  * Press Escape closes the history panel only when it’s visible and no processing or generation is active.
  * Intelligent handling prevents interference with other keyboard input or IME composition, and respects default-prevented events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->