### PR TITLE
feat: add docs-drift gates (CODEOWNERS + Dangerfile + PR template)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+<!-- What does this PR do? Why? -->
+
+## Test Plan
+
+
+## Docs
+- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #___)
+- [ ] No docs update needed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# Behavior-sensitive paths that may require docs updates in darkmatter/nixmac-web.
+# When these paths change, a docs-aware reviewer must approve.
+
+/apps/native/src-tauri/src/evolve/              @fkb032
+/apps/native/src-tauri/src/recovery_resolver.rs @fkb032
+/apps/native/src-tauri/src/cli.rs               @fkb032
+/apps/native/src-tauri/src/darwin.rs             @fkb032
+/apps/native/src-tauri/src/nix.rs                @fkb032
+/apps/native/src-tauri/src/permissions.rs        @fkb032
+/apps/native/src-tauri/src/rollback.rs           @fkb032
+/apps/native/src-tauri/prompts/system.md         @fkb032
+/apps/native/templates/                          @fkb032

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -359,6 +359,50 @@ async function checkDebugStatements(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// 7. Docs-drift gate — behavior code changes need companion docs PR
+// ---------------------------------------------------------------------------
+
+const DOCS_SENSITIVE_PATHS = [
+  "apps/native/src-tauri/src/evolve/",
+  "apps/native/src-tauri/src/recovery_resolver.rs",
+  "apps/native/src-tauri/src/cli.rs",
+  "apps/native/src-tauri/src/darwin.rs",
+  "apps/native/src-tauri/src/nix.rs",
+  "apps/native/src-tauri/src/permissions.rs",
+  "apps/native/src-tauri/src/rollback.rs",
+  "apps/native/src-tauri/prompts/system.md",
+  "apps/native/templates/",
+];
+
+function checkDocsDrift(): void {
+  const allTouched = [...modified, ...created, ...deleted];
+  const touchesDocsSensitivePath = allTouched.some((file) =>
+    DOCS_SENSITIVE_PATHS.some((path) => file.startsWith(path)),
+  );
+
+  if (!touchesDocsSensitivePath) {
+    return;
+  }
+
+  const docsUpdated = body.includes("[x] Docs updated");
+  const noDocsNeeded = body.includes("[x] No docs update needed");
+
+  if (!docsUpdated && !noDocsNeeded) {
+    fail(
+      "This PR touches behavior-sensitive code that is documented in " +
+        "[darkmatter/nixmac-web](https://github.com/darkmatter/nixmac-web). " +
+        "Please either:\n" +
+        "- Open a companion docs PR and check **Docs updated** in the PR description, or\n" +
+        "- Check **No docs update needed** if the change doesn't affect user-facing behavior.",
+    );
+  } else if (docsUpdated) {
+    message("Docs companion PR linked — thank you.");
+  } else {
+    message("No docs update needed — acknowledged.");
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
 
@@ -372,5 +416,6 @@ async function checkDebugStatements(): Promise<void> {
   checkLockfiles();
   flagInfraAndSecrets();
   reportCoverage();
+  checkDocsDrift();
   await checkDebugStatements();
 })();


### PR DESCRIPTION
## Summary
Prevent behavior code changes from silently breaking the docs in darkmatter/nixmac-web.

- **CODEOWNERS**: require @fkb032 review when behavior-sensitive paths change (evolve/, cli.rs, darwin.rs, nix.rs, permissions.rs, rollback.rs, templates/, prompts/system.md)
- **dangerfile.ts**: new `checkDocsDrift()` — fails CI when behavior paths change without the "Docs updated" or "No docs update needed" checkbox
- **PR template**: adds Summary, Test Plan, and Docs checkbox sections

Context: docs now live in darkmatter/nixmac-web (PR #242). This PR closes the drift loop.

## Test Plan
- Danger rule verified against existing dangerfile patterns
- CODEOWNERS syntax verified for GitHub format
- PR template checkbox strings match dangerfile `body.includes()` checks
- Codex (GPT-5.4, xhigh) reviewed: 93% convergence, 0 blockers after fix

## Docs
- [x] No docs update needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)