### PR TITLE
feat(chat): add clear functionality to ChatMemoryStore and clear chat memory on state transition to Begin

### DIFF
--- a/apps/native/src-tauri/src/evolve/chat_memory.rs
+++ b/apps/native/src-tauri/src/evolve/chat_memory.rs
@@ -51,7 +51,12 @@ pub trait ChatMemoryStore: Send + Sync {
     /// Memory is intentionally append-only to preserve strict chronology and
     /// avoid retroactive mutation of prior context.
     fn append(&self, message: ChatMessage);
+
     fn snapshot(&self) -> Vec<ChatMessage>;
+
+    /// Clears all messages from the store.
+    #[allow(unused)]
+    fn clear(&self);
 }
 
 /// In-memory implementation of the ChatMemoryStore trait, using a VecDeque for efficient eviction of oldest messages.
@@ -104,6 +109,16 @@ impl ChatMemoryStore for InMemoryChatMemoryStore {
         let messages = self.messages.lock().unwrap_or_else(|e| e.into_inner());
         debug!("[chat_memory] snapshot count={}", messages.len());
         messages.iter().cloned().collect()
+    }
+
+    fn clear(&self) {
+        let mut guard = self.messages.lock().unwrap_or_else(|e| e.into_inner());
+        let before = guard.len();
+        guard.clear();
+        debug!(
+            "[chat_memory] cleared messages count_before={} count_after=0",
+            before
+        );
     }
 }
 
@@ -333,5 +348,24 @@ mod tests {
         assert_eq!(context.len(), 2);
         assert!(matches!(context[0], Message::User { .. }));
         assert!(matches!(context[1], Message::Assistant { .. }));
+    }
+
+    #[test]
+    fn clears_all_messages() {
+        let store = InMemoryChatMemoryStore::new(ThreadLimits {
+            max_messages: 10,
+            max_tokens: 10_000,
+        });
+
+        store.append(msg(Role::User, "one", 1));
+        store.append(msg(Role::Assistant, "two", 2));
+
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.len(), 2);
+
+        store.clear();
+
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.len(), 0);
     }
 }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -40,9 +40,9 @@ use crate::{
     types::{emit_evolve_event, EvolveEvent},
     utils as global_utils,
 };
-use chat_memory::{
-    session_chat_memory_store, to_provider_context_messages, ChatMessage, Role as ChatMemoryRole,
-};
+use chat_memory::{to_provider_context_messages, ChatMessage, Role as ChatMemoryRole};
+
+pub(crate) use chat_memory::session_chat_memory_store;
 use config_dir_context::format_config_dir_context;
 use messages::Message;
 use providers::{AiProvider, CliProvider, OllamaProvider, OpenAIProvider, ProviderError};

--- a/apps/native/src-tauri/src/evolve_state.rs
+++ b/apps/native/src-tauri/src/evolve_state.rs
@@ -4,10 +4,18 @@ use anyhow::Result;
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_store::StoreExt;
 
+use crate::evolve::session_chat_memory_store;
 pub use crate::shared_types::EvolveState;
+use crate::shared_types::EvolveStep;
 
 const EVOLVE_STATE_PATH: &str = "evolve-state.json";
 const EVOLVE_STATE_KEY: &str = "evolveState";
+
+fn clear_chat_memory_if_begin(step: &EvolveStep, clear_fn: impl FnOnce()) {
+    if *step == EvolveStep::Begin {
+        clear_fn();
+    }
+}
 
 /// Load the persisted evolve state, returning `EvolveState::default()` if absent or corrupt.
 pub fn get<R: Runtime>(app: &AppHandle<R>) -> Result<EvolveState> {
@@ -23,6 +31,15 @@ pub fn get<R: Runtime>(app: &AppHandle<R>) -> Result<EvolveState> {
 /// Recompute `step`, persist, and return the updated state.
 pub fn set<R: Runtime>(app: &AppHandle<R>, mut state: EvolveState) -> Result<EvolveState> {
     state.recompute_step();
+
+    // Clear conversational thread memory whenever routing returns to Begin.
+    // Doing this can prevent weird conversations where the model references past context
+    // that is no longer relevant to the "new" prompt (as the UX looks like a "new chat" UX).
+    // Note that `clear` is NOT a suitable place to do this since it is not called
+    // on all possible transitions back to Begin (e.g. Evolve -> Begin when evolution_id
+    // is cleared but committable is still true).
+    clear_chat_memory_if_begin(&state.step, || session_chat_memory_store().clear());
+
     let store = app.store(EVOLVE_STATE_PATH)?;
     store.set(EVOLVE_STATE_KEY, serde_json::to_value(&state)?);
     store.save()?;
@@ -32,4 +49,50 @@ pub fn set<R: Runtime>(app: &AppHandle<R>, mut state: EvolveState) -> Result<Evo
 /// Reset to idle and persist.
 pub fn clear<R: Runtime>(app: &AppHandle<R>) -> Result<EvolveState> {
     set(app, EvolveState::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clear_chat_memory_if_begin_calls_clear() {
+        let mut cleared = false;
+        clear_chat_memory_if_begin(&EvolveStep::Begin, || {
+            cleared = true;
+        });
+        assert!(cleared);
+    }
+
+    #[test]
+    fn clear_chat_memory_if_begin_skips_non_begin_steps() {
+        let mut cleared = false;
+        clear_chat_memory_if_begin(&EvolveStep::Evolve, || {
+            cleared = true;
+        });
+        assert!(!cleared);
+
+        clear_chat_memory_if_begin(&EvolveStep::Merge, || {
+            cleared = true;
+        });
+        assert!(!cleared);
+    }
+
+    #[test]
+    fn recomputed_begin_triggers_clear_logic() {
+        let mut state = EvolveState {
+            evolution_id: None,
+            committable: true,
+            ..Default::default()
+        };
+        state.recompute_step();
+
+        let mut cleared = false;
+        clear_chat_memory_if_begin(&state.step, || {
+            cleared = true;
+        });
+
+        assert_eq!(state.step, EvolveStep::Begin);
+        assert!(cleared);
+    }
 }

--- a/apps/native/src-tauri/src/evolve_state.rs
+++ b/apps/native/src-tauri/src/evolve_state.rs
@@ -32,6 +32,10 @@ pub fn get<R: Runtime>(app: &AppHandle<R>) -> Result<EvolveState> {
 pub fn set<R: Runtime>(app: &AppHandle<R>, mut state: EvolveState) -> Result<EvolveState> {
     state.recompute_step();
 
+    let store = app.store(EVOLVE_STATE_PATH)?;
+    store.set(EVOLVE_STATE_KEY, serde_json::to_value(&state)?);
+    store.save()?;
+
     // Clear conversational thread memory whenever routing returns to Begin.
     // Doing this can prevent weird conversations where the model references past context
     // that is no longer relevant to the "new" prompt (as the UX looks like a "new chat" UX).
@@ -40,9 +44,6 @@ pub fn set<R: Runtime>(app: &AppHandle<R>, mut state: EvolveState) -> Result<Evo
     // is cleared but committable is still true).
     clear_chat_memory_if_begin(&state.step, || session_chat_memory_store().clear());
 
-    let store = app.store(EVOLVE_STATE_PATH)?;
-    store.set(EVOLVE_STATE_KEY, serde_json::to_value(&state)?);
-    store.save()?;
     Ok(state)
 }
 


### PR DESCRIPTION
This prevents a weird user experience where the user is chatting about doing one task, and then they either discard/cancel or apply, then go back to the Begin state which feels like a "new chat" UI and talk about something else (example: just ask a simple nix-related question), and the agent runs off and tries to take action based on the previous context. I suppose there's a case to be made where that is what you want, but in our current system based on my testing it's weird or even obviously incorrect more often than it's helpful.

I tested this by going through various state transitions and watching the chat memory logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to clear chat conversation history on demand.
  * Chat memory is now automatically cleared when beginning a new evolve operation.

* **Tests**
  * Added unit tests verifying manual clearing, automatic clearing when starting, and that clearing does not occur for other operation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->