### PR TITLE
feat(tests): enhance manual test helpers with new scripts and Makefile targets

### DIFF
--- a/docs/manual-test-cases.md
+++ b/docs/manual-test-cases.md
@@ -1,14 +1,44 @@
 # Manual Test Cases
 
+## Quick Start -- Manual Test Helper Scripts
+
+- **Purpose:** convenience targets and scripts to run the manual test flow described in here.
+- **Make targets:** run from repo root with `make -C docs/testscripts` or run from `docs/testscripts/` directly:
+  - `make manual-show` : print `evolve-state.json` and `build-state.json` and write combined output to `/tmp/nixmac_state.md`.
+  - `make manual-env` : run a login shell and print `TEST1`, `TEST2`, `TEST3` (approximate external terminal check).
+  - `make manual-summarize` : show `git status` summary and changed files.
+  - `make manual-diff` : show full `git diff` of working tree.
+  - `make manual-commit` : stage & commit (dry-run unless you run the underlying script with `--yes`).
+- **Direct scripts:** helpers live in `docs/testscripts/`:
+  - `docs/testscripts/check-state.sh` supports `--out FILE` and `--copy` to write output and copy to clipboard.
+  - `docs/testscripts/manual-test.sh` orchestrates the frequently used steps (`show-state`, `env-check`, `summarize`, `diff`, `commit`).
+  - `docs/testscripts/assert-state.sh` runs `jq` expressions against `evolve-state.json` and `build-state.json` to automate "Expected:" checks. Example:
+    - `docs/testscripts/assert-state.sh --evolve '.evolveState.step == "commit"'`
+    - `docs/testscripts/assert-state.sh --build '.buildState.changesetId != null'`
+
+Example quick run:
+
+```bash
+# From testscripts directory:
+make manual-show        # write state snapshot to /tmp/nixmac_state.md
+make manual-env         # check TEST1/TEST2/TEST3 in a login shell
+make manual-summarize   # see git summary and staged/unstaged files
+```
+
+## Scripts
+
 Please use these scripts while following the tests:
 
-- **`./docs/testscripts/check-state.sh`** — show both state files in the terminal and copy them to clipboard
-- **`echo $TEST1; echo $TEST2; echo $TEST3`** — run in a **new** terminal **outside** the devenv shell
+- **`./docs/testscripts/check-state.sh`** — show both state files in the terminal. Use `--out FILE` to save combined output and `--copy` to copy to the clipboard.
+- **`docs/testscripts/manual-test.sh show-state`** — higher-level wrapper that calls `check-state.sh --out` and writes a snapshot file.
+- **`echo $TEST1; echo $TEST2; echo $TEST3`** — run in a **new** terminal **outside** the devenv shell (or use `docs/testscripts/manual-test.sh env-check VARS...`).
 
 Outside the repo, check state with:
-```bash
+
+````bash
 { echo '```javascript'; echo "// evolve-state.json"; cat ~/Library/Application\ Support/com.darkmatter.nixmac/evolve-state.json; echo; echo '```'; echo; echo '```javascript'; echo "// build-state.json"; cat ~/Library/Application\ Support/com.darkmatter.nixmac/build-state.json; echo; echo '```'; } | tee >(pbcopy)
-```
+````
+
 ______________________________________________________________________
 
 ## 1. Manual changes
@@ -159,10 +189,10 @@ ______________________________________________________________________
 **Steps:**
 
 1. In your config dir run `git reset HEAD~1`
-1. Run `./docs/testscripts/check-state.sh` to verify initial state
+1. Run `./docs/testscripts/check-state.sh --out /tmp/nixmac_state.md --copy` (or `docs/testscripts/manual-test.sh show-state`) to verify initial state
 1. Write a prompt like: add an environment variable called TEST2 with a value of "success"
 1. Run the prompt
-1. Run `./docs/testscripts/check-state.sh` to check state after evolve
+1. Run `./docs/testscripts/check-state.sh --out /tmp/nixmac_state.md --copy` (or `docs/testscripts/manual-test.sh show-state`) to check state after evolve
 
 **Expected:**
 
@@ -240,7 +270,7 @@ ______________________________________________________________________
 **Steps:**
 
 1. Click **Discard** in the widget
-1. Run `./docs/testscripts/check-state.sh` to verify state after discard
+1. Run `./docs/testscripts/check-state.sh --out /tmp/nixmac_state.md --copy` (or `docs/testscripts/manual-test.sh show-state`) to verify state after discard
 
 **Expected:**
 
@@ -285,9 +315,9 @@ ______________________________________________________________________
 
 1. From **My History** under the input, select: add an environment variable called TEST2 with a value of "success"
 1. Run the prompt
-1. Run `./docs/testscripts/check-state.sh` to check state after evolve
+1. Run `./docs/testscripts/check-state.sh --out /tmp/nixmac_state.md --copy` (or `docs/testscripts/manual-test.sh show-state`) to check state after evolve
 1. Press **Build and Test**
-1. Run `./docs/testscripts/check-state.sh` to check state after build
+1. Run `./docs/testscripts/check-state.sh --out /tmp/nixmac_state.md --copy` (or `docs/testscripts/manual-test.sh show-state`) to check state after build
 1. After build completes, open a terminal **outside the nixmac dir** and run `echo $TEST1; echo $TEST2; echo $TEST3`
 
 **Expected:**
@@ -374,9 +404,9 @@ ______________________________________________________________________
 1. Press continue editing
 1. Write an unrelated simple prompt like: add a cool font
 1. Run the prompt
-1. Run `./docs/testscripts/check-state.sh` to check state after evolve
+1. Run `./docs/testscripts/check-state.sh --out /tmp/nixmac_state.md --copy` (or `docs/testscripts/manual-test.sh show-state`) to check state after evolve
 1. Press **Build and Test**
-1. Run `./docs/testscripts/check-state.sh` to check state after build
+1. Run `./docs/testscripts/check-state.sh --out /tmp/nixmac_state.md --copy` (or `docs/testscripts/manual-test.sh show-state`) to check state after build
 
 **Expected:**
 
@@ -521,7 +551,9 @@ success
 
 ➜  ~
 ```
+
 - this means everything done since the first AI prompt got rolled back
+
 - this is what the AI evolution UI allows for now, but the plumbing for smaller steps is in place
 
 - State after undo all:

--- a/docs/testscripts/Makefile
+++ b/docs/testscripts/Makefile
@@ -1,0 +1,23 @@
+### Convenience targets for manual testing flow (run from repo root with `make -C docs/testscripts` or from this directory)
+.PHONY: manual-show manual-env manual-summarize manual-diff manual-commit manual-help
+
+MANUAL_SCRIPT=./manual-test.sh
+
+manual-show:
+	bash $(MANUAL_SCRIPT) show-state --out /tmp/nixmac_state.md
+
+manual-env:
+	bash $(MANUAL_SCRIPT) env-check
+
+manual-summarize:
+	bash $(MANUAL_SCRIPT) summarize
+
+manual-diff:
+	bash $(MANUAL_SCRIPT) diff
+
+manual-commit:
+	# Perform commit (use with care)
+	bash $(MANUAL_SCRIPT) --yes commit
+
+manual-help:
+	bash $(MANUAL_SCRIPT) help

--- a/docs/testscripts/assert-state.sh
+++ b/docs/testscripts/assert-state.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Simple assertion helper for evolve-state.json and build-state.json using jq.
+# Usage examples:
+#   ./assert-state.sh --evolve '.evolveState.step == "commit"'
+#   ./assert-state.sh --build '.buildState.changesetId != null'
+#   ./assert-state.sh --evolve '.evolveState.step == "commit"' --build '.buildState.changesetId != null'
+
+set -euo pipefail
+
+STATE_DIR="$HOME/Library/Application Support/com.darkmatter.nixmac"
+EVOLVE_FILE="$STATE_DIR/evolve-state.json"
+BUILD_FILE="$STATE_DIR/build-state.json"
+
+E_JQ=""
+B_JQ=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --evolve)
+      shift
+      E_JQ="$1"
+      ;;
+    --build)
+      shift
+      B_JQ="$1"
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: assert-state.sh [--evolve JQ_EXPR] [--build JQ_EXPR]
+
+Runs the provided jq expressions against the corresponding state files and
+exits non-zero if any expression fails (jq returns false or the file is missing).
+Examples:
+  --evolve '.evolveState.step == "commit"'
+  --build '.buildState.changesetId != null'
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+fail=0
+run_check() {
+  local file="$1" expr="$2" label="$3"
+  if [[ -z "$expr" ]]; then
+    return 0
+  fi
+  if [[ ! -f "$file" ]]; then
+    echo "[FAIL] $label: file not found: $file" >&2
+    fail=1
+    return
+  fi
+  if ! jq -e "$expr" "$file" >/dev/null 2>&1; then
+    echo "[FAIL] $label: assertion failed: $expr" >&2
+    echo "------- $file -------" >&2
+    jq . "$file" >&2 || true
+    fail=1
+  else
+    echo "[OK] $label: $expr"
+  fi
+}
+
+run_check "$EVOLVE_FILE" "$E_JQ" "evolve-state"
+run_check "$BUILD_FILE" "$B_JQ" "build-state"
+
+if [[ $fail -ne 0 ]]; then
+  exit 2
+fi
+
+echo "All assertions passed."

--- a/docs/testscripts/check-state.sh
+++ b/docs/testscripts/check-state.sh
@@ -1,3 +1,79 @@
-#!/bin/bash
-# Show evolve-state.json and build-state.json in the terminal and copy both to clipboard.
-{ echo '```javascript'; echo "// evolve-state.json"; cat ~/Library/Application\ Support/com.darkmatter.nixmac/evolve-state.json; echo; echo '```'; echo; echo '```javascript'; echo "// build-state.json"; cat ~/Library/Application\ Support/com.darkmatter.nixmac/build-state.json; echo; echo '```'; } | tee >(pbcopy)
+#!/usr/bin/env bash
+# Show evolve-state.json and build-state.json in the terminal and optionally copy to clipboard or write to a file.
+
+set -euo pipefail
+
+OUT=""    # if non-empty, write combined output to this file
+COPY=false # copy to clipboard via pbcopy when true
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--out)
+			shift
+			OUT="$1"
+			;;
+		--copy)
+			COPY=true
+			;;
+		-h|--help)
+			cat <<'USAGE'
+Usage: check-state.sh [--out FILE] [--copy]
+
+Prints the evolve-state.json and build-state.json stored in
+~/Library/Application Support/com.darkmatter.nixmac/.
+
+Options:
+	--out FILE   Write the combined formatted output to FILE.
+	--copy       Also copy the output to the macOS clipboard (pbcopy).
+	-h, --help   Show this help.
+USAGE
+			exit 0
+			;;
+		*)
+			echo "Unknown arg: $1" >&2
+			exit 2
+			;;
+	esac
+	shift
+done
+
+STATE_DIR="$HOME/Library/Application Support/com.darkmatter.nixmac"
+EVOLVE_FILE="$STATE_DIR/evolve-state.json"
+BUILD_FILE="$STATE_DIR/build-state.json"
+
+output() {
+	echo '```javascript'
+	echo "// evolve-state.json"
+	if [[ -f "$EVOLVE_FILE" ]]; then
+		cat "$EVOLVE_FILE"
+	else
+		echo "// (not found: $EVOLVE_FILE)"
+	fi
+	echo
+	echo '```'
+	echo
+	echo '```javascript'
+	echo "// build-state.json"
+	if [[ -f "$BUILD_FILE" ]]; then
+		cat "$BUILD_FILE"
+	else
+		echo "// (not found: $BUILD_FILE)"
+	fi
+	echo
+	echo '```'
+}
+
+if [[ -n "$OUT" ]]; then
+	# write to file and also print to stdout
+	output | tee "$OUT"
+	if $COPY; then
+		output | pbcopy
+	fi
+else
+	if $COPY; then
+		output | tee >(pbcopy)
+	else
+		output
+	fi
+fi
+

--- a/docs/testscripts/manual-test.sh
+++ b/docs/testscripts/manual-test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Lightweight orchestrator for manual test flow described in docs/manual-test-cases.md
+# Usage: docs/testscripts/manual-test.sh <command> [--yes] [--out FILE]
+
+set -euo pipefail
+
+PROG_NAME=$(basename "$0")
+DRY_RUN=true
+OUT=""
+
+while [[ $# -gt 0 && "$1" == --* ]]; do
+  case "$1" in
+    --yes)
+      DRY_RUN=false
+      shift
+      ;;
+    --out)
+      shift
+      OUT="$1"
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $PROG_NAME <command> [--yes] [--out FILE]"
+      echo "Commands: show-state, env-check, summarize, diff, commit, help"
+      exit 0
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+cmd=${1-}
+shift || true
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+check_state() {
+  if [[ -n "$OUT" ]]; then
+    "$SCRIPT_DIR/check-state.sh" --out "$OUT"
+  else
+    "$SCRIPT_DIR/check-state.sh"
+  fi
+}
+
+env_check() {
+  # Print values for a set of env var names in a login shell.
+  # Usage:
+  #   docs/testscripts/manual-test.sh env-check TEST1 TEST2
+  #   TESTS=MYVAR,OTHERVAR docs/testscripts/manual-test.sh env-check
+  local vars=()
+  if [[ -n "${TESTS-}" ]]; then
+    IFS=',' read -r -a vars <<< "$TESTS"
+  elif [[ $# -gt 0 ]]; then
+    vars=("$@")
+  else
+    vars=(TEST1 TEST2 TEST3)
+  fi
+
+  echo "Running a login shell check for: ${vars[*]}"
+  # Build a single bash -c command that echoes each variable on its own line
+  local cmd=""
+  for v in "${vars[@]}"; do
+    cmd+="echo \"\$$v\"; "
+  done
+  bash -l -c "$cmd"
+}
+
+summarize() {
+  echo "Git status summary:";
+  git status --porcelain=v1 --branch
+  echo
+  echo "Changed files (unstaged and staged):"
+  git diff --name-status || true
+  echo
+  echo "Staged changes (if any):"
+  git diff --cached --name-status || true
+}
+
+show_diff() {
+  echo "Full diff (worktree vs HEAD):"
+  git --no-pager diff || true
+}
+
+do_commit() {
+  if $DRY_RUN; then
+    echo "DRY RUN: would stage and commit. Rerun with --yes to perform."
+    summarize
+    exit 0
+  fi
+
+  msg="$1"
+  if [[ -z "$msg" ]]; then
+    read -r -p "Commit message: " msg
+  fi
+  git add -A
+  git commit -m "$msg"
+  echo "Committed.";
+}
+
+case "$cmd" in
+  show-state)
+    check_state
+    ;;
+  env-check)
+    env_check "$@"
+    ;;
+  summarize)
+    summarize
+    ;;
+  diff)
+    show_diff
+    ;;
+  commit)
+    do_commit "$*"
+    ;;
+  help|""|--help|-h)
+    echo "Usage: $PROG_NAME <command> [--yes] [--out FILE]"
+    echo
+    echo "Commands:"
+    echo "  show-state   Print and optionally copy state files (uses check-state.sh)"
+    echo "  env-check    Run a login shell and print TEST1/TEST2/TEST3"
+    echo "  summarize    Show git status and changed files summary"
+    echo "  diff         Show full git diff"
+    echo "  commit       Stage and commit changes (use --yes to actually commit)"
+    echo "  help         Show this help"
+    ;;
+  *)
+    echo "Unknown command: $cmd" >&2
+    echo "Run: $PROG_NAME help" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
I had not seen the instructions in `manual-test-cases.md` before and found them a little error-prone so I added some wrappers to help with them:

* Added manual-test.sh (wrapper for show-state/env-check/summarize/diff/commit) and assert-state.sh (jq assertions).
* Updated check-state.sh to accept --out FILE and --copy.
* Created Makefile in testscripts with common targets
* Updated README.md and manual-test-cases.md to reflect new flags and usage.

One thing I was still unclear on from the .md documentation was the sigificance of the names `TEST1`, `TEST2`, `TEST3` like if the user is meant to (I guess?) replace these with descriptive test names or something? That could use additional clarification.

## Test Plan
Smoke-tested `manual-test.sh show-state`, `manual-test.sh env-check` and `assert-state.sh --evolve '.evolveState.step == "begin"'`.

## Docs
- [x] Docs updated (companion PR in darkmatter/nixmac-web: #___)
- [ ] No docs update needed
