### PR TITLE
[codex] Use OpenRouter provider value

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The agent reads your config, plans the changes, edits the Nix files, builds the 
 ### Key Features
 
 - **Natural-language config evolution** — an agentic loop with tool use (read, edit, search) that iterates until your system matches the prompt
-- **Multi-provider AI** — OpenAI/OpenRouter (default), Ollama for fully local operation
+- **Multi-provider AI** — OpenRouter (default), OpenAI-compatible endpoints, Ollama for fully local operation
 - **Tool-augmented agent** — `read_file`, `write_file`, `search_packages`, `search_docs`, `search_code` tools give the model deep context about nix-darwin options and nixpkgs
 - **Chat memory** — session context persists across turns for multi-step conversations
 - **Smart summarization** — every changeset and commit gets an AI-generated summary with token-budgeted batching
@@ -139,9 +139,9 @@ nixmac uses separate models for **evolution** (config changes via tool use) and 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `EVOLVE_PROVIDER` | `openai` | `openai`, `openrouter`, or `ollama` |
+| `EVOLVE_PROVIDER` | `openrouter` | `openrouter`, `openai`, or `ollama` |
 | `EVOLVE_MODEL` | `anthropic/claude-sonnet-4` | Model for config evolution |
-| `SUMMARY_AI_PROVIDER` | `openai` | Provider for summarization |
+| `SUMMARY_AI_PROVIDER` | `openrouter` | Provider for summarization |
 | `SUMMARY_MODEL` | `openai/gpt-4o-mini` | Model for summaries |
 | `OLLAMA_API_BASE` | `http://localhost:11434` | Ollama endpoint |
 

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -383,7 +383,7 @@ pub async fn generate_evolution<R: Runtime>(
     let store_provider = store::get_evolve_provider(app).ok().flatten();
     let provider_type = store_provider
         .or_else(|| std::env::var("EVOLVE_PROVIDER").ok())
-        .unwrap_or_else(|| "openai".to_string());
+        .unwrap_or_else(|| "openrouter".to_string());
 
     info!("");
     info!("════════════════════════════════════════════════════════════════");

--- a/apps/native/src-tauri/src/providers/mod.rs
+++ b/apps/native/src-tauri/src/providers/mod.rs
@@ -73,7 +73,7 @@ pub fn create_provider<R: Runtime>(
 
     let provider = store_provider
         .or_else(|| std::env::var("SUMMARY_AI_PROVIDER").ok())
-        .unwrap_or_else(|| "openai".to_string());
+        .unwrap_or_else(|| "openrouter".to_string());
 
     let store_model = app_handle
         .and_then(|app| crate::store::get_summary_model(app).ok())

--- a/apps/native/src-tauri/src/types.rs
+++ b/apps/native/src-tauri/src/types.rs
@@ -46,7 +46,7 @@ pub struct UiPrefs {
     #[serde(rename = "vllmApiKey")]
     pub vllm_api_key: Option<String>,
 
-    /// Provider for summarization (openai/ollama/vllm).
+    /// Provider for summarization (openrouter/openai/ollama/vllm).
     #[serde(rename = "summaryProvider")]
     pub summary_provider: Option<String>,
 
@@ -54,7 +54,7 @@ pub struct UiPrefs {
     #[serde(rename = "summaryModel")]
     pub summary_model: Option<String>,
 
-    /// Provider for evolution (openai/ollama).
+    /// Provider for evolution (openrouter/openai/ollama).
     #[serde(rename = "evolveProvider")]
     pub evolve_provider: Option<String>,
 

--- a/apps/native/src/components/widget/model-combobox.tsx
+++ b/apps/native/src/components/widget/model-combobox.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 import { darwinAPI } from "@/tauri-api";
 
 interface ModelComboboxProps {
-  provider: "openai" | "ollama" | "vllm" | "opencode";
+  provider: "openrouter" | "openai" | "ollama" | "vllm" | "opencode";
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;
@@ -112,7 +112,7 @@ export function ModelCombobox({
     try {
       let freshModels: string[] = [];
 
-      if (provider === "openai") {
+      if (provider === "openrouter" || provider === "openai") {
         freshModels = await fetchOpenRouterModels();
       } else if (provider === "ollama") {
         const prefs = await darwinAPI.ui.getPrefs();

--- a/apps/native/src/components/widget/settings-dialog.tsx
+++ b/apps/native/src/components/widget/settings-dialog.tsx
@@ -12,6 +12,10 @@ import { GeneralTab } from "./settings/general-tab";
 import { PreferencesTab } from "./settings/preferences-tab";
 type ApiKeyStatus = "idle" | "verifying" | "valid" | "invalid";
 
+function normalizeProvider(provider?: string | null) {
+  return provider === "openai" ? "openrouter" : (provider ?? "openrouter");
+}
+
 interface NavItemProps {
   icon: React.ReactNode;
   label: string;
@@ -139,9 +143,9 @@ export function SettingsDialog() {
       ollamaApiBaseUrl: "",
       vllmApiBaseUrl: "",
       vllmApiKey: "",
-      summaryProvider: "openai",
+      summaryProvider: "openrouter",
       summaryModel: "openai/gpt-4o-mini",
-      evolveProvider: "openai",
+      evolveProvider: "openrouter",
       evolveModel: "anthropic/claude-sonnet-4",
       maxIterations: DEFAULT_MAX_ITERATIONS,
       maxBuildAttempts: 5,
@@ -161,9 +165,9 @@ export function SettingsDialog() {
           form.setFieldValue("ollamaApiBaseUrl", prefs.ollamaApiBaseUrl ?? "");
           form.setFieldValue("vllmApiBaseUrl", prefs.vllmApiBaseUrl ?? "");
           form.setFieldValue("vllmApiKey", prefs.vllmApiKey ?? "");
-          form.setFieldValue("summaryProvider", prefs.summaryProvider ?? "openai");
+          form.setFieldValue("summaryProvider", normalizeProvider(prefs.summaryProvider));
           form.setFieldValue("summaryModel", prefs.summaryModel ?? "openai/gpt-4o-mini");
-          form.setFieldValue("evolveProvider", prefs.evolveProvider ?? "openai");
+          form.setFieldValue("evolveProvider", normalizeProvider(prefs.evolveProvider));
           form.setFieldValue("evolveModel", prefs.evolveModel ?? "anthropic/claude-sonnet-4");
           form.setFieldValue("maxIterations", prefs.maxIterations ?? DEFAULT_MAX_ITERATIONS);
           form.setFieldValue("maxBuildAttempts", prefs.maxBuildAttempts ?? 5);

--- a/apps/native/src/components/widget/settings/ai-models-tab.tsx
+++ b/apps/native/src/components/widget/settings/ai-models-tab.tsx
@@ -45,6 +45,7 @@ function isPlainInputCliProvider(provider: string): boolean {
 }
 
 const DEFAULT_EVOLVE_MODEL: Record<string, string> = {
+  openrouter: "anthropic/claude-sonnet-4",
   openai: "anthropic/claude-sonnet-4",
   ollama: "",
   vllm: "gpt-oss-120b",
@@ -54,6 +55,7 @@ const DEFAULT_EVOLVE_MODEL: Record<string, string> = {
 };
 
 const DEFAULT_SUMMARY_MODEL: Record<string, string> = {
+  openrouter: "openai/gpt-4o-mini",
   openai: "openai/gpt-4o-mini",
   ollama: "llama3.1",
   vllm: "gpt-oss-120b",
@@ -76,6 +78,7 @@ function useProviderConfigured(form: AiModelsTabProps["form"]) {
     const subscription = form.store.subscribe(() => {
       const v = form.store.state.values;
       setConfigured({
+        openrouter: !!(v.openrouterApiKey || v.openaiApiKey),
         openai: !!(v.openrouterApiKey || v.openaiApiKey),
         ollama: true,
         vllm: !!v.vllmApiBaseUrl,
@@ -84,6 +87,7 @@ function useProviderConfigured(form: AiModelsTabProps["form"]) {
     // trigger initial
     const v = form.store.state.values;
     setConfigured({
+      openrouter: !!(v.openrouterApiKey || v.openaiApiKey),
       openai: !!(v.openrouterApiKey || v.openaiApiKey),
       ollama: true,
       vllm: !!v.vllmApiBaseUrl,
@@ -103,7 +107,7 @@ function providerDisabledReason(
     return cliStatus[provider] === false ? "not found in PATH" : null;
   }
   if (configured[provider] === false) {
-    if (provider === "openai") return "no API key set";
+    if (provider === "openrouter" || provider === "openai") return "no API key set";
     if (provider === "vllm") return "no base URL set";
   }
   return null;
@@ -124,7 +128,7 @@ export function AiModelsTab({
   const renderProviderItems = () => (
     <>
       {([
-        { value: "openai", label: "OpenAI / OpenRouter" },
+        { value: "openrouter", label: "OpenRouter" },
         { value: "ollama", label: "Ollama" },
         { value: "vllm", label: "vLLM / LiteLLM" },
       ] as const).map(({ value, label }) => {
@@ -211,7 +215,7 @@ export function AiModelsTab({
                         />
                       ) : (
                         <ModelCombobox
-                          provider={evolveProvider as "openai" | "ollama" | "vllm" | "opencode"}
+                          provider={evolveProvider as "openrouter" | "openai" | "ollama" | "vllm" | "opencode"}
                           value={evolveModelField.state.value}
                           onChange={async (value) => {
                             evolveModelField.handleChange(value);
@@ -296,7 +300,7 @@ export function AiModelsTab({
                         />
                       ) : (
                         <ModelCombobox
-                          provider={summaryProvider as "openai" | "ollama" | "vllm" | "opencode"}
+                          provider={summaryProvider as "openrouter" | "openai" | "ollama" | "vllm" | "opencode"}
                           value={summaryModelField.state.value}
                           onChange={async (value) => {
                             summaryModelField.handleChange(value);


### PR DESCRIPTION
## Summary
- Change the AI Models provider dropdown to store `openrouter` while displaying `OpenRouter`.
- Normalize legacy saved `openai` prefs to `openrouter` in the settings UI so existing users are not stranded on an unlisted value.
- Keep `openai` as a backend-compatible legacy alias/fallback and update README defaults to match the OpenRouter-first behavior.

## Why
The UI label had been changed to `OpenRouter`, but the underlying select value still persisted `openai`. That left the visible setting and stored provider value out of sync.

## Test Plan
- Run `devenv up` from the repo root and wait for the local app to launch.
- Open Settings -> AI Models.
- Confirm the Evolution Model provider dropdown displays `OpenRouter`.
- Confirm the Summary Model provider dropdown displays `OpenRouter`.
- Change/select `OpenRouter` in either provider dropdown, close and reopen Settings, and confirm the selection still displays as `OpenRouter`.
- With an existing saved `openai` provider preference, open Settings -> AI Models and confirm the UI normalizes it to the visible `OpenRouter` option instead of showing an empty/unmatched select value.

## Docs
- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #___)
- [x] No docs update needed

This only changes the local app's provider label/value consistency and updates this repo's README defaults. The public docs site does not need a companion update.