### PR TITLE
feat(tests): create a lot of wdio testing infra and some tests that exercise it

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  plugins: ['chai-friendly'],
+  overrides: [
+    {
+      files: ['**/*.spec.{js,mjs,ts,tsx}', 'apps/**/e2e-tauri/**/*.mjs', 'apps/**/tests/**/*.mjs'],
+      rules: {
+        'no-unused-expressions': 'off',
+        'chai-friendly/no-unused-expressions': 'error'
+      }
+    }
+  ]
+};

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -13,5 +13,17 @@
     "perf": "error",
     "style": "warn",
     "suspicious": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.spec.{js,mjs,ts,tsx}",
+        "apps/**/e2e-tauri/**/*.mjs",
+        "apps/**/tests/**/*.mjs"
+      ],
+      "rules": {
+        "no-unused-expressions": "off"
+      }
+    }
+  ]
 }

--- a/apps/native/e2e-tauri/README.md
+++ b/apps/native/e2e-tauri/README.md
@@ -32,9 +32,7 @@ Current test files live in `e2e-tauri/tests`.
      });
      ```
 
-  ```
-  3. Add an npm script in `apps/native/package.json` (optional convenience):
-  ```
+  1. Add an npm script in `apps/native/package.json` (optional convenience):
 
 ```json
       "test:wdio:my-feature": "wdio run e2e-tauri/wdio.my-feature.conf.mjs"
@@ -44,7 +42,7 @@ Current test files live in `e2e-tauri/tests`.
   - If your tests use the vLLM backend, set `VLLM_API_BASE_URL` and `VLLM_API_KEY` in the environment before running the WDIO task (the `setupNixmacTestEnvironment` helper reads those to generate `settings.json`). Example:
 
 ```bash
-      export VLLM_API_BASE_URL="http://100.111.97.14:8002/v1"
+      export VLLM_API_BASE_URL="http://example.com/v1"
       export VLLM_API_KEY="$VLLM_API_KEY"
       bun run test:wdio:my-feature
 ```

--- a/apps/native/e2e-tauri/README.md
+++ b/apps/native/e2e-tauri/README.md
@@ -10,6 +10,54 @@ Current test files live in `e2e-tauri/tests`.
    1. `cargo install tauri-webdriver-automation`
 1. Tauri app compiled in debug mode (default binary = `(repo root)/target/debug/nixmac`)
 
+## Adding new WDIO tests
+
+- Per-test WDIO conf: Each new E2E test suite should get its own small WDIO config file under this folder (for example `wdio.discard.conf.mjs` or `wdio.modify.conf.mjs`).
+
+  - Why: WDIO launches the app binary as part of starting a test run; any environment or on-disk setup that the app relies on (for example: writing `settings.json` or creating a temporary `configDir` git repo) must happen before the app binary is launched. The easiest and most reliable way to guarantee that setup runs before the app is started is to perform it in `onPrepare` of a WDIO config.
+  - Our pattern: `wdio.conf.base.mjs` exports `createWdioConfig({ specs, setupOptions })`. Per-suite configs call that factory and pass `setupOptions` (e.g. `{ initializeConfigRepo: true }`). This ensures `setupNixmacTestEnvironment` runs in `onPrepare` before the Tauri binary starts.
+
+- How to add a new test suite
+
+  1. Create your spec file under `tests/wdio/`, e.g. `tests/wdio/my-feature.spec.mjs`.
+
+  1. Add a per-suite config in this folder, e.g. `wdio.my-feature.conf.mjs`:
+
+     ```js
+     import { createWdioConfig } from './wdio.conf.base.mjs';
+
+     export const config = createWdioConfig({
+     specs: ['./tests/wdio/my-feature.spec.mjs'],
+     setupOptions: { initializeConfigRepo: true }, // customize per-suite
+     });
+     ```
+
+  ```
+  3. Add an npm script in `apps/native/package.json` (optional convenience):
+  ```
+
+```json
+      "test:wdio:my-feature": "wdio run e2e-tauri/wdio.my-feature.conf.mjs"
+```
+
+- Environment and secrets
+  - If your tests use the vLLM backend, set `VLLM_API_BASE_URL` and `VLLM_API_KEY` in the environment before running the WDIO task (the `setupNixmacTestEnvironment` helper reads those to generate `settings.json`). Example:
+
+```bash
+      export VLLM_API_BASE_URL="http://100.111.97.14:8002/v1"
+      export VLLM_API_KEY="$VLLM_API_KEY"
+      bun run test:wdio:my-feature
+```
+
+- Test helpers and hooks
+
+  - Use the existing dev-only test hook pattern when you need to drive or observe app state from WDIO: the app exposes `window.__testWidget` in DEV builds (see `src/utils/widget-test-helpers.ts`). Helpers include `setEvolvePrompt()`, `isEvolveProcessing()`, and `getPromptHistory()` — call them via `browser.execute(...)` from your WDIO helpers.
+  - Prefer using store-driven helpers (above) over DOM event hacks — they are faster and more reliable for React+Zustand apps running in Tauri webviews (noting that we cannot use React Testing Library in a Tauri app unfortunately).
+
+- data-testid's
+
+  - When adding new interactive elements you plan to target from E2E tests, add a `data-testid` attribute (or an `id`) to the element in the component source so selectors are stable and readable.
+
 ## Current WDIO config
 
 `apps/native/wdio.conf.mjs` uses:
@@ -23,33 +71,25 @@ Start `tauri-wd` from `apps/native` for this relative path to work as-is.
 
 ## Run tests
 
-Use three terminals.
+Use two terminals.
 
-### Terminal A: Start frontend dev server (Vite)
+### Terminal A: Start frontend dev server (Vite) and tauri-wd
 
 From `apps/native`:
 
 ```bash
-bun run dev
+bun run test:wdio:services
 ```
 
-Starts on port 5173 by default.
+Starts on port 5173 and port 4444 (respectively) by default.
 
-### Terminal B: Start tauri-wd
-
-From `apps/native`:
-
-```bash
-tauri-wd
-```
-
-Starts on port 4444 by default.
-
-### Terminal C: Run WDIO tests
+### Terminal B: Run WDIO tests
 
 From `apps/native`:
 
 ```bash
+export VLLM_API_BASE_URL=http://example.com/v1
+export VLLM_API_KEY=sk_blahblahblah
 bun run test:wdio
 ```
 

--- a/apps/native/e2e-tauri/tests/wdio/basic-prompts.spec.mjs
+++ b/apps/native/e2e-tauri/tests/wdio/basic-prompts.spec.mjs
@@ -1,0 +1,49 @@
+// oxlint-disable no-unused-expressions
+import {
+  assertPromptFlowReachedEvolveReview,
+  submitPromptMessage,
+  waitForFirstWindow,
+} from './helpers/app-ui.mjs';
+import { loadBuildState, loadEvolveState, getConfigRepoGitDiff } from './helpers/test-env.mjs';
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+use(chaiAsPromised);
+
+describe('basic prompts', () => {
+  it('submits a basic prompt and reaches evolve review with diff', async () => {
+    await waitForFirstWindow();
+
+    await submitPromptMessage('add a new programming font to my system');
+
+    await assertPromptFlowReachedEvolveReview();
+
+    const evolveState = await loadEvolveState();
+    const buildState = await loadBuildState();
+    const gitDiff = await getConfigRepoGitDiff();
+
+    console.log('[wdio:basic-prompts] evolve_state');
+    console.log(JSON.stringify(evolveState, null, 2));
+    console.log('[wdio:basic-prompts] build_state');
+    console.log(JSON.stringify(buildState, null, 2));
+    console.log('[wdio:basic-prompts] git_diff_files');
+    console.log(JSON.stringify(gitDiff.files, null, 2));
+
+    expect(evolveState, 'evolveState should be defined').to.exist;
+    expect(buildState, 'buildState should NOT be defined').to.not.exist;
+    expect(
+      evolveState.step,
+      'Expected evolveState.step to be "evolve" after a successful prompt submission',
+    ).to.equal('evolve');
+    expect(
+      Number(evolveState.currentChangesetId),
+      'Expected evolveState.currentChangesetId to be greater than 0, indicating a changeset was created',
+    ).to.be.greaterThan(0);
+
+    const changedPaths = gitDiff.files.map((file) => file.path);
+    expect(
+      changedPaths.some((filePath) => filePath.endsWith('fonts.nix')),
+      `Expected generated changes to include fonts.nix in git diff. Changed paths: ${changedPaths.join(', ')}`,
+    ).to.be.true;
+  });
+});

--- a/apps/native/e2e-tauri/tests/wdio/discard.spec.mjs
+++ b/apps/native/e2e-tauri/tests/wdio/discard.spec.mjs
@@ -1,0 +1,34 @@
+import {
+  assertPromptFlowReachedEvolveReview,
+  assertReturnedToInitialPromptScreen,
+  clickDiscardAndCancel,
+  clickDiscardAndConfirm,
+  submitPromptMessage,
+  waitForFirstWindow,
+} from './helpers/app-ui.mjs';
+
+describe('discard', () => {
+  it('submits a prompt, reaches evolve review, then discards and returns to initial state', async () => {
+    await waitForFirstWindow();
+
+    await submitPromptMessage('add a new programming font to my system');
+
+    await assertPromptFlowReachedEvolveReview();
+
+    await clickDiscardAndConfirm();
+
+    await assertReturnedToInitialPromptScreen();
+  });
+
+  it('submits a prompt, reaches evolve review, then cancels discard and stays on review', async () => {
+    await waitForFirstWindow();
+
+    await submitPromptMessage('add a new programming font to my system');
+
+    await assertPromptFlowReachedEvolveReview();
+
+    await clickDiscardAndCancel();
+
+    await assertPromptFlowReachedEvolveReview();
+  });
+});

--- a/apps/native/e2e-tauri/tests/wdio/helpers/app-ui.mjs
+++ b/apps/native/e2e-tauri/tests/wdio/helpers/app-ui.mjs
@@ -1,7 +1,45 @@
 import { $, browser } from '@wdio/globals';
+import { expect } from 'chai';
+
+const ERROR_MESSAGE_SELECTOR = '[data-testid="widget-error-message"]';
+
+async function failIfWidgetErrorPresent() {
+  let errorElements = [];
+  try {
+    errorElements = await $$(ERROR_MESSAGE_SELECTOR);
+  } catch {
+    return;
+  }
+
+  if (errorElements.length === 0) {
+    return;
+  }
+
+  const message = (await errorElements[0].getText()).trim();
+  if (!message) {
+    return;
+  }
+
+  expect.fail(`Widget error surfaced during test: ${message}`);
+}
+
+async function waitUntilOrFailOnError(condition, options) {
+  const { timeout, interval, timeoutMsg } = options;
+  await browser.waitUntil(
+    async () => {
+      await failIfWidgetErrorPresent();
+      return await condition();
+    },
+    {
+      timeout,
+      interval,
+      timeoutMsg,
+    },
+  );
+}
 
 async function waitForSelector(selector, { timeout = 15000, interval = 250 } = {}) {
-  await browser.waitUntil(
+  await waitUntilOrFailOnError(
     async () => {
       try {
         const el = await $(selector);
@@ -18,10 +56,63 @@ async function waitForSelector(selector, { timeout = 15000, interval = 250 } = {
   );
 }
 
+export async function clickDiscardAndConfirm() {
+  const discardButtonSelector = '[data-testid="evolve-discard-button"]';
+  const confirmButtonSelector = '[data-testid="confirm-dialog-confirm"]';
+
+  await waitForSelector(discardButtonSelector);
+  await clickWithRetry(discardButtonSelector);
+
+  // Confirmation dialog appears — click Confirm
+  await waitForSelector(confirmButtonSelector, { timeout: 10000 });
+  await clickWithRetry(confirmButtonSelector);
+}
+
+export async function clickDiscardAndCancel() {
+  const discardButtonSelector = '[data-testid="evolve-discard-button"]';
+  const cancelButtonSelector = '[data-testid="confirm-dialog-cancel"]';
+
+  await waitForSelector(discardButtonSelector);
+  await clickWithRetry(discardButtonSelector);
+
+  // Confirmation dialog appears — click Cancel
+  await waitForSelector(cancelButtonSelector, { timeout: 10000 });
+  await clickWithRetry(cancelButtonSelector);
+}
+
+export async function assertEvolveReviewGone() {
+  await waitUntilOrFailOnError(
+    async () => {
+      const heading = await $('//h2[normalize-space()="What else can I change for you?"]');
+      return !(await heading.isExisting());
+    },
+    {
+      timeout: 60000,
+      interval: 500,
+      timeoutMsg: 'Timed out waiting for evolve review screen to disappear after discard',
+    },
+  );
+}
+
+export async function assertReturnedToInitialPromptScreen() {
+  await waitForSelector('//h3[normalize-space()="Get started"]', {
+    timeout: 60000,
+    interval: 500,
+  });
+
+  await waitForSelector('#evolve-prompt-input, [data-testid="evolve-prompt-input"]', {
+    timeout: 60000,
+    interval: 250,
+  });
+
+  await assertEvolveReviewGone();
+}
+
 async function clickWithRetry(selector, { attempts = 12, interval = 250 } = {}) {
   let lastError;
   for (let i = 0; i < attempts; i += 1) {
     try {
+      await failIfWidgetErrorPresent();
       const el = await $(selector);
       if (!(await el.isExisting())) {
         await browser.pause(interval);
@@ -35,14 +126,18 @@ async function clickWithRetry(selector, { attempts = 12, interval = 250 } = {}) 
     }
   }
 
-  throw lastError ?? new Error(`Failed to click selector after retries: ${selector}`);
+  const suffix =
+    lastError instanceof Error && lastError.message
+      ? ` Last error: ${lastError.message}`
+      : '';
+  expect.fail(`Failed to click selector after retries: ${selector}.${suffix}`);
 }
 
 export async function waitForFirstWindow(options = {}) {
   const timeout = options.timeout ?? 45000;
   const interval = options.interval ?? 500;
 
-  await browser.waitUntil(
+  await waitUntilOrFailOnError(
     async () => {
       try {
         const handles = await browser.getWindowHandles();
@@ -77,4 +172,108 @@ export async function clickSettingsTabAndAssert(tabName) {
   await clickWithRetry(tabButtonSelector);
 
   await waitForSelector(`//h2[normalize-space()="${tabName}"]`);
+}
+
+export async function submitPromptMessage(promptMessage) {
+  const promptInputSelector = '#evolve-prompt-input, [data-testid="evolve-prompt-input"]';
+  const sendButtonSelector = '#evolve-prompt-send, [data-testid="evolve-prompt-send"]';
+
+  await waitForSelector(promptInputSelector, { timeout: 60000, interval: 250 });
+
+  // Drive the Zustand store directly via the dev-only window test hook.
+  // This is cleaner and more reliable than trying to simulate DOM events
+  // through WebDriver against a React-controlled textarea.
+  await browser.execute((value) => {
+    window.__testWidget?.setEvolvePrompt(value);
+  }, promptMessage);
+
+  await waitForSelector(sendButtonSelector);
+  await waitUntilOrFailOnError(
+    async () => {
+      const sendButton = await $(sendButtonSelector);
+      return (await sendButton.isExisting()) && (await sendButton.isEnabled());
+    },
+    {
+      timeout: 5000,
+      interval: 200,
+      timeoutMsg: 'Send button did not enable after typing prompt text',
+    },
+  );
+
+  await clickWithRetry(sendButtonSelector, { attempts: 30, interval: 300 });
+}
+
+export async function waitForEvolveProcessingCycle({
+  startedTimeout = 20000,
+  completedTimeout = 120000,
+} = {}) {
+  await waitUntilOrFailOnError(
+    async () =>
+      await browser.execute(() => {
+        return window.__testWidget?.isEvolveProcessing?.() === true;
+      }),
+    {
+      timeout: startedTimeout,
+      interval: 200,
+      timeoutMsg: 'Timed out waiting for evolve processing to start',
+    },
+  );
+
+  await waitUntilOrFailOnError(
+    async () =>
+      await browser.execute(() => {
+        return window.__testWidget?.isEvolveProcessing?.() === false;
+      }),
+    {
+      timeout: completedTimeout,
+      interval: 500,
+      timeoutMsg: 'Timed out waiting for evolve processing to complete',
+    },
+  );
+}
+
+export async function assertPromptHistoryContains(promptText) {
+  await waitUntilOrFailOnError(
+    async () =>
+      await browser.execute((targetPrompt) => {
+        const history = window.__testWidget?.getPromptHistory?.() ?? [];
+        return history.includes(targetPrompt);
+      }, promptText),
+    {
+      timeout: 120000,
+      interval: 500,
+      timeoutMsg: `Timed out waiting for prompt history to include: ${promptText}`,
+    },
+  );
+}
+
+export async function assertPromptFlowReachedEvolveReview() {
+  await waitForSelector('//h2[normalize-space()="What else can I change for you?"]', {
+    timeout: 120000,
+    interval: 500,
+  });
+
+  await waitForSelector('//h2[normalize-space()="What\'s changed"]', {
+    timeout: 120000,
+    interval: 500,
+  });
+
+  await waitForSelector('//button[normalize-space()="Diff"]');
+  await clickWithRetry('//button[normalize-space()="Diff"]');
+
+  await waitUntilOrFailOnError(
+    async () => {
+      const noDiffMatches = await $$('//*[normalize-space()="No diff available"]');
+      return noDiffMatches.length === 0;
+    },
+    {
+      timeout: 120000,
+      interval: 500,
+      timeoutMsg: 'Timed out waiting for generated git diff content',
+    },
+  );
+}
+
+export async function assertNoWidgetError() {
+  await failIfWidgetErrorPresent();
 }

--- a/apps/native/e2e-tauri/tests/wdio/helpers/app-ui.mjs
+++ b/apps/native/e2e-tauri/tests/wdio/helpers/app-ui.mjs
@@ -1,4 +1,4 @@
-import { $, browser } from '@wdio/globals';
+import { $, $$, browser } from '@wdio/globals';
 import { expect } from 'chai';
 
 const ERROR_MESSAGE_SELECTOR = '[data-testid="widget-error-message"]';

--- a/apps/native/e2e-tauri/tests/wdio/helpers/test-env.mjs
+++ b/apps/native/e2e-tauri/tests/wdio/helpers/test-env.mjs
@@ -1,0 +1,316 @@
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import {
+  access,
+  copyFile,
+  cp,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const APPS_NATIVE_DIR = path.resolve(THIS_DIR, '../../../../');
+
+const CONFIG_TEMPLATE_DIR = path.join(APPS_NATIVE_DIR, 'templates', 'nix-darwin-determinate');
+const NIXMAC_APP_SUPPORT_DIR = path.join(
+  os.homedir(),
+  'Library',
+  'Application Support',
+  'com.darkmatter.nixmac',
+);
+const NIXMAC_SETTINGS_PATH = path.join(
+  NIXMAC_APP_SUPPORT_DIR,
+  'settings.json',
+);
+const NIXMAC_EVOLVE_STATE_PATH = path.join(NIXMAC_APP_SUPPORT_DIR, 'evolve-state.json');
+const NIXMAC_BUILD_STATE_PATH = path.join(NIXMAC_APP_SUPPORT_DIR, 'build-state.json');
+
+async function pathExists(filePath) {
+  try {
+    await access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getEvalHostname() {
+  try {
+    const { stdout } = await execFileAsync('scutil', ['--get', 'LocalHostName']);
+    const hostname = stdout.trim();
+    return hostname || 'localhost';
+  } catch {
+    return 'localhost';
+  }
+}
+
+function getCurrentUsername() {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return process.env.USER || 'nobody';
+  }
+}
+
+async function listNixFiles(dirPath) {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listNixFiles(fullPath)));
+    } else if (entry.isFile() && entry.name.endsWith('.nix')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function backupNixmacSettings() {
+  if (!(await pathExists(NIXMAC_SETTINGS_PATH))) {
+    console.log(`[wdio:test-env] No existing settings found to back up at ${NIXMAC_SETTINGS_PATH}`);
+    return null;
+  }
+
+  const backupPath = `${NIXMAC_SETTINGS_PATH}.bak`;
+  await copyFile(NIXMAC_SETTINGS_PATH, backupPath);
+  console.log(`[wdio:test-env] Backed up settings: ${NIXMAC_SETTINGS_PATH} -> ${backupPath}`);
+  return backupPath;
+}
+
+async function restoreNixmacSettings(backupPath) {
+  if (!backupPath) {
+    console.log('[wdio:test-env] No settings backup to restore');
+    return;
+  }
+
+  if (!(await pathExists(backupPath))) {
+    console.log(`[wdio:test-env] Settings backup not found, skipping restore: ${backupPath}`);
+    return;
+  }
+
+  await mkdir(path.dirname(NIXMAC_SETTINGS_PATH), { recursive: true });
+  await copyFile(backupPath, NIXMAC_SETTINGS_PATH);
+  await unlink(backupPath);
+  console.log(`[wdio:test-env] Restored settings from backup: ${backupPath}`);
+}
+
+async function backupJsonState(statePath, label) {
+  if (!(await pathExists(statePath))) {
+    console.log(`[wdio:test-env] No existing ${label} found to back up at ${statePath}`);
+    return null;
+  }
+
+  const backupPath = `${statePath}.bak`;
+  await copyFile(statePath, backupPath);
+  console.log(`[wdio:test-env] Backed up ${label}: ${statePath} -> ${backupPath}`);
+  return backupPath;
+}
+
+async function restoreJsonState(backupPath, targetPath, label) {
+  if (!backupPath) {
+    console.log(`[wdio:test-env] No ${label} backup to restore`);
+    return;
+  }
+
+  if (!(await pathExists(backupPath))) {
+    console.log(`[wdio:test-env] ${label} backup not found, skipping restore: ${backupPath}`);
+    return;
+  }
+
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await copyFile(backupPath, targetPath);
+  await unlink(backupPath);
+  console.log(`[wdio:test-env] Restored ${label} from backup: ${backupPath}`);
+}
+
+async function generateNixmacSettings({ host, configDir, vllmApiBaseUrl, vllmApiKey }) {
+  const settings = {
+    hostAttr: host,
+    configDir,
+    vllmApiBaseUrl: vllmApiBaseUrl ?? null,
+    vllmApiKey: vllmApiKey ?? null,
+    evolveProvider: 'vllm',
+    summaryProvider: 'vllm',
+  };
+
+  await mkdir(path.dirname(NIXMAC_SETTINGS_PATH), { recursive: true });
+  await writeFile(NIXMAC_SETTINGS_PATH, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
+  console.log(`[wdio:test-env] Generated settings at ${NIXMAC_SETTINGS_PATH}`);
+}
+
+async function readJsonFileOrThrow(filePath, label) {
+  if (!(await pathExists(filePath))) {
+    throw new Error(`[wdio:test-env] ${label} file not found at ${filePath}`);
+  }
+
+  const raw = await readFile(filePath, 'utf-8');
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `[wdio:test-env] Failed to parse ${label} JSON at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export async function loadEvolveState() {
+  if (!(await pathExists(NIXMAC_EVOLVE_STATE_PATH))) {
+    console.log(`[wdio:test-env] No evolve-state file found at ${NIXMAC_EVOLVE_STATE_PATH}`);
+    return null;
+  }
+
+  const parsed = await readJsonFileOrThrow(NIXMAC_EVOLVE_STATE_PATH, 'evolve-state');
+  if (parsed == null) return null;
+  return parsed.evolveState ?? parsed;
+}
+
+export async function loadBuildState() {
+  if (!(await pathExists(NIXMAC_BUILD_STATE_PATH))) {
+    console.log(`[wdio:test-env] No build-state file found at ${NIXMAC_BUILD_STATE_PATH}`);
+    return null;
+  }
+
+  const parsed = await readJsonFileOrThrow(NIXMAC_BUILD_STATE_PATH, 'build-state');
+  if (parsed == null) return null;
+  return parsed.buildState ?? parsed;
+}
+
+export async function getConfigRepoGitDiff({ format = 'structured' } = {}) {
+  const settings = await readJsonFileOrThrow(NIXMAC_SETTINGS_PATH, 'settings');
+  const repoDir = settings?.configDir;
+
+  if (!repoDir) {
+    throw new Error('[wdio:test-env] settings.configDir is missing; initializeConfigRepo may be disabled');
+  }
+
+  const [{ stdout: rawDiff }, { stdout: nameStatus }] = await Promise.all([
+    execFileAsync('git', ['diff', '--'], { cwd: repoDir }),
+    execFileAsync('git', ['diff', '--name-status', '--'], { cwd: repoDir }),
+  ]);
+
+  if (format === 'raw') {
+    return rawDiff;
+  }
+
+  const files = nameStatus
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [status, ...pathParts] = line.split(/\s+/);
+      return {
+        status,
+        path: pathParts.join(' '),
+      };
+    });
+
+  return {
+    repoDir,
+    raw: rawDiff,
+    files,
+  };
+}
+
+async function runGit(args, cwd) {
+  await execFileAsync('git', args, { cwd });
+}
+
+async function createNixConfigGitRepo(hostname) {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'nix-config-'));
+  console.log(`[wdio:test-env] Creating temporary config repo at ${tmpDir}`);
+  await cp(CONFIG_TEMPLATE_DIR, tmpDir, { recursive: true });
+
+  const username = getCurrentUsername();
+  const nixFiles = await listNixFiles(tmpDir);
+  for (const nixFile of nixFiles) {
+    const content = await readFile(nixFile, 'utf-8');
+    const updated = content
+      .replaceAll('HOSTNAME_PLACEHOLDER', hostname)
+      .replaceAll('USERNAME_PLACEHOLDER', username)
+      .replaceAll('PLATFORM_PLACEHOLDER', 'aarch64-darwin');
+
+    if (updated !== content) {
+      await writeFile(nixFile, updated, 'utf-8');
+    }
+  }
+
+  await writeFile(path.join(tmpDir, '.gitignore'), 'flake.lock\n', 'utf-8');
+
+  await runGit(['init'], tmpDir);
+  await runGit(['config', 'user.name', 'eval'], tmpDir);
+  await runGit(['config', 'user.email', 'eval@test'], tmpDir);
+  await runGit(['add', '-A'], tmpDir);
+  await runGit(['commit', '-m', 'initial nix config state', '--author', 'eval <eval@test>'], tmpDir);
+  await runGit(['update-index', '--refresh'], tmpDir);
+
+  console.log(`[wdio:test-env] Initialized git repo for test config at ${tmpDir}`);
+
+  return tmpDir;
+}
+
+export async function setupNixmacTestEnvironment(options = {}) {
+  const {
+    initializeConfigRepo = false,
+    host,
+    vllmApiBaseUrl = process.env.VLLM_API_BASE_URL ?? null,
+    vllmApiKey = process.env.VLLM_API_KEY ?? null,
+  } = options;
+
+  const backupPath = await backupNixmacSettings();
+  const evolveBackupPath = await backupJsonState(NIXMAC_EVOLVE_STATE_PATH, 'evolve-state');
+  const buildBackupPath = await backupJsonState(NIXMAC_BUILD_STATE_PATH, 'build-state');
+  const evalHostname = host || (await getEvalHostname());
+  let configDir = null;
+
+  if (initializeConfigRepo) {
+    configDir = await createNixConfigGitRepo(evalHostname);
+  } else {
+    console.log('[wdio:test-env] Skipping temp git repo initialization (initializeConfigRepo=false)');
+  }
+
+  await generateNixmacSettings({ host: evalHostname, configDir, vllmApiBaseUrl, vllmApiKey });
+
+  // Clear any existing evolve/build state so tests start from a clean slate
+  if (await pathExists(NIXMAC_EVOLVE_STATE_PATH)) {
+    await unlink(NIXMAC_EVOLVE_STATE_PATH);
+    console.log(`[wdio:test-env] Cleared existing evolve-state at ${NIXMAC_EVOLVE_STATE_PATH}`);
+  }
+
+  if (await pathExists(NIXMAC_BUILD_STATE_PATH)) {
+    await unlink(NIXMAC_BUILD_STATE_PATH);
+    console.log(`[wdio:test-env] Cleared existing build-state at ${NIXMAC_BUILD_STATE_PATH}`);
+  }
+
+  return {
+    backupPath,
+    evolveBackupPath,
+    buildBackupPath,
+    configDir,
+    hostAttr: evalHostname,
+  };
+}
+
+export async function teardownNixmacTestEnvironment(context) {
+  if (context?.configDir) {
+    console.log(`[wdio:test-env] Removing temporary config repo: ${context.configDir}`);
+    await rm(context.configDir, { recursive: true, force: true });
+  }
+
+  await restoreNixmacSettings(context?.backupPath ?? null);
+  await restoreJsonState(context?.evolveBackupPath ?? null, NIXMAC_EVOLVE_STATE_PATH, 'evolve-state');
+  await restoreJsonState(context?.buildBackupPath ?? null, NIXMAC_BUILD_STATE_PATH, 'build-state');
+}

--- a/apps/native/e2e-tauri/tests/wdio/helpers/test-env.mjs
+++ b/apps/native/e2e-tauri/tests/wdio/helpers/test-env.mjs
@@ -63,6 +63,16 @@ function getCurrentUsername() {
   }
 }
 
+/**
+ * Return a platform triple for templates, e.g. "aarch64-darwin".
+ */
+function getPlatformTriple() {
+  const archMap = { arm64: 'aarch64', x64: 'x86_64' };
+  const arch = archMap[process.arch] ?? process.arch;
+  const platform = process.platform; // 'darwin' etc.
+  return `${arch}-${platform}`;
+}
+
 async function listNixFiles(dirPath) {
   const entries = await readdir(dirPath, { withFileTypes: true });
   const files = [];
@@ -236,12 +246,13 @@ async function createNixConfigGitRepo(hostname) {
 
   const username = getCurrentUsername();
   const nixFiles = await listNixFiles(tmpDir);
+  const platformTriple = getPlatformTriple();
   for (const nixFile of nixFiles) {
     const content = await readFile(nixFile, 'utf-8');
     const updated = content
       .replaceAll('HOSTNAME_PLACEHOLDER', hostname)
       .replaceAll('USERNAME_PLACEHOLDER', username)
-      .replaceAll('PLATFORM_PLACEHOLDER', 'aarch64-darwin');
+      .replaceAll('PLATFORM_PLACEHOLDER', platformTriple);
 
     if (updated !== content) {
       await writeFile(nixFile, updated, 'utf-8');

--- a/apps/native/e2e-tauri/tests/wdio/modify.spec.mjs
+++ b/apps/native/e2e-tauri/tests/wdio/modify.spec.mjs
@@ -1,0 +1,26 @@
+import {
+  assertPromptHistoryContains,
+  assertPromptFlowReachedEvolveReview,
+  submitPromptMessage,
+  waitForEvolveProcessingCycle,
+  waitForFirstWindow,
+} from './helpers/app-ui.mjs';
+
+describe('modify', () => {
+  it('submits sequential prompts on the evolve review screen', async () => {
+    const firstPrompt = 'add a new programming font to my system';
+    const secondPrompt = 'also add a cursive font';
+
+    await waitForFirstWindow();
+
+    await submitPromptMessage(firstPrompt);
+    await waitForEvolveProcessingCycle();
+    await assertPromptHistoryContains(firstPrompt);
+    await assertPromptFlowReachedEvolveReview();
+
+    await submitPromptMessage(secondPrompt);
+    await waitForEvolveProcessingCycle();
+    await assertPromptHistoryContains(secondPrompt);
+    await assertPromptFlowReachedEvolveReview();
+  });
+});

--- a/apps/native/e2e-tauri/wdio.basic-prompts.conf.mjs
+++ b/apps/native/e2e-tauri/wdio.basic-prompts.conf.mjs
@@ -1,0 +1,6 @@
+import { createWdioConfig } from './wdio.conf.base.mjs';
+
+export const config = createWdioConfig({
+  specs: ['./tests/wdio/basic-prompts.spec.mjs'],
+  setupOptions: { initializeConfigRepo: true },
+});

--- a/apps/native/e2e-tauri/wdio.conf.base.mjs
+++ b/apps/native/e2e-tauri/wdio.conf.base.mjs
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  setupNixmacTestEnvironment,
+  teardownNixmacTestEnvironment,
+} from './tests/wdio/helpers/test-env.mjs';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const APPS_NATIVE_DIR = path.resolve(THIS_DIR, '..');
+
+/**
+ * Create a WDIO config for a specific test suite.
+ *
+ * @param {object} opts
+ * @param {string | string[]} opts.specs  - glob(s) for spec files, relative to apps/native/e2e-tauri/
+ * @param {object} [opts.setupOptions]    - options forwarded to setupNixmacTestEnvironment
+ */
+export function createWdioConfig({ specs, setupOptions = {} }) {
+  let testEnvironment;
+
+  const resolvedSpecs = (Array.isArray(specs) ? specs : [specs]).map((s) =>
+    path.resolve(THIS_DIR, s),
+  );
+
+  return {
+    runner: 'local',
+    port: 4444,
+    connectionRetryCount: 10,
+    connectionRetryTimeout: 120000,
+    waitforTimeout: 45000,
+    specs: resolvedSpecs,
+    maxInstances: 1,
+    capabilities: [
+      {
+        'tauri:options': {
+          binary: path.resolve(APPS_NATIVE_DIR, '../../target/debug/nixmac'),
+        },
+      },
+    ],
+    logLevel: 'info',
+    framework: 'mocha',
+    reporters: ['spec'],
+    mochaOpts: {
+      ui: 'bdd',
+      timeout: 120000,
+    },
+    async onPrepare() {
+      testEnvironment = await setupNixmacTestEnvironment(setupOptions);
+    },
+    async onComplete() {
+      await teardownNixmacTestEnvironment(testEnvironment);
+    },
+  };
+}

--- a/apps/native/e2e-tauri/wdio.discard.conf.mjs
+++ b/apps/native/e2e-tauri/wdio.discard.conf.mjs
@@ -1,0 +1,6 @@
+import { createWdioConfig } from './wdio.conf.base.mjs';
+
+export const config = createWdioConfig({
+  specs: ['./tests/wdio/discard.spec.mjs'],
+  setupOptions: { initializeConfigRepo: true },
+});

--- a/apps/native/e2e-tauri/wdio.modify.conf.mjs
+++ b/apps/native/e2e-tauri/wdio.modify.conf.mjs
@@ -1,0 +1,6 @@
+import { createWdioConfig } from './wdio.conf.base.mjs';
+
+export const config = createWdioConfig({
+  specs: ['./tests/wdio/modify.spec.mjs'],
+  setupOptions: { initializeConfigRepo: true },
+});

--- a/apps/native/e2e-tauri/wdio.smoke.conf.mjs
+++ b/apps/native/e2e-tauri/wdio.smoke.conf.mjs
@@ -1,0 +1,6 @@
+import { createWdioConfig } from './wdio.conf.base.mjs';
+
+export const config = createWdioConfig({
+  specs: ['./tests/wdio/smoke.spec.mjs'],
+  setupOptions: { initializeConfigRepo: true },
+});

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -29,7 +29,12 @@
     "test:e2e:report": "playwright show-report",
     "test:e2e:install": "playwright install --with-deps chromium",
     "test:e2e:ui:app": "playwright test --ui",
-    "test:wdio": "wdio run wdio.conf.mjs"
+    "test:wdio:services": "process-compose -f e2e-tauri/process-compose.yaml up",
+    "test:wdio": "wdio run wdio.conf.mjs",
+    "test:wdio:smoke": "wdio run e2e-tauri/wdio.smoke.conf.mjs",
+    "test:wdio:basic-prompts": "wdio run e2e-tauri/wdio.basic-prompts.conf.mjs",
+    "test:wdio:discard": "wdio run e2e-tauri/wdio.discard.conf.mjs",
+    "test:wdio:modify": "wdio run e2e-tauri/wdio.modify.conf.mjs"
   },
   "dependencies": {
     "@distilled.cloud/neon": "^0.7.12",
@@ -146,8 +151,12 @@
     "@wdio/mocha-framework": "^9.27.0",
     "@wdio/spec-reporter": "^9.27.0",
     "autoprefixer": "^10.4.22",
+    "chai": "^6.2.2",
+    "chai-as-promised": "^8.0.2",
     "clsx": "^2.1.1",
+    "eslint-plugin-chai-friendly": "^1.2.0",
     "eslint-plugin-storybook": "^0.11.6",
+    "expect-webdriverio": "^5.6.5",
     "jsdom": "^27.3.0",
     "playwright": "^1.57.0",
     "postcss": "^8.5.6",

--- a/apps/native/src/components/widget/confirmation-dialog.tsx
+++ b/apps/native/src/components/widget/confirmation-dialog.tsx
@@ -74,12 +74,14 @@ export function ConfirmationDialog({
             variant="outline"
             onClick={() => onOpenChange(false)}
             className="border-border/50 hover:border-border"
+            data-testid="confirm-dialog-cancel"
           >
             Cancel
           </Button>
           <Button
             onClick={handleConfirm}
             className={cn("border-2", colors.buttonBg, colors.buttonBorder)}
+            data-testid="confirm-dialog-confirm"
           >
             Confirm
           </Button>

--- a/apps/native/src/components/widget/error-message.tsx
+++ b/apps/native/src/components/widget/error-message.tsx
@@ -47,7 +47,10 @@ export function ErrorMessage() {
   const showSettingsCta = error.includes("API key");
 
   return (
-    <div className="mx-auto max-w-2xl rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400">
+    <div
+      data-testid="widget-error-message"
+      className="mx-auto max-w-2xl rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400"
+    >
       <div className="whitespace-pre-wrap break-words">{error}</div>
       <div className="mt-2 flex items-center gap-3">
         {showSettingsCta && (

--- a/apps/native/src/components/widget/prompt-input.tsx
+++ b/apps/native/src/components/widget/prompt-input.tsx
@@ -58,6 +58,8 @@ export function PromptInput() {
       <BeginEvolveWarning open={warningOpen} onOpenChange={setWarningOpen} handleEvolve={handleEvolve} />
       <InputGroup>
         <InputGroupTextarea
+          id="evolve-prompt-input"
+          data-testid="evolve-prompt-input"
           disabled={isLoading}
           onChange={(e) => setEvolvePrompt(e.target.value)}
           onKeyDown={(e) => {
@@ -98,6 +100,8 @@ export function PromptInput() {
           <InputGroupText className="ml-auto">{contextUsage}</InputGroupText>
           {/* <Separator className="!h-4" orientation="vertical" /> */}
           <InputGroupButton
+            id="evolve-prompt-send"
+            data-testid="evolve-prompt-send"
             className="rounded-full"
             disabled={isLoading || !evolvePrompt.trim()}
             onClick={handleSubmit}

--- a/apps/native/src/components/widget/steps/evolve-step.tsx
+++ b/apps/native/src/components/widget/steps/evolve-step.tsx
@@ -29,6 +29,7 @@ export function EvolveStep() {
           onConfirm={handleRollback}
           message="Discard all current changes?"
           color="amber"
+          data-testid="evolve-discard-button"
         >
           <Eraser className="h-3.5 w-3.5" />
           Discard

--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -37,6 +37,7 @@ import { useSummary } from "@/hooks/use-summary";
 import { useCurrentStep, useWidgetStore } from "@/stores/widget-store";
 import { UpdateBanner } from "@/components/update-banner";
 import { setupErrorTestHelpers } from "@/utils/error-test-helpers";
+import { setupWidgetTestHelpers } from "@/utils/widget-test-helpers";
 import { useEffect } from "react";
 
 /**
@@ -63,10 +64,11 @@ export function DarwinWidget() {
   // Set up error handler to catch unhandled JavaScript errors and promise rejections
   useErrorHandler();
 
-  // Set up test helpers for error handlers (development only)
+  // Set up test helpers for error handlers and widget store (development only)
   useEffect(() => {
     if (import.meta.env.DEV) {
       setupErrorTestHelpers();
+      setupWidgetTestHelpers();
     }
   }, []);
 

--- a/apps/native/src/utils/widget-test-helpers.ts
+++ b/apps/native/src/utils/widget-test-helpers.ts
@@ -1,0 +1,48 @@
+/**
+ * Dev-only test helpers for driving the widget store from e2e tests.
+ * Exposed on window.__testWidget so WDIO tests can call them via browser.execute.
+ */
+
+import { useWidgetStore } from "@/stores/widget-store";
+
+export interface WidgetTestHelpers {
+  /**
+   * Set the evolve prompt input value directly via the store,
+   * bypassing the React event system.
+   * Usage: window.__testWidget.setEvolvePrompt("my prompt")
+   */
+  setEvolvePrompt: (value: string) => void;
+  /**
+   * True while an evolve action is actively processing.
+   */
+  isEvolveProcessing: () => boolean;
+  /**
+   * Current prompt history from the store.
+   */
+  getPromptHistory: () => string[];
+}
+
+export function setupWidgetTestHelpers() {
+  if (typeof window === "undefined") return;
+
+  const helpers: WidgetTestHelpers = {
+    setEvolvePrompt: (value: string) => {
+      useWidgetStore.getState().setEvolvePrompt(value);
+    },
+    isEvolveProcessing: () => {
+      const state = useWidgetStore.getState();
+      return state.isProcessing && state.processingAction === "evolve";
+    },
+    getPromptHistory: () => {
+      return [...(useWidgetStore.getState().promptHistory ?? [])];
+    },
+  };
+
+  window.__testWidget = helpers;
+}
+
+declare global {
+  interface Window {
+    __testWidget?: WidgetTestHelpers;
+  }
+}

--- a/apps/native/wdio.conf.mjs
+++ b/apps/native/wdio.conf.mjs
@@ -1,23 +1,9 @@
-export const config = {
-  runner: 'local',
-  port: 4444,
-  connectionRetryCount: 10,
-  connectionRetryTimeout: 120000,
-  waitforTimeout: 45000,
-  specs: ['./e2e-tauri/tests/wdio/**/*.spec.mjs'],
-  maxInstances: 1,
-  capabilities: [
-    {
-      'tauri:options': {
-        binary: '../../target/debug/nixmac',
-      },
-    },
-  ],
-  logLevel: 'info',
-  framework: 'mocha',
-  reporters: ['spec'],
-  mochaOpts: {
-    ui: 'bdd',
-    timeout: 120000,
-  },
-};
+import { createWdioConfig } from './e2e-tauri/wdio.conf.base.mjs';
+
+// Runs all suites. Uses initializeConfigRepo: true as the superset of
+// requirements across all specs.
+export const config = createWdioConfig({
+  specs: ['./tests/wdio/**/*.spec.mjs'],
+  setupOptions: { initializeConfigRepo: true },
+});
+

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@types/bun": "latest",
         "bun2nix": "^2.0.6",
         "danger": "^12.3.3",
+        "eslint-plugin-chai-friendly": "^1.2.0",
         "oxlint": "^1.0.0",
         "release-it": "^19.0.3",
         "typescript": "^5",
@@ -133,8 +134,12 @@
         "@wdio/mocha-framework": "^9.27.0",
         "@wdio/spec-reporter": "^9.27.0",
         "autoprefixer": "^10.4.22",
+        "chai": "^6.2.2",
+        "chai-as-promised": "^8.0.2",
         "clsx": "^2.1.1",
+        "eslint-plugin-chai-friendly": "^1.2.0",
         "eslint-plugin-storybook": "^0.11.6",
+        "expect-webdriverio": "^5.6.5",
         "jsdom": "^27.3.0",
         "playwright": "^1.57.0",
         "postcss": "^8.5.6",
@@ -1087,7 +1092,7 @@
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
 
@@ -1117,7 +1122,7 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -1155,7 +1160,9 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chai-as-promised": ["chai-as-promised@8.0.2", "", { "dependencies": { "check-error": "^2.1.1" }, "peerDependencies": { "chai": ">= 2.1.2 < 7" } }, "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw=="],
 
     "chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -1365,6 +1372,8 @@
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
+    "eslint-plugin-chai-friendly": ["eslint-plugin-chai-friendly@1.2.0", "", { "peerDependencies": { "eslint": ">=3.0.0" } }, "sha512-um2pBb4ZXNCoTRPRAWiUaXeIaw1dRaPOEZ+G/qcZqfyTdkCXXwOBctnfnbIRbZiQf4AXl3ImV1grt423SlK+mg=="],
+
     "eslint-plugin-storybook": ["eslint-plugin-storybook@0.11.6", "", { "dependencies": { "@storybook/csf": "^0.1.11", "@typescript-eslint/utils": "^8.8.1", "ts-dedent": "^2.2.0" }, "peerDependencies": { "eslint": ">=8" } }, "sha512-3WodYD6Bs9ACqnB+TP2TuLh774c/nacAjxSKOP9bHJ2c8rf+nrhocxjjeAWNmO9IPkFIzTKlcl0vNXI2yYpVOw=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
@@ -1449,7 +1458,7 @@
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
-    "find-up": ["find-up@6.3.0", "", { "dependencies": { "locate-path": "^7.1.0", "path-exists": "^5.0.0" } }, "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw=="],
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
 
@@ -1717,7 +1726,7 @@
 
     "locate-app": ["locate-app@2.5.0", "", { "dependencies": { "@promptbook/utils": "0.69.5", "type-fest": "4.26.0", "userhome": "1.0.1" } }, "sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q=="],
 
-    "locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
@@ -1825,7 +1834,7 @@
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -1937,7 +1946,7 @@
 
     "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
@@ -1975,7 +1984,7 @@
 
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
-    "path-exists": ["path-exists@5.0.0", "", {}, "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="],
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
@@ -2485,7 +2494,7 @@
 
     "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
 
-    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
@@ -2516,10 +2525,6 @@
     "@distilled.cloud/neon/effect": ["effect@4.0.0-beta.43", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-AJYyDimIwJOn87uUz/JzmgDc5GfjxJbXvEbTvNzMa+M3Uer344bLo/O5mMRkqc1vBleA+Ygs4+dbE3QsqOkKTQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -2653,6 +2658,8 @@
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@typescript-eslint/typescript-estree/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
@@ -2662,6 +2669,8 @@
     "@vitest/browser/@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@vitest/expect/@vitest/utils": ["@vitest/utils@2.0.5", "", { "dependencies": { "@vitest/pretty-format": "2.0.5", "estree-walker": "^3.0.3", "loupe": "^3.1.1", "tinyrainbow": "^1.2.0" } }, "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ=="],
+
+    "@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "@vitest/expect/tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
 
@@ -2763,10 +2772,6 @@
 
     "eslint/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
-
-    "eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "expect-webdriverio/@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
 
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -2780,6 +2785,8 @@
     "geckodriver/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "giget/citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -2823,8 +2830,6 @@
 
     "mocha/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "mocha/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
-
     "mocha/glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
 
     "mocha/log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
@@ -2855,7 +2860,7 @@
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
+    "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "pac-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -2887,11 +2892,11 @@
 
     "read-pkg/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
+    "read-pkg-up/find-up": ["find-up@6.3.0", "", { "dependencies": { "locate-path": "^7.1.0", "path-exists": "^5.0.0" } }, "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw=="],
+
     "read-pkg-up/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
-
-    "recursive-readdir/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -2935,6 +2940,8 @@
 
     "test-exclude/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
+    "test-exclude/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "trpc-cli/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "ts-node/arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
@@ -2952,6 +2959,8 @@
     "vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
 
     "vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "vitest/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "vitest/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
@@ -3000,10 +3009,6 @@
     "@distilled.cloud/neon/effect/fast-check": ["fast-check@4.6.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA=="],
 
     "@distilled.cloud/neon/effect/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
-
-    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -3057,6 +3062,8 @@
 
     "@storybook/test/@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
     "@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@2.0.5", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ=="],
 
     "@vitest/expect/@vitest/utils/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
@@ -3109,12 +3116,6 @@
 
     "eslint/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "eslint/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "eslint/find-up/path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
-
-    "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
-
     "expect-webdriverio/@vitest/snapshot/@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
 
     "expect-webdriverio/@vitest/snapshot/@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
@@ -3124,6 +3125,8 @@
     "geckodriver/http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "geckodriver/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "istanbul-lib-report/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -3175,10 +3178,6 @@
 
     "mocha/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
-    "mocha/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "mocha/find-up/path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
-
     "mocha/log-symbols/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "mocha/log-symbols/is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
@@ -3195,13 +3194,15 @@
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "read-pkg-up/find-up/locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
+
+    "read-pkg-up/find-up/path-exists": ["path-exists@5.0.0", "", {}, "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="],
+
     "read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 
     "read-pkg/normalize-package-data/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
-
-    "recursive-readdir/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "release-it/@octokit/rest/@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
 
@@ -3212,6 +3213,8 @@
     "release-it/@octokit/rest/@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
 
     "release-it/async-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "storybook/@vitest/spy/tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
@@ -3224,6 +3227,8 @@
     "test-exclude/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "test-exclude/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "test-exclude/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "vitest/@vitest/spy/tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
@@ -3261,10 +3266,6 @@
 
     "@distilled.cloud/neon/effect/fast-check/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
-    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
     "@jest/types/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "@jest/types/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -3276,6 +3277,8 @@
     "@storybook/test/@testing-library/jest-dom/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@storybook/test/@testing-library/jest-dom/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@wdio/config/glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
@@ -3299,15 +3302,11 @@
 
     "eslint/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "eslint/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
-
-    "eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
     "expect-webdriverio/@vitest/snapshot/@vitest/pretty-format/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "expect-webdriverio/@vitest/snapshot/@vitest/utils/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
-    "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "jest-diff/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -3345,13 +3344,9 @@
 
     "mocha/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "mocha/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
-
     "mocha/log-symbols/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "mocha/log-symbols/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "mocha/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "mocha/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -3359,11 +3354,9 @@
 
     "mocha/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
+
     "read-pkg/normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "readdir-glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "recursive-readdir/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "release-it/@octokit/rest/@octokit/core/@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -3389,6 +3382,8 @@
 
     "test-exclude/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "wait-port/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "wait-port/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -3411,15 +3406,9 @@
 
     "@storybook/test/@testing-library/jest-dom/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "@wdio/config/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
     "cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "eslint/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "eslint/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "jest-diff/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
@@ -3437,13 +3426,13 @@
 
     "memfs-or-file-map-to-github-branch/@octokit/rest/@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
-    "mocha/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
     "mocha/log-symbols/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "mocha/log-symbols/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "mocha/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
     "release-it/@octokit/rest/@octokit/core/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
 
@@ -3453,21 +3442,17 @@
 
     "release-it/@octokit/rest/@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
-    "test-exclude/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
     "wait-port/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "@storybook/test/@testing-library/dom/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "@storybook/test/@testing-library/jest-dom/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "eslint/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "mocha/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
     "mocha/log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "mocha/yargs/cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "read-pkg-up/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "mocha/yargs/cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
   }

--- a/bun.nix
+++ b/bun.nix
@@ -2225,9 +2225,17 @@
     url = "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz";
     hash = "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==";
   };
+  "chai-as-promised@8.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.2.tgz";
+    hash = "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==";
+  };
   "chai@5.3.3" = fetchurl {
     url = "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz";
     hash = "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==";
+  };
+  "chai@6.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz";
+    hash = "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==";
   };
   "chalk@2.4.2" = fetchurl {
     url = "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz";
@@ -2728,6 +2736,10 @@
   "escodegen@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz";
     hash = "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==";
+  };
+  "eslint-plugin-chai-friendly@1.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.2.0.tgz";
+    hash = "sha512-um2pBb4ZXNCoTRPRAWiUaXeIaw1dRaPOEZ+G/qcZqfyTdkCXXwOBctnfnbIRbZiQf4AXl3ImV1grt423SlK+mg==";
   };
   "eslint-plugin-storybook@0.11.6" = fetchurl {
     url = "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.11.6.tgz";

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/bun": "latest",
     "bun2nix": "^2.0.6",
     "danger": "^12.3.3",
+    "eslint-plugin-chai-friendly": "^1.2.0",
     "oxlint": "^1.0.0",
     "release-it": "^19.0.3",
     "typescript": "^5",


### PR DESCRIPTION
## Summary

Some real WebDriver testing beyond the previous POC:

- Created new test files for basic prompts, discard functionality, and modify prompts in the e2e tests.
- Implemented helper functions for test environment setup and teardown in `helpers/test-env.mjs`.
- Added widget test helpers to facilitate interaction with the widget store during e2e tests.
- Established base WDIO configuration for various test suites, ensuring proper initialization of the test environment.
- Added some data-testid's to the system.

## Test Plan

I run the tests to test the tests.

## Docs

- [X] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [ ] No docs update needed
