### PR TITLE
feat(completion-log): implement debug logging for provider completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ bun run db:generate  # generate migrations
 
 - **darwin-rebuild logs:** `~/Library/Logs/nixmac/`
 - **App logs:** stdout/stderr (or set `NIXMAC_LOGFILE` for file output)
+- **Provider completion logs**: set NIXMAC_RECORD_COMPLETIONS for full provider completions
 
 ```bash
 # Merged tail of everything

--- a/apps/native/src-tauri/src/completion_log.rs
+++ b/apps/native/src-tauri/src/completion_log.rs
@@ -1,0 +1,84 @@
+use async_openai::types::CreateChatCompletionResponse;
+use chrono::Local;
+use log::{error, info};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Returns the daily-rotated JSONL path for the given prefix.
+///
+/// Files land in `~/Library/Application Support/nixmac/logs/{prefix}_YYYY-MM-DD.jsonl`.
+pub fn log_path_for_today(prefix: &str) -> PathBuf {
+    let date = Local::now().format("%Y-%m-%d");
+    dirs::data_local_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("nixmac")
+        .join("logs")
+        .join(format!("{prefix}_{date}.jsonl"))
+}
+
+/// Checks `NIXMAC_RECORD_COMPLETIONS`, ensures the log directory exists, and
+/// logs the target path. Returns `true` when recording should be enabled.
+pub fn init_recording(prefix: &str, label: &str) -> bool {
+    if std::env::var_os("NIXMAC_RECORD_COMPLETIONS").is_none() {
+        return false;
+    }
+
+    let path = log_path_for_today(prefix);
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            error!(
+                "Failed to create completion-recording log directory {}: {}",
+                parent.display(),
+                e
+            );
+            return false;
+        }
+    }
+
+    info!(
+        "NIXMAC_RECORD_COMPLETIONS is set; recording raw {label} completion JSONL to {} (daily rotated)",
+        path.display()
+    );
+    true
+}
+
+/// Appends a single serialized `CreateChatCompletionResponse` line to the
+/// daily JSONL file for `prefix`. No-ops when `record_completions` is false.
+pub fn append_jsonl(record_completions: bool, prefix: &str, response: &CreateChatCompletionResponse) {
+    if !record_completions {
+        return;
+    }
+
+    let path = log_path_for_today(prefix);
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            error!(
+                "Failed to create completion-recording log directory {}: {}",
+                parent.display(),
+                e
+            );
+            return;
+        }
+    }
+
+    let line = match serde_json::to_string(response) {
+        Ok(json) => json,
+        Err(e) => {
+            error!("Failed to serialize provider response for JSONL recording: {}", e);
+            return;
+        }
+    };
+
+    let mut file = match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(file) => file,
+        Err(e) => {
+            error!("Failed to open completion-recording file {}: {}", path.display(), e);
+            return;
+        }
+    };
+
+    if let Err(e) = writeln!(file, "{}", line) {
+        error!("Failed to append completion JSONL to {}: {}", path.display(), e);
+    }
+}

--- a/apps/native/src-tauri/src/completion_log.rs
+++ b/apps/native/src-tauri/src/completion_log.rs
@@ -4,10 +4,12 @@ use log::{error, info};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
+use tokio::task::spawn_blocking;
 
 /// Returns the daily-rotated JSONL path for the given prefix.
 ///
-/// Files land in `~/Library/Application Support/nixmac/logs/{prefix}_YYYY-MM-DD.jsonl`.
+/// Files land in `~/Library/Application Support/nixmac/logs/{prefix}_YYYY-MM-DD.jsonl`
+/// on a Mac.
 pub fn log_path_for_today(prefix: &str) -> PathBuf {
     let date = Local::now().format("%Y-%m-%d");
     dirs::data_local_dir()
@@ -37,7 +39,7 @@ pub fn init_recording(prefix: &str, label: &str) -> bool {
     }
 
     info!(
-        "NIXMAC_RECORD_COMPLETIONS is set; recording raw {label} completion JSONL to {} (daily rotated)",
+        "NIXMAC_RECORD_COMPLETIONS is set; recording raw {label} completion JSONL to {}",
         path.display()
     );
     true
@@ -45,40 +47,45 @@ pub fn init_recording(prefix: &str, label: &str) -> bool {
 
 /// Appends a single serialized `CreateChatCompletionResponse` line to the
 /// daily JSONL file for `prefix`. No-ops when `record_completions` is false.
-pub fn append_jsonl(record_completions: bool, prefix: &str, response: &CreateChatCompletionResponse) {
+///
+/// The write is dispatched to a blocking thread via `spawn_blocking` so the
+/// Tokio runtime is not stalled. Each append serializes to a single
+/// newline-terminated buffer and writes it with `write_all`, which issues one
+/// `write(2)` syscall. Combined with `O_APPEND`, this makes each line
+/// effectively atomic for the typical response sizes seen here.
+pub async fn append_jsonl(
+    record_completions: bool,
+    prefix: &str,
+    response: &CreateChatCompletionResponse,
+) {
     if !record_completions {
         return;
-    }
-
-    let path = log_path_for_today(prefix);
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            error!(
-                "Failed to create completion-recording log directory {}: {}",
-                parent.display(),
-                e
-            );
-            return;
-        }
     }
 
     let line = match serde_json::to_string(response) {
         Ok(json) => json,
         Err(e) => {
-            error!("Failed to serialize provider response for JSONL recording: {}", e);
+            error!(
+                "Failed to serialize provider response for JSONL recording: {}",
+                e
+            );
             return;
         }
     };
 
-    let mut file = match OpenOptions::new().create(true).append(true).open(&path) {
-        Ok(file) => file,
-        Err(e) => {
-            error!("Failed to open completion-recording file {}: {}", path.display(), e);
-            return;
-        }
-    };
+    let path = log_path_for_today(prefix);
+    // Build the complete line buffer before entering spawn_blocking.
+    let buf = format!("{line}\n").into_bytes();
 
-    if let Err(e) = writeln!(file, "{}", line) {
-        error!("Failed to append completion JSONL to {}: {}", path.display(), e);
+    if let Err(e) = spawn_blocking(move || -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        file.write_all(&buf)
+    })
+    .await
+    {
+        error!("Failed to append completion JSONL for prefix '{prefix}': {e}");
     }
 }

--- a/apps/native/src-tauri/src/evolve/providers/openai.rs
+++ b/apps/native/src-tauri/src/evolve/providers/openai.rs
@@ -20,6 +20,7 @@ use reqwest::StatusCode;
 pub struct OpenAIProvider {
     client: Client<OpenAIConfig>,
     model: String,
+    record_completions: bool,
 }
 
 impl OpenAIProvider {
@@ -28,7 +29,13 @@ impl OpenAIProvider {
             .with_api_key(api_key)
             .with_api_base(api_base);
         let client = Client::with_config(config);
-        Self { client, model }
+        let record_completions =
+            crate::completion_log::init_recording("evolve_provider_completions", "evolve provider");
+        Self {
+            client,
+            model,
+            record_completions,
+        }
     }
 }
 
@@ -69,6 +76,12 @@ impl AiProvider for OpenAIProvider {
             .create(request)
             .await
             .map_err(normalize_openai_error)?;
+
+        crate::completion_log::append_jsonl(
+            self.record_completions,
+            "evolve_provider_completions",
+            &response,
+        );
 
         let choice = response
             .choices

--- a/apps/native/src-tauri/src/evolve/providers/openai.rs
+++ b/apps/native/src-tauri/src/evolve/providers/openai.rs
@@ -81,7 +81,8 @@ impl AiProvider for OpenAIProvider {
             self.record_completions,
             "evolve_provider_completions",
             &response,
-        );
+        )
+        .await;
 
         let choice = response
             .choices

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -9,6 +9,7 @@
 
 mod apply_system_defaults;
 mod build_state;
+mod completion_log;
 mod changes_from_diff;
 mod cli;
 mod commands;

--- a/apps/native/src-tauri/src/providers/openai.rs
+++ b/apps/native/src-tauri/src/providers/openai.rs
@@ -95,7 +95,8 @@ impl ChatCompletionProvider for OpenAIClient {
             self.record_completions,
             "summary_provider_completions",
             &response,
-        );
+        )
+        .await;
         let usage = TokenUsage {
             input: response.usage.as_ref().map(|u| u.prompt_tokens),
             output: response.usage.as_ref().map(|u| u.completion_tokens),
@@ -155,7 +156,8 @@ impl ChatCompletionProvider for OpenAIClient {
             self.record_completions,
             "summary_provider_completions",
             &response,
-        );
+        )
+        .await;
         let usage = TokenUsage {
             input: response.usage.as_ref().map(|u| u.prompt_tokens),
             output: response.usage.as_ref().map(|u| u.completion_tokens),

--- a/apps/native/src-tauri/src/providers/openai.rs
+++ b/apps/native/src-tauri/src/providers/openai.rs
@@ -29,6 +29,7 @@ fn normalize_completion_error(e: OpenAIError) -> anyhow::Error {
 pub struct OpenAIClient {
     client: Client<OpenAIConfig>,
     model: String,
+    record_completions: bool,
 }
 
 impl OpenAIClient {
@@ -37,9 +38,14 @@ impl OpenAIClient {
             .with_api_key(api_key)
             .with_api_base(base_url);
         let client = Client::with_config(config);
+        let record_completions = crate::completion_log::init_recording(
+            "summary_provider_completions",
+            "summary provider",
+        );
         Self {
             client,
             model: model.to_string(),
+            record_completions,
         }
     }
 }
@@ -85,11 +91,15 @@ impl ChatCompletionProvider for OpenAIClient {
             .create(request)
             .await
             .map_err(normalize_completion_error)?;
+        crate::completion_log::append_jsonl(
+            self.record_completions,
+            "summary_provider_completions",
+            &response,
+        );
         let usage = TokenUsage {
             input: response.usage.as_ref().map(|u| u.prompt_tokens),
             output: response.usage.as_ref().map(|u| u.completion_tokens),
         };
-
         Ok((
             response
                 .choices
@@ -141,6 +151,11 @@ impl ChatCompletionProvider for OpenAIClient {
             .create(request)
             .await
             .map_err(normalize_completion_error)?;
+        crate::completion_log::append_jsonl(
+            self.record_completions,
+            "summary_provider_completions",
+            &response,
+        );
         let usage = TokenUsage {
             input: response.usage.as_ref().map(|u| u.prompt_tokens),
             output: response.usage.as_ref().map(|u| u.completion_tokens),


### PR DESCRIPTION
## Summary

Env-var-triggered logging of raw(ish) chat completion responses. This is something I've wanted in the past for debugging, and now I'm going to use it to help with integration testing. The logs go in separate log files (by provider type, rotated by date) in the normal log location in JSONL format.

## Test Plan

Ran locally with and without the env var set.

## Docs

- [x] Docs updated
- [ ] No docs update needed
