### PR TITLE
fix(native): add validation per title description couple for summary …

### DIFF
--- a/apps/native/src-tauri/src/summarize/queue_summarizer.rs
+++ b/apps/native/src-tauri/src/summarize/queue_summarizer.rs
@@ -6,7 +6,7 @@
 //! ```
 //! The future returns once the queue is empty ("goes dormant").
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::Path;
 use tauri::{AppHandle, Emitter, Runtime};
 
@@ -35,6 +35,9 @@ pub async fn process<R: Runtime>(
     app: AppHandle<R>,
     db_path: std::path::PathBuf,
 ) -> Result<()> {
+    if let Some(ref specific_ids) = ids {
+        crate::summarize::sumlog::queue_log_started(specific_ids);
+    }
     let mut first_pass = true;
     loop {
         let items = {
@@ -59,21 +62,24 @@ pub async fn process<R: Runtime>(
             break;
         }
 
+        let mut passed = 0usize;
+        let mut retrying = 0usize;
         for item in &items {
-            process_item(item, &app, &db_path).await;
+            match try_process_item(item, &app, &db_path).await {
+                Ok(_) => passed += 1,
+                Err(e) => {
+                    log::warn!("[queue_summarizer] item {} error: {:#}", item.id, e);
+                    retrying += 1;
+                }
+            }
             emit_update(&app, &db_path);
         }
+        crate::summarize::sumlog::queue_log_done(passed, retrying);
     }
     Ok(())
 }
 
 // ── Per-item processing ───────────────────────────────────────────────────────
-
-async fn process_item<R: Runtime>(item: &QueuedSummary, app: &AppHandle<R>, db_path: &Path) {
-    if let Err(e) = try_process_item(item, app, db_path).await {
-        log::warn!("[queue_summarizer] item {} error: {:#}", item.id, e);
-    }
-}
 
 async fn try_process_item<R: Runtime>(
     item: &QueuedSummary,
@@ -101,8 +107,31 @@ async fn try_process_item<R: Runtime>(
 
     match item.summary_type.as_str() {
         "NEW_SINGLE" => handle_new_single(item, app, db_path, new_count).await?,
-        "NEW_GROUP" => handle_new_group(item, app, db_path, new_count).await?,
-        "EVOLVED_GROUP" => handle_evolved_group(item, app, db_path, new_count).await?,
+        "NEW_GROUP" => {
+            handle_group(
+                item,
+                db_path,
+                new_count,
+                || crate::summarize::model_calls::summarize_new_group(&item.prompt, Some(app)),
+            )
+            .await?
+        }
+        "EVOLVED_GROUP" => {
+            let group_summary_id = item.group_summary_id.unwrap_or(0);
+            handle_group(
+                item,
+                db_path,
+                new_count,
+                || {
+                    crate::summarize::model_calls::summarize_evolved_group(
+                        &item.prompt,
+                        group_summary_id,
+                        Some(app),
+                    )
+                },
+            )
+            .await?
+        }
         other => log::warn!("[queue_summarizer] unknown summary_type: {}", other),
     }
 
@@ -117,8 +146,24 @@ async fn handle_new_single<R: Runtime>(
     db_path: &Path,
     new_count: i64,
 ) -> Result<()> {
+    crate::summarize::sumlog::queue_log_prompt(item.id, &item.prompt);
     match crate::summarize::model_calls::summarize_new_single(&item.prompt, Some(app)).await {
         Ok((summary, _)) => {
+            crate::summarize::sumlog::queue_log_response(
+                item.id,
+                &serde_json::to_string(&summary).unwrap_or_else(|_| "{}".to_string()),
+            );
+            let summary = validate_or_retry(
+                summary,
+                db_path,
+                item.id,
+                |s| validate_hunk_summary(s, "single"),
+                || crate::summarize::model_calls::summarize_new_single(&item.prompt, Some(app)),
+            )
+            .await?;
+            crate::summarize::sumlog::queue_log_validation_ok(item.id, 1);
+            let model_response =
+                serde_json::to_string(&summary).unwrap_or_else(|_| "{}".to_string());
             let pairs = parse_pairs(item)?;
             if let Some(pair) = pairs.first() {
                 let mut conn = rusqlite::Connection::open(db_path)?;
@@ -129,8 +174,6 @@ async fn handle_new_single<R: Runtime>(
                     &summary.title,
                     &summary.description,
                 )?;
-                let model_response =
-                    serde_json::to_string(&summary).unwrap_or_else(|_| "{}".to_string());
                 crate::db::changesets::mark_queued_done(&tx, item.id, &model_response)?;
                 tx.commit()?;
             }
@@ -149,16 +192,44 @@ async fn handle_new_single<R: Runtime>(
     Ok(())
 }
 
-async fn handle_new_group<R: Runtime>(
+/// Shared handler for NEW_GROUP and EVOLVED_GROUP.
+/// `call` is invoked for both the initial model request and, if validation fails, the retry.
+async fn handle_group<F, Fut>(
     item: &QueuedSummary,
-    app: &AppHandle<R>,
     db_path: &Path,
     new_count: i64,
-) -> Result<()> {
-    match crate::summarize::model_calls::summarize_new_group(&item.prompt, Some(app)).await {
+    call: F,
+) -> Result<()>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<
+        Output = Result<(
+            crate::summarize::model_output_types::EvolvedGroupSummary,
+            crate::providers::TokenUsage,
+        )>,
+    >,
+{
+    let pairs = parse_pairs(item)?;
+    let group_summary_id = item.group_summary_id.unwrap_or(0);
+
+    crate::summarize::sumlog::queue_log_prompt(item.id, &item.prompt);
+    match call().await {
         Ok((summary, _)) => {
-            let pairs = parse_pairs(item)?;
-            let group_summary_id = item.group_summary_id.unwrap_or(0);
+            crate::summarize::sumlog::queue_log_response(
+                item.id,
+                &serialize_group_response(&summary.group, &pairs, &summary.own_summaries),
+            );
+            let summary = validate_or_retry(
+                summary,
+                db_path,
+                item.id,
+                |s| validate_group_response(s, &pairs),
+                call,
+            )
+            .await?;
+            crate::summarize::sumlog::queue_log_validation_ok(item.id, pairs.len());
+            let model_response =
+                serialize_group_response(&summary.group, &pairs, &summary.own_summaries);
             let mut conn = rusqlite::Connection::open(db_path)?;
             let tx = conn.transaction()?;
             crate::db::changesets::update_change_summary_content(
@@ -168,21 +239,22 @@ async fn handle_new_group<R: Runtime>(
                 &summary.group.description,
             )?;
             for pair in &pairs {
-                if let Some(own) = summary.own_summaries.get(&pair.hash) {
-                    crate::db::changesets::update_change_summary_content(
-                        &tx,
-                        pair.summary_id,
-                        &own.title,
-                        &own.description,
-                    )?;
-                }
+                let own = summary
+                    .own_summaries
+                    .get(&pair.hash)
+                    .ok_or_else(|| anyhow::anyhow!("hash {} missing after validation", pair.hash))?;
+                crate::db::changesets::update_change_summary_content(
+                    &tx,
+                    pair.summary_id,
+                    &own.title,
+                    &own.description,
+                )?;
             }
-            let model_response = serialize_group_response(&summary.group, &pairs, &summary.own_summaries);
             crate::db::changesets::mark_queued_done(&tx, item.id, &model_response)?;
             tx.commit()?;
         }
         Err(e) => {
-            log::warn!("[queue_summarizer] NEW_GROUP {} failed: {:#}", item.id, e);
+            log::warn!("[queue_summarizer] group {} failed: {:#}", item.id, e);
             if new_count >= FAILED_AFTER_TRIES {
                 let mut conn = rusqlite::Connection::open(db_path)?;
                 let tx = conn.transaction()?;
@@ -195,52 +267,84 @@ async fn handle_new_group<R: Runtime>(
     Ok(())
 }
 
-async fn handle_evolved_group<R: Runtime>(
-    item: &QueuedSummary,
-    app: &AppHandle<R>,
+fn increment_attempts_now(db_path: &Path, id: i64) -> Result<()> {
+    let mut conn = rusqlite::Connection::open(db_path)?;
+    let tx = conn.transaction()?;
+    crate::db::changesets::increment_queued_attempts(&tx, id)?;
+    tx.commit()?;
+    Ok(())
+}
+
+// ── Retry helper ──────────────────────────────────────────────────────────────
+
+/// Validates a model result. On failure, increments the attempt counter and
+/// retries `call` once. Returns the validated result, or an error if the retry
+/// also fails validation.
+async fn validate_or_retry<T, Retry, Fut>(
+    result: T,
     db_path: &Path,
-    new_count: i64,
-) -> Result<()> {
-    let group_summary_id = item.group_summary_id.unwrap_or(0);
-    match crate::summarize::model_calls::summarize_evolved_group(
-        &item.prompt,
-        group_summary_id,
-        Some(app),
-    )
-    .await
-    {
-        Ok((summary, _)) => {
-            let pairs = parse_pairs(item)?;
-            let mut conn = rusqlite::Connection::open(db_path)?;
-            let tx = conn.transaction()?;
-            crate::db::changesets::update_change_summary_content(
-                &tx,
-                group_summary_id,
-                &summary.group.title,
-                &summary.group.description,
-            )?;
-            for pair in &pairs {
-                if let Some(own) = summary.own_summaries.get(&pair.hash) {
-                    crate::db::changesets::update_change_summary_content(
-                        &tx,
-                        pair.summary_id,
-                        &own.title,
-                        &own.description,
-                    )?;
-                }
-            }
-            let model_response = serialize_group_response(&summary.group, &pairs, &summary.own_summaries);
-            crate::db::changesets::mark_queued_done(&tx, item.id, &model_response)?;
-            tx.commit()?;
-        }
+    item_id: i64,
+    validate: impl Fn(&T) -> Result<()>,
+    retry: Retry,
+) -> Result<T>
+where
+    Retry: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<(T, crate::providers::TokenUsage)>>,
+{
+    match validate(&result) {
+        Ok(()) => Ok(result),
         Err(e) => {
-            log::warn!("[queue_summarizer] EVOLVED_GROUP {} failed: {:#}", item.id, e);
-            if new_count >= FAILED_AFTER_TRIES {
-                let mut conn = rusqlite::Connection::open(db_path)?;
-                let tx = conn.transaction()?;
-                crate::db::changesets::mark_queued_failed(&tx, item.id)?;
-                fail_change_summaries(&tx, item)?;
-                tx.commit()?;
+            log::warn!(
+                "[queue_summarizer] item {} validation failed, retrying: {}",
+                item_id,
+                e
+            );
+            increment_attempts_now(db_path, item_id)?;
+            let (result2, _) = retry().await.with_context(|| {
+                format!("failed to summarize queued item {}, retry model call failed", item_id)
+            })?;
+            if let Err(e2) = validate(&result2) {
+                increment_attempts_now(db_path, item_id)?;
+                return Err(e2).with_context(|| {
+                    format!(
+                        "failed to summarize queued item {}, retry validation also failed",
+                        item_id
+                    )
+                });
+            }
+            Ok(result2)
+        }
+    }
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+fn validate_hunk_summary(summary: &HunkSummary, label: &str) -> Result<()> {
+    if summary.title.trim().is_empty() {
+        return Err(anyhow::anyhow!("{}: title is empty", label));
+    }
+    if summary.description.trim().is_empty() {
+        return Err(anyhow::anyhow!("{}: description is empty", label));
+    }
+    Ok(())
+}
+
+fn validate_group_response(
+    summary: &crate::summarize::model_output_types::EvolvedGroupSummary,
+    pairs: &[HashSummaryPair],
+) -> Result<()> {
+    validate_hunk_summary(&summary.group, "group")?;
+    for pair in pairs {
+        match summary.own_summaries.get(&pair.hash) {
+            None => {
+                return Err(anyhow::anyhow!(
+                    "hash {} (summary_id {}) missing from model response",
+                    pair.hash,
+                    pair.summary_id
+                ));
+            }
+            Some(own) => {
+                validate_hunk_summary(own, &format!("hash {}", pair.hash))?;
             }
         }
     }
@@ -303,5 +407,97 @@ fn emit_update<R: Runtime>(app: &AppHandle<R>, db_path: &Path) {
     })();
     if let Err(e) = result {
         log::warn!("[queue_summarizer] emit_update failed: {:#}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::summarize::model_output_types::EvolvedGroupSummary;
+    use std::collections::HashMap;
+
+    fn hunk(title: &str, description: &str) -> HunkSummary {
+        HunkSummary { title: title.into(), description: description.into() }
+    }
+
+    fn pair(hash: &str, summary_id: i64) -> HashSummaryPair {
+        HashSummaryPair { hash: hash.into(), summary_id }
+    }
+
+    fn group_summary(group: HunkSummary, own: HashMap<String, HunkSummary>) -> EvolvedGroupSummary {
+        EvolvedGroupSummary { former_group_id: 0, group, own_summaries: own }
+    }
+
+    // ── validate_hunk_summary ─────────────────────────────────────────────────
+
+    #[test]
+    fn hunk_empty_title_fails() {
+        assert!(validate_hunk_summary(&hunk("", "some desc"), "test").is_err());
+    }
+
+    #[test]
+    fn hunk_empty_description_fails() {
+        assert!(validate_hunk_summary(&hunk("Title", ""), "test").is_err());
+    }
+
+    #[test]
+    fn hunk_whitespace_only_fails() {
+        assert!(validate_hunk_summary(&hunk("  ", "  "), "test").is_err());
+    }
+
+    #[test]
+    fn hunk_valid_passes() {
+        assert!(validate_hunk_summary(&hunk("Title", "Description"), "test").is_ok());
+    }
+
+    // ── validate_group_response ───────────────────────────────────────────────
+
+    #[test]
+    fn group_missing_hash_fails() {
+        let summary = group_summary(hunk("Group", "Desc"), HashMap::new());
+        let pairs = vec![pair("abc123", 1)];
+        assert!(validate_group_response(&summary, &pairs).is_err());
+    }
+
+    #[test]
+    fn group_empty_changes_array_fails() {
+        // Reproduces the exact bug: group present, changes: []
+        let summary = group_summary(
+            hunk("MyApp Integration", "SOPS key, LaunchAgent, encrypted secret"),
+            HashMap::new(),
+        );
+        let pairs = vec![pair("a3a0d3", 38), pair("37c4ac", 39), pair("f0d85a", 40)];
+        assert!(validate_group_response(&summary, &pairs).is_err());
+    }
+
+    #[test]
+    fn group_empty_individual_title_fails() {
+        let mut own = HashMap::new();
+        own.insert("a3a0d3".into(), hunk("", "some desc"));
+        let summary = group_summary(hunk("Group", "Desc"), own);
+        let pairs = vec![pair("a3a0d3", 38)];
+        assert!(validate_group_response(&summary, &pairs).is_err());
+    }
+
+    #[test]
+    fn group_empty_group_title_fails() {
+        let mut own = HashMap::new();
+        own.insert("a3a0d3".into(), hunk("SOPS Key", "Replaced placeholder"));
+        let summary = group_summary(hunk("", "Group desc"), own);
+        let pairs = vec![pair("a3a0d3", 38)];
+        assert!(validate_group_response(&summary, &pairs).is_err());
+    }
+
+    #[test]
+    fn group_valid_passes() {
+        let mut own = HashMap::new();
+        own.insert("a3a0d3".into(), hunk("SOPS Key", "Replaced placeholder with real age key"));
+        own.insert("37c4ac".into(), hunk("LaunchAgent", "Adds myapp user launchd service"));
+        let summary = group_summary(
+            hunk("MyApp Integration", "SOPS key, LaunchAgent, encrypted secret"),
+            own,
+        );
+        let pairs = vec![pair("a3a0d3", 38), pair("37c4ac", 39)];
+        assert!(validate_group_response(&summary, &pairs).is_ok());
     }
 }

--- a/apps/native/src-tauri/src/summarize/sumlog.rs
+++ b/apps/native/src-tauri/src/summarize/sumlog.rs
@@ -11,6 +11,7 @@ pub const GROUP_EXISTING: bool = false;
 pub const SIMPLIFY_GROUP: bool = false;
 pub const FRESH_CHANGESET: bool = false;
 pub const EVOLVED_CHANGESET: bool = false;
+pub const QUEUE_SUMMARIZER: bool = false;
 
 // ── Imports ───────────────────────────────────────────────────────────────────
 
@@ -261,4 +262,54 @@ pub fn grouped_log_assignments(assignments: &Assignments) {
         return;
     }
     emit_json("EVOLVED_CHANGESET", "assignments", assignments);
+}
+
+// ── queue_summarizer ──────────────────────────────────────────────────────────
+
+pub fn queue_log_started(ids: &[i64]) {
+    if !QUEUE_SUMMARIZER {
+        return;
+    }
+    emit_json("QUEUE_SUMMARIZER", "started", &serde_json::json!({ "ids": ids }));
+}
+
+pub fn queue_log_prompt(queued_id: i64, prompt: &str) {
+    if !QUEUE_SUMMARIZER {
+        return;
+    }
+    let label = format!("QUEUE_SUMMARIZER — item {}", queued_id);
+    emit_text(&label, "prompt", prompt);
+}
+
+pub fn queue_log_response(queued_id: i64, response: &str) {
+    if !QUEUE_SUMMARIZER {
+        return;
+    }
+    emit_json(
+        "QUEUE_SUMMARIZER",
+        &format!("item {} response", queued_id),
+        &serde_json::json!({ "response": response }),
+    );
+}
+
+pub fn queue_log_validation_ok(queued_id: i64, pair_count: usize) {
+    if !QUEUE_SUMMARIZER {
+        return;
+    }
+    emit_json(
+        "QUEUE_SUMMARIZER",
+        &format!("item {} validation ok", queued_id),
+        &serde_json::json!({ "pairs_validated": pair_count }),
+    );
+}
+
+pub fn queue_log_done(passed: usize, retrying: usize) {
+    if !QUEUE_SUMMARIZER {
+        return;
+    }
+    emit_json(
+        "QUEUE_SUMMARIZER",
+        "done",
+        &serde_json::json!({ "passed": passed, "retrying": retrying }),
+    );
 }


### PR DESCRIPTION
## Summary

Four queued_summaries jobs were silently completing as DONE with `"changes": []`
from the model. The individual change_summaries rows were permanently stuck as QUEUED
because the write loop used `if let Some` to skip missing hashes, then
`mark_queued_done` ran unconditionally — making the state unrecoverable without manual
DB intervention.

- Validate every model response before any DB write: non-empty title/description,
  and all expected hashes present in the response
- On validation failure, immediately increment the attempt counter and retry once
  within the same handler; if the retry also fails, increment again and propagate Err
  so the outer loop's existing retry mechanism continues
- Merge `handle_new_group` / `handle_evolved_group` into a single `handle_group`
  parameterized by a model-call closure; shared write path via `validate_or_retry<T>`
- Replace silent `if let Some` hash skip with `ok_or_else` post-validation guard
- Add `QUEUE_SUMMARIZER` sumlog switch with prompt, response, validation ok, and
  done-pass-summary log points

## Test Plan

- [x] 9 unit tests added for `validate_hunk_summary` and `validate_group_response`,
  including a test that reproduces the exact `"changes": []` bug
- [ ] Manual: trigger a changeset and confirm summaries resolve correctly end-to-end

## Docs

- [x] No docs update needed