### PR TITLE
Cas/reset evolve state on dirchange ENG-441

### DIFF
--- a/apps/native/src-tauri/examples/specta_gen_ts.rs
+++ b/apps/native/src-tauri/examples/specta_gen_ts.rs
@@ -52,7 +52,8 @@ fn main() {
         .register::<shared_types::EvolutionTelemetry>()
         .register::<shared_types::EvolutionResult>()
         .register::<shared_types::EvolutionFailureResult>()
-        .register::<shared_types::RollbackResult>();
+        .register::<shared_types::RollbackResult>()
+        .register::<shared_types::SetDirResult>();
 
     let shared_output_path = "../src/types/shared.ts";
 

--- a/apps/native/src-tauri/src/commands.rs
+++ b/apps/native/src-tauri/src/commands.rs
@@ -25,6 +25,24 @@ fn capture_err<E: std::fmt::Display>(cmd: &str, e: E) -> String {
     e.to_string()
 }
 
+/// Initializes app state after switching to a new config directory:
+/// caches git status, starts the file watcher, resets evolve state, and lists hosts.
+fn handle_new_config_dir(
+    app: &AppHandle,
+    dir: &str,
+) -> Result<(shared_types::EvolveState, Option<Vec<String>>), String> {
+    let git_status = git::status(dir).ok();
+    let changes = git_status.as_ref().map(|s| s.changes.clone()).unwrap_or_default();
+    if let Some(ref s) = git_status {
+        let _ = store::set_cached_git_status(app, s);
+    }
+    watcher::start_watching(app.clone(), dir.to_string(), 2500);
+    let evolve_state = evolve_state::set(app, shared_types::EvolveState::default(), &changes)
+        .map_err(|e| e.to_string())?;
+    let hosts = nix::list_darwin_hosts(dir).ok();
+    Ok((evolve_state, hosts))
+}
+
 // =============================================================================
 // Configuration Commands
 // =============================================================================
@@ -80,16 +98,9 @@ pub async fn config_set_dir(
         .map_err(|e| capture_err("config_set_dir", e))?;
 
     let (evolve_state, hosts) = if prev_dir.as_deref() != Some(&new_dir) {
-        let git_status = git::status(&new_dir).ok();
-        let changes = git_status.as_ref().map(|s| s.changes.clone()).unwrap_or_default();
-        if let Some(ref s) = git_status {
-            let _ = store::set_cached_git_status(&app, s);
-        }
-        watcher::start_watching(app.clone(), new_dir.clone(), 2500);
-        let evolve_state = evolve_state::set(&app, shared_types::EvolveState::default(), &changes)
+        let (es, hosts) = handle_new_config_dir(&app, &new_dir)
             .map_err(|e| capture_err("config_set_dir", e))?;
-        let hosts = nix::list_darwin_hosts(&new_dir).ok();
-        (Some(evolve_state), hosts)
+        (Some(es), hosts)
     } else {
         (None, None)
     };
@@ -121,16 +132,9 @@ pub async fn config_pick_dir(
         store::set_config_dir(&app, &dir).map_err(|e| capture_err("config_pick_dir", e))?;
         store::ensure_config_dir_exists(&app).map_err(|e| capture_err("config_pick_dir", e))?;
         let (evolve_state, hosts) = if dir != prev_dir {
-            let git_status = git::status(&dir).ok();
-            let changes = git_status.as_ref().map(|s| s.changes.clone()).unwrap_or_default();
-            if let Some(ref s) = git_status {
-                let _ = store::set_cached_git_status(&app, s);
-            }
-            watcher::start_watching(app.clone(), dir.clone(), 2500);
-            let evolve_state = evolve_state::set(&app, shared_types::EvolveState::default(), &changes)
+            let (es, hosts) = handle_new_config_dir(&app, &dir)
                 .map_err(|e| capture_err("config_pick_dir", e))?;
-            let hosts = nix::list_darwin_hosts(&dir).ok();
-            (Some(evolve_state), hosts)
+            (Some(es), hosts)
         } else {
             (None, None)
         };

--- a/apps/native/src-tauri/src/commands.rs
+++ b/apps/native/src-tauri/src/commands.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     darwin, db, default_config, editor, evolution, evolve_state, feedback, finalize_restore, git,
-    lsp, nix, peek, permissions, rollback, scanner, shared_types, store, types, utils,
+    lsp, nix, peek, permissions, rollback, scanner, shared_types, store, types, utils, watcher,
 };
 use std::path::Path;
 use std::process::Command;
@@ -55,7 +55,10 @@ pub async fn config_set_host_attr(
 
 /// Sets the flake configuration directory path.
 #[tauri::command]
-pub async fn config_set_dir(app: AppHandle, dir: String) -> Result<serde_json::Value, String> {
+pub async fn config_set_dir(
+    app: AppHandle,
+    dir: String,
+) -> Result<shared_types::SetDirResult, String> {
     let normalized_dir =
         utils::normalize_dir_input(&dir).map_err(|e| capture_err("config_set_dir", e))?;
 
@@ -71,30 +74,67 @@ pub async fn config_set_dir(app: AppHandle, dir: String) -> Result<serde_json::V
         ));
     }
 
-    store::set_config_dir(&app, &normalized_dir.to_string_lossy())
+    let prev_dir = store::get_config_dir(&app).ok();
+    let new_dir = normalized_dir.to_string_lossy().to_string();
+    store::set_config_dir(&app, &new_dir)
         .map_err(|e| capture_err("config_set_dir", e))?;
-    Ok(serde_json::json!({"ok": true}))
+
+    let (evolve_state, hosts) = if prev_dir.as_deref() != Some(&new_dir) {
+        let git_status = git::status(&new_dir).ok();
+        let changes = git_status.as_ref().map(|s| s.changes.clone()).unwrap_or_default();
+        if let Some(ref s) = git_status {
+            let _ = store::set_cached_git_status(&app, s);
+        }
+        watcher::start_watching(app.clone(), new_dir.clone(), 2500);
+        let evolve_state = evolve_state::set(&app, shared_types::EvolveState::default(), &changes)
+            .map_err(|e| capture_err("config_set_dir", e))?;
+        let hosts = nix::list_darwin_hosts(&new_dir).ok();
+        (Some(evolve_state), hosts)
+    } else {
+        (None, None)
+    };
+
+    Ok(shared_types::SetDirResult { dir: new_dir, evolve_state, hosts })
 }
 
 /// Opens a native folder picker dialog to select the flake directory.
 #[tauri::command]
-pub async fn config_pick_dir(app: AppHandle) -> Result<Option<String>, String> {
+pub async fn config_pick_dir(
+    app: AppHandle,
+) -> Result<Option<shared_types::SetDirResult>, String> {
     let dialog = app.dialog();
     // Try to open the picker at the currently configured directory
-    let default_dir = store::get_config_dir(&app).map_err(|e| capture_err("config_pick_dir", e))?;
+    let prev_dir = store::get_config_dir(&app).map_err(|e| capture_err("config_pick_dir", e))?;
     let result = dialog
         .file()
         .set_title(
             "Select Configuration Directory - TIP: press '⌘'+'⇧'+'.' to show hidden directories",
         )
-        .set_directory(std::path::PathBuf::from(default_dir))
+        .set_directory({
+            let p = std::path::PathBuf::from(&prev_dir);
+            p.parent().map(std::path::PathBuf::from).unwrap_or(p)
+        })
         .blocking_pick_folder();
 
     if let Some(path) = result {
         let dir = path.to_string();
         store::set_config_dir(&app, &dir).map_err(|e| capture_err("config_pick_dir", e))?;
         store::ensure_config_dir_exists(&app).map_err(|e| capture_err("config_pick_dir", e))?;
-        return Ok(Some(dir));
+        let (evolve_state, hosts) = if dir != prev_dir {
+            let git_status = git::status(&dir).ok();
+            let changes = git_status.as_ref().map(|s| s.changes.clone()).unwrap_or_default();
+            if let Some(ref s) = git_status {
+                let _ = store::set_cached_git_status(&app, s);
+            }
+            watcher::start_watching(app.clone(), dir.clone(), 2500);
+            let evolve_state = evolve_state::set(&app, shared_types::EvolveState::default(), &changes)
+                .map_err(|e| capture_err("config_pick_dir", e))?;
+            let hosts = nix::list_darwin_hosts(&dir).ok();
+            (Some(evolve_state), hosts)
+        } else {
+            (None, None)
+        };
+        return Ok(Some(shared_types::SetDirResult { dir, evolve_state, hosts }));
     }
 
     Ok(None)

--- a/apps/native/src-tauri/src/default_config.rs
+++ b/apps/native/src-tauri/src/default_config.rs
@@ -179,10 +179,22 @@ pub fn bootstrap(app: &AppHandle, hostname: &str) -> Result<(), String> {
         .map_err(|e| format!("Failed to ensure config dir: {}", e))?;
     let dest_path = Path::new(&dir);
 
+    // If a flake.nix already exists, just make the initial git commit without
+    // copying any template files (the user brought their own config).
+    if dest_path.join("flake.nix").exists() {
+        git::init_repo(&dir).map_err(|e| format!("Failed to init git: {}", e))?;
+        let info = git::commit_all(&dir, "chore: initial nix-darwin configuration")
+            .map_err(|e| format!("Failed to commit: {}", e))?;
+        if let Err(e) = git::tag_commit(&dir, &format!("nixmac-base-{}", &info.hash[..8]), &info.hash, false) {
+            log::warn!("Failed to tag initial commit as base: {}", e);
+        }
+        return Ok(());
+    }
+
     // Safety check: only proceed if directory is empty or contains only .git
     if !is_dir_safe_for_bootstrap(dest_path)? {
         return Err(
-            "Directory is not empty. Please use an empty directory or remove existing files."
+            "Directory is not empty. Please use an empty directory or a directory containing a flake.nix."
                 .to_string(),
         );
     }

--- a/apps/native/src-tauri/src/shared_types.rs
+++ b/apps/native/src-tauri/src/shared_types.rs
@@ -178,6 +178,20 @@ impl Default for EvolveState {
 
 
 // =============================================================================
+// Config dir result types
+// =============================================================================
+
+/// Result returned when the config directory is set (typed or picked).
+/// `evolve_state` and `hosts` are `Some` only when the directory actually changed.
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SetDirResult {
+    pub dir: String,
+    pub evolve_state: Option<EvolveState>,
+    pub hosts: Option<Vec<String>>,
+}
+
+// =============================================================================
 // Rollback result types
 // =============================================================================
 

--- a/apps/native/src/components/widget/bootstrap-config.tsx
+++ b/apps/native/src/components/widget/bootstrap-config.tsx
@@ -3,8 +3,10 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
-import { AlertCircle, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { useWidgetStore } from "@/stores/widget-store";
+import { darwinAPI } from "@/tauri-api";
+import { AlertCircle, GitCommit, Sparkles } from "lucide-react";
+import { useEffect, useState } from "react";
 
 interface BootstrapConfigProps {
   label: string;
@@ -13,12 +15,41 @@ interface BootstrapConfigProps {
 
 export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
   const [hostname, setHostname] = useState("macbook");
+  const [localError, setLocalError] = useState<string | null>(null);
   const { bootstrap, isBootstrapping } = useDarwinConfig();
+  const configDir = useWidgetStore((state) => state.configDir);
+  const gitStatus = useWidgetStore((state) => state.gitStatus);
+  const [flakeExists, setFlakeExists] = useState(false);
+
+  useEffect(() => {
+    setLocalError(null);
+    if (!configDir) {
+      setFlakeExists(false);
+      return;
+    }
+    darwinAPI.flake.existsAt(configDir).then(setFlakeExists).catch(() => setFlakeExists(false));
+  }, [configDir]);
+
+  const needsInitialCommit = flakeExists && (gitStatus === null || gitStatus.headCommitHash === "");
+
+  const message = needsInitialCommit
+    ? "flake.nix found but not committed — Nix needs a git commit to evaluate your flake"
+    : "No nix-darwin configuration found in this directory";
+  const buttonLabel = needsInitialCommit ? "Make initial commit" : "Create Default Configuration";
+  const loadingLabel = needsInitialCommit ? "Committing..." : "Creating Configuration...";
+  const helpText = needsInitialCommit
+    ? "Stages all files and creates the first commit"
+    : "This will create a basic nix-darwin flake in the directory";
 
   const handleBootstrap = async (): Promise<void> => {
-    await bootstrap(hostname);
-    // window.location.reload();
-    onSuccess?.();
+    setLocalError(null);
+    await bootstrap(needsInitialCommit ? "" : hostname);
+    const storeError = useWidgetStore.getState().error;
+    if (storeError) {
+      setLocalError(storeError);
+    } else {
+      onSuccess?.();
+    }
   };
 
   return (
@@ -27,51 +58,55 @@ export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
       <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
         <div className="flex items-start gap-2">
           <AlertCircle className="mt-0.5 h-4 w-4 text-muted-foreground" />
-          <p className="text-muted-foreground text-sm">
-            No nix-darwin configuration found in this directory
-          </p>
+          <p className="text-muted-foreground text-sm">{message}</p>
         </div>
 
         <div className="space-y-3">
-          <div className="space-y-2">
-            <label htmlFor="hostname" className="text-sm">
-              Host name
-            </label>
-            <Input
-              id="hostname"
-              type="text"
-              value={hostname}
-              onChange={(e) => setHostname(e.target.value)}
-              placeholder="macbook"
-              className="font-mono text-xs"
-              disabled={isBootstrapping}
-            />
-            <p className="text-muted-foreground text-xs">
-              This will be your darwinConfiguration name
-            </p>
-          </div>
+          {!needsInitialCommit && (
+            <div className="space-y-2">
+              <label htmlFor="hostname" className="text-sm">
+                Host name
+              </label>
+              <Input
+                id="hostname"
+                type="text"
+                value={hostname}
+                onChange={(e) => setHostname(e.target.value)}
+                placeholder="macbook"
+                className="font-mono text-xs"
+                disabled={isBootstrapping}
+              />
+              <p className="text-muted-foreground text-xs">
+                This will be your darwinConfiguration name
+              </p>
+            </div>
+          )}
 
           <Button
             onClick={handleBootstrap}
             className="w-full"
             data-testid="create-default-config-button"
-            disabled={!hostname.trim() || isBootstrapping}
+            disabled={(!needsInitialCommit && !hostname.trim()) || isBootstrapping}
           >
             {isBootstrapping ? (
               <>
                 <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-solid border-current border-r-transparent" />
-                Creating Configuration...
+                {loadingLabel}
+              </>
+            ) : needsInitialCommit ? (
+              <>
+                <GitCommit className="mr-2 h-4 w-4" />
+                {buttonLabel}
               </>
             ) : (
               <>
                 <Sparkles className="mr-2 h-4 w-4" />
-                Create Default Configuration
+                {buttonLabel}
               </>
             )}
           </Button>
-          <p className="text-muted-foreground text-xs">
-            This will create a basic nix-darwin flake in the directory
-          </p>
+          {localError && <p className="text-rose-300 text-xs">{localError}</p>}
+          <p className="text-muted-foreground text-xs">{helpText}</p>
         </div>
       </div>
     </div>

--- a/apps/native/src/components/widget/directory-picker.tsx
+++ b/apps/native/src/components/widget/directory-picker.tsx
@@ -54,23 +54,19 @@ export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
     }
 
     try {
-      await darwinAPI.config.setDir(normalizedPath);
-      setConfigDir(normalizedPath);
-      setValue(normalizedPath);
+      const result = await darwinAPI.config.setDir(normalizedPath);
+      setConfigDir(result.dir);
+      setValue(result.dir);
+      if (result.evolveState) {
+        useWidgetStore.getState().setEvolveState(result.evolveState);
 
-      // If we made it this far, we should clear the hosts and make
-      // the user re-select from the one(s) available in the new directory.
-      setHost("");
-      try {
-        await darwinAPI.config.setHostAttr("");
-      } catch {}
+        // Dir changed — clear host and reload the host list for the new directory.
+        setHost("");
+        try {
+          await darwinAPI.config.setHostAttr("");
+        } catch {}
 
-      try {
-        const hosts = await darwinAPI.flake.listHosts();
-        setHosts(Array.isArray(hosts) ? hosts : []);
-      } catch {
-        // No flake.nix found - shows bootstrap interface
-        setHosts([]);
+        setHosts(result.hosts ?? []);
       }
 
       // Don't validate flake here — missing flake.nix is handled above by

--- a/apps/native/src/components/widget/directory-picker.tsx
+++ b/apps/native/src/components/widget/directory-picker.tsx
@@ -14,10 +14,7 @@ type DirectoryPickerProps = {
 
 export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
   const configDir = useWidgetStore((state) => state.configDir);
-  const setConfigDir = useWidgetStore((state) => state.setConfigDir);
-  const setHosts = useWidgetStore((state) => state.setHosts);
-  const setHost = useWidgetStore((state) => state.setHost);
-  const { pickDir } = useDarwinConfig();
+  const { pickDir, setDir } = useDarwinConfig();
 
   const [value, setValue] = useState<string>(configDir || "");
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
@@ -42,40 +39,26 @@ export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
     })();
   }, [configDir]);
 
-  const onBlur = async () => {
+  const submit = async (): Promise<boolean> => {
     const normalizedPath = await normalizePathInput(value);
-    if (!normalizedPath) {
-      return;
-    }
-
-    // Check path existence first and show immediate feedback
-    if (!(await validateDirectoryExists(normalizedPath))) {
-      return;
-    }
-
+    if (!normalizedPath) return false;
+    if (!(await validateDirectoryExists(normalizedPath))) return false;
     try {
-      const result = await darwinAPI.config.setDir(normalizedPath);
-      setConfigDir(result.dir);
+      const result = await setDir(normalizedPath);
       setValue(result.dir);
-      if (result.evolveState) {
-        useWidgetStore.getState().setEvolveState(result.evolveState);
-
-        // Dir changed — clear host and reload the host list for the new directory.
-        setHost("");
-        try {
-          await darwinAPI.config.setHostAttr("");
-        } catch {}
-
-        setHosts(result.hosts ?? []);
-      }
-
-      // Don't validate flake here — missing flake.nix is handled above by
-      // hosts=[], which shows the bootstrap UI. This keeps typed input
-      // behavior consistent with the Browse flow.
+      return true;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       setValidationMessage(`${message}`);
+      return false;
     }
+  };
+
+  const onBlur = () => { submit(); };
+  const onKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    const target = e.currentTarget;
+    if (await submit()) target.blur();
   };
 
   async function normalizePathInput(input: string): Promise<string | null> {
@@ -148,6 +131,7 @@ export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onBlur={onBlur}
+            onKeyDown={onKeyDown}
             placeholder="Not selected"
             aria-label={label}
           />
@@ -156,7 +140,7 @@ export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
             Browse
           </Button>
         </div>
-        {validationMessage && <p className="text-destructive text-xs">{validationMessage}</p>}
+        {validationMessage && <p className="text-rose-300 text-xs">{validationMessage}</p>}
         <p className="text-muted-foreground text-xs">
           Press ⌘+⇧+. when browsing to show hidden folders like{" "}
           <code className="rounded bg-muted px-1">.darwin</code>

--- a/apps/native/src/components/widget/directory-picker.tsx
+++ b/apps/native/src/components/widget/directory-picker.tsx
@@ -12,6 +12,9 @@ type DirectoryPickerProps = {
   subLabel?: string;
 };
 
+const INITIAL_HINT =
+  "Select your own, or proceed below for defaults";
+
 export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
   const configDir = useWidgetStore((state) => state.configDir);
   const { pickDir, setDir } = useDarwinConfig();
@@ -83,11 +86,15 @@ export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
     }
   }
 
+  function validateOrInitial(path: string | undefined, fallback: string): void {
+    setValidationMessage(path?.endsWith("/.darwin") ? INITIAL_HINT : fallback);
+  }
+
   async function validateDirectoryExists(path: string): Promise<boolean> {
     try {
       const exists = await darwinAPI.path.exists(path);
       if (!exists) {
-        setValidationMessage(`Directory does not exist: ${path}`);
+        validateOrInitial(path, `Directory does not exist: ${path}`);
         return false;
       }
 
@@ -107,7 +114,7 @@ export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
         return true;
       }
 
-      setValidationMessage("flake.nix not found in this directory");
+      validateOrInitial(path, "flake.nix not found in this directory");
       return false;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
@@ -140,7 +147,11 @@ export function DirectoryPicker({ label, subLabel }: DirectoryPickerProps) {
             Browse
           </Button>
         </div>
-        {validationMessage && <p className="text-rose-300 text-xs">{validationMessage}</p>}
+        {validationMessage && (
+          <p className={`text-xs ${validationMessage === INITIAL_HINT ? "text-teal-300" : "text-rose-300"}`}>
+            {validationMessage}
+          </p>
+        )}
         <p className="text-muted-foreground text-xs">
           Press ⌘+⇧+. when browsing to show hidden folders like{" "}
           <code className="rounded bg-muted px-1">.darwin</code>

--- a/apps/native/src/components/widget/error-message.tsx
+++ b/apps/native/src/components/widget/error-message.tsx
@@ -15,7 +15,6 @@ export function ErrorMessage() {
   const setError = useWidgetStore((s) => s.setError);
   const openFeedback = useWidgetStore((s) => s.openFeedback);
   const setSettingsOpen = useWidgetStore((s) => s.setSettingsOpen);
-  const host = useWidgetStore((s) => s.host);
   const step = useCurrentStep();
   const dismissedRef = useRef<string | null>(null);
 
@@ -25,13 +24,9 @@ export function ErrorMessage() {
     error === dismissedRef.current &&
     loopingErrorPatterns.some((pattern) => error?.includes(pattern));
 
-  // "not a git repository" is expected on setup when nothing is configured yet.
-  // If host is set, we landed here unexpectedly (e.g. repo deleted) — show the error.
-  const isExpectedSetupError = step === "setup" && !host;
   const isSuppressedError =
     isDismissed ||
-    (step === "setup" && error?.includes("Failed to list hosts: path")) ||
-    (isExpectedSetupError && error?.includes("is not a git repository")) ||
+    step === "setup" ||
     ((step === "evolve" || step === "begin") && error?.includes("cancelled by user"));
 
   if (!error || isSuppressedError) {

--- a/apps/native/src/components/widget/error-message.tsx
+++ b/apps/native/src/components/widget/error-message.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useCurrentStep, useWidgetStore } from "@/stores/widget-store";
 import { FeedbackType } from "@/types/feedback";
 import { Settings } from "lucide-react";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 /**
  * Error message component - displays errors from store.
@@ -17,6 +17,10 @@ export function ErrorMessage() {
   const setSettingsOpen = useWidgetStore((s) => s.setSettingsOpen);
   const step = useCurrentStep();
   const dismissedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (error && step === "setup") setError(null);
+  }, [error, step]);
 
   // more persistent dismissal for certain looping (watcher) errors
   const loopingErrorPatterns = ["is not a git repository"];

--- a/apps/native/src/components/widget/header.tsx
+++ b/apps/native/src/components/widget/header.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { Clock, Settings, MessageSquarePlus } from "lucide-react";
 import { APP_NAME } from "../../../shared/constants";
 import { useWidgetStore } from "@/stores/widget-store";
+import { computeCurrentStep } from "@/components/widget/utils";
 
 export function Header() {
   const setSettingsOpen = useWidgetStore((s) => s.setSettingsOpen);
@@ -17,7 +18,8 @@ export function Header() {
   // Flash the feedback icon when an error occurs (subscribe to detect all changes)
   useEffect(() => {
     return useWidgetStore.subscribe((state, prevState) => {
-      if (state.error && state.error !== prevState.error) {
+      const step = computeCurrentStep(state);
+      if (step !== "setup" && state.error && state.error !== prevState.error) {
         setIsPulsing(true);
         setTimeout(() => setIsPulsing(false), 2000);
       }

--- a/apps/native/src/components/widget/steps/setup-step.tsx
+++ b/apps/native/src/components/widget/steps/setup-step.tsx
@@ -21,7 +21,7 @@ export function SetupStep() {
   const { saveHost } = useDarwinConfig();
 
   const hasConfigDir = Boolean(configDir);
-  const hasFlake = hasConfigDir && hosts.length > 0;
+  const hasHosts = hasConfigDir && hosts.length > 0;
 
   return (
     <div className="flex flex-col items-center justify-center space-y-6 py-8">
@@ -41,7 +41,7 @@ export function SetupStep() {
 
       {hasConfigDir && (
         <div className="w-full max-w-sm space-y-2">
-          {hasFlake ? (
+          {hasHosts ? (
             <>
               <label className="font-medium text-foreground text-sm">
                 2. Configuration

--- a/apps/native/src/hooks/use-darwin-config.ts
+++ b/apps/native/src/hooks/use-darwin-config.ts
@@ -1,29 +1,40 @@
 import { useWidgetStore } from "@/stores/widget-store";
 import { darwinAPI } from "@/tauri-api";
+import type { SetDirResult } from "@/types/shared";
 import { useCallback, useRef } from "react";
 
 export function useDarwinConfig() {
   const isBootstrapping = useWidgetStore((state) => state.isBootstrapping);
   const storeRef = useRef(useWidgetStore.getState());
 
-  const pickDir = useCallback(async () => {
-    const result = await darwinAPI.config.pickDir();
-    if (!result) {
-      return;
-    }
-
+  const applyDirResult = useCallback(async (result: SetDirResult) => {
     const store = storeRef.current;
     store.setConfigDir(result.dir);
     if (result.evolveState) {
       store.setEvolveState(result.evolveState);
+      store.setGitStatus(null);
       store.setHost("");
       try {
         await darwinAPI.config.setHostAttr("");
-      } catch {
-      }
+      } catch {}
       store.setHosts(result.hosts ?? []);
     }
   }, []);
+
+  const setDir = useCallback(
+    async (dir: string) => {
+      const result = await darwinAPI.config.setDir(dir);
+      await applyDirResult(result);
+      return result;
+    },
+    [applyDirResult]
+  );
+
+  const pickDir = useCallback(async () => {
+    const result = await darwinAPI.config.pickDir();
+    if (!result) return;
+    await applyDirResult(result);
+  }, [applyDirResult]);
 
   const saveHost = useCallback(
     async (host: string) => {
@@ -42,10 +53,7 @@ export function useDarwinConfig() {
 
   const bootstrap = useCallback(
     async (hostname: string) => {
-      if (!hostname.trim()) {
-        return;
-      }
-
+      const commitExisting = !hostname.trim();
       const store = storeRef.current;
       store.setError(null);
       store.setBootstrapping(true);
@@ -53,12 +61,21 @@ export function useDarwinConfig() {
       try {
         await darwinAPI.flake.bootstrapDefault(hostname);
 
-        // Set the host directly from the hostname used for bootstrap.
-        // We can't call listHosts() here because Nix may not be installed yet
-        // (listHosts requires `nix eval` which needs Nix).
-        store.setHosts([hostname]);
-        await darwinAPI.config.setHostAttr(hostname);
-        store.setHost(hostname);
+        if (commitExisting) {
+          const hosts = await darwinAPI.flake.listHosts();
+          store.setHosts(hosts);
+          if (hosts.length === 1) {
+            await darwinAPI.config.setHostAttr(hosts[0]);
+            store.setHost(hosts[0]);
+          }
+        } else {
+          // Set the host directly from the hostname used for bootstrap.
+          // We can't call listHosts() here because Nix may not be installed yet
+          // (listHosts requires `nix eval` which needs Nix).
+          store.setHosts([hostname]);
+          await darwinAPI.config.setHostAttr(hostname);
+          store.setHost(hostname);
+        }
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         store.setError(`Failed to create configuration: ${message}`);
@@ -69,5 +86,5 @@ export function useDarwinConfig() {
     []
   );
 
-  return { pickDir, saveHost, bootstrap, isBootstrapping };
+  return { setDir, pickDir, saveHost, bootstrap, isBootstrapping };
 }

--- a/apps/native/src/hooks/use-darwin-config.ts
+++ b/apps/native/src/hooks/use-darwin-config.ts
@@ -7,30 +7,21 @@ export function useDarwinConfig() {
   const storeRef = useRef(useWidgetStore.getState());
 
   const pickDir = useCallback(async () => {
-    const dir = (await darwinAPI.config.pickDir()) as string | null;
-    if (!dir) {
+    const result = await darwinAPI.config.pickDir();
+    if (!result) {
       return;
     }
 
     const store = storeRef.current;
-    store.setConfigDir(dir);
-    store.setHost("");
-    try {
-      await darwinAPI.config.setHostAttr("");
-    } catch {
-    }
-
-    // Check if flake exists and load hosts
-    try {
-      const hosts = await darwinAPI.flake.listHosts();
-      if (Array.isArray(hosts)) {
-        store.setHosts(hosts);
-      } else {
-        store.setHosts([]);
+    store.setConfigDir(result.dir);
+    if (result.evolveState) {
+      store.setEvolveState(result.evolveState);
+      store.setHost("");
+      try {
+        await darwinAPI.config.setHostAttr("");
+      } catch {
       }
-    } catch {
-      // No flake.nix found - shows bootstrap interface
-      store.setHosts([]);
+      store.setHosts(result.hosts ?? []);
     }
   }, []);
 

--- a/apps/native/src/tauri-api.ts
+++ b/apps/native/src/tauri-api.ts
@@ -11,6 +11,7 @@ import type {
   HistoryItem,
   RollbackResult,
   SemanticChangeMap,
+  SetDirResult,
 } from "./types/shared";
 
 export type {
@@ -25,6 +26,7 @@ export type {
   GitStatus,
   HistoryItem,
   SemanticChangeMap,
+  SetDirResult,
   SummarizedChangeSet,
   WatcherEvent,
 } from "./types/shared";
@@ -236,8 +238,8 @@ export interface ConfigChangedEvent {
 export const darwinAPI = {
   config: {
     get: () => invoke<DarwinConfig | null>("config_get"),
-    setDir: (dir: string) => invoke("config_set_dir", { dir }),
-    pickDir: () => invoke("config_pick_dir"),
+    setDir: (dir: string) => invoke<SetDirResult>("config_set_dir", { dir }),
+    pickDir: () => invoke<SetDirResult | null>("config_pick_dir"),
     setHostAttr: (host: string) => invoke("config_set_host_attr", { host }),
   },
   git: {

--- a/apps/native/src/types/shared.ts
+++ b/apps/native/src/types/shared.ts
@@ -117,6 +117,12 @@ export type SemanticChangeGroup = { summary: ChangeSummary; changes: ChangeWithS
 
 export type SemanticChangeMap = { groups: SemanticChangeGroup[]; singles: ChangeWithSummary[]; unsummarizedHashes: string[] }
 
+/**
+ * Result returned when the config directory is set (typed or picked).
+ * `evolve_state` and `hosts` are `Some` only when the directory actually changed.
+ */
+export type SetDirResult = { dir: string; evolveState: EvolveState | null; hosts: string[] | null }
+
 export type SummarizedChange = { change: Change; ownSummary: ChangeSummary | null; groupSummary: ChangeSummary | null }
 
 export type SummarizedChangeSet = { changeSet: ChangeSet; changes: SummarizedChange[]; missedHashes: string[] }


### PR DESCRIPTION
## Summary
- Recompute step and evolve state from actual git status of the new config dir
- Return `SetDirResult { dir, evolveState?, hosts? }` from `config_set_dir` / `config_pick_dir` — frontend applies evolve state and host list immediately without extra round trips
- Restart watcher + seed git status to fix git repo error propagation and missed flake detections
- Browse picker now opens at parent of dir, not inside it
- Host list unaffected when same dir is picked
<!-- additions -->
- `BootstrapConfig` detects whether `flake.nix` exists and whether the repo has any commits — offers "Make initial commit" instead of failing when a flake is present but uncommitted
- `bootstrap_default_config` handles existing `flake.nix` — commits it in place rather than returning "directory is not empty"
- After committing an existing single-host flake, that host is auto-selected
- Bootstrap errors displayed inline below the button (not via global error banner, which the watcher can clobber)
- Global error banner suppressed entirely on the setup step
- Directory picker submits on Enter and only blurs if validation succeeds

## Test Plan
- [x] Remove config dir → setup step; pick a dir with a valid flake → host selector shows (not bootstrap)
- [x] Change config dir in settings → watcher switches immediately, evolve state resets
- [x] Same dir re-selected → no state change
- [x] Browse opens at parent of currently selected dir
- [x] Cancelling Browse leaves state unchanged
<!-- additions -->
- [x] Pick a dir with `flake.nix` and no git commits → "Make initial commit" button shown (not "Create Default Configuration")
- [x] Click "Make initial commit" → commit created, host auto-selected if flake has exactly one `darwinConfiguration`
- [x] Pick an empty dir → "Create Default Configuration" with hostname input shown
- [x] Pick a non-empty dir without `flake.nix` → bootstrap shows "Create Default Configuration" (not commit variant)
- [x] Bootstrap fails (e.g. non-empty dir without flake) → error shown inline below button, clears when a new dir is selected
- [x] Type a path in the directory input and press Enter → validates and blurs on success, stays focused on error
