### PR TITLE
feat(budgets): refactor token budget computation to use tiktoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,12 +600,27 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -693,6 +708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1792,11 +1808,22 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -3643,7 +3670,7 @@ dependencies = [
  "clap",
  "cocoa",
  "dirs 5.0.1",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "fuzzy-matcher",
  "glob",
  "hex",
@@ -3690,6 +3717,7 @@ dependencies = [
  "tempfile",
  "tera",
  "thiserror 2.0.18",
+ "tiktoken-rs",
  "tokio",
  "toml 1.0.4+spec-1.1.0",
  "tracing",
@@ -7281,6 +7309,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44075987ee2486402f0808505dd65692163d243a337fc54363d49afac41087f6"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bstr",
+ "fancy-regex 0.13.0",
+ "lazy_static",
+ "parking_lot",
+ "regex",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -76,6 +76,7 @@ rowan = "0.16.1"
 fuzzy-matcher = "0.3.7"
 rusqlite_migration = "1.2"
 tauri-plugin-webdriver-automation = "0.1.3"
+tiktoken-rs = "0.6"
 
 [dependencies.tauri-plugin-sql]
 features = ["sqlite"] # or "postgres", or "mysql"

--- a/apps/native/src-tauri/src/providers/cli.rs
+++ b/apps/native/src-tauri/src/providers/cli.rs
@@ -129,14 +129,13 @@ fn extract_response(tool: &CliTool, raw: &str) -> Result<String> {
         CliTool::Claude => {
             // `claude -p --output-format json` returns:
             // {"type":"result","subtype":"success","is_error":false,"result":"...","cost_usd":...}
-            let json: serde_json::Value =
-                serde_json::from_str(raw.trim()).map_err(|e| {
-                    anyhow!(
-                        "Failed to parse Claude CLI JSON: {} — starts with: {}",
-                        e,
-                        &raw[..raw.len().min(200)]
-                    )
-                })?;
+            let json: serde_json::Value = serde_json::from_str(raw.trim()).map_err(|e| {
+                anyhow!(
+                    "Failed to parse Claude CLI JSON: {} — starts with: {}",
+                    e,
+                    &raw[..raw.len().min(200)]
+                )
+            })?;
 
             if json
                 .get("is_error")
@@ -162,11 +161,7 @@ fn extract_response(tool: &CliTool, raw: &str) -> Result<String> {
 /// Build the CLI args for a given tool + optional model override.
 fn build_args(tool: &CliTool, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = match tool {
-        CliTool::Claude => vec![
-            "-p".into(),
-            "--output-format".into(),
-            "json".into(),
-        ],
+        CliTool::Claude => vec!["-p".into(), "--output-format".into(), "json".into()],
         CliTool::Codex => vec!["--quiet".into()],
         CliTool::OpenCode => vec!["-p".into()],
     };
@@ -194,7 +189,7 @@ impl ChatCompletionProvider for CliCompletionClient {
         system_prompt: &str,
         user_prompt: &str,
         _max_tokens: u32,
-        _num_ctx: Option<u32>,
+        _context_window_tokens: Option<u32>,
         _temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)> {
@@ -208,10 +203,15 @@ impl ChatCompletionProvider for CliCompletionClient {
             request_id
         );
 
-        let raw =
-            run_cli_process(self.tool.binary_name(), &arg_refs, &combined, 300).await?;
+        let raw = run_cli_process(self.tool.binary_name(), &arg_refs, &combined, 300).await?;
         let content = extract_response(&self.tool, &raw)?;
-        Ok((content, TokenUsage { input: None, output: None }))
+        Ok((
+            content,
+            TokenUsage {
+                input: None,
+                output: None,
+            },
+        ))
     }
 
     async fn json_completion(
@@ -219,7 +219,7 @@ impl ChatCompletionProvider for CliCompletionClient {
         system_prompt: &str,
         user_prompt: &str,
         max_tokens: u32,
-        num_ctx: Option<u32>,
+        context_window_tokens: Option<u32>,
         temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)> {
@@ -231,7 +231,7 @@ impl ChatCompletionProvider for CliCompletionClient {
             &augmented,
             user_prompt,
             max_tokens,
-            num_ctx,
+            context_window_tokens,
             temperature,
             request_id,
         )

--- a/apps/native/src-tauri/src/providers/mod.rs
+++ b/apps/native/src-tauri/src/providers/mod.rs
@@ -28,13 +28,14 @@ pub trait ChatCompletionProvider: Send + Sync {
     fn model(&self) -> &str;
 
     /// Request a chat completion.
-    /// `num_ctx` — overrides Ollama default context-window size
+    /// `context_window_tokens` sets a provider context-window target.
+    /// For Ollama this maps to `num_ctx`; OpenAI-compatible providers ignore it.
     async fn completion(
         &self,
         system_prompt: &str,
         user_prompt: &str,
         max_tokens: u32,
-        num_ctx: Option<u32>,
+        context_window_tokens: Option<u32>,
         temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)>;
@@ -45,7 +46,7 @@ pub trait ChatCompletionProvider: Send + Sync {
         system_prompt: &str,
         user_prompt: &str,
         max_tokens: u32,
-        num_ctx: Option<u32>,
+        context_window_tokens: Option<u32>,
         temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)> {
@@ -53,7 +54,7 @@ pub trait ChatCompletionProvider: Send + Sync {
             system_prompt,
             user_prompt,
             max_tokens,
-            num_ctx,
+            context_window_tokens,
             temperature,
             request_id,
         )

--- a/apps/native/src-tauri/src/providers/ollama.rs
+++ b/apps/native/src-tauri/src/providers/ollama.rs
@@ -67,7 +67,7 @@ impl ChatCompletionProvider for OllamaClient {
         system_prompt: &str,
         user_prompt: &str,
         max_tokens: u32,
-        num_ctx: Option<u32>,
+        context_window_tokens: Option<u32>,
         temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)> {
@@ -89,7 +89,7 @@ impl ChatCompletionProvider for OllamaClient {
             options: OllamaOptions {
                 temperature,
                 num_predict: max_tokens,
-                num_ctx,
+                num_ctx: context_window_tokens,
             },
             format: None,
         };
@@ -120,17 +120,17 @@ impl ChatCompletionProvider for OllamaClient {
         system_prompt: &str,
         user_prompt: &str,
         max_tokens: u32,
-        num_ctx: Option<u32>,
+        context_window_tokens: Option<u32>,
         temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)> {
         let url = format!("{}/api/chat", self.base_url);
 
         log::info!(
-            "json_completion called: model={} format=json max_tokens={} num_ctx={:?} [id: {}]",
+            "json_completion called: model={} format=json max_tokens={} context_window_tokens={:?} [id: {}]",
             self.model,
             max_tokens,
-            num_ctx,
+            context_window_tokens,
             request_id
         );
 
@@ -150,7 +150,7 @@ impl ChatCompletionProvider for OllamaClient {
             options: OllamaOptions {
                 temperature,
                 num_predict: max_tokens,
-                num_ctx,
+                num_ctx: context_window_tokens,
             },
             format: Some("json"),
         };

--- a/apps/native/src-tauri/src/providers/openai.rs
+++ b/apps/native/src-tauri/src/providers/openai.rs
@@ -61,7 +61,7 @@ impl ChatCompletionProvider for OpenAIClient {
         system_prompt: &str,
         user_prompt: &str,
         max_tokens: u32,
-        _num_ctx: Option<u32>,
+        _context_window_tokens: Option<u32>,
         temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)> {
@@ -116,7 +116,7 @@ impl ChatCompletionProvider for OpenAIClient {
         system_prompt: &str,
         user_prompt: &str,
         max_tokens: u32,
-        _num_ctx: Option<u32>,
+        _context_window_tokens: Option<u32>,
         temperature: f32,
         request_id: &str,
     ) -> Result<(String, TokenUsage)> {

--- a/apps/native/src-tauri/src/summarize/model_calls.rs
+++ b/apps/native/src-tauri/src/summarize/model_calls.rs
@@ -20,27 +20,29 @@ const TEMPERATURE: f32 = 0.3;
 async fn request_json<R: Runtime, T: serde::de::DeserializeOwned>(
     system_prompt: &str,
     user_prompt: &str,
-    completion_tokens: u32,
-    input_tokens_budget: Option<u32>,
+    budget_for: fn(&str, &str) -> crate::summarize::token_budgets::TokenAllocation,
     temperature: f32,
     fn_name: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(T, TokenUsage)> {
     let provider = create_provider(app_handle)?;
+    let allocation = budget_for(user_prompt, provider.model());
     let request_id = uuid::Uuid::new_v4().to_string();
     debug!(
-        "[{}] requesting from {} [id: {}]",
+        "[{}] requesting from {} [id: {}] output_tokens={} context_window_tokens={}",
         fn_name,
         provider.model(),
-        request_id
+        request_id,
+        allocation.output_tokens,
+        allocation.required_context_tokens
     );
 
     let (raw_response, tokens_used) = match provider
         .json_completion(
             system_prompt,
             user_prompt,
-            completion_tokens,
-            input_tokens_budget,
+            allocation.output_tokens,
+            Some(allocation.required_context_tokens),
             temperature,
             &request_id,
         )
@@ -57,8 +59,12 @@ async fn request_json<R: Runtime, T: serde::de::DeserializeOwned>(
 
     if raw_response.trim().is_empty() {
         warn!(
-            "[{}] model returned empty response [id: {}] for user prompt: {} and system prompt: {}",
-            fn_name, request_id, user_prompt, system_prompt
+            "[{}] model returned empty response [id: {}]",
+            fn_name, request_id,
+        );
+        debug!(
+            "[{}] user prompt: {}\nsystem prompt: {}",
+            fn_name, user_prompt, system_prompt
         );
         return Err(anyhow::anyhow!(
             "{}: model returned empty response",
@@ -89,12 +95,10 @@ pub async fn generate_commit_message<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(String, TokenUsage)> {
-    let budget = commit_message_budget(prompt);
     let (parsed, usage) = request_json::<_, CommitMessageJson>(
         "",
         prompt,
-        budget.output_tokens,
-        Some(budget.required_context_tokens),
+        commit_message_budget,
         0.2,
         "generate_commit_message",
         app_handle,
@@ -121,12 +125,10 @@ pub async fn map_relations<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(Vec<RawNewMapEntry>, TokenUsage)> {
-    let budget = map_relations_budget(prompt);
     let (raw, usage) = request_json::<_, RawNewMapResponse>(
         "",
         prompt,
-        budget.output_tokens,
-        Some(budget.required_context_tokens),
+        map_relations_budget,
         TEMPERATURE,
         "map_relations",
         app_handle,
@@ -147,12 +149,10 @@ pub async fn map_relations_to_existing<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(Vec<RawHunkPlacement>, TokenUsage)> {
-    let budget = map_relations_to_existing_budget(prompt);
     let (raw, usage) = request_json::<_, RawPlacementResponse>(
         "",
         prompt,
-        budget.output_tokens,
-        Some(budget.required_context_tokens),
+        map_relations_to_existing_budget,
         TEMPERATURE,
         "map_relations_to_existing",
         app_handle,
@@ -181,13 +181,11 @@ pub async fn summarize_evolved_group<R: Runtime>(
     former_group_id: i64,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(EvolvedGroupSummary, TokenUsage)> {
-    let budget = group_budget(prompt);
     let fn_name = format!("summarize_evolved_group[{}]", former_group_id);
     let (raw, usage) = request_json::<_, EvolvedGroupRaw>(
         "",
         prompt,
-        budget.output_tokens,
-        Some(budget.required_context_tokens),
+        group_budget,
         TEMPERATURE,
         &fn_name,
         app_handle,
@@ -220,12 +218,10 @@ pub async fn summarize_new_group<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(EvolvedGroupSummary, TokenUsage)> {
-    let budget = group_budget(prompt);
     let (raw, usage) = request_json::<_, EvolvedGroupRaw>(
         "",
         prompt,
-        budget.output_tokens,
-        Some(budget.required_context_tokens),
+        group_budget,
         TEMPERATURE,
         "summarize_new_group",
         app_handle,
@@ -258,16 +254,10 @@ pub async fn summarize_new_single<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(HunkSummary, TokenUsage)> {
-    let budget = single_budget(prompt);
-    debug!(
-        "summarize_new_single: completion_tokens {}, required_context_tokens {}",
-        budget.output_tokens, budget.required_context_tokens
-    );
     request_json::<_, HunkSummary>(
         "",
         prompt,
-        budget.output_tokens,
-        Some(budget.required_context_tokens),
+        single_budget,
         TEMPERATURE,
         "summarize_new_single",
         app_handle,

--- a/apps/native/src-tauri/src/summarize/model_calls.rs
+++ b/apps/native/src-tauri/src/summarize/model_calls.rs
@@ -7,29 +7,43 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Runtime};
 
 use crate::providers::{create_provider, TokenUsage};
+use crate::summarize::model_output_types::{
+    EvolvedGroupSummary, HunkSummary, RawHunkPlacement, RawNewMapEntry,
+};
 use crate::summarize::token_budgets::{
     commit_message_budget, group_budget, map_relations_budget, map_relations_to_existing_budget,
-    new_single_budget,
+    single_budget,
 };
-use crate::summarize::model_output_types::{EvolvedGroupSummary, HunkSummary, RawHunkPlacement, RawNewMapEntry};
 
 const TEMPERATURE: f32 = 0.3;
 
 async fn request_json<R: Runtime, T: serde::de::DeserializeOwned>(
     system_prompt: &str,
     user_prompt: &str,
-    max_output_tokens: u32,
-    num_ctx: Option<u32>,
+    completion_tokens: u32,
+    input_tokens_budget: Option<u32>,
     temperature: f32,
     fn_name: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(T, TokenUsage)> {
     let provider = create_provider(app_handle)?;
     let request_id = uuid::Uuid::new_v4().to_string();
-    debug!("[{}] requesting from {} [id: {}]", fn_name, provider.model(), request_id);
+    debug!(
+        "[{}] requesting from {} [id: {}]",
+        fn_name,
+        provider.model(),
+        request_id
+    );
 
     let (raw_response, tokens_used) = match provider
-        .json_completion(system_prompt, user_prompt, max_output_tokens, num_ctx, temperature, &request_id)
+        .json_completion(
+            system_prompt,
+            user_prompt,
+            completion_tokens,
+            input_tokens_budget,
+            temperature,
+            &request_id,
+        )
         .await
     {
         Ok(t) => t,
@@ -42,14 +56,23 @@ async fn request_json<R: Runtime, T: serde::de::DeserializeOwned>(
     };
 
     if raw_response.trim().is_empty() {
-        warn!("[{}] model returned empty response [id: {}]", fn_name, request_id);
-        return Err(anyhow::anyhow!("{}: model returned empty response", fn_name));
+        warn!(
+            "[{}] model returned empty response [id: {}] for user prompt: {} and system prompt: {}",
+            fn_name, request_id, user_prompt, system_prompt
+        );
+        return Err(anyhow::anyhow!(
+            "{}: model returned empty response",
+            fn_name
+        ));
     }
 
     match serde_json::from_str::<T>(&raw_response) {
         Ok(parsed) => Ok((parsed, tokens_used)),
         Err(e) => {
-            warn!("[{}] failed to parse JSON [id: {}]: {}. Raw: {}", fn_name, request_id, e, raw_response);
+            warn!(
+                "[{}] failed to parse JSON [id: {}]: {}. Raw: {}",
+                fn_name, request_id, e, raw_response
+            );
             Err(anyhow::anyhow!("{}: failed to parse JSON: {}", fn_name, e))
         }
     }
@@ -66,19 +89,21 @@ pub async fn generate_commit_message<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(String, TokenUsage)> {
-    let (max_out, ctx) = commit_message_budget(prompt);
+    let budget = commit_message_budget(prompt);
     let (parsed, usage) = request_json::<_, CommitMessageJson>(
         "",
         prompt,
-        max_out,
-        Some(ctx),
+        budget.output_tokens,
+        Some(budget.required_context_tokens),
         0.2,
         "generate_commit_message",
         app_handle,
     )
     .await?;
     if parsed.message.trim().is_empty() {
-        return Err(anyhow::anyhow!("generate_commit_message: parsed empty message"));
+        return Err(anyhow::anyhow!(
+            "generate_commit_message: parsed empty message"
+        ));
     }
     Ok((parsed.message.trim().to_string(), usage))
 }
@@ -96,12 +121,12 @@ pub async fn map_relations<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(Vec<RawNewMapEntry>, TokenUsage)> {
-    let (max_out, ctx) = map_relations_budget(prompt);
+    let budget = map_relations_budget(prompt);
     let (raw, usage) = request_json::<_, RawNewMapResponse>(
         "",
         prompt,
-        max_out,
-        Some(ctx),
+        budget.output_tokens,
+        Some(budget.required_context_tokens),
         TEMPERATURE,
         "map_relations",
         app_handle,
@@ -122,12 +147,12 @@ pub async fn map_relations_to_existing<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(Vec<RawHunkPlacement>, TokenUsage)> {
-    let (max_out, ctx) = map_relations_to_existing_budget(prompt);
+    let budget = map_relations_to_existing_budget(prompt);
     let (raw, usage) = request_json::<_, RawPlacementResponse>(
         "",
         prompt,
-        max_out,
-        Some(ctx),
+        budget.output_tokens,
+        Some(budget.required_context_tokens),
         TEMPERATURE,
         "map_relations_to_existing",
         app_handle,
@@ -156,29 +181,51 @@ pub async fn summarize_evolved_group<R: Runtime>(
     former_group_id: i64,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(EvolvedGroupSummary, TokenUsage)> {
-    let (max_out, ctx) = group_budget(prompt);
+    let budget = group_budget(prompt);
     let fn_name = format!("summarize_evolved_group[{}]", former_group_id);
-    let (raw, usage) =
-        request_json::<_, EvolvedGroupRaw>("", prompt, max_out, Some(ctx), TEMPERATURE, &fn_name, app_handle)
-            .await?;
+    let (raw, usage) = request_json::<_, EvolvedGroupRaw>(
+        "",
+        prompt,
+        budget.output_tokens,
+        Some(budget.required_context_tokens),
+        TEMPERATURE,
+        &fn_name,
+        app_handle,
+    )
+    .await?;
     let own_summaries = raw
         .changes
         .into_iter()
-        .map(|e| (e.hash, HunkSummary { title: e.title, description: e.description }))
+        .map(|e| {
+            (
+                e.hash,
+                HunkSummary {
+                    title: e.title,
+                    description: e.description,
+                },
+            )
+        })
         .collect();
-    Ok((EvolvedGroupSummary { former_group_id, group: raw.group, own_summaries }, usage))
+    Ok((
+        EvolvedGroupSummary {
+            former_group_id,
+            group: raw.group,
+            own_summaries,
+        },
+        usage,
+    ))
 }
 
 pub async fn summarize_new_group<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(EvolvedGroupSummary, TokenUsage)> {
-    let (max_out, ctx) = group_budget(prompt);
+    let budget = group_budget(prompt);
     let (raw, usage) = request_json::<_, EvolvedGroupRaw>(
         "",
         prompt,
-        max_out,
-        Some(ctx),
+        budget.output_tokens,
+        Some(budget.required_context_tokens),
         TEMPERATURE,
         "summarize_new_group",
         app_handle,
@@ -187,18 +234,45 @@ pub async fn summarize_new_group<R: Runtime>(
     let own_summaries = raw
         .changes
         .into_iter()
-        .map(|e| (e.hash, HunkSummary { title: e.title, description: e.description }))
+        .map(|e| {
+            (
+                e.hash,
+                HunkSummary {
+                    title: e.title,
+                    description: e.description,
+                },
+            )
+        })
         .collect();
-    Ok((EvolvedGroupSummary { former_group_id: 0, group: raw.group, own_summaries }, usage))
+    Ok((
+        EvolvedGroupSummary {
+            former_group_id: 0,
+            group: raw.group,
+            own_summaries,
+        },
+        usage,
+    ))
 }
 
 pub async fn summarize_new_single<R: Runtime>(
     prompt: &str,
     app_handle: Option<&AppHandle<R>>,
 ) -> Result<(HunkSummary, TokenUsage)> {
-    let (max_out, ctx) = new_single_budget(prompt);
-    request_json::<_, HunkSummary>("", prompt, max_out, Some(ctx), TEMPERATURE, "summarize_new_single", app_handle)
-        .await
+    let budget = single_budget(prompt);
+    debug!(
+        "summarize_new_single: completion_tokens {}, required_context_tokens {}",
+        budget.output_tokens, budget.required_context_tokens
+    );
+    request_json::<_, HunkSummary>(
+        "",
+        prompt,
+        budget.output_tokens,
+        Some(budget.required_context_tokens),
+        TEMPERATURE,
+        "summarize_new_single",
+        app_handle,
+    )
+    .await
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────

--- a/apps/native/src-tauri/src/summarize/token_budgets.rs
+++ b/apps/native/src-tauri/src/summarize/token_budgets.rs
@@ -4,6 +4,7 @@ use once_cell::sync::Lazy;
 use tiktoken_rs::{cl100k_base, CoreBPE};
 
 const DEFAULT_MODEL_CONTEXT_WINDOW: u32 = 8192;
+const MIN_MEANINGFUL_OUTPUT_TOKENS: u32 = 128;
 
 #[derive(Debug, Clone, Copy)]
 pub struct TokenAllocation {
@@ -32,27 +33,49 @@ pub fn compute_token_allocation(
 
     let safety_margin = (max_context_tokens / 16).max(128);
 
-    let required_context_tokens = input_est
+    let desired_total = input_est
         .saturating_add(requested_output_tokens)
-        .saturating_add(safety_margin)
-        .min(max_context_tokens);
+        .saturating_add(safety_margin);
 
-    // Never reduce output_tokens
-    let output_tokens = requested_output_tokens;
-
-    // Only warn when we *know* truncation risk exists
-    if input_est + requested_output_tokens + safety_margin > max_context_tokens {
-        log::warn!(
-            "Token budget overflow (non-fatal). input={}, output={}, ctx={}",
-            input_est,
-            requested_output_tokens,
-            max_context_tokens
-        );
+    if desired_total <= max_context_tokens {
+        return TokenAllocation {
+            output_tokens: requested_output_tokens,
+            required_context_tokens: desired_total,
+        };
     }
 
+    let available_for_output = max_context_tokens
+        .saturating_sub(input_est)
+        .saturating_sub(safety_margin);
+
+    if available_for_output < MIN_MEANINGFUL_OUTPUT_TOKENS {
+        log::warn!(
+            "Prompt exceeds context window without enough room for meaningful completion. input={} available_output={} min_output={} ctx={}",
+            input_est,
+            available_for_output,
+            MIN_MEANINGFUL_OUTPUT_TOKENS,
+            max_context_tokens
+        );
+
+        return TokenAllocation {
+            output_tokens: 0,
+            required_context_tokens: max_context_tokens,
+        };
+    }
+
+    let clamped_output = requested_output_tokens.min(available_for_output);
+
+    log::warn!(
+        "Token allocation clamped. input={} requested_output={} clamped_output={} ctx={}",
+        input_est,
+        requested_output_tokens,
+        clamped_output,
+        max_context_tokens
+    );
+
     TokenAllocation {
-        output_tokens,
-        required_context_tokens,
+        output_tokens: clamped_output,
+        required_context_tokens: max_context_tokens,
     }
 }
 
@@ -150,14 +173,15 @@ mod tests {
         let prompt = "one line";
         let input = estimate_input_tokens(prompt);
         let requested_output = 300;
-        let max_ctx = input + requested_output + 100 + 50;
+        let safety_margin = (4096 / 16).max(128);
+        let max_ctx = input + requested_output + safety_margin + 50;
 
         let alloc = compute_token_allocation(prompt, requested_output, max_ctx);
 
         assert_eq!(alloc.output_tokens, requested_output);
         assert_eq!(
             alloc.required_context_tokens,
-            input + requested_output + 100 + 50
+            input + requested_output + safety_margin
         );
     }
 
@@ -166,12 +190,29 @@ mod tests {
         let prompt = "one line";
         let input = estimate_input_tokens(prompt);
         let requested_output = 300;
-        let available_output = 42;
-        let max_ctx = input + 100 + 50 + available_output;
+        let max_ctx = 4096;
+        let safety_margin = (max_ctx / 16).max(128);
+        let available_output = 256;
+        let max_ctx = input + safety_margin + available_output;
 
         let alloc = compute_token_allocation(prompt, requested_output, max_ctx);
 
         assert_eq!(alloc.output_tokens, available_output);
+        assert_eq!(alloc.required_context_tokens, max_ctx);
+    }
+
+    #[test]
+    fn returns_zero_output_when_only_tiny_completion_would_fit() {
+        let prompt = "one line";
+        let input = estimate_input_tokens(prompt);
+        let max_ctx = 4096;
+        let safety_margin = (max_ctx / 16).max(128);
+        let tiny_available_output = MIN_MEANINGFUL_OUTPUT_TOKENS - 1;
+        let max_ctx = input + safety_margin + tiny_available_output;
+
+        let alloc = compute_token_allocation(prompt, 300, max_ctx);
+
+        assert_eq!(alloc.output_tokens, 0);
         assert_eq!(alloc.required_context_tokens, max_ctx);
     }
 

--- a/apps/native/src-tauri/src/summarize/token_budgets.rs
+++ b/apps/native/src-tauri/src/summarize/token_budgets.rs
@@ -1,52 +1,118 @@
 //! Token budget constants and prompt-length based budget computation for model calls.
 
-const OUTPUT_PER_LINE: u32 = 5;
+use once_cell::sync::Lazy;
+use tiktoken_rs::{cl100k_base, CoreBPE};
+
 const CTX_SAFETY_MARGIN: u32 = 512;
 
-/// Returns `(max_output_tokens, num_ctx)` scaled to prompt line count, clamped to `[min, max]`.
-pub fn prompt_budget(prompt: &str, min_tokens: u32, max_tokens: u32) -> (u32, u32) {
-    let lines = prompt.lines().count() as u32;
-    let max_output = (min_tokens + lines * OUTPUT_PER_LINE).min(max_tokens);
-    let input_est = (prompt.len() as u32) / 4;
-    (max_output, input_est + max_output + CTX_SAFETY_MARGIN)
+#[derive(Debug, Clone, Copy)]
+pub struct TokenAllocation {
+    pub output_tokens: u32,
+    pub required_context_tokens: u32,
+}
+
+static CL100K_BPE: Lazy<Option<CoreBPE>> = Lazy::new(|| cl100k_base().ok());
+
+fn estimate_input_tokens(prompt: &str) -> u32 {
+    if let Some(bpe) = CL100K_BPE.as_ref() {
+        // cl100k is a strong default across OpenAI-compatible chat models.
+        return bpe.encode_with_special_tokens(prompt).len() as u32;
+    }
+
+    // Fallback keeps behavior stable even if tokenizer init fails.
+    (prompt.len() as u32) / 4
+}
+
+/// Computes token allocation for a model call from completion and context budgets.
+pub fn compute_token_allocation(
+    prompt: &str,
+    completion_tokens: u32,
+    max_context_tokens: u32,
+) -> TokenAllocation {
+    let input_est = estimate_input_tokens(prompt);
+
+    let required_context_tokens = input_est
+        .saturating_add(CTX_SAFETY_MARGIN)
+        .min(max_context_tokens);
+
+    TokenAllocation {
+        output_tokens: completion_tokens,
+        required_context_tokens,
+    }
 }
 
 // ── map_relations ─────────────────────────────────────────────────────────────
-const MAP_MIN: u32 = 800;
-const MAP_MAX: u32 = 8000;
+const MAP_COMPLETION_TOKENS: u32 = 800;
+const MAP_MAX_CONTEXT_TOKENS: u32 = 8000;
 
-pub fn map_relations_budget(prompt: &str) -> (u32, u32) {
-    prompt_budget(prompt, MAP_MIN, MAP_MAX)
+pub fn map_relations_budget(prompt: &str) -> TokenAllocation {
+    compute_token_allocation(prompt, MAP_COMPLETION_TOKENS, MAP_MAX_CONTEXT_TOKENS)
 }
 
 // ── map_relations_to_existing ─────────────────────────────────────────────────
-const MAP_TO_MIN: u32 = 800;
-const MAP_TO_MAX: u32 = 8000;
+const MAP_TO_EXISTING_COMPLETION_TOKENS: u32 = 800;
+const MAP_TO_EXISTING_MAX_CONTEXT_TOKENS: u32 = 8000;
 
-pub fn map_relations_to_existing_budget(prompt: &str) -> (u32, u32) {
-    prompt_budget(prompt, MAP_TO_MIN, MAP_TO_MAX)
+pub fn map_relations_to_existing_budget(prompt: &str) -> TokenAllocation {
+    compute_token_allocation(
+        prompt,
+        MAP_TO_EXISTING_COMPLETION_TOKENS,
+        MAP_TO_EXISTING_MAX_CONTEXT_TOKENS,
+    )
 }
 
 // ── summarize_evolved_group / summarize_new_group ─────────────────────────────
-const GROUP_MIN: u32 = 700;
-const GROUP_MAX: u32 = 6000;
+const GROUP_COMPLETION_TOKENS: u32 = 700;
+const GROUP_MAX_CONTEXT_TOKENS: u32 = 6000;
 
-pub fn group_budget(prompt: &str) -> (u32, u32) {
-    prompt_budget(prompt, GROUP_MIN, GROUP_MAX)
+pub fn group_budget(prompt: &str) -> TokenAllocation {
+    compute_token_allocation(prompt, GROUP_COMPLETION_TOKENS, GROUP_MAX_CONTEXT_TOKENS)
 }
 
 // ── summarize_new_single ──────────────────────────────────────────────────────
-const SINGLE_MIN: u32 = 400;
-const SINGLE_MAX: u32 = 4000;
+const SINGLE_COMPLETION_TOKENS: u32 = 800;
+const SINGLE_MAX_CONTEXT_TOKENS: u32 = 2500;
 
-pub fn new_single_budget(prompt: &str) -> (u32, u32) {
-    prompt_budget(prompt, SINGLE_MIN, SINGLE_MAX)
+pub fn single_budget(prompt: &str) -> TokenAllocation {
+    compute_token_allocation(prompt, SINGLE_COMPLETION_TOKENS, SINGLE_MAX_CONTEXT_TOKENS)
 }
 
 // ── generate_commit_message_from_map ─────────────────────────────────────────
-const MSG_MIN: u32 = 300;
-const MSG_MAX: u32 = 600;
+const COMMIT_MESSAGE_COMPLETION_TOKENS: u32 = 300;
+const COMMIT_MESSAGE_MAX_CONTEXT_TOKENS: u32 = 600;
 
-pub fn commit_message_budget(prompt: &str) -> (u32, u32) {
-    prompt_budget(prompt, MSG_MIN, MSG_MAX)
+pub fn commit_message_budget(prompt: &str) -> TokenAllocation {
+    compute_token_allocation(
+        prompt,
+        COMMIT_MESSAGE_COMPLETION_TOKENS,
+        COMMIT_MESSAGE_MAX_CONTEXT_TOKENS,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_grows_with_prompt_size() {
+        let short = "small prompt";
+        let long = "small prompt\nwith additional context\nand even more details";
+
+        let short_alloc = compute_token_allocation(short, 400, 4000);
+        let long_alloc = compute_token_allocation(long, 400, 4000);
+
+        assert!(long_alloc.required_context_tokens >= short_alloc.required_context_tokens);
+    }
+
+    #[test]
+    fn output_budget_matches_configured_completion_tokens() {
+        let single = "one line";
+        let multi = "one line\ntwo line\nthree line";
+
+        let single_alloc = compute_token_allocation(single, 300, 600);
+        let multi_alloc = compute_token_allocation(multi, 300, 600);
+
+        assert_eq!(single_alloc.output_tokens, 300);
+        assert_eq!(multi_alloc.output_tokens, 300);
+    }
 }

--- a/apps/native/src-tauri/src/summarize/token_budgets.rs
+++ b/apps/native/src-tauri/src/summarize/token_budgets.rs
@@ -3,7 +3,7 @@
 use once_cell::sync::Lazy;
 use tiktoken_rs::{cl100k_base, CoreBPE};
 
-const CTX_SAFETY_MARGIN: u32 = 512;
+const DEFAULT_MODEL_CONTEXT_WINDOW: u32 = 8192;
 
 #[derive(Debug, Clone, Copy)]
 pub struct TokenAllocation {
@@ -23,69 +23,110 @@ fn estimate_input_tokens(prompt: &str) -> u32 {
     (prompt.len() as u32) / 4
 }
 
-/// Computes token allocation for a model call from completion and context budgets.
 pub fn compute_token_allocation(
     prompt: &str,
-    completion_tokens: u32,
+    requested_output_tokens: u32,
     max_context_tokens: u32,
 ) -> TokenAllocation {
     let input_est = estimate_input_tokens(prompt);
 
+    let safety_margin = (max_context_tokens / 16).max(128);
+
     let required_context_tokens = input_est
-        .saturating_add(CTX_SAFETY_MARGIN)
+        .saturating_add(requested_output_tokens)
+        .saturating_add(safety_margin)
         .min(max_context_tokens);
 
+    // Never reduce output_tokens
+    let output_tokens = requested_output_tokens;
+
+    // Only warn when we *know* truncation risk exists
+    if input_est + requested_output_tokens + safety_margin > max_context_tokens {
+        log::warn!(
+            "Token budget overflow (non-fatal). input={}, output={}, ctx={}",
+            input_est,
+            requested_output_tokens,
+            max_context_tokens
+        );
+    }
+
     TokenAllocation {
-        output_tokens: completion_tokens,
+        output_tokens,
         required_context_tokens,
     }
 }
 
-// ── map_relations ─────────────────────────────────────────────────────────────
-const MAP_COMPLETION_TOKENS: u32 = 800;
-const MAP_MAX_CONTEXT_TOKENS: u32 = 8000;
+/// Returns a best-effort context window size for a model identifier.
+pub fn model_context_window(model: &str) -> u32 {
+    let m = model.to_ascii_lowercase();
 
-pub fn map_relations_budget(prompt: &str) -> TokenAllocation {
-    compute_token_allocation(prompt, MAP_COMPLETION_TOKENS, MAP_MAX_CONTEXT_TOKENS)
+    if m.contains("gpt-oss")
+        || m.contains("o1")
+        || m.contains("o3")
+        || m.contains("gpt-4.1")
+        || m.contains("claude-3")
+        || m.contains("gemini-1.5")
+        || m.contains("gemini-2")
+    {
+        return 32768;
+    }
+
+    if m.contains("gpt-4o")
+        || m.contains("llama3")
+        || m.contains("qwen")
+        || m.contains("mistral")
+        || m.contains("codellama")
+    {
+        return 16384;
+    }
+
+    DEFAULT_MODEL_CONTEXT_WINDOW
+}
+
+// ── map_relations ─────────────────────────────────────────────────────────────
+const MAP_MAX_OUTPUT_TOKENS: u32 = 800;
+
+pub fn map_relations_budget(prompt: &str, model: &str) -> TokenAllocation {
+    compute_token_allocation(prompt, MAP_MAX_OUTPUT_TOKENS, model_context_window(model))
 }
 
 // ── map_relations_to_existing ─────────────────────────────────────────────────
-const MAP_TO_EXISTING_COMPLETION_TOKENS: u32 = 800;
-const MAP_TO_EXISTING_MAX_CONTEXT_TOKENS: u32 = 8000;
+const MAP_TO_EXISTING_MAX_OUTPUT_TOKENS: u32 = 800;
 
-pub fn map_relations_to_existing_budget(prompt: &str) -> TokenAllocation {
+pub fn map_relations_to_existing_budget(prompt: &str, model: &str) -> TokenAllocation {
     compute_token_allocation(
         prompt,
-        MAP_TO_EXISTING_COMPLETION_TOKENS,
-        MAP_TO_EXISTING_MAX_CONTEXT_TOKENS,
+        MAP_TO_EXISTING_MAX_OUTPUT_TOKENS,
+        model_context_window(model),
     )
 }
 
 // ── summarize_evolved_group / summarize_new_group ─────────────────────────────
-const GROUP_COMPLETION_TOKENS: u32 = 700;
-const GROUP_MAX_CONTEXT_TOKENS: u32 = 6000;
+const GROUP_MAX_OUTPUT_TOKENS: u32 = 700;
 
-pub fn group_budget(prompt: &str) -> TokenAllocation {
-    compute_token_allocation(prompt, GROUP_COMPLETION_TOKENS, GROUP_MAX_CONTEXT_TOKENS)
+pub fn group_budget(prompt: &str, model: &str) -> TokenAllocation {
+    compute_token_allocation(prompt, GROUP_MAX_OUTPUT_TOKENS, model_context_window(model))
 }
 
 // ── summarize_new_single ──────────────────────────────────────────────────────
-const SINGLE_COMPLETION_TOKENS: u32 = 800;
-const SINGLE_MAX_CONTEXT_TOKENS: u32 = 2500;
+const SINGLE_MAX_OUTPUT_TOKENS: u32 = 800;
 
-pub fn single_budget(prompt: &str) -> TokenAllocation {
-    compute_token_allocation(prompt, SINGLE_COMPLETION_TOKENS, SINGLE_MAX_CONTEXT_TOKENS)
+pub fn single_budget(prompt: &str, model: &str) -> TokenAllocation {
+    compute_token_allocation(
+        prompt,
+        SINGLE_MAX_OUTPUT_TOKENS,
+        model_context_window(model),
+    )
 }
 
 // ── generate_commit_message_from_map ─────────────────────────────────────────
-const COMMIT_MESSAGE_COMPLETION_TOKENS: u32 = 300;
-const COMMIT_MESSAGE_MAX_CONTEXT_TOKENS: u32 = 600;
+const COMMIT_MESSAGE_MAX_OUTPUT_TOKENS: u32 = 300;
 
-pub fn commit_message_budget(prompt: &str) -> TokenAllocation {
+pub fn commit_message_budget(prompt: &str, model: &str) -> TokenAllocation {
     compute_token_allocation(
         prompt,
-        COMMIT_MESSAGE_COMPLETION_TOKENS,
-        COMMIT_MESSAGE_MAX_CONTEXT_TOKENS,
+        COMMIT_MESSAGE_MAX_OUTPUT_TOKENS,
+        model_context_window(model),
     )
 }
 
@@ -105,14 +146,42 @@ mod tests {
     }
 
     #[test]
-    fn output_budget_matches_configured_completion_tokens() {
-        let single = "one line";
-        let multi = "one line\ntwo line\nthree line";
+    fn returns_requested_output_when_budget_fits() {
+        let prompt = "one line";
+        let input = estimate_input_tokens(prompt);
+        let requested_output = 300;
+        let max_ctx = input + requested_output + 100 + 50;
 
-        let single_alloc = compute_token_allocation(single, 300, 600);
-        let multi_alloc = compute_token_allocation(multi, 300, 600);
+        let alloc = compute_token_allocation(prompt, requested_output, max_ctx);
 
-        assert_eq!(single_alloc.output_tokens, 300);
-        assert_eq!(multi_alloc.output_tokens, 300);
+        assert_eq!(alloc.output_tokens, requested_output);
+        assert_eq!(
+            alloc.required_context_tokens,
+            input + requested_output + 100 + 50
+        );
+    }
+
+    #[test]
+    fn clamps_output_to_available_context_when_needed() {
+        let prompt = "one line";
+        let input = estimate_input_tokens(prompt);
+        let requested_output = 300;
+        let available_output = 42;
+        let max_ctx = input + 100 + 50 + available_output;
+
+        let alloc = compute_token_allocation(prompt, requested_output, max_ctx);
+
+        assert_eq!(alloc.output_tokens, available_output);
+        assert_eq!(alloc.required_context_tokens, max_ctx);
+    }
+
+    #[test]
+    fn model_context_window_uses_reasonable_defaults() {
+        assert_eq!(model_context_window("openai/gpt-4o-mini"), 16384);
+        assert_eq!(model_context_window("gpt-oss-120b"), 32768);
+        assert_eq!(
+            model_context_window("unknown-model"),
+            DEFAULT_MODEL_CONTEXT_WINDOW
+        );
     }
 }


### PR DESCRIPTION
## Summary

I have been testing a diff with a really long line of code, and I observed that we don't create good summary token budgets in this case.

Anyway, it's better to use a real tokenizer and take most of the heuristics out of it. I've used tiktoken in the past on Python projects so let's use it here.

Once I got into this, I found the "min" and "max" terminology used in token_budgets.rs to be rather misleading so I cleaned the names up, at least at the bottom two levels of the call stack.

## Test Plan

Manual testing of a few prompts and unit tests.

## Docs

- [ ] Docs updated
- [x] No docs update needed
