### PR TITLE
feat(homebrew): integrate direct, non-AI Homebrew support into Nix configuration

### DIFF
--- a/apps/native/src-tauri/examples/specta_gen_ts.rs
+++ b/apps/native/src-tauri/examples/specta_gen_ts.rs
@@ -36,6 +36,7 @@ fn main() {
 
     let mut shared_collection = TypeCollection::default();
     let shared_types_reg = shared_collection
+        .register::<shared_types::HomebrewState>()
         .register::<shared_types::SummarizedChange>()
         .register::<shared_types::SummarizedChangeSet>()
         .register::<shared_types::ChangeWithSummary>()

--- a/apps/native/src-tauri/src/apply_system_defaults.rs
+++ b/apps/native/src-tauri/src/apply_system_defaults.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use tauri::AppHandle;
 
-use crate::{db, evolve_state, git, scanner, shared_types, store, summarize};
+use crate::{managed_edit, scanner};
 
 /// Writes detected system defaults to a .nix module file, injects the import
 /// into flake.nix, creates an evolution + summarization pipeline so the
@@ -12,7 +12,8 @@ pub async fn apply_system_defaults(
     app: &AppHandle,
     defaults: Vec<scanner::SystemDefault>,
 ) -> Result<serde_json::Value> {
-    let dir = store::ensure_config_dir_exists(app).context("Failed to get config directory")?;
+    let context = managed_edit::prepare_managed_edit(app)?;
+    let dir = context.dir.clone();
 
     // 1. Generate nix file content
     log::info!(
@@ -74,82 +75,20 @@ pub async fn apply_system_defaults(
         target_path
     );
 
-    // 5. Wire into the evolve pipeline — leave changes in the working tree so
-    //    the summarizer can read the diff, then set EvolveState so the frontend
-    //    transitions to the evolve step.
-    let db_path = db::get_db_path(app).context("Failed to get DB path")?;
-
-    // Store the current HEAD commit so the changeset has a base.
-    let _base_commit_id =
-        db::commits::store_head_commit(&db_path, &dir, None).context("Failed to store HEAD commit")?;
-
-    // Reuse an existing evolution if one is already active.
-    let existing_evo_id = evolve_state::get(app).ok().and_then(|s| s.evolution_id);
-    let branch = git::current_branch(&dir).unwrap_or_else(|| "main".to_string());
-    let evolution_id = db::evolutions::upsert(&db_path, existing_evo_id, &branch)
-        .context("Failed to upsert evolution")?;
-    log::info!("[apply_system_defaults] Using evolution_id={}", evolution_id);
-
-    // Persist the evolve state so the frontend can start rendering the evolve step.
-    let initial_state = shared_types::EvolveState {
-        evolution_id: Some(evolution_id),
-        current_changeset_id: None,
-        changeset_at_build: None,
-        committable: false,
-        backup_branch: None,
-        rollback_branch: None,
-        rollback_store_path: None,
-        rollback_changeset_id: None,
-        step: shared_types::EvolveStep::Evolve,
-    };
     let working_tree_status =
-        git::status(&dir).context("Failed to get working tree status for evolve state")?;
-    let mut evolve_state = evolve_state::set(app, initial_state, &working_tree_status.changes)
-        .context("Failed to set evolve state")?;
-
-    // Run the summarization pipeline against the working tree diff.
-    // `new_changeset` reads `git::status().diff` which includes untracked files,
-    // so system-defaults.nix and the modified import file are both captured.
-    match summarize::new_changeset(app, Some(evolution_id)).await {
-        Ok(Some(changeset_id)) => {
-            log::info!(
-                "[apply_system_defaults] Changeset created: id={}",
-                changeset_id
-            );
-            evolve_state.current_changeset_id = Some(changeset_id);
-            evolve_state =
-                evolve_state::set(app, evolve_state, &working_tree_status.changes)
-                    .context("Failed to update evolve state with changeset")?;
-        }
-        Ok(None) => {
-            log::warn!("[apply_system_defaults] Summarizer returned None — diff may be empty");
-        }
-        Err(e) => {
-            log::error!("[apply_system_defaults] Summarizer error: {}", e);
-            // Non-fatal — evolve state is already set; summaries will be pending.
-        }
-    }
-
-    // Build the change map from whatever the DB has right now (may include
-    // queued/pending summaries that the background processor will fill in).
-    let change_sets = summarize::find_existing::for_current_state(&db_path, &dir)
-        .unwrap_or_default();
-    let change_map = summarize::group_existing::from_change_sets(change_sets);
-
-    // Get current git status and cache it so the watcher doesn't fire spuriously.
-    let git_status = git::status_and_cache(&dir, app).context("Failed to get git status")?;
+        crate::git::status(&dir).context("Failed to get working tree status for evolve state")?;
 
     log::info!(
-        "[apply_system_defaults] Complete — {} defaults applied, evolution_id={}",
-        defaults.len(),
-        evolution_id
+        "[apply_system_defaults] Complete — {} defaults applied",
+        defaults.len()
     );
 
-    Ok(serde_json::json!({
-        "ok": true,
-        "count": defaults.len(),
-        "changeMap": change_map,
-        "gitStatus": git_status,
-        "evolveState": evolve_state,
-    }))
+    managed_edit::finalize_managed_edit(
+        app,
+        context,
+        working_tree_status,
+        defaults.len(),
+        "apply_system_defaults",
+    )
+    .await
 }

--- a/apps/native/src-tauri/src/commands.rs
+++ b/apps/native/src-tauri/src/commands.rs
@@ -9,7 +9,8 @@
 
 use crate::{
     darwin, db, default_config, editor, evolution, evolve_state, feedback, finalize_restore, git,
-    lsp, nix, peek, permissions, rollback, scanner, shared_types, store, types, utils, watcher,
+    lsp, mac, nix, peek, permissions, rollback, scanner, shared_types, store, types, utils,
+    watcher,
 };
 use std::path::Path;
 use std::process::Command;
@@ -32,7 +33,10 @@ fn handle_new_config_dir(
     dir: &str,
 ) -> Result<(shared_types::EvolveState, Option<Vec<String>>), String> {
     let git_status = git::status(dir).ok();
-    let changes = git_status.as_ref().map(|s| s.changes.clone()).unwrap_or_default();
+    let changes = git_status
+        .as_ref()
+        .map(|s| s.changes.clone())
+        .unwrap_or_default();
     if let Some(ref s) = git_status {
         let _ = store::set_cached_git_status(app, s);
     }
@@ -94,25 +98,26 @@ pub async fn config_set_dir(
 
     let prev_dir = store::get_config_dir(&app).ok();
     let new_dir = normalized_dir.to_string_lossy().to_string();
-    store::set_config_dir(&app, &new_dir)
-        .map_err(|e| capture_err("config_set_dir", e))?;
+    store::set_config_dir(&app, &new_dir).map_err(|e| capture_err("config_set_dir", e))?;
 
     let (evolve_state, hosts) = if prev_dir.as_deref() != Some(&new_dir) {
-        let (es, hosts) = handle_new_config_dir(&app, &new_dir)
-            .map_err(|e| capture_err("config_set_dir", e))?;
+        let (es, hosts) =
+            handle_new_config_dir(&app, &new_dir).map_err(|e| capture_err("config_set_dir", e))?;
         (Some(es), hosts)
     } else {
         (None, None)
     };
 
-    Ok(shared_types::SetDirResult { dir: new_dir, evolve_state, hosts })
+    Ok(shared_types::SetDirResult {
+        dir: new_dir,
+        evolve_state,
+        hosts,
+    })
 }
 
 /// Opens a native folder picker dialog to select the flake directory.
 #[tauri::command]
-pub async fn config_pick_dir(
-    app: AppHandle,
-) -> Result<Option<shared_types::SetDirResult>, String> {
+pub async fn config_pick_dir(app: AppHandle) -> Result<Option<shared_types::SetDirResult>, String> {
     let dialog = app.dialog();
     // Try to open the picker at the currently configured directory
     let prev_dir = store::get_config_dir(&app).map_err(|e| capture_err("config_pick_dir", e))?;
@@ -132,13 +137,17 @@ pub async fn config_pick_dir(
         store::set_config_dir(&app, &dir).map_err(|e| capture_err("config_pick_dir", e))?;
         store::ensure_config_dir_exists(&app).map_err(|e| capture_err("config_pick_dir", e))?;
         let (evolve_state, hosts) = if dir != prev_dir {
-            let (es, hosts) = handle_new_config_dir(&app, &dir)
-                .map_err(|e| capture_err("config_pick_dir", e))?;
+            let (es, hosts) =
+                handle_new_config_dir(&app, &dir).map_err(|e| capture_err("config_pick_dir", e))?;
             (Some(es), hosts)
         } else {
             (None, None)
         };
-        return Ok(Some(shared_types::SetDirResult { dir, evolve_state, hosts }));
+        return Ok(Some(shared_types::SetDirResult {
+            dir,
+            evolve_state,
+            hosts,
+        }));
     }
 
     Ok(None)
@@ -238,6 +247,30 @@ pub async fn debug_sentry_event() -> Result<serde_json::Value, String> {
     sentry::capture_message("Debug Sentry event from Rust backend", sentry::Level::Error);
 
     Ok(serde_json::json!({"ok": true, "message": "Debug event captured from Rust"}))
+}
+
+// =============================================================================
+// Homebrew Commands
+// =============================================================================
+#[tauri::command]
+pub async fn homebrew_apply_diff(
+    app: AppHandle,
+    diff: shared_types::HomebrewState,
+) -> Result<serde_json::Value, String> {
+    crate::mac::homebrew::apply_homebrew_diff(&app, diff)
+        .await
+        .map_err(|e| capture_err("homebrew_apply_diff", e))
+}
+
+#[tauri::command]
+pub async fn homebrew_get_state_diff(
+    app: AppHandle,
+) -> Result<shared_types::HomebrewState, String> {
+    let dir = store::ensure_config_dir_exists(&app)
+        .map_err(|e| capture_err("homebrew_get_state_diff", e))?;
+
+    mac::homebrew::get_homebrew_state_diff(Path::new(&dir))
+        .map_err(|e| capture_err("homebrew_get_state_diff", e))
 }
 
 // =============================================================================
@@ -729,7 +762,9 @@ pub async fn summarize_current(
     let dir = store::get_config_dir(&app).map_err(|e| capture_err("summarize_current", e))?;
     let change_sets = crate::summarize::find_existing::for_current_state(&db_path, &dir)
         .map_err(|e| capture_err("summarize_current", e))?;
-    Ok(crate::summarize::group_existing::from_change_sets(change_sets))
+    Ok(crate::summarize::group_existing::from_change_sets(
+        change_sets,
+    ))
 }
 
 /// Returns all commits on the main branch, each paired with optional DB metadata, summary,
@@ -785,8 +820,8 @@ pub async fn generate_commit_message(app: AppHandle) -> Result<String, String> {
 /// Returns all UI preferences.
 #[tauri::command]
 pub async fn ui_get_prefs(app: AppHandle) -> Result<types::UiPrefs, String> {
-    let openrouter_api_key =
-        store::get_effective_openrouter_api_key(&app).map_err(|e| capture_err("ui_get_prefs", e))?;
+    let openrouter_api_key = store::get_effective_openrouter_api_key(&app)
+        .map_err(|e| capture_err("ui_get_prefs", e))?;
     let openai_api_key =
         store::get_effective_openai_api_key(&app).map_err(|e| capture_err("ui_get_prefs", e))?;
     let send_diagnostics =
@@ -819,6 +854,9 @@ pub async fn ui_get_prefs(app: AppHandle) -> Result<types::UiPrefs, String> {
     let auto_summarize_on_focus =
         store::get_bool_pref(&app, store::AUTO_SUMMARIZE_ON_FOCUS_KEY, false)
             .map_err(|e| capture_err("ui_get_prefs", e))?;
+    let scan_homebrew_on_startup =
+        store::get_bool_pref(&app, store::SCAN_HOMEBREW_ON_STARTUP_KEY, true)
+            .map_err(|e| capture_err("ui_get_prefs", e))?;
 
     Ok(types::UiPrefs {
         openrouter_api_key,
@@ -841,6 +879,7 @@ pub async fn ui_get_prefs(app: AppHandle) -> Result<types::UiPrefs, String> {
         confirm_clear,
         confirm_rollback,
         auto_summarize_on_focus,
+        scan_homebrew_on_startup,
     })
 }
 
@@ -921,8 +960,23 @@ pub async fn ui_set_prefs(
         .get(store::AUTO_SUMMARIZE_ON_FOCUS_KEY)
         .and_then(|v| v.as_bool())
     {
-        store::set_bool_pref(&app, store::AUTO_SUMMARIZE_ON_FOCUS_KEY, auto_summarize_on_focus)
-            .map_err(|e| capture_err("ui_set_prefs", e))?;
+        store::set_bool_pref(
+            &app,
+            store::AUTO_SUMMARIZE_ON_FOCUS_KEY,
+            auto_summarize_on_focus,
+        )
+        .map_err(|e| capture_err("ui_set_prefs", e))?;
+    }
+    if let Some(scan_homebrew_on_startup) = prefs
+        .get(store::SCAN_HOMEBREW_ON_STARTUP_KEY)
+        .and_then(|v| v.as_bool())
+    {
+        store::set_bool_pref(
+            &app,
+            store::SCAN_HOMEBREW_ON_STARTUP_KEY,
+            scan_homebrew_on_startup,
+        )
+        .map_err(|e| capture_err("ui_set_prefs", e))?;
     }
 
     Ok(serde_json::json!({"ok": true}))

--- a/apps/native/src-tauri/src/evolve/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/edit_nix_file.rs
@@ -30,17 +30,6 @@ pub(crate) const NIX_EXPR_MARKER_KEY: &str = "__nixExpr";
 /// and renders it as `builtins.path { path = ...; }`.
 pub(crate) const NIX_BUILTINS_PATH_MARKER_KEY: &str = "__nixBuiltinsPath";
 
-#[allow(dead_code)]
-pub(crate) fn nix_path_meta_value(path: &str) -> serde_json::Value {
-    let mut value = serde_json::Map::new();
-    value.insert(
-        NIX_PATH_MARKER_KEY.to_string(),
-        serde_json::Value::String(path.to_string()),
-    );
-    serde_json::Value::Object(value)
-}
-
-#[allow(dead_code)]
 pub(crate) fn nix_expr_meta_value(expression: &str) -> serde_json::Value {
     let mut value = serde_json::Map::new();
     value.insert(
@@ -50,7 +39,6 @@ pub(crate) fn nix_expr_meta_value(expression: &str) -> serde_json::Value {
     serde_json::Value::Object(value)
 }
 
-#[allow(dead_code)]
 pub(crate) fn nix_builtins_path_meta_value(path: &str) -> serde_json::Value {
     let mut value = serde_json::Map::new();
     value.insert(
@@ -827,6 +815,23 @@ fn infer_inner_indent(attrset_text: &str) -> String {
     "    ".to_string() // default: 4 spaces
 }
 
+/// Quote and escape a list of string values for safe insertion into Nix list literals.
+///
+/// This escapes backslashes, double quotes and dollar signs, and wraps each value
+/// in double quotes so callers can insert them into a Nix list like: `[ "a" "b" ]`.
+pub(crate) fn nix_quote_values(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| {
+            let escaped = value
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('$', "\\$");
+            format!("\"{}\"", escaped)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1177,27 +1182,6 @@ environment.systemPackages = with pkgs; [
     }
 
     #[test]
-    fn set_attrs_renders_nix_path_literal_marker_without_quotes() {
-        let mut attrs = serde_json::Map::new();
-        attrs.insert(
-            "sopsFile".to_string(),
-            nix_path_meta_value("../../secrets/ssh-private-key.yaml"),
-        );
-
-        let edited = set_attrs(WITH_PKGS_EMPTY, "sops.secrets.\"ssh-private-key\"", &attrs)
-            .expect("set_attrs should render nix path literal marker");
-
-        assert!(
-            edited.contains("sopsFile = ../../secrets/ssh-private-key.yaml;"),
-            "expected sopsFile to render as a Nix path literal"
-        );
-        assert!(
-            !edited.contains("sopsFile = \"../../secrets/ssh-private-key.yaml\";"),
-            "expected sopsFile not to be rendered as a quoted string"
-        );
-    }
-
-    #[test]
     fn set_attrs_renders_nix_expr_marker_without_quotes() {
         let mut attrs = serde_json::Map::new();
         attrs.insert(
@@ -1245,7 +1229,7 @@ environment.systemPackages = with pkgs; [
       # "dotenvx/brew" # required for dotenvx formula
     ];
 
-    # Homebrew formulae (non-GUI packages)
+    # Homebrew brews (non-GUI packages)
     brews = [
       # "git" # required for CLI workflows
     ];
@@ -1277,5 +1261,36 @@ environment.systemPackages = with pkgs; [
             1,
             "should not insert duplicate taps assignment"
         );
+    }
+
+    #[test]
+    fn nix_quote_values_basic() {
+        let input = vec!["git".to_string(), "visual-studio-code".to_string()];
+        let quoted = nix_quote_values(&input);
+        assert_eq!(
+            quoted,
+            vec!["\"git\"".to_string(), "\"visual-studio-code\"".to_string()]
+        );
+    }
+
+    #[test]
+    fn nix_quote_values_escapes() {
+        let input = vec!["a\"b".to_string(), "c\\d".to_string(), "e$f".to_string()];
+        let quoted = nix_quote_values(&input);
+        assert_eq!(
+            quoted,
+            vec![
+                "\"a\\\"b\"".to_string(),
+                "\"c\\\\d\"".to_string(),
+                "\"e\\$f\"".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn nix_quote_values_empty() {
+        let input: Vec<String> = vec![];
+        let quoted = nix_quote_values(&input);
+        assert!(quoted.is_empty());
     }
 }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -3,7 +3,7 @@
 mod age;
 mod chat_memory;
 mod config_dir_context;
-mod edit_nix_file;
+pub(crate) mod edit_nix_file;
 mod ensure_secret;
 pub(crate) mod file_ops;
 mod gitignore;
@@ -14,7 +14,7 @@ pub mod search_docs;
 mod search_packages;
 mod sops;
 mod tools;
-mod types;
+pub(crate) mod types;
 mod utils;
 
 /// Directories ignored by file listing and search helpers.

--- a/apps/native/src-tauri/src/mac/homebrew.rs
+++ b/apps/native/src-tauri/src/mac/homebrew.rs
@@ -1,0 +1,528 @@
+use crate::evolve::edit_nix_file::{apply_semantic_edit, nix_quote_values};
+use crate::evolve::types::{FileEditAction, SemanticFileEdit};
+use crate::nix_ast_lists::parse_string_lists_by_attrpath;
+use crate::scanner::inject_module_import;
+use crate::shared_types::HomebrewState;
+use crate::{mac, managed_edit, shared_types};
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+
+/// Checks if Homebrew is installed by trying to run `brew --version`.
+fn is_homebrew_installed() -> bool {
+    std::process::Command::new("brew")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+// Private factory to create a HomebrewState with common defaults.
+fn make_homebrew_state(is_installed: bool, source: Option<String>) -> HomebrewState {
+    HomebrewState {
+        is_installed,
+        casks: Vec::new(),
+        brews: Vec::new(),
+        taps: Vec::new(),
+        source,
+        last_checked: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64,
+    }
+}
+
+/// Gets the current homebrew state from the system and nix config, computes the diff, and returns it.
+pub fn get_homebrew_state_diff(config_dir: &std::path::Path) -> Result<HomebrewState> {
+    let installed = scan_homebrew();
+    let config = load_nix_config_homebrew(config_dir);
+    Ok(compute_homebrew_diff(installed, config))
+}
+
+/// Writes the Homebrew diff into config files, snapshots the pre-edit tree onto a rollback
+/// branch, and enters the managed review flow so the frontend lands on the evolve step.
+pub async fn apply_homebrew_diff(
+    app: &AppHandle,
+    diff: shared_types::HomebrewState,
+) -> Result<serde_json::Value> {
+    let context = managed_edit::prepare_managed_edit(app)?;
+    let dir = context.dir.clone();
+
+    let item_count = diff.casks.len() + diff.brews.len() + diff.taps.len();
+
+    mac::homebrew::apply_homebrew_import(diff, std::path::Path::new(&dir))
+        .context("Failed to apply Homebrew diff")?;
+
+    let working_tree_status =
+        crate::git::status(&dir).context("Failed to get working tree status for evolve state")?;
+    managed_edit::finalize_managed_edit(
+        app,
+        context,
+        working_tree_status,
+        item_count,
+        "apply_homebrew",
+    )
+    .await
+}
+
+/// Scan the system for Homebrew packages, casks, and taps.
+/// Only includes explicitly installed brews and casks, not their dependencies.
+/// Excludes default taps (homebrew/core, homebrew/cask).
+/// If homebrew is not installed, returns an empty state with is_installed set to false.
+pub fn scan_homebrew() -> HomebrewState {
+    let mut state = make_homebrew_state(is_homebrew_installed(), None);
+    if let Ok(output) = std::process::Command::new("brew")
+        .args(["list", "--formula"])
+        .output()
+    {
+        if output.status.success() {
+            state.brews = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::to_owned)
+                .collect();
+        }
+    }
+    if let Ok(output) = std::process::Command::new("brew")
+        .args(["list", "--cask"])
+        .output()
+    {
+        if output.status.success() {
+            state.casks = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::to_owned)
+                .collect();
+        }
+    }
+    if let Ok(output) = std::process::Command::new("brew").args(["tap"]).output() {
+        if output.status.success() {
+            state.taps = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter(|line| {
+                    // Exclude default taps
+                    !line.starts_with("homebrew/core") && !line.starts_with("homebrew/cask")
+                })
+                .map(str::to_owned)
+                .collect();
+        }
+    }
+
+    return state;
+}
+
+/// Reads the homebrew state currently in nix config in the provided config dir, if it exists.
+/// Otherwise returns an empty state.
+/// The only supported nix config layouts for homebrew are:
+/// - modules/darwin/homebrew.nix
+/// - flake-modules/darwin.nix inline lists
+/// Depending on which one exists, we'll set the source field to the full
+/// path of the file or "flake-modules/darwin.nix" respectively, which can be used to determine where to write changes.
+pub fn load_nix_config_homebrew(config_dir: &std::path::Path) -> HomebrewState {
+    let mut state = make_homebrew_state(is_homebrew_installed(), None);
+
+    let homebrew_nix = config_dir.join("modules/darwin/homebrew.nix");
+    if homebrew_nix.exists() {
+        state.source = Some("modules/darwin/homebrew.nix".to_string());
+        if let Ok(contents) = std::fs::read_to_string(&homebrew_nix) {
+            let parsed = parse_string_lists_by_attrpath(&contents);
+            state.casks = parsed
+                .get("homebrew.casks")
+                .or_else(|| parsed.get("casks"))
+                .cloned()
+                .unwrap_or_default();
+            state.brews = parsed
+                .get("homebrew.brews")
+                .or_else(|| parsed.get("brews"))
+                .cloned()
+                .unwrap_or_default();
+            state.taps = parsed
+                .get("homebrew.taps")
+                .or_else(|| parsed.get("taps"))
+                .cloned()
+                .unwrap_or_default();
+        }
+    } else {
+        let flake_darwin = config_dir.join("flake-modules/darwin.nix");
+        if flake_darwin.exists() {
+            state.source = Some("flake-modules/darwin.nix".to_string());
+            if let Ok(contents) = std::fs::read_to_string(&flake_darwin) {
+                let parsed = parse_string_lists_by_attrpath(&contents);
+                state.casks = parsed.get("homebrew.casks").cloned().unwrap_or_default();
+                state.brews = parsed.get("homebrew.brews").cloned().unwrap_or_default();
+                state.taps = parsed.get("homebrew.taps").cloned().unwrap_or_default();
+            }
+        }
+    }
+
+    state
+}
+
+/// Finds what's missing from the config compared to the installed state,
+/// which is what we would want to add to the nix config to match the installed state.
+/// The source field of the diff is taken from the config, since that's where we would want to write the changes.
+pub fn compute_homebrew_diff(installed: HomebrewState, config: HomebrewState) -> HomebrewState {
+    let mut state = make_homebrew_state(installed.is_installed, config.source.clone());
+
+    state.casks = installed
+        .casks
+        .into_iter()
+        .filter(|c| !config.casks.contains(c))
+        .collect();
+
+    state.brews = installed
+        .brews
+        .into_iter()
+        .filter(|f| !config.brews.contains(f))
+        .collect();
+
+    state.taps = installed
+        .taps
+        .into_iter()
+        .filter(|t| !config.taps.contains(t))
+        .collect();
+
+    state
+}
+
+/// Writes missing items in the diff to the nix config, using the source field to determine where to write.
+/// If the source is empty, we'll set up a new modules/darwin/homebrew.nix file and write to that.
+/// We also need to hook up to flake.nix in that case.
+/// We will use the existing editing tool in edit_nix_file.rs.
+#[allow(dead_code)]
+pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) -> Result<()> {
+    if diff.casks.is_empty() && diff.brews.is_empty() && diff.taps.is_empty() {
+        return Ok(());
+    }
+
+    let source_rel = diff
+        .source
+        .clone()
+        .unwrap_or_else(|| "modules/darwin/homebrew.nix".to_string());
+    let source = config_dir.join(&source_rel);
+    let creating_default_module = diff.source.is_none();
+
+    // If the source doesn't exist, use the homebrew.nix template from templates/nix-darwin-determinate:
+    if !source.exists() {
+        if let Some(parent) = source.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory '{}'", parent.display()))?;
+        }
+
+        let template =
+            include_str!("../../../templates/nix-darwin-determinate/modules/darwin/homebrew.nix");
+        std::fs::write(&source, template)?;
+    }
+
+    // If we created a new module because there was no existing source, ensure flake imports it.
+    if creating_default_module {
+        let flake_path = config_dir.join("flake.nix");
+        if flake_path.exists() {
+            let flake_content = std::fs::read_to_string(&flake_path)
+                .with_context(|| format!("failed to read flake file '{}'", flake_path.display()))?;
+
+            let updated = inject_module_import(&flake_content, "./modules/darwin/homebrew.nix")
+                .map_err(anyhow::Error::msg)
+                .with_context(|| {
+                    format!(
+                        "failed to inject homebrew module import into '{}'",
+                        flake_path.display()
+                    )
+                })?;
+
+            if updated != flake_content {
+                std::fs::write(&flake_path, updated).with_context(|| {
+                    format!("failed to write flake file '{}'", flake_path.display())
+                })?;
+            }
+        }
+    }
+
+    // Use semantic edits so list updates are idempotent and preserve existing structure.
+    if !diff.taps.is_empty() {
+        apply_semantic_edit(
+            config_dir,
+            &SemanticFileEdit {
+                path: source_rel.clone(),
+                action: FileEditAction::Add {
+                    path: "homebrew.taps".to_string(),
+                    values: nix_quote_values(&diff.taps),
+                },
+            },
+            None,
+        )?;
+    }
+
+    if !diff.brews.is_empty() {
+        apply_semantic_edit(
+            config_dir,
+            &SemanticFileEdit {
+                path: source_rel.clone(),
+                action: FileEditAction::Add {
+                    path: "homebrew.brews".to_string(),
+                    values: nix_quote_values(&diff.brews),
+                },
+            },
+            None,
+        )?;
+    }
+
+    if !diff.casks.is_empty() {
+        apply_semantic_edit(
+            config_dir,
+            &SemanticFileEdit {
+                path: source_rel,
+                action: FileEditAction::Add {
+                    path: "homebrew.casks".to_string(),
+                    values: nix_quote_values(&diff.casks),
+                },
+            },
+            None,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(path: &std::path::Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("failed to create parent directories");
+        }
+        std::fs::write(path, content).expect("failed to write test file");
+    }
+
+    #[test]
+    fn load_nix_config_homebrew_reads_modules_file() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let homebrew_file = temp.path().join("modules/darwin/homebrew.nix");
+        write_file(
+            &homebrew_file,
+            r#"{ config, pkgs, ... }:
+{
+  homebrew = {
+    casks = [ "iterm2" "raycast" ];
+    brews = [ "git" "jq" ];
+    taps = [ "homebrew/cask-fonts" ];
+  };
+}
+"#,
+        );
+
+        let state = load_nix_config_homebrew(temp.path());
+
+        assert_eq!(
+            state.source.as_deref(),
+            Some("modules/darwin/homebrew.nix"),
+            "expected module source to be detected"
+        );
+        assert_eq!(state.casks, vec!["iterm2", "raycast"]);
+        assert_eq!(state.brews, vec!["git", "jq"]);
+        assert_eq!(state.taps, vec!["homebrew/cask-fonts"]);
+    }
+
+    #[test]
+    fn load_nix_config_homebrew_reads_flake_modules_file() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let darwin_file = temp.path().join("flake-modules/darwin.nix");
+        write_file(
+            &darwin_file,
+            r#"{ config, pkgs, ... }:
+{
+  homebrew.casks = [ "iterm2" ];
+  homebrew.brews = [ "git" ];
+  homebrew.taps = [ "homebrew/cask-fonts" ];
+}
+"#,
+        );
+
+        let state = load_nix_config_homebrew(temp.path());
+
+        assert_eq!(
+            state.source.as_deref(),
+            Some("flake-modules/darwin.nix"),
+            "expected flake-modules source to be detected"
+        );
+        assert_eq!(state.casks, vec!["iterm2"]);
+        assert_eq!(state.brews, vec!["git"]);
+        assert_eq!(state.taps, vec!["homebrew/cask-fonts"]);
+    }
+
+    #[test]
+    fn load_nix_config_homebrew_reads_multiline_lists() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let homebrew_file = temp.path().join("modules/darwin/homebrew.nix");
+        write_file(
+            &homebrew_file,
+            r#"{ config, pkgs, ... }:
+{
+    homebrew = {
+        casks = [
+            "iterm2"
+            "raycast"
+        ];
+        brews = [
+            "git"
+            "jq"
+        ];
+        taps = [
+            "homebrew/cask-fonts"
+        ];
+    };
+}
+"#,
+        );
+
+        let state = load_nix_config_homebrew(temp.path());
+
+        assert_eq!(state.casks, vec!["iterm2", "raycast"]);
+        assert_eq!(state.brews, vec!["git", "jq"]);
+        assert_eq!(state.taps, vec!["homebrew/cask-fonts"]);
+    }
+
+    #[test]
+    fn compute_homebrew_diff_returns_only_missing_items() {
+        let installed = HomebrewState {
+            casks: vec!["iterm2".to_string(), "raycast".to_string()],
+            brews: vec!["git".to_string(), "jq".to_string()],
+            taps: vec!["homebrew/cask-fonts".to_string()],
+            source: None,
+            is_installed: true,
+            last_checked: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        };
+        let config = HomebrewState {
+            casks: vec!["iterm2".to_string()],
+            brews: vec!["git".to_string()],
+            taps: vec![],
+            source: Some("modules/darwin/homebrew.nix".to_string()),
+            is_installed: true,
+            last_checked: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        };
+
+        let diff = compute_homebrew_diff(installed, config);
+
+        assert_eq!(diff.casks, vec!["raycast"]);
+        assert_eq!(diff.brews, vec!["jq"]);
+        assert_eq!(diff.taps, vec!["homebrew/cask-fonts"]);
+        assert_eq!(diff.source.as_deref(), Some("modules/darwin/homebrew.nix"));
+    }
+
+    #[test]
+    fn apply_homebrew_import_creates_module_and_injects_flake_import() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let flake = temp.path().join("flake.nix");
+        write_file(
+            &flake,
+            r#"{
+  outputs = { self }: {
+    darwinConfigurations.host = {
+      modules = [
+        ./modules/darwin/system.nix
+      ];
+    };
+  };
+}
+"#,
+        );
+
+        let diff = HomebrewState {
+            casks: vec!["iterm2".to_string()],
+            brews: vec!["git".to_string()],
+            taps: vec!["homebrew/cask-fonts".to_string()],
+            source: None,
+            is_installed: true,
+            last_checked: 0,
+        };
+
+        apply_homebrew_import(diff, temp.path()).expect("apply_homebrew_import should succeed");
+
+        let homebrew_file = temp.path().join("modules/darwin/homebrew.nix");
+        let homebrew_content =
+            std::fs::read_to_string(homebrew_file).expect("homebrew module should exist");
+        assert!(
+            homebrew_content.contains("taps = [ \"homebrew/cask-fonts\" ];"),
+            "expected taps to be inserted"
+        );
+        assert!(
+            homebrew_content.contains("brews = [ \"git\" ];"),
+            "expected brews to be inserted"
+        );
+        assert!(
+            homebrew_content.contains("casks = [ \"iterm2\" ];"),
+            "expected casks to be inserted"
+        );
+
+        let flake_content = std::fs::read_to_string(flake).expect("flake should remain readable");
+        assert!(
+            flake_content.contains("./modules/darwin/homebrew.nix"),
+            "expected flake import to be injected"
+        );
+    }
+
+    #[test]
+    fn apply_homebrew_import_does_not_modify_flake_when_source_is_explicit() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let flake = temp.path().join("flake.nix");
+        let flake_initial = r#"{
+  outputs = { self }: {
+    darwinConfigurations.host = {
+      modules = [
+        ./modules/darwin/system.nix
+      ];
+    };
+  };
+}
+"#;
+        write_file(&flake, flake_initial);
+
+        let homebrew_file = temp.path().join("modules/darwin/homebrew.nix");
+        write_file(
+            &homebrew_file,
+            r#"{ config, pkgs, ... }:
+{
+  homebrew = {
+    taps = [ ];
+    brews = [ ];
+    casks = [ ];
+  };
+}
+"#,
+        );
+
+        let diff = HomebrewState {
+            casks: vec!["iterm2".to_string()],
+            brews: vec![],
+            taps: vec![],
+            source: Some("modules/darwin/homebrew.nix".to_string()),
+            is_installed: true,
+            last_checked: 0,
+        };
+
+        apply_homebrew_import(diff, temp.path()).expect("apply_homebrew_import should succeed");
+
+        let flake_content = std::fs::read_to_string(flake).expect("flake should remain readable");
+        assert_eq!(
+            flake_content, flake_initial,
+            "expected explicit source mode not to touch flake imports"
+        );
+    }
+
+    #[test]
+    #[ignore = "manual: requires Homebrew installed locally; run with -- --ignored --nocapture"]
+    fn scan_homebrew_manual_output() {
+        let state = scan_homebrew();
+        println!(
+            "scan_homebrew => brews: {:?}\ncasks: {:?}\ntaps: {:?}",
+            state.brews, state.casks, state.taps
+        );
+
+        // Keep this permissive because local systems vary and Homebrew may not be installed.
+        assert!(true);
+    }
+}

--- a/apps/native/src-tauri/src/mac/homebrew.rs
+++ b/apps/native/src-tauri/src/mac/homebrew.rs
@@ -11,6 +11,7 @@ use tauri::AppHandle;
 fn is_homebrew_installed() -> bool {
     std::process::Command::new("brew")
         .arg("--version")
+        .env("PATH", crate::nix::get_nix_path())
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
@@ -72,6 +73,7 @@ pub fn scan_homebrew() -> HomebrewState {
     let mut state = make_homebrew_state(is_homebrew_installed(), None);
     if let Ok(output) = std::process::Command::new("brew")
         .args(["list", "--formula"])
+        .env("PATH", crate::nix::get_nix_path())
         .output()
     {
         if output.status.success() {
@@ -83,6 +85,7 @@ pub fn scan_homebrew() -> HomebrewState {
     }
     if let Ok(output) = std::process::Command::new("brew")
         .args(["list", "--cask"])
+        .env("PATH", crate::nix::get_nix_path())
         .output()
     {
         if output.status.success() {
@@ -92,7 +95,11 @@ pub fn scan_homebrew() -> HomebrewState {
                 .collect();
         }
     }
-    if let Ok(output) = std::process::Command::new("brew").args(["tap"]).output() {
+    if let Ok(output) = std::process::Command::new("brew")
+        .args(["tap"])
+        .env("PATH", crate::nix::get_nix_path())
+        .output()
+    {
         if output.status.success() {
             state.taps = String::from_utf8_lossy(&output.stdout)
                 .lines()

--- a/apps/native/src-tauri/src/mac/homebrew.rs
+++ b/apps/native/src-tauri/src/mac/homebrew.rs
@@ -1,4 +1,5 @@
 use crate::evolve::edit_nix_file::{apply_semantic_edit, nix_quote_values};
+use crate::evolve::file_ops::resolve_path_in_dir_allow_create;
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 use crate::nix_ast_lists::parse_string_lists_by_attrpath;
 use crate::scanner::inject_module_import;
@@ -66,13 +67,13 @@ pub async fn apply_homebrew_diff(
 }
 
 /// Scan the system for Homebrew packages, casks, and taps.
-/// Only includes explicitly installed brews and casks, not their dependencies.
+/// Only includes explicitly installed brews and casks (via `--installed-on-request`), not their dependencies.
 /// Excludes default taps (homebrew/core, homebrew/cask).
 /// If homebrew is not installed, returns an empty state with is_installed set to false.
 pub fn scan_homebrew() -> HomebrewState {
     let mut state = make_homebrew_state(is_homebrew_installed(), None);
     if let Ok(output) = std::process::Command::new("brew")
-        .args(["list", "--formula"])
+        .args(["list", "--installed-on-request", "--formula"])
         .env("PATH", crate::nix::get_nix_path())
         .output()
     {
@@ -84,7 +85,7 @@ pub fn scan_homebrew() -> HomebrewState {
         }
     }
     if let Ok(output) = std::process::Command::new("brew")
-        .args(["list", "--cask"])
+        .args(["list", "--installed-on-request", "--cask"])
         .env("PATH", crate::nix::get_nix_path())
         .output()
     {
@@ -203,7 +204,8 @@ pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) 
         .source
         .clone()
         .unwrap_or_else(|| "modules/darwin/homebrew.nix".to_string());
-    let source = config_dir.join(&source_rel);
+    let source = resolve_path_in_dir_allow_create(config_dir, &source_rel)
+        .with_context(|| format!("invalid homebrew source path '{}'", source_rel))?;
     let creating_default_module = diff.source.is_none();
 
     // If the source doesn't exist, use the homebrew.nix template from templates/nix-darwin-determinate:

--- a/apps/native/src-tauri/src/mac/mod.rs
+++ b/apps/native/src-tauri/src/mac/mod.rs
@@ -1,0 +1,1 @@
+pub mod homebrew;

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -29,7 +29,10 @@ mod git;
 mod historelog;
 mod log_summarizer;
 mod lsp;
+mod mac;
+mod managed_edit;
 mod nix;
+mod nix_ast_lists;
 mod panic_handler;
 mod peek;
 mod permissions;
@@ -321,6 +324,9 @@ fn run_gui_mode(
             commands::trigger_test_panic,
             #[cfg(debug_assertions)]
             commands::debug_sentry_event,
+            // Homebrew
+            commands::homebrew_apply_diff,
+            commands::homebrew_get_state_diff,
             // Git
             commands::git_init_repo,
             commands::git_status,

--- a/apps/native/src-tauri/src/managed_edit.rs
+++ b/apps/native/src-tauri/src/managed_edit.rs
@@ -1,0 +1,117 @@
+//! Reusable managed review helpers for non-AI edits.
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+
+use crate::{build_state, db, evolve_state, git, shared_types, store, summarize};
+
+pub struct ManagedEditContext {
+    pub dir: String,
+    pub db_path: std::path::PathBuf,
+    pub evolution_id: i64,
+    pub evolve_state: shared_types::EvolveState,
+}
+
+pub fn prepare_managed_edit(app: &AppHandle) -> Result<ManagedEditContext> {
+    let dir = store::ensure_config_dir_exists(app).context("Failed to get config directory")?;
+    let db_path = db::get_db_path(app).context("Failed to get DB path")?;
+    let pre_edit_status =
+        git::status(&dir).context("Failed to get pre-edit working tree status")?;
+
+    let _base_commit_id = db::commits::store_head_commit(&db_path, &dir, None)
+        .context("Failed to store HEAD commit")?;
+
+    let pre_state = evolve_state::get(app).unwrap_or_default();
+    let branch = git::current_branch(&dir).unwrap_or_else(|| "main".to_string());
+    let evolution_id = db::evolutions::upsert(&db_path, pre_state.evolution_id, &branch)
+        .context("Failed to upsert evolution")?;
+
+    let changeset_id = pre_state.current_changeset_id.unwrap_or(0);
+    let backup_branch = git::create_evolution_backup(&dir, Some(evolution_id), changeset_id)
+        .context("Failed to create backup branch")?;
+
+    let rollback_branch = pre_state
+        .rollback_branch
+        .clone()
+        .or_else(|| backup_branch.clone());
+    let (rollback_store_path, rollback_changeset_id) = if pre_state.rollback_store_path.is_some() {
+        (
+            pre_state.rollback_store_path.clone(),
+            pre_state.rollback_changeset_id,
+        )
+    } else {
+        let build = build_state::get(app).ok();
+        (
+            build
+                .as_ref()
+                .and_then(|state| state.nixmac_built_store_path.clone()),
+            build.as_ref().and_then(|state| state.changeset_id),
+        )
+    };
+
+    let evolve_state = evolve_state::set(
+        app,
+        shared_types::EvolveState {
+            evolution_id: Some(evolution_id),
+            current_changeset_id: None,
+            changeset_at_build: None,
+            committable: false,
+            backup_branch,
+            rollback_branch,
+            rollback_store_path,
+            rollback_changeset_id,
+            step: shared_types::EvolveStep::Evolve,
+        },
+        &pre_edit_status.changes,
+    )
+    .context("Failed to set evolve state")?;
+
+    Ok(ManagedEditContext {
+        dir,
+        db_path,
+        evolution_id,
+        evolve_state,
+    })
+}
+
+pub async fn finalize_managed_edit(
+    app: &AppHandle,
+    mut context: ManagedEditContext,
+    post_edit_status: shared_types::GitStatus,
+    count: usize,
+    log_tag: &str,
+) -> Result<serde_json::Value> {
+    context.evolve_state = evolve_state::set(app, context.evolve_state, &post_edit_status.changes)
+        .context("Failed to update evolve state for post-edit status")?;
+
+    match summarize::new_changeset(app, Some(context.evolution_id)).await {
+        Ok(Some(changeset_id)) => {
+            context.evolve_state.current_changeset_id = Some(changeset_id);
+            context.evolve_state =
+                evolve_state::set(app, context.evolve_state, &post_edit_status.changes)
+                    .context("Failed to update evolve state with changeset")?;
+        }
+        Ok(None) => {
+            log::warn!("[{log_tag}] Summarizer returned None - diff may be empty");
+        }
+        Err(error) => {
+            log::error!("[{log_tag}] Summarizer error: {}", error);
+        }
+    }
+
+    let change_sets =
+        summarize::find_existing::for_current_state(context.db_path.as_path(), &context.dir)
+            .unwrap_or_default();
+
+    let change_map = summarize::group_existing::from_change_sets(change_sets);
+    let git_status =
+        git::status_and_cache(&context.dir, app).context("Failed to get git status")?;
+
+    Ok(serde_json::json!({
+        "ok": true,
+        "count": count,
+        "changeMap": change_map,
+        "gitStatus": git_status,
+        "evolveState": context.evolve_state,
+    }))
+}

--- a/apps/native/src-tauri/src/nix_ast_lists.rs
+++ b/apps/native/src-tauri/src/nix_ast_lists.rs
@@ -51,18 +51,28 @@ fn parse_nix_string_literal(value: &str) -> Option<String> {
     let value = value.trim();
 
     if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
+        let inner = &value[1..value.len() - 1];
         let mut out = String::new();
-        let bytes = value.as_bytes();
-        let mut i = 1usize;
-        while i + 1 < bytes.len() {
-            match bytes[i] {
-                b'\\' if i + 2 < bytes.len() => {
-                    i += 1;
-                    out.push(bytes[i] as char);
-                }
-                ch => out.push(ch as char),
+        let mut chars = inner.chars();
+
+        while let Some(ch) = chars.next() {
+            if ch != '\\' {
+                out.push(ch);
+                continue;
             }
-            i += 1;
+
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('r') => out.push('\r'),
+                Some('t') => out.push('\t'),
+                Some('"') => out.push('"'),
+                Some('\\') => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
         }
         return Some(out);
     }

--- a/apps/native/src-tauri/src/nix_ast_lists.rs
+++ b/apps/native/src-tauri/src/nix_ast_lists.rs
@@ -1,0 +1,199 @@
+use rnix::ast::List;
+use rnix::{Parse, Root};
+use rowan::ast::AstNode;
+use rowan::TextSize;
+use std::collections::HashMap;
+
+/// Parse all string-only list assignments from Nix source and return a map of
+/// normalized attrpaths to values. For nested attrsets, the returned key is a
+/// dotted path (for example `homebrew.taps`).
+pub fn parse_string_lists_by_attrpath(content: &str) -> HashMap<String, Vec<String>> {
+    let parsed: Parse<Root> = Root::parse(content);
+    let Ok(root) = parsed.ok() else {
+        return HashMap::new();
+    };
+
+    let mut out = HashMap::new();
+    for node in root.syntax().descendants() {
+        if List::cast(node.clone()).is_none() {
+            continue;
+        }
+
+        let start = text_size_to_usize(node.text_range().start());
+        let Some(attrpath) = list_full_attrpath(content, start) else {
+            continue;
+        };
+
+        let values = extract_package_list(&node);
+        if !values.is_empty() {
+            out.insert(attrpath, values);
+        }
+    }
+
+    out
+}
+
+fn text_size_to_usize(size: TextSize) -> usize {
+    u32::from(size) as usize
+}
+
+fn extract_package_list(node: &rnix::SyntaxNode) -> Vec<String> {
+    let Some(list) = List::cast(node.clone()) else {
+        return Vec::new();
+    };
+
+    list.items()
+        .filter_map(|expr| parse_nix_string_literal(expr.to_string().trim()))
+        .collect()
+}
+
+fn parse_nix_string_literal(value: &str) -> Option<String> {
+    let value = value.trim();
+
+    if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
+        let mut out = String::new();
+        let bytes = value.as_bytes();
+        let mut i = 1usize;
+        while i + 1 < bytes.len() {
+            match bytes[i] {
+                b'\\' if i + 2 < bytes.len() => {
+                    i += 1;
+                    out.push(bytes[i] as char);
+                }
+                ch => out.push(ch as char),
+            }
+            i += 1;
+        }
+        return Some(out);
+    }
+
+    if value.starts_with("''") && value.ends_with("''") && value.len() >= 4 {
+        return Some(value[2..value.len() - 2].to_string());
+    }
+
+    None
+}
+
+fn normalize_attrpath_for_match(input: &str) -> String {
+    input
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '"')
+        .collect()
+}
+
+fn assignment_lhs_at_equals(content: &str, equals_pos: usize) -> Option<&str> {
+    let before_equals = content.get(..equals_pos)?;
+    let statement_start = before_equals
+        .rfind([';', '{', '}'])
+        .map_or(0, |idx| idx + 1);
+
+    let lhs_region = before_equals.get(statement_start..)?;
+    let lhs_line = lhs_region.lines().rev().find_map(|line| {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })?;
+
+    if lhs_line.is_empty() {
+        return None;
+    }
+
+    Some(lhs_line)
+}
+
+fn list_full_attrpath(content: &str, list_start: usize) -> Option<String> {
+    let before_list = content.get(..list_start)?;
+    let equals_pos = before_list.rfind('=')?;
+
+    let immediate_lhs = assignment_lhs_at_equals(content, equals_pos)?;
+    let mut path_segments = vec![immediate_lhs.to_string()];
+
+    let mut brace_depth = 0;
+    let before_equals = content.get(..equals_pos)?;
+    let char_indices: Vec<(usize, char)> = before_equals.char_indices().collect();
+    for (idx, ch) in char_indices.iter().rev() {
+        match ch {
+            '}' => brace_depth += 1,
+            '{' if brace_depth > 0 => {
+                brace_depth -= 1;
+            }
+            '{' if brace_depth == 0 => {
+                let brace_pos = *idx;
+                if let Some(parent_equals) = content.get(..brace_pos).and_then(|s| s.rfind('=')) {
+                    if let Some(parent_lhs) = assignment_lhs_at_equals(content, parent_equals) {
+                        path_segments.insert(0, parent_lhs.to_string());
+                    }
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let joined = path_segments.join(".");
+    Some(normalize_attrpath_for_match(&joined))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nested_attrset_lists() {
+        let content = r#"{ config, ... }:
+{
+  homebrew = {
+    taps = [
+            "homebrew/cask-fonts"
+    ];
+        brews = [ "git" "jq" ];
+  };
+}
+"#;
+
+        let parsed = parse_string_lists_by_attrpath(content);
+        assert_eq!(
+            parsed.get("homebrew.taps"),
+            Some(&vec!["homebrew/cask-fonts".to_string()])
+        );
+        assert_eq!(
+            parsed.get("homebrew.brews"),
+            Some(&vec!["git".to_string(), "jq".to_string()])
+        );
+    }
+
+    #[test]
+    fn parses_flat_attrpath_lists() {
+        let content = r#"{ config, ... }:
+{
+    homebrew.casks = [ "iterm2" ];
+    homebrew.taps = [ "homebrew/cask-fonts" ];
+}
+"#;
+
+        let parsed = parse_string_lists_by_attrpath(content);
+        assert_eq!(
+            parsed.get("homebrew.casks"),
+            Some(&vec!["iterm2".to_string()])
+        );
+        assert_eq!(
+            parsed.get("homebrew.taps"),
+            Some(&vec!["homebrew/cask-fonts".to_string()])
+        );
+    }
+
+    #[test]
+    fn ignores_non_string_entries() {
+        let content = r#"{ config, ... }:
+{
+    homebrew.brews = [ "git" pkgs.jq ];
+}
+"#;
+
+        let parsed = parse_string_lists_by_attrpath(content);
+        assert_eq!(parsed.get("homebrew.brews"), Some(&vec!["git".to_string()]));
+    }
+}

--- a/apps/native/src-tauri/src/nix_ast_lists.rs
+++ b/apps/native/src-tauri/src/nix_ast_lists.rs
@@ -71,7 +71,7 @@ fn parse_nix_string_literal(value: &str) -> Option<String> {
                     out.push('\\');
                     out.push(other);
                 }
-                None => out.push('\\'),
+                None => return None,
             }
         }
         return Some(out);
@@ -114,6 +114,9 @@ fn assignment_lhs_at_equals(content: &str, equals_pos: usize) -> Option<&str> {
     Some(lhs_line)
 }
 
+/// Returns the dotted attrpath for the list whose source starts at `list_start`.
+/// Supports up to one level of parent attrset nesting (e.g. `homebrew.taps` but not `a.b.c`).
+/// For deeper nesting, only the immediate parent key is included in the path.
 fn list_full_attrpath(content: &str, list_start: usize) -> Option<String> {
     let before_list = content.get(..list_start)?;
     let equals_pos = before_list.rfind('=')?;
@@ -205,5 +208,37 @@ mod tests {
 
         let parsed = parse_string_lists_by_attrpath(content);
         assert_eq!(parsed.get("homebrew.brews"), Some(&vec!["git".to_string()]));
+    }
+
+    #[test]
+    fn parse_nix_string_literal_handles_escape_sequences() {
+        assert_eq!(
+            parse_nix_string_literal(r#""hello\nworld""#),
+            Some("hello\nworld".to_string())
+        );
+        assert_eq!(
+            parse_nix_string_literal(r#""tab\there""#),
+            Some("tab\there".to_string())
+        );
+        assert_eq!(
+            parse_nix_string_literal(r#""back\\slash""#),
+            Some("back\\slash".to_string())
+        );
+        assert_eq!(
+            parse_nix_string_literal(r#""quote\"here""#),
+            Some("quote\"here".to_string())
+        );
+        // Unknown escape sequences preserve the backslash
+        assert_eq!(
+            parse_nix_string_literal(r#""foo\xbar""#),
+            Some("foo\\xbar".to_string())
+        );
+        // Trailing backslash (invalid Nix string) returns None
+        assert_eq!(parse_nix_string_literal(r#""trailing\""#), None);
+        // Plain strings pass through unchanged
+        assert_eq!(
+            parse_nix_string_literal(r#""aws/tap""#),
+            Some("aws/tap".to_string())
+        );
     }
 }

--- a/apps/native/src-tauri/src/shared_types.rs
+++ b/apps/native/src-tauri/src/shared_types.rs
@@ -53,6 +53,20 @@ pub struct WatcherEvent {
 }
 
 // =============================================================================
+// Homebrew types
+// =============================================================================
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HomebrewState {
+    pub is_installed: bool,
+    pub casks: Vec<String>,
+    pub brews: Vec<String>,
+    pub taps: Vec<String>,
+    pub source: Option<String>,
+    pub last_checked: i64,
+}
+
+// =============================================================================
 // Query return types
 // =============================================================================
 
@@ -176,7 +190,6 @@ impl Default for EvolveState {
     }
 }
 
-
 // =============================================================================
 // Config dir result types
 // =============================================================================
@@ -287,4 +300,5 @@ pub struct UiPrefs {
     pub confirm_clear: bool,
     pub confirm_rollback: bool,
     pub auto_summarize_on_focus: bool,
+    pub scan_homebrew_on_startup: bool,
 }

--- a/apps/native/src-tauri/src/store.rs
+++ b/apps/native/src-tauri/src/store.rs
@@ -30,6 +30,9 @@ pub const CONFIRM_ROLLBACK_KEY: &str = "confirmRollback";
 // Summarization preference keys
 pub const AUTO_SUMMARIZE_ON_FOCUS_KEY: &str = "autoSummarizeOnFocus";
 
+// Startup scan preference keys
+pub const SCAN_HOMEBREW_ON_STARTUP_KEY: &str = "scanHomebrewOnStartup";
+
 pub const DEFAULT_MAX_ITERATIONS: usize = 25;
 const KEYCHAIN_SERVICE: &str = "com.darkmatter.nixmac";
 

--- a/apps/native/src-tauri/src/summarize/find_existing.rs
+++ b/apps/native/src-tauri/src/summarize/find_existing.rs
@@ -4,9 +4,9 @@ use anyhow::Result;
 use rusqlite::Connection;
 use std::path::Path;
 
-use crate::summarize::sumlog as dbg;
 use crate::shared_types::{SummarizedChange, SummarizedChangeSet};
 use crate::sqlite_types::ChangeSet;
+use crate::summarize::sumlog as dbg;
 
 /// Type shared only between `for_current_state` and `group_existing::from_change_sets`.
 /// Ensures missing hashes can be passed through when DB had nothing
@@ -33,7 +33,11 @@ pub fn by_base_with_hashes(
     hashes: &[String],
 ) -> Result<FoundSetForCurrent> {
     let conn = Connection::open(db_path)?;
-    match crate::db::changesets::query_change_set_for_base_with_hashes(&conn, base_commit_id, hashes)? {
+    match crate::db::changesets::query_change_set_for_base_with_hashes(
+        &conn,
+        base_commit_id,
+        hashes,
+    )? {
         Some(cs) => Ok(FoundSetForCurrent::from(cs)),
         None => Ok(FoundSetForCurrent {
             change_set: None,
@@ -69,7 +73,11 @@ pub fn for_current_state(db_path: &Path, dir: &str) -> Result<Vec<FoundSetForCur
     });
     let conn = Connection::open(db_path)?;
     let result: Vec<FoundSetForCurrent> =
-        match crate::db::changesets::query_change_set_for_base_with_hashes(&conn, commit.id, &diff_hashes)? {
+        match crate::db::changesets::query_change_set_for_base_with_hashes(
+            &conn,
+            commit.id,
+            &diff_hashes,
+        )? {
             Some(cs) => vec![FoundSetForCurrent::from(cs)],
             None => vec![FoundSetForCurrent {
                 change_set: None,
@@ -78,6 +86,12 @@ pub fn for_current_state(db_path: &Path, dir: &str) -> Result<Vec<FoundSetForCur
             }],
         };
 
-    dbg::find_log_result(result.iter().map(|e| (e.change_set.is_some(), e.changes.len(), e.missed_hashes.len())));
+    dbg::find_log_result(result.iter().map(|e| {
+        (
+            e.change_set.is_some(),
+            e.changes.len(),
+            e.missed_hashes.len(),
+        )
+    }));
     Ok(result)
 }

--- a/apps/native/src-tauri/src/summarize/token_budgets.rs
+++ b/apps/native/src-tauri/src/summarize/token_budgets.rs
@@ -107,14 +107,14 @@ pub fn model_context_window(model: &str) -> u32 {
 }
 
 // ── map_relations ─────────────────────────────────────────────────────────────
-const MAP_MAX_OUTPUT_TOKENS: u32 = 800;
+const MAP_MAX_OUTPUT_TOKENS: u32 = 1600;
 
 pub fn map_relations_budget(prompt: &str, model: &str) -> TokenAllocation {
     compute_token_allocation(prompt, MAP_MAX_OUTPUT_TOKENS, model_context_window(model))
 }
 
 // ── map_relations_to_existing ─────────────────────────────────────────────────
-const MAP_TO_EXISTING_MAX_OUTPUT_TOKENS: u32 = 800;
+const MAP_TO_EXISTING_MAX_OUTPUT_TOKENS: u32 = 1600;
 
 pub fn map_relations_to_existing_budget(prompt: &str, model: &str) -> TokenAllocation {
     compute_token_allocation(
@@ -125,14 +125,14 @@ pub fn map_relations_to_existing_budget(prompt: &str, model: &str) -> TokenAlloc
 }
 
 // ── summarize_evolved_group / summarize_new_group ─────────────────────────────
-const GROUP_MAX_OUTPUT_TOKENS: u32 = 700;
+const GROUP_MAX_OUTPUT_TOKENS: u32 = 1400;
 
 pub fn group_budget(prompt: &str, model: &str) -> TokenAllocation {
     compute_token_allocation(prompt, GROUP_MAX_OUTPUT_TOKENS, model_context_window(model))
 }
 
 // ── summarize_new_single ──────────────────────────────────────────────────────
-const SINGLE_MAX_OUTPUT_TOKENS: u32 = 800;
+const SINGLE_MAX_OUTPUT_TOKENS: u32 = 1600;
 
 pub fn single_budget(prompt: &str, model: &str) -> TokenAllocation {
     compute_token_allocation(
@@ -143,7 +143,7 @@ pub fn single_budget(prompt: &str, model: &str) -> TokenAllocation {
 }
 
 // ── generate_commit_message_from_map ─────────────────────────────────────────
-const COMMIT_MESSAGE_MAX_OUTPUT_TOKENS: u32 = 300;
+const COMMIT_MESSAGE_MAX_OUTPUT_TOKENS: u32 = 600;
 
 pub fn commit_message_budget(prompt: &str, model: &str) -> TokenAllocation {
     compute_token_allocation(

--- a/apps/native/src/components/config-edit-overlay-panel.tsx
+++ b/apps/native/src/components/config-edit-overlay-panel.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useWidgetStore } from "@/stores/widget-store";
+import { Loader2 } from "lucide-react";
+
+/**
+ * Generic overlay for non-agent config edits that are being written into the repo.
+ * This intentionally sits before the rebuild overlay: once a build starts,
+ * `rebuild.isRunning` takes over with richer progress UI.
+ */
+export function ConfigEditOverlayPanel() {
+  const isProcessing = useWidgetStore((s) => s.isProcessing);
+  const processingAction = useWidgetStore((s) => s.processingAction);
+  const rebuildRunning = useWidgetStore((s) => s.rebuild.isRunning);
+
+  if (!(isProcessing && processingAction === "apply") || rebuildRunning) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center bg-background/90 backdrop-blur-sm">
+      <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-2xl border border-border bg-background/95 px-6 py-8 text-center shadow-2xl">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <div className="space-y-1">
+          <h2 className="font-medium text-base">Applying changes</h2>
+          <p className="text-muted-foreground text-sm">
+            Updating your configuration and preparing the review step.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/native/src/components/widget/homebrew-badge.tsx
+++ b/apps/native/src/components/widget/homebrew-badge.tsx
@@ -21,6 +21,7 @@ export function HomebrewBadge() {
   const prefsLoaded = useWidgetStore((s) => s.prefsLoaded);
   const scanHomebrewOnStartup = useWidgetStore((s) => s.scanHomebrewOnStartup);
   const shouldScan = prefsLoaded && scanHomebrewOnStartup;
+  const setConversationalResponse = useWidgetStore((s) => s.setConversationalResponse);
   const { diff, hasDiff, isApplying, applyDiff } = useHomebrewDiff(shouldScan);
 
   // Only show on the begin step (clean tree, no in-progress evolution).
@@ -62,7 +63,10 @@ export function HomebrewBadge() {
             size="sm"
             className="mt-3 w-full"
             disabled={isApplying}
-            onClick={applyDiff}
+            onClick={() => {
+              applyDiff();
+              setConversationalResponse(null);
+            }}
           >
             {isApplying ? "Adding…" : "Add to config"}
           </Button>

--- a/apps/native/src/components/widget/homebrew-badge.tsx
+++ b/apps/native/src/components/widget/homebrew-badge.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { BadgeButton } from "@/components/ui/badge-button";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { countDiffItems, useHomebrewDiff } from "@/hooks/use-homebrew-diff";
+import { useWidgetStore } from "@/stores/widget-store";
+import { Package } from "lucide-react";
+
+/**
+ * Badge + popover for untracked Homebrew packages.
+ * Appears in the prompt badge row when Homebrew is installed,
+ * the working tree is clean, and there are packages not yet in config.
+ */
+export function HomebrewBadge() {
+  const evolveState = useWidgetStore((s) => s.evolveState);
+  const prefsLoaded = useWidgetStore((s) => s.prefsLoaded);
+  const scanHomebrewOnStartup = useWidgetStore((s) => s.scanHomebrewOnStartup);
+  const shouldScan = prefsLoaded && scanHomebrewOnStartup;
+  const { diff, hasDiff, isApplying, applyDiff } = useHomebrewDiff(shouldScan);
+
+  // Only show on the begin step (clean tree, no in-progress evolution).
+  if (!shouldScan || evolveState?.step !== "begin" || !diff || !diff.isInstalled) return null;
+
+  if (!hasDiff) {
+    return (
+      <BadgeButton icon={Package} badgeVariant="muted" disabled>
+        All Homebrew items tracked
+      </BadgeButton>
+    );
+  }
+
+  const total = countDiffItems(diff);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <BadgeButton icon={Package} badgeVariant="muted">
+          {total} untracked Homebrew {total === 1 ? "item" : "items"}
+        </BadgeButton>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-72 p-3" align="start">
+        <div className="flex flex-col text-sm">
+          <div className="max-h-56 overflow-y-auto pr-2">
+            {diff.taps.length > 0 && (
+              <HomebrewGroup label="Taps" items={diff.taps} />
+            )}
+            {diff.brews.length > 0 && (
+              <HomebrewGroup label="Brews" items={diff.brews} />
+            )}
+            {diff.casks.length > 0 && (
+              <HomebrewGroup label="Casks" items={diff.casks} />
+            )}
+          </div>
+
+          <Button
+            size="sm"
+            className="mt-3 w-full"
+            disabled={isApplying}
+            onClick={applyDiff}
+          >
+            {isApplying ? "Adding…" : "Add to config"}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function HomebrewGroup({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className="mb-2 last:mb-0">
+      <p className="mb-1 font-medium text-foreground/80">
+        {label} ({items.length})
+      </p>
+      <ul className="space-y-0.5 text-muted-foreground">
+        {items.map((item) => (
+          <li key={item} className="flex items-center gap-1.5">
+            <span className="text-muted-foreground/50">–</span>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/native/src/components/widget/prompt-input.tsx
+++ b/apps/native/src/components/widget/prompt-input.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/input-group";
 import { BeginEvolveWarning } from "@/components/widget/begin-evolve-warning";
 import { MacRecommendationChip } from "@/components/widget/mac-recommendation-chip";
+import { HomebrewBadge } from "@/components/widget/homebrew-badge";
 import { PromptHistoryBadge } from "@/components/widget/prompt-history-badge";
 import { SystemDefaultsCTA } from "@/components/widget/system-defaults-cta";
 import { useEvolve } from "@/hooks/use-evolve";
@@ -210,6 +211,7 @@ export function PromptInput() {
           ))}
           <MacRecommendationChip />
           <SystemDefaultsCTA />
+          <HomebrewBadge />
         </div>
         <div className="ml-auto shrink-0">
           <PromptHistoryBadge />

--- a/apps/native/src/components/widget/settings/preferences-tab.tsx
+++ b/apps/native/src/components/widget/settings/preferences-tab.tsx
@@ -8,6 +8,7 @@ export function PreferencesTab() {
   const confirmClear = useWidgetStore((s) => s.confirmClear);
   const confirmRollback = useWidgetStore((s) => s.confirmRollback);
   const autoSummarizeOnFocus = useWidgetStore((s) => s.autoSummarizeOnFocus);
+  const scanHomebrewOnStartup = useWidgetStore((s) => s.scanHomebrewOnStartup);
 
   return (
     <div className="space-y-6">
@@ -61,6 +62,23 @@ export function PreferencesTab() {
               <Switch
                 checked={autoSummarizeOnFocus}
                 onCheckedChange={(checked) => setPref("autoSummarizeOnFocus", checked)}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div className="space-y-3">
+          <div className="font-medium text-sm">Startup scans</div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between rounded-lg border border-border p-3">
+              <div className="space-y-0.5">
+                <div className="text-sm">Scan Homebrew</div>
+                <div className="text-muted-foreground text-xs">Detect Homebrew drift and offer to resolve</div>
+              </div>
+              <Switch
+                checked={scanHomebrewOnStartup}
+                onCheckedChange={(checked) => setPref("scanHomebrewOnStartup", checked)}
               />
             </div>
           </div>

--- a/apps/native/src/components/widget/system-defaults-cta.tsx
+++ b/apps/native/src/components/widget/system-defaults-cta.tsx
@@ -81,6 +81,9 @@ export function SystemDefaultsCTA() {
       const result = await darwinAPI.scanner.applyDefaults(defaults);
       useWidgetStore.getState().setEvolveState(result.evolveState);
       useWidgetStore.getState().setChangeMap(result.changeMap);
+      useWidgetStore.getState().setSummaryAvailable(
+        result.changeMap.groups.length > 0 || result.changeMap.singles.length > 0,
+      );
       useWidgetStore.getState().setGitStatus(result.gitStatus);
       // Invalidate recommended prompt — settings changed
       useWidgetStore.getState().setRecommendedPrompt(undefined);

--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ConfigEditOverlayPanel } from "@/components/config-edit-overlay-panel";
 import { EditorPanel } from "@/components/editor-panel";
 import { EvolveOverlayPanel } from "@/components/evolve-overlay-panel";
 import { RebuildOverlayPanel } from "@/components/rebuild-overlay-panel";
@@ -160,6 +161,7 @@ export function DarwinWidget() {
       </StepContentWrapper>
 
       <EvolveOverlayPanel />
+      <ConfigEditOverlayPanel />
       <RebuildOverlayPanel />
       <EditorPanel />
 

--- a/apps/native/src/hooks/use-homebrew-diff.ts
+++ b/apps/native/src/hooks/use-homebrew-diff.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { darwinAPI } from "@/tauri-api";
+import { useWidgetStore } from "@/stores/widget-store";
+import type { HomebrewState } from "@/types/shared";
+import { useCallback, useEffect, useState } from "react";
+
+const TWENTY_MINUTES_SECS = 20 * 60;
+
+function hasDiffItems(diff: HomebrewState): boolean {
+  return diff.casks.length > 0 || diff.brews.length > 0 || diff.taps.length > 0;
+}
+
+function isStale(diff: HomebrewState): boolean {
+  const nowSecs = Math.floor(Date.now() / 1000);
+  return nowSecs - diff.lastChecked > TWENTY_MINUTES_SECS;
+}
+
+export function countDiffItems(diff: HomebrewState): number {
+  return diff.casks.length + diff.brews.length + diff.taps.length;
+}
+
+export function useHomebrewDiff(enabled = true) {
+  const [diff, setDiff] = useState<HomebrewState | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    setIsLoading(true);
+    setError(null);
+    darwinAPI.homebrew
+      .getStateDiff()
+      .then(setDiff)
+      .catch((e: unknown) => setError(String(e)))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setDiff(null);
+      setIsLoading(false);
+      return;
+    }
+
+    if (diff === null || isStale(diff)) {
+      refresh();
+    }
+  }, [diff, enabled, refresh]);
+
+  const applyDiff = useCallback(async () => {
+    if (!diff || !hasDiffItems(diff)) return;
+    const store = useWidgetStore.getState();
+    setIsApplying(true);
+    store.setProcessing(true, "apply");
+    try {
+      const result = await darwinAPI.homebrew.applyDiff(diff);
+      store.setEvolveState(result.evolveState);
+      store.setChangeMap(result.changeMap);
+      store.setSummaryAvailable(
+        result.changeMap.groups.length > 0 || result.changeMap.singles.length > 0,
+      );
+      store.setGitStatus(result.gitStatus);
+      store.setRecommendedPrompt(undefined);
+      // Clear so we re-fetch on next render (the watcher will also advance the step).
+      setDiff(null);
+    } catch (e: unknown) {
+      setError(String(e));
+    } finally {
+      setIsApplying(false);
+      store.setProcessing(false);
+    }
+  }, [diff]);
+
+  const hasDiff = enabled && diff !== null && diff.isInstalled && hasDiffItems(diff);
+
+  return { diff, hasDiff, isLoading, isApplying, error, refresh, applyDiff };
+}

--- a/apps/native/src/hooks/use-prefs.ts
+++ b/apps/native/src/hooks/use-prefs.ts
@@ -3,11 +3,15 @@ import { darwinAPI } from "@/tauri-api";
 
 export function usePrefs() {
   const loadPrefs = async () => {
-    const prefs = await darwinAPI.ui.getPrefs();
+    const prefs = await darwinAPI.ui.getPrefs().catch(() => null);
     if (prefs) {
       useWidgetStore.getState().initConfirmPrefs(prefs);
       useWidgetStore.getState().setAutoSummarizeOnFocus(prefs.autoSummarizeOnFocus ?? false);
+      useWidgetStore
+        .getState()
+        .setBoolPref("scanHomebrewOnStartup", prefs.scanHomebrewOnStartup ?? true);
     }
+    useWidgetStore.getState().setPrefsLoaded(true);
   };
 
   const setPref = async (key: BoolPrefKey, value: boolean) => {

--- a/apps/native/src/stores/widget-store.test.ts
+++ b/apps/native/src/stores/widget-store.test.ts
@@ -33,6 +33,7 @@ describe("createWidgetStore — initial state", () => {
     expect(s.confirmBuild).toBe(true);
     expect(s.confirmClear).toBe(true);
     expect(s.confirmRollback).toBe(true);
+    expect(s.scanHomebrewOnStartup).toBe(true);
     // analyzing-hash set starts empty but is an actual Set.
     expect(s.analyzingHistoryForHashes).toBeInstanceOf(Set);
     expect(s.analyzingHistoryForHashes.size).toBe(0);
@@ -152,6 +153,14 @@ describe("confirmation preferences", () => {
     // missing keys -> default true
     expect(s.confirmClear).toBe(true);
     expect(s.confirmRollback).toBe(true);
+  });
+
+  it("setBoolPref toggles scanHomebrewOnStartup", () => {
+    const store = createWidgetStore();
+    store.getState().setBoolPref("scanHomebrewOnStartup", false);
+    const s = store.getState();
+    expect(s.scanHomebrewOnStartup).toBe(false);
+    expect(s.confirmBuild).toBe(true);
   });
 });
 

--- a/apps/native/src/stores/widget-store.ts
+++ b/apps/native/src/stores/widget-store.ts
@@ -29,7 +29,7 @@ export type SettingsTab = "general" | "api-keys" | "ai-models" | "preferences";
 export type WidgetStep = "permissions" | "nix-setup" | "setup" | "begin" | "evolve" | "commit" | "manualEvolve" | "manualCommit" | "history";
 export type ProcessingAction = "evolve" | "apply" | "merge" | "cancel" | null;
 export type ConfirmPrefKey = "confirmBuild" | "confirmClear" | "confirmRollback";
-export type BoolPrefKey = ConfirmPrefKey | "autoSummarizeOnFocus";
+export type BoolPrefKey = ConfirmPrefKey | "autoSummarizeOnFocus" | "scanHomebrewOnStartup";
 
 // Rebuild state for showing progress inline in the widget
 export type RebuildErrorType =
@@ -119,6 +119,7 @@ export interface WidgetState {
   isGenerating: boolean;
   settingsOpen: boolean;
   settingsActiveTab: SettingsTab | null;
+  prefsLoaded: boolean;
   showHistory: boolean;
   feedbackOpen: boolean;
   feedbackTypeOverride: FeedbackType | null;
@@ -140,6 +141,9 @@ export interface WidgetState {
 
   // Summarization preferences
   autoSummarizeOnFocus: boolean;
+
+  // Startup scanning preferences
+  scanHomebrewOnStartup: boolean;
 
   // Editor
   editingFile: string | null;
@@ -170,6 +174,7 @@ export interface WidgetActions {
   setProcessing: (isProcessing: boolean, action?: ProcessingAction) => void;
   setChangeMap: (map: SemanticChangeMap | null) => void;
   setSettingsOpen: (open: boolean, tab?: SettingsTab | null) => void;
+  setPrefsLoaded: (loaded: boolean) => void;
   setShowHistory: (show: boolean) => void;
   setFeedbackOpen: (open: boolean) => void;
   setError: (error: string | null) => void;
@@ -297,6 +302,7 @@ export const initialWidgetState: WidgetState = {
   isGenerating: false,
   settingsOpen: false,
   settingsActiveTab: null,
+  prefsLoaded: false,
   showHistory: false,
   feedbackOpen: false,
   feedbackTypeOverride: null,
@@ -312,6 +318,9 @@ export const initialWidgetState: WidgetState = {
 
   // Summarization preferences
   autoSummarizeOnFocus: false,
+
+  // Startup scanning preferences
+  scanHomebrewOnStartup: true,
 
   // Editor
   editingFile: null,
@@ -373,6 +382,7 @@ export function createWidgetStore(initialState?: Partial<WidgetState>) {
       }),
     setSettingsOpen: (settingsOpen, tab) =>
       set({ settingsOpen, settingsActiveTab: tab ?? null }),
+    setPrefsLoaded: (prefsLoaded) => set({ prefsLoaded }),
     setShowHistory: (showHistory) => set({ showHistory }),
     setFeedbackOpen: (feedbackOpen) => set({ feedbackOpen }),
     setFeedbackTypeOverride: (feedbackTypeOverride) => set({ feedbackTypeOverride }),

--- a/apps/native/src/tauri-api.ts
+++ b/apps/native/src/tauri-api.ts
@@ -8,6 +8,7 @@ import type {
   EvolutionResult,
   EvolveState,
   GitStatus,
+  HomebrewState,
   HistoryItem,
   RollbackResult,
   SemanticChangeMap,
@@ -25,6 +26,7 @@ export type {
   EvolveStep,
   GitFileStatus,
   GitStatus,
+  HomebrewState,
   HistoryItem,
   SemanticChangeMap,
   SetDirResult,
@@ -47,6 +49,14 @@ export interface DarwinConfig {
 export const DEFAULT_MAX_ITERATIONS = 25;
 
 export interface ApplyResult {
+  gitStatus: GitStatus;
+  evolveState: EvolveState;
+}
+
+export interface ConfigEditApplyResult {
+  ok: boolean;
+  count: number;
+  changeMap: SemanticChangeMap;
   gitStatus: GitStatus;
   evolveState: EvolveState;
 }
@@ -317,13 +327,7 @@ export const darwinAPI = {
     getRecommendedPrompt: () => invoke<RecommendedPrompt | null>("get_recommended_prompt"),
     scanDefaults: () => invoke<SystemDefaultsScan>("scan_system_defaults"),
     applyDefaults: (defaults: SystemDefault[]) =>
-      invoke<{
-        ok: boolean;
-        count: number;
-        changeMap: SemanticChangeMap;
-        gitStatus: GitStatus;
-        evolveState: EvolveState;
-      }>("apply_system_defaults", { defaults }),
+      invoke<ConfigEditApplyResult>("apply_system_defaults", { defaults }),
   },
   permissions: {
     checkAll: () => invoke<PermissionsState>("permissions_check_all"),
@@ -357,6 +361,11 @@ export const darwinAPI = {
     start: () => invoke<void>("lsp_start"),
     send: (message: string) => invoke<void>("lsp_send", { message }),
     stop: () => invoke<void>("lsp_stop"),
+  },
+
+  homebrew: {
+    getStateDiff: () => invoke<HomebrewState>("homebrew_get_state_diff"),
+    applyDiff: (diff: HomebrewState) => invoke<ConfigEditApplyResult>("homebrew_apply_diff", { diff }),
   },
 };
 

--- a/apps/native/src/types/shared.ts
+++ b/apps/native/src/types/shared.ts
@@ -108,6 +108,8 @@ export type GitStatus = { files: GitFileStatus[]; branch: string | null; diff: s
  */
 export type HistoryItem = { hash: string; message: string | null; createdAt: number; isBuilt: boolean; isBase: boolean; isExternal: boolean; fileCount: number; commit: Commit | null; changeMap: SemanticChangeMap | null; unsummarizedHashes: string[]; rawChanges: Change[]; originMessage: string | null; originHash: string | null; isOrphanedRestore: boolean; isUndone: boolean }
 
+export type HomebrewState = { isInstalled: boolean; casks: string[]; brews: string[]; taps: string[]; source: string | null; lastChecked: number }
+
 /**
  * Result returned from a rollback erase operation.
  */
@@ -130,7 +132,7 @@ export type SummarizedChangeSet = { changeSet: ChangeSet; changes: SummarizedCha
 /**
  * User interface preferences (synced to settings.json via tauri-plugin-store).
  */
-export type UiPrefs = { openrouterApiKey: string | null; openaiApiKey: string | null; ollamaApiBaseUrl: string | null; vllmApiBaseUrl: string | null; vllmApiKey: string | null; summaryProvider: string | null; summaryModel: string | null; evolveProvider: string | null; evolveModel: string | null; maxIterations: number | null; maxBuildAttempts: number | null; sendDiagnostics: boolean; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean }
+export type UiPrefs = { openrouterApiKey: string | null; openaiApiKey: string | null; ollamaApiBaseUrl: string | null; vllmApiBaseUrl: string | null; vllmApiKey: string | null; summaryProvider: string | null; summaryModel: string | null; evolveProvider: string | null; evolveModel: string | null; maxIterations: number | null; maxBuildAttempts: number | null; sendDiagnostics: boolean; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean }
 
 /**
  * Event payload emitted by the git status watcher.


### PR DESCRIPTION
## Summary

Implements the requested Homebrew scan/diff/add-to-config feature:

* Refactor existing "manual change" logic in apply_system_defaults to be reusable as "managed_edit".
* Add Tauri commands for Homebrew scanning stuff.
* Add some new reusable nix-parsing functions that use rnix as "nix_ast_lists".
* Fullstack preference wiring for homebrew scanning option.
* Temp increase token budgets for summarization until we can do further work in this area.
* UI for showing untracked brew stuff and adding it to the config.
* Check if homebrew is installed and available.
* Wiring to scan and diff homebrew vs nix config (homebrew.rs).
* Track if preferences are loaded in React to avoid weird race conditions.

## Screenshots:
<img width="657" height="492" alt="Screenshot 2026-05-01 at 3 08 37 PM" src="https://github.com/user-attachments/assets/4e2f1c72-751a-483d-94d6-3cba2c9a1f88" />
<hr/>
<img width="753" height="390" alt="Screenshot 2026-04-29 at 9 54 21 AM" src="https://github.com/user-attachments/assets/9f92d10b-c4e6-42af-8a6c-888328a5ded2" />
<hr/>
<img width="338" height="492" alt="Screenshot 2026-05-01 at 4 05 13 PM" src="https://github.com/user-attachments/assets/b7de853f-08a1-4abe-8571-9abc43f67cd9" />
<hr/>
<img width="412" height="442" alt="Screenshot 2026-04-29 at 9 57 36 AM" src="https://github.com/user-attachments/assets/87b8a5c2-ac50-4e3a-a7ec-0fcc886b8d01" />

## Test Plan

There are new unit tests where possible/appropriate, and I manually tested this by moving things in and out of my own homebrew.nix.

## Docs

- [ ] Docs updated
- [x] No docs update needed -- not dev docs anyway; we should perhaps start maintaining end-user docs separately.