### PR TITLE
Document Product Proof hook behavior

### DIFF
--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -120,6 +120,8 @@ lib.mkIf (!(config.container.isBuilding or false)) {
   # Formatting
   treefmt.enable = true;
   treefmt.config = {
+    # The commit hook runs treefmt repo-wide; enabling more formatters here
+    # expands pre-commit cost and can surface unrelated formatting drift.
     programs.rustfmt.enable = false;
     programs.yamlfmt.enable = false;
     programs.mdformat.enable = true;
@@ -132,6 +134,8 @@ lib.mkIf (!(config.container.isBuilding or false)) {
 
     # Run treefmt on commit
     hooks.treefmt.enable = true;
+    # Pinned git-hooks.nix forces treefmt pass_filenames=true; override until
+    # the pinned upstream default is false.
     hooks.treefmt.pass_filenames = lib.mkForce false;
 
     hooks.shellcheck.enable = true;

--- a/tools/computer-use-e2e/README.md
+++ b/tools/computer-use-e2e/README.md
@@ -79,13 +79,6 @@ The runner:
 - does not confirm Discard unless `NIXMAC_E2E_DISPOSABLE_CONFIG=true` and
   `NIXMAC_E2E_ALLOW_DISCARD_CONFIRM=true` are both set by a setup step that has
   proven the app is using a per-run disposable config;
-
-Direct Homebrew import is revalidated at apply time. The backend intersects the
-UI-submitted diff with a fresh Homebrew/config scan and writes only items that
-are still missing, using the current config source rather than trusting a stale
-submitted source. Stale no-longer-missing items are silently dropped for this
-phase; the existing post-apply refetch refreshes the chip state.
-
 - marks provider-blocked paths bluntly, for example OpenRouter billing/credits
   failures;
 - renders coverage gaps, PR-specific focus, evidence grades, primary artifact
@@ -98,6 +91,12 @@ phase; the existing post-apply refetch refreshes the chip state.
 - exits non-zero when the final report verdict is `fail` or `inconclusive`
   unless `NIXMAC_E2E_STRICT_VERDICT=false` is set. For PRs, keep the check
   non-blocking through branch protection rather than by forcing a green result.
+
+Direct Homebrew import is revalidated at apply time. The backend intersects the
+UI-submitted diff with a fresh Homebrew/config scan and writes only items that
+are still missing, using the current config source rather than trusting a stale
+submitted source. Stale no-longer-missing items are silently dropped for this
+phase; the existing post-apply refetch refreshes the chip state.
 
 Planned next coverage feature: the suite should stay fresh with `main`. That
 means maintaining a scenario manifest for every major user-visible nixmac


### PR DESCRIPTION
## Summary
- documents why the Product Proof treefmt hook uses `lib.mkForce false`
- calls out that the treefmt pre-commit hook now scans the repo when it runs
- keeps the Computer Use runner behavior list contiguous in the README, moving the Homebrew revalidation paragraph below it

## Latest Product Proof evidence
- PR: #69
- Head: `08050cdc`
- Computer Use E2E run: https://github.com/darkmatter/nixmac/actions/runs/25250382889
- Public HTML report: https://htmlpreview.github.io/?https://github.com/darkmatter/nixmac/blob/gh-pages/computer-use-e2e/pr-69/run-25250382889-1/index.html
- Artifact backup: https://github.com/darkmatter/nixmac/actions/runs/25250382889/artifacts/6762687503
- Local downloaded artifact: `artifacts/computer-use-remote/live-pr69-25250382889-1/2026-05-02T110941125Z`
- Result: `26 pass / 0 fail / 0 inconclusive`
- Screenshots: `63`
- Visual assertions: `16 pass`
- Coverage drift: `0`
- Readiness: `ok=true`, `0` failures
- Adversarial replay: `artifacts/computer-use-adversarial/2026-05-02T112508199Z/index.html`
- Adversarial result: `28 caught / 0 missed / 0 blocked`
- Adversarial digest: `45247498dec4d4436f26b0d096d0864c238c3ada5943e1afb8489d86be5139ec`

## Test plan
- [x] `treefmt --no-cache --fail-on-change`
- [x] `prek run treefmt --hook-stage pre-commit` on the original staged cleanup
- [x] `prek run --hook-stage pre-commit` on the original staged cleanup
- [x] committed through the generated pre-commit hook without `--no-verify`
- [x] GitHub Danger passed: https://github.com/darkmatter/nixmac/actions/runs/25250382884
- [x] GitHub Build macOS App passed: https://github.com/darkmatter/nixmac/actions/runs/25250382885
- [x] GitHub Computer Use E2E passed: https://github.com/darkmatter/nixmac/actions/runs/25250382889

## Docs
- [x] Docs updated
