### PR TITLE
ci(build): sync shipped releases to Linear

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -469,6 +469,19 @@ jobs:
             --content-type "application/json"
 
           echo "✅ Uploaded to R2: v${VERSION}"
+      # Sync the shipped release to Linear so issues referenced in commits since
+      # the previous release get linked. Runs only after R2 upload succeeds, so
+      # Linear releases track what actually shipped. Skipped for `-test.N` tags
+      # to match the GitHub Release / R2 upload skip.
+      - name: Sync release to Linear
+        if: (steps.release-version.outputs.mode == 'tag' ||
+          steps.release-version.outputs.mode == 'release') &&
+          !contains(steps.release-version.outputs.tag, '-test.')
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ steps.release-version.outputs.version }}
+          name: nixmac v${{ steps.release-version.outputs.version }}
       - name: Cleanup keychain
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- Wire `linear/linear-release-action@v0` into `build.yaml` after the R2 upload step
- Runs only on `tag` and `release` modes; skips branch builds and `-test.N` tags
- Uses the computed semver (`steps.release-version.outputs.version`) as the Linear release version, with name `nixmac vX.Y.Z`

## Test plan
- [x] Confirm `LINEAR_ACCESS_KEY` secret is set on the repo
- [ ] Merge to `main` and verify a Linear release is created with the same version as the GitHub Release / R2 `latest.json`
- [ ] Verify commits referencing Linear IDs (e.g. `ENG-123`) are linked to the release
- [ ] Verify a `-test.N` tag does NOT create a Linear release
- [ ] Verify PR/branch builds do NOT create a Linear release

🤖 Generated with [Claude Code](https://claude.com/claude-code)