### PR TITLE
fix(updater): allow non https url

### DIFF
--- a/apps/native/src-tauri/src/updater_pin.rs
+++ b/apps/native/src-tauri/src/updater_pin.rs
@@ -15,6 +15,12 @@
 //!      `check().download_and_install()` exactly like the production path.
 //!
 //! Gated to release builds because the updater plugin isn't registered in dev.
+//!
+//! NOTE: requires `plugins.updater.dangerousInsecureTransportProtocol: true`
+//! in `tauri.conf.json`. Without it, `endpoints(...)` rejects `http://` URLs —
+//! including the loopback manifest URL we serve here. The production endpoint
+//! is still HTTPS and minisign-verified; this flag only relaxes the *scheme*
+//! check at the URL-validation layer.
 
 #[allow(dead_code)]
 const RELEASES_BASE: &str = "https://releases.nixmac.com";

--- a/apps/native/src-tauri/tauri.conf.json
+++ b/apps/native/src-tauri/tauri.conf.json
@@ -67,7 +67,8 @@
       "endpoints": [
         "https://releases.nixmac.com/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDEyQ0ZGMjJEOTNBMDUxQ0IKUldUTFVhQ1RMZkxQRXNDYXVyblBpa3BVbVdUK3QwUFpzaXl0MVVoQThjcjJkU3hkYlBwNHo1L3cK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDEyQ0ZGMjJEOTNBMDUxQ0IKUldUTFVhQ1RMZkxQRXNDYXVyblBpa3BVbVdUK3QwUFpzaXl0MVVoQThjcjJkU3hkYlBwNHo1L3cK",
+      "dangerousInsecureTransportProtocol": true
     }
   }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why? -->

## Test Plan

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [ ] No docs update needed
