### PR TITLE
feat: Add .gitignore to nix-darwin-determinate template

### DIFF
--- a/apps/native/templates/nix-darwin-determinate/.gitignore
+++ b/apps/native/templates/nix-darwin-determinate/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
## Summary

This is probably more generally useful, but as a specific example, if the user opens up a Finder window on their config directory, we may detect the .DS_Store file as a "change" but not display it in nix-mac, which causes confusing UI state.

## Test Plan

Manual

## Docs

- [ ] Docs updated
- [x] No docs update needed
