### PR TITLE
remove clearpreview and summaryavailable

### DIFF
--- a/apps/native/src/components/widget/evolve-flow.stories.tsx
+++ b/apps/native/src/components/widget/evolve-flow.stories.tsx
@@ -200,7 +200,6 @@ function AnimatedEvolveFlow() {
         evolveState: evolveStateEvolve,
         gitStatus: mockGitStatus,
         changeMap: mockChangeMap,
-        summaryAvailable: true,
       });
     }, completionTime);
     timeoutsRef.current.push(t2);
@@ -282,7 +281,6 @@ export const Review = meta.story({
         evolveState: evolveStateEvolve,
         gitStatus: mockGitStatus,
         changeMap: mockChangeMap,
-        summaryAvailable: true,
         evolveEvents: mockEvolveEvents,
       }}
     />
@@ -298,7 +296,6 @@ export const Merge = meta.story({
         evolveState: evolveStateMerge,
         gitStatus: mockGitStatus,
         changeMap: mockChangeMap,
-        summaryAvailable: true,
         commitMessageSuggestion: "feat: add system monitoring tools (htop, btop, bottom, bandwhich, procs)",
       }}
     />

--- a/apps/native/src/components/widget/system-defaults-cta.tsx
+++ b/apps/native/src/components/widget/system-defaults-cta.tsx
@@ -81,9 +81,6 @@ export function SystemDefaultsCTA() {
       const result = await darwinAPI.scanner.applyDefaults(defaults);
       useWidgetStore.getState().setEvolveState(result.evolveState);
       useWidgetStore.getState().setChangeMap(result.changeMap);
-      useWidgetStore.getState().setSummaryAvailable(
-        result.changeMap.groups.length > 0 || result.changeMap.singles.length > 0,
-      );
       useWidgetStore.getState().setGitStatus(result.gitStatus);
       // Invalidate recommended prompt — settings changed
       useWidgetStore.getState().setRecommendedPrompt(undefined);

--- a/apps/native/src/hooks/use-evolve.ts
+++ b/apps/native/src/hooks/use-evolve.ts
@@ -45,7 +45,6 @@ export function useEvolve() {
     store.setExternalBuildDetected(false);
     store.clearEvolveEvents();
     store.clearLogs();
-    store.clearPreview();
     store.setConversationalResponse(null);
     store.appendLog(`\n> Evolving: "${store.evolvePrompt}"\n`);
 
@@ -69,8 +68,6 @@ export function useEvolve() {
 
       if (isConversational) {
         useWidgetStore.getState().setConversationalResponse(result.conversationalResponse ?? null);
-      } else {
-        store.setSummaryAvailable(true);
       }
       if (result?.gitStatus) {
         useWidgetStore.getState().setGitStatus(result.gitStatus);

--- a/apps/native/src/hooks/use-git-operations.ts
+++ b/apps/native/src/hooks/use-git-operations.ts
@@ -75,7 +75,6 @@ export function useGitOperations() {
         useWidgetStore.getState().appendLog("✓ Committed successfully\n");
         useWidgetStore.getState().setError(null);
         toast.success("Committed successfully");
-        useWidgetStore.getState().clearPreview();
         useWidgetStore.getState().setChangeMap(null);
         useWidgetStore.getState().setEvolveState(result.evolveState);
         await refreshGitStatus();

--- a/apps/native/src/hooks/use-homebrew-diff.ts
+++ b/apps/native/src/hooks/use-homebrew-diff.ts
@@ -57,9 +57,6 @@ export function useHomebrewDiff(enabled = true) {
       const result = await darwinAPI.homebrew.applyDiff(diff);
       store.setEvolveState(result.evolveState);
       store.setChangeMap(result.changeMap);
-      store.setSummaryAvailable(
-        result.changeMap.groups.length > 0 || result.changeMap.singles.length > 0,
-      );
       store.setGitStatus(result.gitStatus);
       store.setRecommendedPrompt(undefined);
       // Clear so we re-fetch on next render (the watcher will also advance the step).

--- a/apps/native/src/hooks/use-queue-summarizer.ts
+++ b/apps/native/src/hooks/use-queue-summarizer.ts
@@ -22,9 +22,6 @@ export function useQueueSummarizer() {
         const store = useWidgetStore.getState();
         const map = event.payload.semanticMap;
         store.setChangeMap(map);
-        store.setSummaryAvailable(
-          map.groups.length > 0 || map.singles.length > 0,
-        );
         if (store.showHistory) {
           loadHistory();
         }

--- a/apps/native/src/hooks/use-rollback.ts
+++ b/apps/native/src/hooks/use-rollback.ts
@@ -23,7 +23,6 @@ export function useRollback() {
       store.setGitStatus(result.gitStatus);
       store.setEvolveState(result.evolveState);
       store.setEvolvePrompt("");
-      store.clearPreview();
       store.appendLog("✓ Changes discarded\n");
 
       if (result.rollbackStorePath && wasCommittable) {

--- a/apps/native/src/hooks/use-summary.ts
+++ b/apps/native/src/hooks/use-summary.ts
@@ -9,12 +9,11 @@ export function useSummary() {
   const autoSummarizeOnFocus = useWidgetStore((s) => s.autoSummarizeOnFocus);
 
   const findChangeMap = useCallback(async (): Promise<void> => {
-    const { setChangeMap, setSummaryAvailable } = useWidgetStore.getState();
+    const { setChangeMap } = useWidgetStore.getState();
     try {
       const map = await darwinAPI.summarizedChanges.findChangeMap();
       if (map) {
         setChangeMap(map);
-        setSummaryAvailable(map.groups.length > 0 || map.singles.length > 0);
       }
     } catch (e) {
       console.error("[SemanticChangeMap] error", e);
@@ -33,12 +32,11 @@ export function useSummary() {
   }, []);
 
   const generateCurrentSummary = useCallback(async () => {
-    const { setSummarizing, setChangeMap, setSummaryAvailable } = useWidgetStore.getState();
+    const { setSummarizing, setChangeMap } = useWidgetStore.getState();
     setSummarizing(true);
     try {
       const map = await darwinAPI.summarizedChanges.summarizeCurrent();
       setChangeMap(map);
-      setSummaryAvailable(map.groups.length > 0 || map.singles.length > 0);
     } finally {
       setSummarizing(false);
     }

--- a/apps/native/src/hooks/use-watcher.ts
+++ b/apps/native/src/hooks/use-watcher.ts
@@ -36,7 +36,6 @@ export function useWatcher() {
           store.setGitStatus(gitStatus ?? null);
           if (changeMap) {
             store.setChangeMap(changeMap);
-            store.setSummaryAvailable(changeMap.groups.length > 0 || changeMap.singles.length > 0);
           }
           if (evolveState) {
             store.setEvolveState(evolveState);

--- a/apps/native/src/stores/widget-store.test.ts
+++ b/apps/native/src/stores/widget-store.test.ts
@@ -334,14 +334,4 @@ describe("UI helpers", () => {
     expect(s.feedbackInitialText).toBe("something broke");
   });
 
-  it("clearPreview wipes changeMap and summaryAvailable", () => {
-    const store = createWidgetStore({
-      changeMap: { foo: "bar" } as never,
-      summaryAvailable: true,
-    });
-    store.getState().clearPreview();
-    const s = store.getState();
-    expect(s.changeMap).toBeNull();
-    expect(s.summaryAvailable).toBe(false);
-  });
 });

--- a/apps/native/src/stores/widget-store.ts
+++ b/apps/native/src/stores/widget-store.ts
@@ -114,7 +114,6 @@ export interface WidgetState {
   analyzingHistoryForHashes: Set<string>;
 
   // UI
-  summaryAvailable: boolean;
   isSummarizing: boolean;
   isGenerating: boolean;
   settingsOpen: boolean;
@@ -186,7 +185,6 @@ interface WidgetActions {
     details: { message: string; location?: string; backtrace?: string; timestamp: string } | null,
   ) => void;
   setPromptHistory: (history: string[]) => void;
-  setSummaryAvailable: (available: boolean) => void;
   setRecommendedPrompt: (prompt: RecommendedPrompt | null | undefined) => void;
 
   // History
@@ -209,7 +207,6 @@ interface WidgetActions {
   // Client-side state (NOT from server)
   setSummarizing: (summarizing: boolean) => void;
   setGenerating: (generating: boolean) => void;
-  clearPreview: () => void;
   setFeedbackTypeOverride: (type: FeedbackType | null) => void;
   openFeedback: (type?: FeedbackType, initialText?: string) => void;
 
@@ -293,7 +290,6 @@ const initialWidgetState: WidgetState = {
   analyzingHistoryForHashes: new Set<string>(),
 
   changeMap: null,
-  summaryAvailable: false,
 
   // Commit message suggestion
   commitMessageSuggestion: null,
@@ -371,7 +367,6 @@ export function createWidgetStore(initialState?: Partial<WidgetState>) {
         processingAction: isProcessing ? action : null,
       }),
     setChangeMap: (changeMap) => set({ changeMap }),
-    setSummaryAvailable: (summaryAvailable) => set({ summaryAvailable }),
     setBoolPref: (key: BoolPrefKey, value: boolean) => set({ [key]: value }),
     initConfirmPrefs: (prefs) =>
       set({
@@ -421,11 +416,6 @@ export function createWidgetStore(initialState?: Partial<WidgetState>) {
     setDarwinRebuildPrefetching: (darwinRebuildPrefetching) => set({ darwinRebuildPrefetching }),
     setSummarizing: (isSummarizing) => set({ isSummarizing }),
     setGenerating: (isGenerating) => set({ isGenerating }),
-    clearPreview: () =>
-      set({
-        changeMap: null,
-        summaryAvailable: false,
-      }),
 
     // Console
     appendLog: (text) => set((state) => ({ consoleLogs: state.consoleLogs + text })),

--- a/apps/native/src/utils/widget-test-helpers.ts
+++ b/apps/native/src/utils/widget-test-helpers.ts
@@ -44,7 +44,6 @@ export function setupWidgetTestHelpers() {
       const state = useWidgetStore.getState();
       state.setEvolvePrompt("");
       state.setPromptHistory([]);
-      state.clearPreview();
       state.clearLogs();
       state.clearEvolveEvents();
       state.setConversationalResponse(null);


### PR DESCRIPTION
## Summary

clearpreview was not useful, rather evolution result should return whatever data it needs to the frontend, or the frontend needs to call for it, but clearing data before knowing the result did not serve any purpose

summary available was being written in places but never read

## Test Plan

Ran tests, made changes
Ran tests again, one fewer passed as one was removed

- make a change 
- read the summary
- tigger conversational


Summary stays, and is not overwritten by the default changemap in the evolution return, as the conditional check catches 

## Docs

- [X] No docs update needed
