### PR TITLE
ENG-467 Add Support Nixmac settings link

### DIFF
--- a/apps/native/src/components/widget/settings/general-tab.test.tsx
+++ b/apps/native/src/components/widget/settings/general-tab.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { open } from "@tauri-apps/plugin-shell";
+import { describe, expect, it, vi } from "vitest";
+import { GeneralTab } from "./general-tab";
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn().mockResolvedValue("0.0.0-test"),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/components/widget/controls/directory-picker", () => ({
+  DirectoryPicker: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+vi.mock("@/components/widget/controls/bootstrap-config", () => ({
+  BootstrapConfig: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+vi.mock("@/tauri-api", () => ({
+  darwinAPI: {
+    ui: {
+      setPrefs: vi.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+
+const sendDiagnosticsField = {
+  state: { value: false },
+  handleChange: vi.fn(),
+};
+
+describe("GeneralTab", () => {
+  it("opens the Support Nixmac page from settings", async () => {
+    render(
+      <GeneralTab
+        configDir="/Users/test/.darwin"
+        handleRefreshHosts={vi.fn()}
+        hasFlake
+        host="Test-MacBook"
+        hosts={["Test-MacBook"]}
+        saveHost={vi.fn()}
+        sendDiagnosticsField={sendDiagnosticsField as never}
+        setSettingsOpen={vi.fn()}
+      />,
+    );
+
+    await screen.findByText("0.0.0-test");
+    expect(screen.getByText("Support Nixmac")).toBeInTheDocument();
+    expect(screen.getByText("Help fund continued development.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Support Nixmac" }));
+
+    expect(open).toHaveBeenCalledWith("https://nixmac.com/support");
+  });
+});

--- a/apps/native/src/components/widget/settings/general-tab.tsx
+++ b/apps/native/src/components/widget/settings/general-tab.tsx
@@ -13,8 +13,9 @@ import { getWebSiteUrl } from "@/lib/env";
 import { useWidgetStore } from "@/stores/widget-store";
 import { darwinAPI } from "@/tauri-api";
 import { getVersion } from "@tauri-apps/api/app";
-import { open } from '@tauri-apps/plugin-shell';
+import { open } from "@tauri-apps/plugin-shell";
 import type { AnyFieldApi } from "@tanstack/react-form";
+import { ExternalLink } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 interface GeneralTabProps {
@@ -27,6 +28,18 @@ interface GeneralTabProps {
   setSettingsOpen: (open: boolean) => void;
   // biome-ignore lint/suspicious/noExplicitAny: tanstack form types are complex
   sendDiagnosticsField: AnyFieldApi;
+}
+
+// Support should always land on the public website, even in local app builds.
+const SUPPORT_NIXMAC_URL = "https://nixmac.com/support";
+
+async function openExternalUrl(url: string) {
+  try {
+    await open(url);
+  } catch (error) {
+    console.warn("Failed to open external URL with Tauri shell; falling back to browser window.", error);
+    window.open(url, "_blank");
+  }
 }
 
 export function GeneralTab({
@@ -87,15 +100,9 @@ export function GeneralTab({
                 <div>
                   <button
                     type="button"
-                    onClick={async () => {
+                    onClick={() => {
                       const base = getWebSiteUrl().replace(/\/$/, "");
-                      const url = `${base}/privacy-policy`;
-                      try {
-                        await open(url);
-                      } catch (err) {
-                        // Fallback to window.open if Tauri shell fails for some reason (e.g. during direct development in the web app)
-                        window.open(url, "_blank");
-                      }
+                      openExternalUrl(`${base}/privacy-policy`);
                     }}
                     className="mt-2 text-xs text-zinc-400 underline hover:text-zinc-200"
                   >
@@ -118,6 +125,24 @@ export function GeneralTab({
                 }
               }}
             />
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-border p-3">
+            <div className="space-y-0.5">
+              <div className="font-medium text-sm">Support Nixmac</div>
+              <div className="text-muted-foreground text-xs">
+                Help fund continued development.
+              </div>
+            </div>
+            <Button
+              aria-label="Open Support Nixmac"
+              onClick={() => openExternalUrl(SUPPORT_NIXMAC_URL)}
+              size="sm"
+              variant="outline"
+            >
+              Open
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Button>
           </div>
 
           <VersionRow />


### PR DESCRIPTION
## Summary

Adds a lightweight `Support Nixmac` row to Settings > General. The row keeps the visible action compact (`Open`) while using a specific accessible label (`Open Support Nixmac`) and opens the public support page at `https://nixmac.com/support`.

Also extracts the existing external-link fallback into a small helper so the privacy-policy link and support link share the same Tauri-shell fallback behavior.

## Test Plan

- [x] `bun --cwd apps/native test:unit -- src/components/widget/settings/general-tab.test.tsx`
- [x] Scoped oxlint on changed files with minimal config: `bunx oxlint -c <temp-empty-json> src/components/widget/settings/general-tab.tsx src/components/widget/settings/general-tab.test.tsx`
- [ ] `bun --cwd apps/native build` currently fails on existing `apps/native/src/components/widget/controls/directory-picker.test.tsx` TypeScript errors unrelated to this PR.

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #___)
- [x] No docs update needed
