### PR TITLE
ci(e2e): run Computer Use on develop PRs

### DIFF
--- a/.github/workflows/computer-use-e2e.yml
+++ b/.github/workflows/computer-use-e2e.yml
@@ -2,7 +2,7 @@ name: Computer Use E2E
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- allow the Computer Use E2E workflow to run on PRs targeting `develop`
- keep `main` in the trigger for compatibility

## How to test
- `actionlint .github/workflows/computer-use-e2e.yml`

## Notes
This is intentionally scoped to the workflow trigger only; no runner logic or E2E code changed.