### PR TITLE
Update .gitignore to include additional Nix build outputs and environment files that may reasonably exist

### DIFF
--- a/apps/native/templates/nix-darwin-determinate/.gitignore
+++ b/apps/native/templates/nix-darwin-determinate/.gitignore
@@ -1,1 +1,16 @@
+# Nix build outputs
+result
+result-*
+
+# direnv
+.direnv/
+
+# devenv (if used)
+.devenv/
+
+# macOS Finder metadata
 .DS_Store
+
+# Local overrides/secrets
+.env
+.envrc.local


### PR DESCRIPTION
## Summary

Adds some other speculative (but likely, especially in the case of `result`) things to the template .gitignore that we set up.

## Test Plan

n/a

## Docs

- [ ] Docs updated
- [x] No docs update needed
