### PR TITLE
fix: Implement banned tools feature, use in CLI evolution process

### DIFF
--- a/apps/native/src-tauri/src/cli.rs
+++ b/apps/native/src-tauri/src/cli.rs
@@ -207,7 +207,14 @@ pub async fn handle_evolve_command(app: &AppHandle, cfg: EvolveConfig) -> Result
 
     // DO IT!
     println!("Starting evolution with prompt: {}", prompt);
-    let outcome = crate::evolve::lifecycle::backup_evolve_and_record_changeset(app, &prompt).await;
+    // Disable tools that require user input in the middle of evolution, since we won't be able to respond to questions in CLI mode.
+    let banned_tools = ["ask_user"];
+    let outcome = crate::evolve::lifecycle::backup_evolve_and_record_changeset(
+        app,
+        &prompt,
+        Some(&banned_tools),
+    )
+    .await;
 
     let (ok, output_value, failure_message) = match outcome {
         Ok(output) => {

--- a/apps/native/src-tauri/src/commands/evolve.rs
+++ b/apps/native/src-tauri/src/commands/evolve.rs
@@ -11,7 +11,8 @@ pub async fn darwin_evolve(
     evolve::session_control::set_evolve_cancelled(false);
 
     let result =
-        match evolve::lifecycle::backup_evolve_and_record_changeset(&app, &description).await {
+        match evolve::lifecycle::backup_evolve_and_record_changeset(&app, &description, None).await
+        {
             Ok(result) => result,
             Err(failure) => {
                 let is_cancelled = evolve::session_control::is_evolve_cancelled()

--- a/apps/native/src-tauri/src/evolve/lifecycle.rs
+++ b/apps/native/src-tauri/src/evolve/lifecycle.rs
@@ -112,6 +112,7 @@ fn elapsed_since(start_time_ms: i64) -> i64 {
 pub async fn backup_evolve_and_record_changeset(
     app: &AppHandle,
     description: &str,
+    banned_tools: Option<&[&str]>,
 ) -> std::result::Result<EvolutionResult, EvolutionFailureResult> {
     let start_time_ms: i64 = chrono::Utc::now().timestamp_millis();
     let start_time_s: i64 = start_time_ms / 1000;
@@ -194,7 +195,14 @@ pub async fn backup_evolve_and_record_changeset(
     }
 
     // Step 2: Run AI evolution
-    let evolution = match evolve::generate_evolution(app, &config_dir, description).await {
+    let evolution = match evolve::generate_evolution(
+        app,
+        &config_dir,
+        description,
+        banned_tools.unwrap_or(&[]),
+    )
+    .await
+    {
         Ok(evolution) => evolution,
         Err(e) => {
             let duration_ms = elapsed_since(start_time_ms);

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -339,6 +339,7 @@ pub async fn generate_evolution<R: Runtime>(
     app: &AppHandle<R>,
     config_dir: &str,
     prompt: &str,
+    banned_tools: &[&str],
 ) -> Result<Evolution> {
     let start_time = chrono::Utc::now().timestamp();
 
@@ -452,7 +453,7 @@ pub async fn generate_evolution<R: Runtime>(
         max_build_attempts
     );
 
-    let tools = create_tools();
+    let tools = create_tools(banned_tools);
     let allowed_tool_names = tools
         .iter()
         .map(|tool| tool.name.as_str())

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -29,14 +29,14 @@ use std::path::{Component, Path};
 // =============================================================================
 
 /// Creates provider-agnostic tools
-pub fn create_tools() -> Vec<Tool> {
+pub fn create_tools(banned_tools: &[&str]) -> Vec<Tool> {
     let search_docs_limit_description = format!(
         "Maximum results to return (default: {}, max: {})",
         search_docs_default_limit(),
         search_docs_max_limit()
     );
 
-    vec![
+    let allowed_tools = vec![
         Tool {
             name: "think".to_string(),
             description: "Use this tool to think through problems step by step. You should use this \
@@ -446,7 +446,12 @@ IMPORTANT: The generated Nix code is syntax-validated before writing. Edits with
                 "required": ["summary"]
             }),
         },
-    ]
+    ];
+
+    allowed_tools
+        .into_iter()
+        .filter(|tool| !banned_tools.contains(&tool.name.as_str()))
+        .collect()
 }
 
 // =============================================================================
@@ -1328,5 +1333,22 @@ mod tests {
             err_chain.contains("ignored by .gitignore"),
             "unexpected error: {err:#}"
         );
+    }
+
+    #[test]
+    fn create_tools_allows_bans() {
+        let banned_tools = ["edit_file", "edit_nix_file"];
+        let tools = super::create_tools(&banned_tools);
+
+        // Ensure tools doesn't contain either of the banned ones
+        // by looking for the tools with the banned names and asserting they are not found.
+        for banned in &banned_tools {
+            let found = tools.iter().find(|tool| tool.name == *banned);
+            assert!(
+                found.is_none(),
+                "Banned tool '{}' should not be in the tools list",
+                banned
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Changes the internal `create_tools` function to allow for a "banned" tools list. This is needed because in the CLI we can't do user-interactive things during evolution (at least not right now). The main use case is automated testing for the time being.

## Test Plan

Running AI eval tests. Also added a new unit test.

## Docs

- [ ] Docs updated
- [x] No docs update needed
