### PR TITLE
feat: stub allowUnfree in default template

### DIFF
--- a/apps/native/templates/nix-darwin-determinate/flake.nix
+++ b/apps/native/templates/nix-darwin-determinate/flake.nix
@@ -76,6 +76,9 @@
 
           # Enable Homebrew management through nix-darwin
           homebrew.enable = true;
+
+          # Enable if you want to allow unfree packages (e.g. some fonts, or certain applications). Leave false to avoid them entirely.
+          # nixpkgs.config.allowUnfree = true;
         };
     in
     {


### PR DESCRIPTION
## Summary

Stub out `allowUnfree` in the main template config. Makes it easier to create a consistent "unfree" story while doing eval testing, and also should make it easier for the agent to correctly enable this if it ever comes up in evolve.

## Test Plan

Darwin build with it.

## Docs

- [ ] Docs updated
- [x] No docs update needed
