### PR TITLE
feat(ci): add unit test step to build workflow and update package scripts, fix broken vite test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,11 @@
 name: Build macOS App
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags:
       - "v*"
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
   merge_group:
   workflow_dispatch:
 env:
@@ -67,7 +67,7 @@ jobs:
         run: bash ops/scripts/release/sync-version.sh
       - name: Check for code signing secrets
         id: check-secrets
-        shell: "sops exec-env ops/secrets/secrets.yaml \"bash -e {0}\""
+        shell: 'sops exec-env ops/secrets/secrets.yaml "bash -e {0}"'
         run: |
           if [ -n "$APPLE_CERTIFICATE" ]; then
             echo "has_certificate=true" >> $GITHUB_OUTPUT
@@ -85,7 +85,7 @@ jobs:
       # replaces the keychain search list and breaks DMG bundling on tag runs.
       - name: Build Tauri app
         run: bun run desktop:build
-        shell: "sops exec-env ops/secrets/secrets.yaml \"bash -e {0}\""
+        shell: 'sops exec-env ops/secrets/secrets.yaml "bash -e {0}"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Pass DSNs and build metadata into the tauri action step so build.rs can read them
@@ -95,6 +95,9 @@ jobs:
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_NIXMAC_ENV: prod
           VITE_NIXMAC_VERSION: ${{ steps.sync-version.outputs.build_version }}
+      - name: Unit Test Tauri app
+        run: bun run desktop:test
+
       # Import Apple Developer certificate (only for releases with secrets).
       # Placed AFTER the Tauri build to avoid replacing the keychain search list
       # before `bun run desktop:build`, which caused DMG bundling failures on tags.
@@ -102,7 +105,7 @@ jobs:
         if: (steps.release-version.outputs.mode == 'tag' ||
           steps.release-version.outputs.mode == 'release') &&
           steps.check-secrets.outputs.has_certificate == 'true'
-        shell: "sops exec-env ops/secrets/secrets.yaml \"bash -e {0}\""
+        shell: 'sops exec-env ops/secrets/secrets.yaml "bash -e {0}"'
         run: bash ops/scripts/release/import-certificate.sh
       # Sign the app bundle (required for notarization)
       - name: Sign app bundle
@@ -126,7 +129,7 @@ jobs:
         if: (steps.release-version.outputs.mode == 'tag' ||
           steps.release-version.outputs.mode == 'release') &&
           steps.check-secrets.outputs.has_notarization == 'true'
-        shell: "sops exec-env ops/secrets/secrets.yaml \"bash -e {0}\""
+        shell: 'sops exec-env ops/secrets/secrets.yaml "bash -e {0}"'
         run: bash ops/scripts/release/notarize.sh
       - name: Get artifact paths
         id: artifacts
@@ -194,7 +197,7 @@ jobs:
         if: (steps.release-version.outputs.mode == 'tag' ||
           steps.release-version.outputs.mode == 'release') &&
           !contains(steps.release-version.outputs.tag, '-test.')
-        shell: "sops exec-env ops/secrets/secrets.yaml \"bash -e {0}\""
+        shell: 'sops exec-env ops/secrets/secrets.yaml "bash -e {0}"'
         env:
           AWS_DEFAULT_REGION: auto
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -11,6 +11,7 @@
     "build": "tsc && vite build",
     "desktop:dev": "TAURI_CONFIG=dev tauri dev",
     "desktop:build": "tauri build",
+    "desktop:test": "cargo test --manifest-path src-tauri/Cargo.toml && bun run test:unit",
     "lint": "oxlint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/apps/native/src/components/widget/widget.test.tsx
+++ b/apps/native/src/components/widget/widget.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/tauri-api", () => ({
     git: {
       status: vi.fn().mockResolvedValue({ hasChanges: false, files: [] }),
     },
+    debug: {
+      logBreadcrumb: vi.fn().mockResolvedValue(undefined),
+      markBootStage: vi.fn().mockResolvedValue(undefined),
+    },
     config: {
       read: vi.fn().mockResolvedValue({ configDir: "/Users/test/nixmac" }),
       listHosts: vi.fn().mockResolvedValue(["Test-MacBook"]),

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "bun -F native dev",
     "desktop:dev": "bun -F native desktop:dev",
     "desktop:build": "bun -F native desktop:build",
+    "desktop:test": "bun -F native desktop:test",
     "postinstall": "bun2nix -o bun.nix",
     "release": "release-it",
     "test:e2e": "bun -F native test:e2e",


### PR DESCRIPTION
## Summary

We've had a long-outstanding item I entered saying that we weren't running unit tests in CI. I fixed them and inserted them after the main tauri app build step.

## Test Plan

Run in CI.

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
