### PR TITLE
ci(e2e): make E2E workflows manual-only

### DIFF
--- a/.github/workflows/computer-use-e2e.yml
+++ b/.github/workflows/computer-use-e2e.yml
@@ -1,9 +1,6 @@
 name: Computer Use E2E
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       build_artifact_attempts:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ on:
         default: ''
 
 concurrency:
-  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -49,14 +49,11 @@ jobs:
         id: ref
         env:
           INPUT_BRANCH: ${{ inputs.branch || '' }}
-          PR_HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
-          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          TARGET_SHA: ${{ github.sha }}
         run: |
           if [ -n "$INPUT_BRANCH" ]; then
             echo "branch=$INPUT_BRANCH" >> "$GITHUB_OUTPUT"
-          elif [ -n "$PR_HEAD_REF" ]; then
-            echo "branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
           else
             echo "branch=$REF_NAME" >> "$GITHUB_OUTPUT"
           fi
@@ -65,39 +62,12 @@ jobs:
       - name: Resolve scenario list
         id: resolve
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_SCENARIO: ${{ inputs.scenario || 'nix-install' }}
-          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          SCENARIOS=""
-
-          # --- Method 1: workflow_dispatch ---
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ "$INPUT_SCENARIO" = "all" ]; then
-              # List all scenario files
-              SCENARIOS=$(find tests/e2e/scenarios -maxdepth 1 -type f -name '*.sh' -exec basename {} .sh \; | jq -R . | jq -s .)
-            else
-              SCENARIOS=$(jq -cn --arg scenario "$INPUT_SCENARIO" '[$scenario]')
-            fi
-
-          # --- Method 2: Label-based ---
-          elif [ "$EVENT_NAME" = "pull_request" ]; then
-            # Check for e2e:* labels
-            E2E_LABELS=$(jq -r '.[] | select(startswith("e2e:")) | sub("^e2e:"; "")' <<< "$PR_LABELS")
-
-            if grep -qx "all" <<< "$E2E_LABELS"; then
-              SCENARIOS=$(find tests/e2e/scenarios -maxdepth 1 -type f -name '*.sh' -exec basename {} .sh \; | jq -R . | jq -s .)
-            elif [ -n "$E2E_LABELS" ]; then
-              SCENARIOS=$(jq -R . <<< "$E2E_LABELS" | jq -s .)
-            fi
-
-            # --- Method 3: Path-based fallback ---
-            if [ -z "$SCENARIOS" ] || [ "$SCENARIOS" = "[]" ] || [ "$SCENARIOS" = "null" ]; then
-              # Default: run nix-install for any native code change
-              SCENARIOS='["nix-install"]'
-            fi
+          if [ "$INPUT_SCENARIO" = "all" ]; then
+            SCENARIOS=$(find tests/e2e/scenarios -maxdepth 1 -type f -name '*.sh' -exec basename {} .sh \; | jq -R . | jq -s .)
           else
-            SCENARIOS='["nix-install"]'
+            SCENARIOS=$(jq -cn --arg scenario "$INPUT_SCENARIO" '[$scenario]')
           fi
 
           echo "Resolved scenarios: $SCENARIOS"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,28 +1,19 @@
 name: E2E Tests
 
 # ============================================================================
-# Multi-scenario E2E test runner for nixmac
+# Manual multi-scenario E2E test runner for nixmac
 #
-# Trigger methods:
-#   1. Path-based (automatic): Changes to specific paths trigger matching scenarios
-#   2. Label-based (manual): Add e2e:<scenario> labels to PRs
-#   3. workflow_dispatch: Run any scenario on demand
+# Trigger method:
+#   workflow_dispatch: Run any scenario on demand
 #
 # Scenario routing:
-#   - e2e:install   → nix-install scenario (full install flow)
-#   - e2e:all       → run all scenarios sequentially
-#   - Path fallback → nix-install (safe default for any native change)
+#   - nix-install → nix-install scenario (full install flow)
+#   - all         → run all scenarios sequentially
 #
 # Future: AI-generated scenarios from PR diffs (Layer 4)
 # ============================================================================
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    paths:
-      - 'apps/native/src-tauri/**'
-      - 'tests/e2e/**'
-      - '.github/workflows/e2e.yml'
   workflow_dispatch:
     inputs:
       scenario:

--- a/.github/workflows/peekaboo-e2e.yml
+++ b/.github/workflows/peekaboo-e2e.yml
@@ -1,22 +1,6 @@
 name: Peekaboo E2E
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'package.json'
-      - 'bun.lock'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'devenv.nix'
-      - 'devenv.lock'
-      - 'apps/native/**'
-      - 'tests/e2e/**'
-      - 'tools/computer-use-e2e/**'
-      - '.github/workflows/build.yaml'
-      - '.github/workflows/peekaboo-e2e.yml'
   workflow_dispatch:
     inputs:
       build_attempts:


### PR DESCRIPTION
## Summary

- makes the legacy E2E, Peekaboo E2E, and Computer Use E2E workflows manual-only while Tart-based E2E work is in progress
- deletes the automatic `pull_request` triggers instead of commenting them out
- keeps `workflow_dispatch` available for explicit debugging runs
- updates the legacy E2E header so it no longer advertises path/label-triggered execution

Claude review ran before implementation. No blockers. Callouts from review: `e2e:*` label-triggered scenarios are intentionally paused too; in-flight E2E runs may still finish/comment unless cancelled; manual runs currently provide workflow summaries/artifacts rather than PR-hosted report comments.

## Test Plan

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/e2e.yml .github/workflows/peekaboo-e2e.yml .github/workflows/computer-use-e2e.yml`
- `actionlint -shellcheck= .github/workflows/e2e.yml .github/workflows/peekaboo-e2e.yml .github/workflows/computer-use-e2e.yml`
- `rg -n "^  pull_request:|^  workflow_dispatch:|pull_request\.branches|types: \[opened|labeled\]" .github/workflows/e2e.yml .github/workflows/peekaboo-e2e.yml .github/workflows/computer-use-e2e.yml`

## Docs

- [x] No docs update needed
