### PR TITLE
feat: show stats about evolution duration

### DIFF
--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -57,6 +57,18 @@ use providers::{AiProvider, CliProvider, OllamaProvider, OpenAIProvider, Provide
 
 use self::types::FileEdit;
 
+/// Format a duration in seconds as a human-readable string (e.g. "1m 23s", "45s").
+fn format_duration_secs(secs: i64) -> String {
+    let secs = secs.max(0);
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m {}s", secs / 3600, (secs % 3600) / 60, secs % 60)
+    }
+}
+
 /// Return short hex prefix for correlation of error messages without risking sensitive content exposure.
 fn short_hash(s: &str) -> String {
     let mut h = Sha256::new();
@@ -1149,11 +1161,13 @@ Could you provide more specific guidance on what aspects of your configuration n
         debug!("[evolve] saved assistant message to session chat memory");
     }
 
+    let elapsed_secs = chrono::Utc::now().timestamp().saturating_sub(start_time).max(0);
     info!("════════════════════════════════════════════════════════════════");
     info!("EVOLUTION COMPLETE");
     info!("════════════════════════════════════════════════════════════════");
     info!("ID: {}", evolution.id);
     info!("State: {:?}", evolution.state);
+    info!("Duration: {}", format_duration_secs(elapsed_secs));
     info!("Iterations: {}", evolution.iterations);
     info!("Build attempts: {}", evolution.build_attempts);
     info!("Total tokens: {}", evolution.total_tokens);

--- a/apps/native/src/components/widget/steps/evolve-step.tsx
+++ b/apps/native/src/components/widget/steps/evolve-step.tsx
@@ -7,6 +7,8 @@ import { StepActionsHeader } from "@/components/widget/layout/step-actions-heade
 import { SummaryOrDiff } from "@/components/widget/summaries/summary-or-diff";
 import { useApply } from "@/hooks/use-apply";
 import { useRollback } from "@/hooks/use-rollback";
+import { formatDurationMs } from "@/lib/utils";
+import { useWidgetStore } from "@/stores/widget-store";
 import { Eraser, Wrench } from "lucide-react";
 
 /**
@@ -16,6 +18,7 @@ import { Eraser, Wrench } from "lucide-react";
 export function EvolveStep() {
   const { handleApply } = useApply();
   const { handleRollback } = useRollback();
+  const telemetry = useWidgetStore((s) => s.evolutionTelemetry);
 
   return (
     <>
@@ -46,6 +49,12 @@ export function EvolveStep() {
           Build & Test
         </ConfirmButton>
       </StepActionsHeader>
+      {telemetry && (
+        <p className="text-muted-foreground text-xs pb-2">
+          Evolution completed in {formatDurationMs(telemetry.durationMs)} and{" "}
+          {telemetry.iterations} iteration{telemetry.iterations === 1 ? "" : "s"}.
+        </p>
+      )}
       <SummaryOrDiff />
       <PromptInputSection />
     </>

--- a/apps/native/src/components/widget/steps/evolve-step.tsx
+++ b/apps/native/src/components/widget/steps/evolve-step.tsx
@@ -50,10 +50,10 @@ export function EvolveStep() {
         </ConfirmButton>
       </StepActionsHeader>
       {telemetry && (
-        <p className="text-muted-foreground text-xs pb-2">
-          Evolution completed in {formatDurationMs(telemetry.durationMs)} and{" "}
-          {telemetry.iterations} iteration{telemetry.iterations === 1 ? "" : "s"}.
-        </p>
+        <span className="pointer-events-none absolute top-1 right-2 z-10 text-[10px] text-muted-foreground/60">
+          Evolution complete in {formatDurationMs(telemetry.durationMs)} and {telemetry.iterations} iteration
+          {telemetry.iterations === 1 ? "" : "s"}
+        </span>
       )}
       <SummaryOrDiff />
       <PromptInputSection />

--- a/apps/native/src/hooks/use-evolve.ts
+++ b/apps/native/src/hooks/use-evolve.ts
@@ -3,6 +3,7 @@ import { useWidgetStore } from "@/stores/widget-store";
 import { EVOLVE_EVENT_CHANNEL } from "@/lib/constants";
 import { tauriAPI, ipcRenderer } from "@/ipc/api";
 import type { EvolveEvent } from "@/ipc/types";
+import { formatDurationMs } from "@/lib/utils";
 
 /**
  * Hook for the evolution operation.
@@ -64,6 +65,7 @@ const handleEvolve = async () => {
   store.clearLogs();
   store.clearPreview();
   store.setConversationalResponse(null);
+  store.setEvolutionTelemetry(null);
   store.appendLog(`\n> Evolving: "${store.evolvePrompt}"\n`);
 
   // Set up evolve event listener
@@ -82,7 +84,14 @@ const handleEvolve = async () => {
     const result = await tauriAPI.darwin.evolve(store.evolvePrompt);
     const isConversational = result?.telemetry?.state === "conversational";
 
-    useWidgetStore.getState().appendLog("✓ Evolution complete\n");
+    const telemetry = result?.telemetry;
+    const completionMsg = telemetry
+      ? `✓ Evolution complete in ${formatDurationMs(telemetry.durationMs)} and ${telemetry.iterations} iteration${telemetry.iterations === 1 ? "" : "s"}\n`
+      : "✓ Evolution complete\n";
+    useWidgetStore.getState().appendLog(completionMsg);
+    if (telemetry) {
+      useWidgetStore.getState().setEvolutionTelemetry(telemetry);
+    }
 
     if (isConversational) {
       useWidgetStore.getState().setConversationalResponse(result.conversationalResponse ?? null);

--- a/apps/native/src/lib/utils.ts
+++ b/apps/native/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatDurationMs(ms: number): string {
+  const secs = Math.max(0, Math.round(ms / 1000));
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  return `${h}h ${m}m ${s}s`;
+}

--- a/apps/native/src/stores/widget-store.impl.ts
+++ b/apps/native/src/stores/widget-store.impl.ts
@@ -1,6 +1,7 @@
 import { computeCurrentStep } from "@/components/widget/utils";
 import { FeedbackType } from "@/types/feedback";
 import type {
+  EvolutionTelemetry,
   EvolveEvent,
   EvolveState,
   FileDiffContents,
@@ -102,6 +103,7 @@ export interface WidgetState {
   evolveEvents: EvolveEvent[];
   promptHistory: string[];
   conversationalResponse: string | null;
+  evolutionTelemetry: EvolutionTelemetry | null;
 
   changeMap: SemanticChangeMap | null;
 
@@ -245,6 +247,7 @@ interface WidgetActions {
   // Evolve events
   appendEvolveEvent: (event: EvolveEvent) => void;
   clearEvolveEvents: () => void;
+  setEvolutionTelemetry: (telemetry: EvolutionTelemetry | null) => void;
 
   setConversationalResponse: (response: string | null) => void;
 
@@ -312,6 +315,7 @@ const initialWidgetState: WidgetState = {
   evolveEvents: [],
   promptHistory: [],
   conversationalResponse: null,
+  evolutionTelemetry: null,
 
   // History
   history: [],
@@ -471,6 +475,7 @@ export function createWidgetStore(initialState?: Partial<WidgetState>) {
     appendEvolveEvent: (event) =>
       set((state) => ({ evolveEvents: [...state.evolveEvents, event] })),
     clearEvolveEvents: () => set({ evolveEvents: [] }),
+    setEvolutionTelemetry: (evolutionTelemetry) => set({ evolutionTelemetry }),
 
     // Conversational response
     setConversationalResponse: (conversationalResponse) => set({ conversationalResponse }),


### PR DESCRIPTION
## Summary

Show stats about evolution duration in:
- Terminal
- Console message in the app
- Review page on the app  

The way I've added `EvolutionTelemtry` to the `WidgetStore` is not consistent with what I suggest in my document, but I think it is better to deal with that as part of the larger refactor.

## Test Plan

Run and try some evolution.

## Docs

- [x] No docs update needed
