### PR TITLE
build: add tauri-wd to devenv shell

### DIFF
--- a/apps/native/e2e-tauri/README.md
+++ b/apps/native/e2e-tauri/README.md
@@ -84,8 +84,10 @@ The script outputs clear pass/fail status for each suite in real-time, making it
 
 ## Prerequisites
 
-1. `tauri-wd` installed and available on `PATH`:
-   1. `cargo install tauri-webdriver-automation`
+1. `tauri-wd` available on `PATH`. The `devenv shell` provides it via
+   `nix/pkgs/tauri-wd.nix` (included from `nix/dev.nix`); no manual install
+   required. If you're not using the devenv shell, install it with
+   `cargo install tauri-webdriver-automation`.
 1. Tauri app compiled in debug mode (default binary = `(repo root)/target/debug/nixmac`)
 
 ## Adding new WDIO tests

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -4,7 +4,7 @@
   config,
   ...
 }:
-lib.mkIf (!(config.container.isBuilding or false)) {
+lib.mkIf (! config.container.isBuilding) {
   # Dev-only packages (excluded from container builds by conditional import).
   packages = [
     pkgs.rustPackages.rustc
@@ -37,6 +37,7 @@ lib.mkIf (!(config.container.isBuilding or false)) {
     pkgs.apple-sdk_15
     pkgs.lldb
     pkgs.llvmPackages.bintools
+    (pkgs.callPackage ./pkgs/tauri-wd.nix { })
   ]
   ++ lib.optionals (builtins.getEnv "_PROFILE" == "development") [
     pkgs.starship

--- a/nix/e2e/default.nix
+++ b/nix/e2e/default.nix
@@ -13,12 +13,6 @@ let
   };
   ensureDependencies = ''
     ${pkgs.bun}/bin/bun install
-
-    if ! command -v tauri-wd >/dev/null 2>&1; then
-      cd ${tauriDir}
-      ${pkgs.cargo}/bin/cargo install tauri-webdriver-automation
-      cd ${nativeDir}
-    fi
   '';
 in
 lib.mkMerge [

--- a/nix/pkgs/tauri-wd.nix
+++ b/nix/pkgs/tauri-wd.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  apple-sdk_15,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "tauri-webdriver-automation";
+  version = "0.1.3-unstable-2026-05-23";
+
+  src = fetchFromGitHub {
+    owner = "danielraffel";
+    repo = "tauri-webdriver";
+    rev = "e61687f1c8c26a9998ef4086dd552dfb38eb62ed";
+    hash = "sha256-8pW3cGhmrkSouC+N/N3ETJxEK1zgHjR3OfMTudG9ie4=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+  };
+
+  cargoBuildFlags = [
+    "-p"
+    "tauri-webdriver-automation"
+  ];
+
+  # The workspace also contains the in-app Tauri plugin and a fixture, neither
+  # of which builds standalone. Run no tests; we only ship the `tauri-wd` binary.
+  doCheck = false;
+
+  buildInputs = lib.optionals stdenv.isDarwin [ apple-sdk_15 ];
+
+  meta = {
+    description = "macOS WebDriver server for Tauri apps (provides the tauri-wd binary)";
+    homepage = "https://github.com/danielraffel/tauri-webdriver";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    mainProgram = "tauri-wd";
+    platforms = lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Summary

Add missing package to `devenv` shell.

## Test Plan

- Run `devenv shell` (may need `--refresh-eval-cache`) and check that `tauri-wd` is there.

## Docs

- [x] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [ ] No docs update needed
