### PR TITLE
fix(ENG-277): remove bootstrap directory check that blocked crash recovery

### DIFF
--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -82,33 +82,6 @@ fn copy_template_dir(
     Ok(())
 }
 
-/// Checks if a directory is empty or only contains a .git folder.
-///
-/// This safety check prevents accidentally overwriting existing configurations.
-fn is_dir_safe_for_bootstrap(path: &Path) -> Result<bool, String> {
-    let entries: Vec<_> = fs::read_dir(path)
-        .map_err(|e| format!("Failed to read directory: {}", e))?
-        .filter_map(|e| e.ok())
-        .filter(|entry| entry.file_name().to_str() != Some(".DS_Store"))
-        .collect();
-
-    // Empty directory is safe
-    if entries.is_empty() {
-        return Ok(true);
-    }
-
-    // Only .git directory is safe
-    if entries.len() == 1 {
-        if let Some(name) = entries[0].file_name().to_str() {
-            if name == ".git" {
-                return Ok(true);
-            }
-        }
-    }
-
-    Ok(false)
-}
-
 /// Resolves the path to the bundled template directory.
 ///
 /// Searches in order:
@@ -179,7 +152,6 @@ fn resolve_template_path(app: &AppHandle) -> Result<std::path::PathBuf, String> 
 ///
 /// # Errors
 /// Returns an error if:
-/// - The target directory is not empty
 /// - Template directory cannot be found
 /// - File operations fail
 /// - Git commands fail
@@ -203,14 +175,6 @@ pub fn bootstrap(app: &AppHandle, hostname: &str) -> Result<(), String> {
             log::warn!("Failed to tag initial commit as base: {}", e);
         }
         return Ok(());
-    }
-
-    // Safety check: only proceed if directory is empty or contains only .git
-    if !is_dir_safe_for_bootstrap(dest_path)? {
-        return Err(
-            "Directory is not empty. Please use an empty directory or a directory containing a flake.nix."
-                .to_string(),
-        );
     }
 
     let platform = detect_darwin_platform();
@@ -294,19 +258,30 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_safety_ignores_finder_metadata() {
-        let temp = tempfile::tempdir().expect("create temp dir");
-        fs::write(temp.path().join(".DS_Store"), "").expect("create finder metadata");
+    fn copy_template_dir_overwrites_partial_files_on_retry() {
+        let src = tempfile::tempdir().expect("create source temp dir");
+        let dest = tempfile::tempdir().expect("create dest temp dir");
 
-        assert!(is_dir_safe_for_bootstrap(temp.path()).expect("check directory"));
-    }
+        fs::write(
+                src.path().join("flake.nix"),
+                "host = \"HOSTNAME_PLACEHOLDER\"; platform = \"PLATFORM_PLACEHOLDER\"; user = \"USERNAME_PLACEHOLDER\";",
+            )
+            .expect("write source flake");
+        fs::write(dest.path().join("flake.nix"), "partial copy").expect("write partial flake");
 
-    #[test]
-    fn bootstrap_safety_allows_git_with_finder_metadata() {
-        let temp = tempfile::tempdir().expect("create temp dir");
-        fs::create_dir_all(temp.path().join(".git")).expect("create git dir");
-        fs::write(temp.path().join(".DS_Store"), "").expect("create finder metadata");
+        copy_template_dir(
+            src.path(),
+            dest.path(),
+            "macbook",
+            "aarch64-darwin",
+            "alice",
+        )
+        .expect("copy template");
 
-        assert!(is_dir_safe_for_bootstrap(temp.path()).expect("check directory"));
+        let copied = fs::read_to_string(dest.path().join("flake.nix")).expect("read copied flake");
+        assert_eq!(
+            copied,
+            "host = \"macbook\"; platform = \"aarch64-darwin\"; user = \"alice\";"
+        );
     }
 }

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -729,12 +729,6 @@ fn run_gui_mode(
                     .visible(true)
                     .always_on_top(false)
                     .visible_on_all_workspaces(true)
-                    .hidden_title(!e2e_opaque_window)
-                    .title_bar_style(if e2e_opaque_window {
-                        tauri::TitleBarStyle::Visible
-                    } else {
-                        tauri::TitleBarStyle::Overlay
-                    })
                     .on_page_load(move |window, payload| {
                         log::debug!(
                             "main webview page load {:?}: {}",
@@ -757,6 +751,17 @@ fn run_gui_mode(
                             }
                         }
                     });
+
+            #[cfg(target_os = "macos")]
+            {
+                main_window_builder = main_window_builder
+                    .hidden_title(!e2e_opaque_window)
+                    .title_bar_style(if e2e_opaque_window {
+                        tauri::TitleBarStyle::Visible
+                    } else {
+                        tauri::TitleBarStyle::Overlay
+                    });
+            }
 
             if e2e_opaque_window {
                 main_window_builder = main_window_builder
@@ -905,11 +910,14 @@ fn run_gui_mode(
             }
 
             // Click Nixmac icon to show
-            if let RunEvent::Reopen { .. } = &event {
-                if let Some(window) = app_handle.get_webview_window("main") {
-                    // fire-and-forget: show/set_focus fail only on destroyed window.
-                    let _ = window.show();
-                    let _ = window.set_focus();
+            #[cfg(target_os = "macos")]
+            {
+                if let RunEvent::Reopen { .. } = &event {
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        // fire-and-forget: show/set_focus fail only on destroyed window.
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                    }
                 }
             }
         });

--- a/apps/native/src-tauri/src/peek.rs
+++ b/apps/native/src-tauri/src/peek.rs
@@ -495,6 +495,7 @@ pub fn create_preview_indicator_window<R: Runtime>(app: &AppHandle<R>) -> Result
         logical_height
     );
 
+    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
     let window = WebviewWindowBuilder::new(
         app,
         "preview-indicator",


### PR DESCRIPTION
## Summary

- Removes the `is_dir_safe_for_bootstrap` guard that rejected any config directory containing files beyond `.git`
- This guard caused nixmac to get stuck after a mid-copy crash: nixmac itself wrote partial template files, then refused to continue on restart with "Directory is not empty"
- The `flake.nix` existence check at the top of `bootstrap()` already handles the "user brought their own config" case — the extra guard was redundant and harmful for retry scenarios

## Root cause

`copy_template_dir` can fail partway through (crash, killed process, etc.). On restart, the config dir has partial template files but no `flake.nix`. `is_dir_safe_for_bootstrap` returned false → hard error. The user was stuck with no recovery path.

## Why it's safe to remove

- `ensure_config_dir_exists` returns a nixmac-managed dedicated directory, not an arbitrary user path
- `copy_template_dir` naturally overwrites any existing files
- `git::init_repo` is already idempotent (skips if already a repo)
- The `flake.nix` existence check at line 166 covers the only case the guard was protecting: user has an existing working config

## Test plan

- [ ] Fresh install: no `flake.nix`, empty dir → should proceed normally
- [ ] Retry after mid-copy crash: partial files present, no `flake.nix` → should now succeed instead of erroring
- [ ] User's existing config with `flake.nix` → still handled by early-return path, no template copy

Closes ENG-277

https://claude.ai/code/session_018Guk2ZgprctXWZtFg4Gvch

---
_Generated by [Claude Code](https://claude.ai/code/session_018Guk2ZgprctXWZtFg4Gvch)_