### PR TITLE
feat: show stats about evolution duration IN TOAST

### DIFF
--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -57,6 +57,18 @@ use providers::{AiProvider, CliProvider, OllamaProvider, OpenAIProvider, Provide
 
 use self::types::FileEdit;
 
+/// Format a duration in seconds as a human-readable string (e.g. "1m 23s", "45s").
+fn format_duration_secs(secs: i64) -> String {
+    let secs = secs.max(0);
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m {}s", secs / 3600, (secs % 3600) / 60, secs % 60)
+    }
+}
+
 /// Return short hex prefix for correlation of error messages without risking sensitive content exposure.
 fn short_hash(s: &str) -> String {
     let mut h = Sha256::new();
@@ -1149,11 +1161,13 @@ Could you provide more specific guidance on what aspects of your configuration n
         debug!("[evolve] saved assistant message to session chat memory");
     }
 
+    let elapsed_secs = chrono::Utc::now().timestamp().saturating_sub(start_time).max(0);
     info!("════════════════════════════════════════════════════════════════");
     info!("EVOLUTION COMPLETE");
     info!("════════════════════════════════════════════════════════════════");
     info!("ID: {}", evolution.id);
     info!("State: {:?}", evolution.state);
+    info!("Duration: {}", format_duration_secs(elapsed_secs));
     info!("Iterations: {}", evolution.iterations);
     info!("Build attempts: {}", evolution.build_attempts);
     info!("Total tokens: {}", evolution.total_tokens);

--- a/apps/native/src/hooks/use-evolve.ts
+++ b/apps/native/src/hooks/use-evolve.ts
@@ -3,6 +3,8 @@ import { useWidgetStore } from "@/stores/widget-store";
 import { EVOLVE_EVENT_CHANNEL } from "@/lib/constants";
 import { tauriAPI, ipcRenderer } from "@/ipc/api";
 import type { EvolveEvent } from "@/ipc/types";
+import { formatDurationMs } from "@/lib/utils";
+import { toast } from "sonner";
 
 /**
  * Hook for the evolution operation.
@@ -64,6 +66,7 @@ const handleEvolve = async () => {
   store.clearLogs();
   store.clearPreview();
   store.setConversationalResponse(null);
+  store.setEvolutionTelemetry(null);
   store.appendLog(`\n> Evolving: "${store.evolvePrompt}"\n`);
 
   // Set up evolve event listener
@@ -82,7 +85,15 @@ const handleEvolve = async () => {
     const result = await tauriAPI.darwin.evolve(store.evolvePrompt);
     const isConversational = result?.telemetry?.state === "conversational";
 
-    useWidgetStore.getState().appendLog("✓ Evolution complete\n");
+    const telemetry = result?.telemetry;
+    const completionMsg = telemetry
+      ? `✓ Evolution complete in ${formatDurationMs(telemetry.durationMs)} and ${telemetry.iterations} iteration${telemetry.iterations === 1 ? "" : "s"}\n`
+      : "✓ Evolution complete\n";
+    useWidgetStore.getState().appendLog(completionMsg);
+    toast.success(completionMsg);
+    if (telemetry) {
+      useWidgetStore.getState().setEvolutionTelemetry(telemetry);
+    }
 
     if (isConversational) {
       useWidgetStore.getState().setConversationalResponse(result.conversationalResponse ?? null);

--- a/apps/native/src/lib/utils.ts
+++ b/apps/native/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatDurationMs(ms: number): string {
+  const secs = Math.max(0, Math.round(ms / 1000));
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  return `${h}h ${m}m ${s}s`;
+}

--- a/apps/native/src/stores/widget-store.impl.ts
+++ b/apps/native/src/stores/widget-store.impl.ts
@@ -1,6 +1,7 @@
 import { computeCurrentStep } from "@/components/widget/utils";
 import { FeedbackType } from "@/types/feedback";
 import type {
+  EvolutionTelemetry,
   EvolveEvent,
   EvolveState,
   FileDiffContents,
@@ -102,6 +103,7 @@ export interface WidgetState {
   evolveEvents: EvolveEvent[];
   promptHistory: string[];
   conversationalResponse: string | null;
+  evolutionTelemetry: EvolutionTelemetry | null;
 
   changeMap: SemanticChangeMap | null;
 
@@ -245,6 +247,7 @@ interface WidgetActions {
   // Evolve events
   appendEvolveEvent: (event: EvolveEvent) => void;
   clearEvolveEvents: () => void;
+  setEvolutionTelemetry: (telemetry: EvolutionTelemetry | null) => void;
 
   setConversationalResponse: (response: string | null) => void;
 
@@ -312,6 +315,7 @@ const initialWidgetState: WidgetState = {
   evolveEvents: [],
   promptHistory: [],
   conversationalResponse: null,
+  evolutionTelemetry: null,
 
   // History
   history: [],
@@ -471,6 +475,7 @@ export function createWidgetStore(initialState?: Partial<WidgetState>) {
     appendEvolveEvent: (event) =>
       set((state) => ({ evolveEvents: [...state.evolveEvents, event] })),
     clearEvolveEvents: () => set({ evolveEvents: [] }),
+    setEvolutionTelemetry: (evolutionTelemetry) => set({ evolutionTelemetry }),
 
     // Conversational response
     setConversationalResponse: (conversationalResponse) => set({ conversationalResponse }),


### PR DESCRIPTION
## Summary

Fixes [#192](https://github.com/darkmatter/nixmac/pull/192), by implementing the requested changes.

## Test Plan

Identical to develop: 

| Suite | Pass | Fail | Skip |
|---|---:|---:|---:|
| rust | 294 | 0 | 2 |
| vitest | 90 | 0 | 0 |
| basic-prompts | 2 | 1 | 0 |
| conversational | 1 | 1 | 0 |
| discard | 2 | 0 | 0 |
| manual-changes | 2 | 0 | 0 |
| modify | 0 | 1 | 0 |
| onboarding | 0 | 1 | 0 |
| smoke | 4 | 0 | 0 |


## Docs

- [x] No docs update needed
