### PR TITLE
feat: optional preview feedback before sending

### DIFF
--- a/apps/native/src-tauri/examples/specta_gen_ts.rs
+++ b/apps/native/src-tauri/examples/specta_gen_ts.rs
@@ -9,6 +9,8 @@
 #[path = "../src/sqlite_types.rs"]
 mod sqlite_types;
 
+// This module can cause false-positive dead-code warnings since it's only used for type generation.
+#[allow(dead_code)]
 #[path = "../src/shared_types.rs"]
 mod shared_types;
 
@@ -53,6 +55,10 @@ fn main() {
         .register::<shared_types::FeedbackPanicDetails>()
         .register::<shared_types::EvolveEvent>()
         .register::<shared_types::EvolveEventType>()
+        .register::<shared_types::FileEdit>()
+        .register::<shared_types::ThinkingEntry>()
+        .register::<shared_types::ToolCallRecord>()
+        .register::<shared_types::Evolution>()
         .register::<shared_types::HomebrewState>()
         .register::<shared_types::SummarizedChange>()
         .register::<shared_types::SummarizedChangeSet>()

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -5,6 +5,8 @@
 //!
 //! Uses OpenAI function calling to generate structured file edits.
 
+use crate::shared_types::FileEdit;
+
 use super::gitignore::is_ignored_by_matcher;
 use super::utils::normalize_relative_path;
 use ignore::gitignore::Gitignore;
@@ -371,7 +373,7 @@ pub(crate) fn validate_file_content(file_path: &str, content: &str) -> anyhow::R
 
 pub fn apply_file_edits(
     base: &Path,
-    edit: &super::types::FileEdit,
+    edit: &FileEdit,
     gitignore_matcher: Option<&Gitignore>,
 ) -> anyhow::Result<()> {
     reject_gitignored_edit_path(base, &edit.path, "apply file edit", gitignore_matcher)?;
@@ -461,7 +463,7 @@ fn reject_gitignored_edit_path(
 mod tests {
     use super::{apply_file_edits, rewrite_existing_file_in_dir};
     use crate::evolve::gitignore::load_gitignore_matcher;
-    use crate::evolve::types::FileEdit;
+    use crate::shared_types::FileEdit;
     use std::fs;
 
     #[test]

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -26,7 +26,7 @@ pub(crate) const IGNORED_DIRS: [&str; 2] = [".git", "result"];
 use crate::evolve::utils::{escape_user_query, format_duration_secs, short_hash};
 use crate::git::exec::repo_root;
 // Re-export public API
-use crate::shared_types::EvolutionState;
+use crate::shared_types::{Evolution, EvolutionState, FileEdit};
 use crate::system::nix;
 use anyhow::{anyhow, Result};
 use chrono::Utc;
@@ -41,7 +41,6 @@ use std::time::Duration;
 use tauri::{AppHandle, Runtime};
 use tokio::time::sleep;
 use tools::{create_tools, execute_tool, is_editing_tool, ToolResult};
-pub use types::Evolution;
 pub use types::{EvolutionProgress, EvolutionRunError};
 
 use crate::{
@@ -55,8 +54,6 @@ pub(crate) use chat_memory::session_chat_memory_store;
 use config_dir_context::format_config_dir_context;
 use messages::Message;
 use providers::{AiProvider, CliProvider, OllamaProvider, OpenAIProvider, ProviderError};
-
-use self::types::FileEdit;
 
 /// Strategy for retaining evolution messages in the conversation history for provider context.
 /// This is used to balance keeping important context visible to the model with limiting token usage

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -4,6 +4,7 @@ use crate::evolve::edit_nix_file::{apply_semantic_edit, nix_quote_values};
 use crate::evolve::ensure_secret::{execute_ensure_secret, EnsureSecretResult};
 use crate::evolve::search_packages::SearchPackageResult;
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
+use crate::shared_types::FileEdit;
 
 use super::file_ops::{
     apply_file_edits, ensure_path_under_base, join_in_dir, resolve_existing_path_in_dir,
@@ -16,7 +17,6 @@ use super::search_docs::{
     max_limit as search_docs_max_limit, DocsSource,
 };
 use super::search_packages::execute_search_packages;
-use super::types::FileEdit;
 use super::utils::normalize_relative_path;
 
 use anyhow::{anyhow, Context, Result};

--- a/apps/native/src-tauri/src/evolve/types.rs
+++ b/apps/native/src-tauri/src/evolve/types.rs
@@ -1,14 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::shared_types::EvolutionState;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FileEdit {
-    pub path: String,
-    pub search: String,
-    pub replace: String,
-}
+use crate::shared_types::{Evolution, EvolutionState, ThinkingEntry, ToolCallRecord};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -36,66 +28,6 @@ pub enum FileEditAction {
 pub struct SemanticFileEdit {
     pub path: String, // the nix file being edited
     pub action: FileEditAction,
-}
-
-/// A single thinking entry from the agent's reasoning process
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ThinkingEntry {
-    /// When this thought occurred (ms since evolution start)
-    pub timestamp_ms: i64,
-    /// The iteration number when this thought occurred
-    pub iteration: usize,
-    /// Category of thinking (planning, analysis, debugging, etc.)
-    pub category: String,
-    /// The actual thought content
-    pub content: String,
-}
-
-/// A tool call record for the activity log
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ToolCallRecord {
-    /// When this tool was called (ms since evolution start)
-    pub timestamp_ms: i64,
-    /// The iteration number
-    pub iteration: usize,
-    /// Tool name
-    pub tool: String,
-    /// Tool arguments (simplified)
-    pub args_summary: String,
-    /// Result summary
-    pub result_summary: String,
-    /// Whether the call succeeded
-    pub success: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Evolution {
-    pub id: String,
-    pub created_at: i64,
-    pub state: EvolutionState,
-    pub prompt: String,
-    pub edits: Vec<FileEdit>,
-    pub commit_hash: Option<String>,
-    pub summary: Option<String>,
-    /// Full message history for context
-    pub messages: Vec<serde_json::Value>,
-    /// Agent's thinking/reasoning log
-    pub thinking: Vec<ThinkingEntry>,
-    /// Tool call activity log
-    pub tool_calls: Vec<ToolCallRecord>,
-    /// Total tokens used
-    pub total_tokens: u32,
-    /// Number of iterations
-    pub iterations: usize,
-    /// Number of build attempts
-    pub build_attempts: usize,
-    /// AI-generated summary of changes for preview
-    pub changes_summary: Option<String>,
-    /// AI-generated commit message suggestion
-    pub suggested_commit_message: Option<String>,
 }
 
 impl Evolution {

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -4,6 +4,7 @@
 //! from the frontend.
 //! All collection respects the ShareOptions flags provided by the user.
 
+use crate::shared_types::Evolution;
 use crate::storage::store;
 use crate::system::{nix, secret_scanner};
 use crate::{git, types};
@@ -142,7 +143,7 @@ pub fn gather_app_logs() -> Option<String> {
 // =============================================================================
 
 /// Gather the most recent evolution log from stored metadata
-pub fn gather_evolution_log(app: &AppHandle) -> Option<String> {
+pub fn gather_evolution_log(app: &AppHandle) -> Option<Evolution> {
     let store = store::get_store(app).ok()?;
 
     let metadata = store.get("evolveMetadata")?;
@@ -153,7 +154,7 @@ pub fn gather_evolution_log(app: &AppHandle) -> Option<String> {
     match serde_json::from_str::<Value>(metadata_str) {
         Ok(json) => {
             // Return pretty-printed JSON for readability (will be redacted in gather_metadata)
-            serde_json::to_string_pretty(&json).ok()
+            serde_json::from_value::<Evolution>(json).ok()
         }
         Err(e) => {
             warn!("Failed to parse evolution metadata: {}", e);
@@ -426,13 +427,6 @@ fn redact_metadata_with_scanner(
     let mut redacted_fields: Vec<&'static str> = Vec::new();
 
     // Redact all string fields
-    if let Some(ref mut content) = metadata.evolution_log_content {
-        let (redacted, changed) = scanner.redact_string(content);
-        if changed {
-            redacted_fields.push("evolution_log_content");
-        }
-        *content = redacted;
-    }
     if let Some(ref mut content) = metadata.changed_nix_files_diff {
         let (redacted, changed) = scanner.redact_string(content);
         if changed {
@@ -463,6 +457,20 @@ fn redact_metadata_with_scanner(
         }
         *state = redacted;
     }
+
+    if let Some(ref mut content) = metadata.evolution_log_content {
+        // Convert to JSON, redact, convert back
+        if let Ok(json) = serde_json::to_value(&*content) {
+            let (redacted, changed) = scanner.redact_json(json);
+            if changed {
+                redacted_fields.push("evolution_log_content");
+            }
+            if let Ok(redacted_info) = serde_json::from_value(redacted) {
+                *content = redacted_info;
+            }
+        }
+    }
+
     if let Some(ref mut info) = metadata.ai_provider_model_info {
         // Convert to JSON, redact, convert back
         if let Ok(json) = serde_json::to_value(&*info) {
@@ -722,7 +730,7 @@ pub fn gather_metadata(
 #[cfg(test)]
 mod tests {
     use super::{redact_metadata_with_scanner, types};
-    use crate::system::secret_scanner::SecretScanner;
+    use crate::{shared_types::Evolution, system::secret_scanner::SecretScanner};
     use serde_json::json;
 
     fn test_scanner() -> SecretScanner {
@@ -758,7 +766,7 @@ regex = "token=([A-Za-z0-9]+)"
     fn redacts_string_fields() {
         let scanner = test_scanner();
         let mut metadata = empty_metadata();
-        metadata.evolution_log_content = Some("token=abc123".to_string());
+        metadata.evolution_log_content = Some(Evolution::new("token=abc123"));
         metadata.changed_nix_files_diff = Some("no secrets here".to_string());
         metadata.build_error_output = Some("token=xyz".to_string());
 
@@ -770,6 +778,7 @@ regex = "token=([A-Za-z0-9]+)"
         assert!(metadata
             .evolution_log_content
             .unwrap()
+            .prompt
             .contains("[REDACTED]"));
         assert_eq!(metadata.changed_nix_files_diff.unwrap(), "no secrets here");
         assert!(metadata.build_error_output.unwrap().contains("[REDACTED]"));
@@ -820,12 +829,12 @@ regex = "token=([A-Za-z0-9]+)"
     fn no_redaction_returns_empty_list() {
         let scanner = test_scanner();
         let mut metadata = empty_metadata();
-        metadata.evolution_log_content = Some("safe text".to_string());
+        metadata.evolution_log_content = Some(Evolution::new("safe text"));
 
         let (metadata, redacted_fields) = redact_metadata_with_scanner(metadata, &scanner);
 
         assert!(redacted_fields.is_empty());
-        assert_eq!(metadata.evolution_log_content.unwrap(), "safe text");
+        assert_eq!(metadata.evolution_log_content.unwrap().prompt, "safe text");
     }
 
     #[test]
@@ -833,18 +842,18 @@ regex = "token=([A-Za-z0-9]+)"
         let scanner = test_scanner_no_rules();
         let mut metadata = empty_metadata();
         let token = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-        let high_entropy = format!("This log has a secret in it: {token} see how that works?");
-        metadata.evolution_log_content = Some(high_entropy.to_string());
+        let high_entropy = format!("This prompt has a secret in it: {token} see how that works?");
+        metadata.evolution_log_content = Some(Evolution::new(&high_entropy));
 
         let (metadata, redacted_fields) = redact_metadata_with_scanner(metadata, &scanner);
 
         assert!(redacted_fields.contains(&"evolution_log_content"));
         let content = metadata.evolution_log_content.unwrap();
-        assert!(content.contains("High Entropy"));
-        assert!(!content.contains(token));
+        assert!(content.prompt.contains("High Entropy"));
+        assert!(!content.prompt.contains(token));
         assert_eq!(
-            content,
-            "This log has a secret in it: [REDACTED (High Entropy)] see how that works?"
+            content.prompt,
+            "This prompt has a secret in it: [REDACTED (High Entropy)] see how that works?"
         );
     }
 

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -152,10 +152,7 @@ pub fn gather_evolution_log(app: &AppHandle) -> Option<Evolution> {
     // The stored metadata is already a JSON string of the Evolution struct
     // We'll parse it to validate it's proper JSON and return it formatted
     match serde_json::from_str::<Value>(metadata_str) {
-        Ok(json) => {
-            // Return pretty-printed JSON for readability (will be redacted in gather_metadata)
-            serde_json::from_value::<Evolution>(json).ok()
-        }
+        Ok(json) => serde_json::from_value::<Evolution>(json).ok(),
         Err(e) => {
             warn!("Failed to parse evolution metadata: {}", e);
             None
@@ -511,7 +508,23 @@ pub async fn submit(app: &AppHandle, payload: String) -> Result<bool> {
             return Ok(false);
         }
     };
-    let parsed: Value = serde_json::from_str(&payload).unwrap_or(Value::String(payload.clone()));
+
+    // We expect valid JSON, but users can manually edit the payload preview.
+    // If parsing fails, preserve the raw content inside a minimal general
+    // feedback object so the backend still receives valid JSON.
+    let parsed: Value = match serde_json::from_str(&payload) {
+        Ok(value) => value,
+        Err(error) => {
+            warn!(
+                "[feedback] Payload preview is invalid JSON; falling back to general/text payload: {}",
+                error
+            );
+            serde_json::json!({
+                "type": "general",
+                "text": payload,
+            })
+        }
+    };
     let client = reqwest::Client::new();
 
     let sent = match client

--- a/apps/native/src-tauri/src/shared_types/evolve.rs
+++ b/apps/native/src-tauri/src/shared_types/evolve.rs
@@ -3,6 +3,74 @@ use specta::Type;
 
 use super::git::{GitStatus, SemanticChangeMap};
 
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct FileEdit {
+    pub path: String,
+    pub search: String,
+    pub replace: String,
+}
+
+/// A single thinking entry from the agent's reasoning process
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ThinkingEntry {
+    /// When this thought occurred (ms since evolution start)
+    pub timestamp_ms: i64,
+    /// The iteration number when this thought occurred
+    pub iteration: usize,
+    /// Category of thinking (planning, analysis, debugging, etc.)
+    pub category: String,
+    /// The actual thought content
+    pub content: String,
+}
+
+/// A tool call record for the activity log
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolCallRecord {
+    /// When this tool was called (ms since evolution start)
+    pub timestamp_ms: i64,
+    /// The iteration number
+    pub iteration: usize,
+    /// Tool name
+    pub tool: String,
+    /// Tool arguments (simplified)
+    pub args_summary: String,
+    /// Result summary
+    pub result_summary: String,
+    /// Whether the call succeeded
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Evolution {
+    pub id: String,
+    pub created_at: i64,
+    pub state: EvolutionState,
+    pub prompt: String,
+    pub edits: Vec<FileEdit>,
+    pub commit_hash: Option<String>,
+    pub summary: Option<String>,
+    /// Full message history for context
+    pub messages: Vec<serde_json::Value>,
+    /// Agent's thinking/reasoning log
+    pub thinking: Vec<ThinkingEntry>,
+    /// Tool call activity log
+    pub tool_calls: Vec<ToolCallRecord>,
+    /// Total tokens used
+    pub total_tokens: u32,
+    /// Number of iterations
+    pub iterations: usize,
+    /// Number of build attempts
+    pub build_attempts: usize,
+    /// AI-generated summary of changes for preview
+    pub changes_summary: Option<String>,
+    /// AI-generated commit message suggestion
+    pub suggested_commit_message: Option<String>,
+}
+
 /// Event type for streaming evolve progress updates.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]

--- a/apps/native/src-tauri/src/shared_types/feedback.rs
+++ b/apps/native/src-tauri/src/shared_types/feedback.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use specta::Type;
 
+use crate::shared_types::Evolution;
+
 /// Options indicating which feedback artifacts the user allows sharing.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
@@ -126,7 +128,7 @@ pub struct FeedbackMetadata {
     /// Aggregated local usage statistics.
     pub usage_stats: Option<FeedbackUsageStats>,
     /// Captured evolution log content.
-    pub evolution_log_content: Option<String>,
+    pub evolution_log_content: Option<Evolution>,
     /// Diff for changed Nix files at submission time.
     pub changed_nix_files_diff: Option<String>,
     /// AI provider/model metadata for the related run.

--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -290,7 +290,6 @@ export function FeedbackDialog() {
   const [promptHistory, setPromptHistory] = useState<string[]>([]);
   const [relatedPrompt, setRelatedPrompt] = useState("");
   const [shareOptions, setShareOptions] = useState<ShareOptions>(DEFAULT_SHARE_OPTIONS);
-  const [previewReport, setPreviewReport] = useState(true);
   const [isPreviewingReport, setIsPreviewingReport] = useState(false);
   const [previewReportText, setPreviewReportText] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -353,7 +352,6 @@ export function FeedbackDialog() {
     setEmail("");
     setRelatedPrompt("");
     setShareOptions(DEFAULT_SHARE_OPTIONS);
-    setPreviewReport(true);
     setIsPreviewingReport(false);
     setPreviewReportText("");
     setFeedbackTypeOverride(null);
@@ -423,14 +421,23 @@ export function FeedbackDialog() {
     try {
       if (isPreviewingReport) {
         await submitPayload(previewReportText);
-      } else if (previewReport) {
-        const payload = await buildFeedbackPayload();
-        setPreviewReportText(payload);
-        setIsPreviewingReport(true);
       } else {
         const payload = await buildFeedbackPayload();
         await submitPayload(payload);
       }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handlePreview = async () => {
+    if (submitting || isPreviewingReport) return;
+
+    setSubmitting(true);
+    try {
+      const payload = await buildFeedbackPayload();
+      setPreviewReportText(payload);
+      setIsPreviewingReport(true);
     } finally {
       setSubmitting(false);
     }
@@ -974,31 +981,23 @@ export function FeedbackDialog() {
           )}
         </div>
 
-        {!isPreviewingReport && (
-          <div className="pt-2 border-t border-border/40">
-            <div className="flex items-center justify-center gap-2">
-              <Checkbox
-                id="preview-report"
-                checked={previewReport}
-                onCheckedChange={(checked: boolean | "indeterminate") =>
-                  setPreviewReport(checked === true)
-                }
-              />
-              <Label
-                htmlFor="preview-report"
-                className="cursor-pointer font-medium text-sm text-foreground"
-              >
-                Preview report before sending
-              </Label>
-            </div>
-          </div>
-        )}
-
         <DialogFooter>
           {!isPreviewingReport && showSentryDebugButton && (
-            <Button variant="secondary" onClick={handleDebugSentryEvent} disabled={submitting}>
-              Send Sentry Debug Event
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={handleDebugSentryEvent}
+                  disabled={submitting}
+                  aria-label="Send Sentry debug event"
+                >
+                  <Bug className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">Send Sentry Debug Event</TooltipContent>
+            </Tooltip>
           )}
           {isPreviewingReport ? (
             <>
@@ -1017,6 +1016,9 @@ export function FeedbackDialog() {
             <>
               <Button variant="outline" onClick={handleClose} disabled={submitting}>
                 Cancel
+              </Button>
+              <Button variant="outline" onClick={handlePreview} disabled={submitting}>
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Preview"}
               </Button>
               <Button onClick={handleSubmit} disabled={submitting} aria-label="Send feedback">
                 {submitting ? (

--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -290,6 +290,9 @@ export function FeedbackDialog() {
   const [promptHistory, setPromptHistory] = useState<string[]>([]);
   const [relatedPrompt, setRelatedPrompt] = useState("");
   const [shareOptions, setShareOptions] = useState<ShareOptions>(DEFAULT_SHARE_OPTIONS);
+  const [previewReport, setPreviewReport] = useState(true);
+  const [isPreviewingReport, setIsPreviewingReport] = useState(false);
+  const [previewReportText, setPreviewReportText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const showSentryDebugButton = import.meta.env.DEV;
 
@@ -350,60 +353,64 @@ export function FeedbackDialog() {
     setEmail("");
     setRelatedPrompt("");
     setShareOptions(DEFAULT_SHARE_OPTIONS);
+    setPreviewReport(true);
+    setIsPreviewingReport(false);
+    setPreviewReportText("");
     setFeedbackTypeOverride(null);
     useWidgetStore.setState({ feedbackInitialText: null, panicDetails: null });
   };
 
-  const handleSubmit = async () => {
-    if (submitting) return;
-    setSubmitting(true);
+  const buildFeedbackPayload = async () => {
+    let metadata: Awaited<ReturnType<typeof tauriAPI.feedback.gatherMetadata>> | null = null;
+    try {
+      metadata = await tauriAPI.feedback.gatherMetadata(feedbackType, shareOptions);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("Failed to gather feedback metadata:", err);
+    }
 
+    const relatedPromptText =
+      (feedbackType === FeedbackType.Issue || feedbackType === FeedbackType.Error) && relatedPrompt
+        ? relatedPrompt
+        : undefined;
+    const selectedPromptText = shareOptions.lastPrompt ? relatedPromptText : undefined;
+
+    const feedbackModel = new FeedbackModel({
+      type: feedbackType,
+      text: feedbackText,
+      email: email || undefined,
+      expectedText: feedbackType === FeedbackType.Bug ? expectedText : undefined,
+      share: shareOptions,
+      // artifact fields left empty for now; will be populated by caller when collecting logs
+      lastPromptText: selectedPromptText,
+      currentAppStateSnapshot: metadata?.currentAppStateSnapshot ?? undefined,
+      systemInfo: metadata?.systemInfo ?? undefined,
+      usageStats: metadata?.usageStats ?? undefined,
+      evolutionLogContent: metadata?.evolutionLogContent ?? undefined,
+      changedNixFilesDiff: metadata?.changedNixFilesDiff ?? undefined,
+      aiProviderModelInfo: metadata?.aiProviderModelInfo ?? undefined,
+      buildErrorOutput: metadata?.buildErrorOutput ?? undefined,
+      flakeInputsSnapshot: metadata?.flakeInputsSnapshot ?? undefined,
+      appLogsContent: metadata?.appLogsContent ?? undefined,
+      panicDetails: feedbackType === FeedbackType.Error ? (panicDetails ?? undefined) : undefined,
+    });
+
+    const validation = feedbackModel.validate();
+    if (!validation.ok) {
+      console.warn("Feedback validation failed:", validation.errors);
+    }
+
+    // Since we support preview, we should prettify this JSON string.
+    return JSON.stringify(feedbackModel.toJSON(), null, 2);
+  };
+
+  const submitPayload = async (payload: string) => {
+    if (submitting) return;
+
+    setSubmitting(true);
     let sentSuccessfully = false;
     try {
-      let metadata: Awaited<ReturnType<typeof tauriAPI.feedback.gatherMetadata>> | null = null;
-      try {
-        metadata = await tauriAPI.feedback.gatherMetadata(feedbackType, shareOptions);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn("Failed to gather feedback metadata:", err);
-      }
-
-      // Build a typed Feedback model and log it (replace with submission later)
-      const modelType = feedbackType;
-      const relatedPromptText =
-        (feedbackType === FeedbackType.Issue || feedbackType === FeedbackType.Error) &&
-        relatedPrompt
-          ? relatedPrompt
-          : undefined;
-      const selectedPromptText = shareOptions.lastPrompt ? relatedPromptText : undefined;
-
-      const feedbackModel = new FeedbackModel({
-        type: modelType,
-        text: feedbackText,
-        email: email || undefined,
-        expectedText: feedbackType === FeedbackType.Bug ? expectedText : undefined,
-        share: shareOptions,
-        // artifact fields left empty for now; will be populated by caller when collecting logs
-        lastPromptText: selectedPromptText,
-        currentAppStateSnapshot: metadata?.currentAppStateSnapshot ?? undefined,
-        systemInfo: metadata?.systemInfo ?? undefined,
-        usageStats: metadata?.usageStats ?? undefined,
-        evolutionLogContent: metadata?.evolutionLogContent ?? undefined,
-        changedNixFilesDiff: metadata?.changedNixFilesDiff ?? undefined,
-        aiProviderModelInfo: metadata?.aiProviderModelInfo ?? undefined,
-        buildErrorOutput: metadata?.buildErrorOutput ?? undefined,
-        flakeInputsSnapshot: metadata?.flakeInputsSnapshot ?? undefined,
-        appLogsContent: metadata?.appLogsContent ?? undefined,
-        panicDetails: feedbackType === FeedbackType.Error ? (panicDetails ?? undefined) : undefined,
-      });
-
-      const validation = feedbackModel.validate();
-      if (!validation.ok) {
-        console.warn("Feedback validation failed:", validation.errors);
-      }
-
-      const json = JSON.stringify(feedbackModel.toJSON());
-      const sent = await tauriAPI.feedback.submit(json);
+      const sent = await tauriAPI.feedback.submit(payload);
 
       if (sent) {
         toast.success("Thanks — feedback sent");
@@ -418,6 +425,30 @@ export function FeedbackDialog() {
     if (sentSuccessfully) {
       handleClose();
     }
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+
+    if (isPreviewingReport) {
+      await submitPayload(previewReportText);
+      return;
+    }
+
+    if (previewReport) {
+      setSubmitting(true);
+      try {
+        const payload = await buildFeedbackPayload();
+        setPreviewReportText(payload);
+        setIsPreviewingReport(true);
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
+
+    const payload = await buildFeedbackPayload();
+    await submitPayload(payload);
   };
 
   const handleDebugSentryEvent = async () => {
@@ -498,463 +529,521 @@ export function FeedbackDialog() {
         </DialogHeader>
 
         <div className="space-y-6 flex-1 overflow-y-auto pr-2">
-          {/* Type Selection */}
-          {!isIssue && !isError && (
+          {isPreviewingReport ? (
             <div className="space-y-3">
-              <Label className="text-muted-foreground">TYPE</Label>
-              <RadioGroup
-                value={feedbackType}
-                onValueChange={(value: string) => setFeedbackType(value as FeedbackType)}
-                className="grid grid-cols-3 gap-4"
-              >
-                <Label
-                  className={`flex cursor-pointer flex-row items-center gap-3 rounded-lg border border-input bg-transparent p-3 hover:bg-accent transition-opacity ${
-                    feedbackType === FeedbackType.Suggestion ? "opacity-100" : "opacity-40"
-                  }`}
-                  htmlFor="suggestion"
-                >
-                  <RadioGroupItem className="sr-only" value="suggestion" id="suggestion" />
-                  <Lightbulb className="h-5 w-5 text-muted-foreground" />
-                  <span className="font-medium text-sm">Suggestion</span>
-                </Label>
-
-                <Label
-                  className={`flex cursor-pointer flex-row items-center gap-3 rounded-lg border border-input bg-transparent p-3 hover:bg-accent transition-opacity ${
-                    feedbackType === FeedbackType.Bug ? "opacity-100" : "opacity-40"
-                  }`}
-                  htmlFor="bug"
-                >
-                  <RadioGroupItem className="sr-only" value="bug" id="bug" />
-                  <Bug className="h-5 w-5 text-muted-foreground" />
-                  <span className="font-medium text-sm">Bug</span>
-                </Label>
-
-                <Label
-                  className={`flex cursor-pointer flex-row items-center gap-3 rounded-lg border border-input bg-transparent p-3 hover:bg-accent transition-opacity ${
-                    feedbackType === FeedbackType.General ? "opacity-100" : "opacity-40"
-                  }`}
-                  htmlFor="general"
-                >
-                  <RadioGroupItem className="sr-only" value="general" id="general" />
-                  <MessageCircle className="h-5 w-5 text-muted-foreground" />
-                  <span className="font-medium text-sm">General</span>
-                </Label>
-              </RadioGroup>
-            </div>
-          )}
-
-          {/* Feedback Text */}
-          <div className="space-y-2">
-            <Label htmlFor="feedback-text" className="text-foreground">
-              {getTextboxLabel()}
-            </Label>
-            <Textarea
-              id="feedback-text"
-              value={feedbackText}
-              onChange={(e) => setFeedbackText(e.target.value)}
-              placeholder="Tell us more..."
-              rows={3}
-              className="resize-none"
-            />
-
-            {/* Email input (optional) */}
-          </div>
-
-          {/* Prompt selector - visible for all feedback types */}
-          <div className="space-y-2">
-            <Label className="text-foreground">PROMPT (optional)</Label>
-            <Select value={relatedPrompt} onValueChange={setRelatedPrompt}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select a prompt (optional)" />
-              </SelectTrigger>
-              <SelectContent>
-                {promptHistory.length > 0 ? (
-                  promptHistory.map((prompt) => (
-                    <SelectItem key={prompt} value={prompt}>
-                      <span className="line-clamp-2">{prompt}</span>
-                    </SelectItem>
-                  ))
-                ) : (
-                  <SelectItem disabled value="__empty__">
-                    No prompt history
-                  </SelectItem>
-                )}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Email input (optional) - moved below RELATED PROMPT for issue flow */}
-          <div className="mt-2 flex items-center gap-3">
-            <Label htmlFor="feedback-email" className="text-foreground text-sm">
-              Email (optional)
-            </Label>
-            <Input
-              id="feedback-email"
-              type="email"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="max-w-xs"
-            />
-          </div>
-
-          {/* Expected Text (Bug only) */}
-          {feedbackType === FeedbackType.Bug && (
-            <div className="space-y-2">
-              <Label htmlFor="expected-text" className="text-foreground">
-                WHAT DID YOU EXPECT
+              <Label htmlFor="feedback-preview" className="text-foreground">
+                PREVIEW REPORT
               </Label>
+              <p className="text-sm text-muted-foreground">
+                Review and edit the exact payload that will be sent.
+              </p>
               <Textarea
-                id="expected-text"
-                value={expectedText}
-                onChange={(e) => setExpectedText(e.target.value)}
-                placeholder="What should have happened instead?"
-                rows={3}
-                className="resize-none"
+                id="feedback-preview"
+                value={previewReportText}
+                onChange={(e) => setPreviewReportText(e.target.value)}
+                rows={18}
+                className="resize-none font-mono text-xs"
               />
             </div>
+          ) : (
+            <>
+              {/* Type Selection */}
+              {!isIssue && !isError && (
+                <div className="space-y-3">
+                  <Label className="text-muted-foreground">TYPE</Label>
+                  <RadioGroup
+                    value={feedbackType}
+                    onValueChange={(value: string) => setFeedbackType(value as FeedbackType)}
+                    className="grid grid-cols-3 gap-4"
+                  >
+                    <Label
+                      className={`flex cursor-pointer flex-row items-center gap-3 rounded-lg border border-input bg-transparent p-3 hover:bg-accent transition-opacity ${
+                        feedbackType === FeedbackType.Suggestion ? "opacity-100" : "opacity-40"
+                      }`}
+                      htmlFor="suggestion"
+                    >
+                      <RadioGroupItem className="sr-only" value="suggestion" id="suggestion" />
+                      <Lightbulb className="h-5 w-5 text-muted-foreground" />
+                      <span className="font-medium text-sm">Suggestion</span>
+                    </Label>
+
+                    <Label
+                      className={`flex cursor-pointer flex-row items-center gap-3 rounded-lg border border-input bg-transparent p-3 hover:bg-accent transition-opacity ${
+                        feedbackType === FeedbackType.Bug ? "opacity-100" : "opacity-40"
+                      }`}
+                      htmlFor="bug"
+                    >
+                      <RadioGroupItem className="sr-only" value="bug" id="bug" />
+                      <Bug className="h-5 w-5 text-muted-foreground" />
+                      <span className="font-medium text-sm">Bug</span>
+                    </Label>
+
+                    <Label
+                      className={`flex cursor-pointer flex-row items-center gap-3 rounded-lg border border-input bg-transparent p-3 hover:bg-accent transition-opacity ${
+                        feedbackType === FeedbackType.General ? "opacity-100" : "opacity-40"
+                      }`}
+                      htmlFor="general"
+                    >
+                      <RadioGroupItem className="sr-only" value="general" id="general" />
+                      <MessageCircle className="h-5 w-5 text-muted-foreground" />
+                      <span className="font-medium text-sm">General</span>
+                    </Label>
+                  </RadioGroup>
+                </div>
+              )}
+
+              {/* Feedback Text */}
+              <div className="space-y-2">
+                <Label htmlFor="feedback-text" className="text-foreground">
+                  {getTextboxLabel()}
+                </Label>
+                <Textarea
+                  id="feedback-text"
+                  value={feedbackText}
+                  onChange={(e) => setFeedbackText(e.target.value)}
+                  placeholder="Tell us more..."
+                  rows={3}
+                  className="resize-none"
+                />
+
+                {/* Email input (optional) */}
+              </div>
+
+              {/* Prompt selector - visible for all feedback types */}
+              <div className="space-y-2">
+                <Label className="text-foreground">PROMPT (optional)</Label>
+                <Select value={relatedPrompt} onValueChange={setRelatedPrompt}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select a prompt (optional)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {promptHistory.length > 0 ? (
+                      promptHistory.map((prompt) => (
+                        <SelectItem key={prompt} value={prompt}>
+                          <span className="line-clamp-2">{prompt}</span>
+                        </SelectItem>
+                      ))
+                    ) : (
+                      <SelectItem disabled value="__empty__">
+                        No prompt history
+                      </SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Email input (optional) - moved below RELATED PROMPT for issue flow */}
+              <div className="mt-2 flex items-center gap-3">
+                <Label htmlFor="feedback-email" className="text-foreground text-sm">
+                  Email (optional)
+                </Label>
+                <Input
+                  id="feedback-email"
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="max-w-xs"
+                />
+              </div>
+
+              {/* Expected Text (Bug only) */}
+              {feedbackType === FeedbackType.Bug && (
+                <div className="space-y-2">
+                  <Label htmlFor="expected-text" className="text-foreground">
+                    WHAT DID YOU EXPECT
+                  </Label>
+                  <Textarea
+                    id="expected-text"
+                    value={expectedText}
+                    onChange={(e) => setExpectedText(e.target.value)}
+                    placeholder="What should have happened instead?"
+                    rows={3}
+                    className="resize-none"
+                  />
+                </div>
+              )}
+
+              {/* Share with team */}
+              <div className="space-y-2">
+                <Label className="text-foreground">SHARE WITH THE TEAM</Label>
+                <div className="space-y-2 max-h-[28vh] overflow-y-auto pr-2">
+                  {shouldShowCurrentAppState(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-app-state"
+                        checked={shareOptions.currentAppState}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            currentAppState: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-app-state"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        Current app state
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.currentAppState}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowSystemInfo(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-system-info"
+                        checked={shareOptions.systemInfo}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            systemInfo: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-system-info"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        System info
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.systemInfo}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowUsageStats(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-usage-stats"
+                        checked={shareOptions.usageStats}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            usageStats: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-usage-stats"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        Usage stats
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.usageStats}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowEvolutionLog(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-evolution-log"
+                        checked={shareOptions.evolutionLog}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            evolutionLog: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-evolution-log"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        Evolution log
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.evolutionLog}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowChangedNixFiles(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-changed-nix-files"
+                        checked={shareOptions.changedNixFiles}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            changedNixFiles: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-changed-nix-files"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        Changed nix files
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.changedNixFiles}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowAiProviderModelInfo(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-ai-provider-model-info"
+                        checked={shareOptions.aiProviderModelInfo}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            aiProviderModelInfo: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-ai-provider-model-info"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        AI provider and model info
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.aiProviderModelInfo}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowBuildErrorOutput(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-build-error-output"
+                        checked={shareOptions.buildErrorOutput}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            buildErrorOutput: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-build-error-output"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        Build error output
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.buildErrorOutput}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowFlakeInputsSnapshot(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-flake-inputs-snapshot"
+                        checked={shareOptions.flakeInputsSnapshot}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            flakeInputsSnapshot: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-flake-inputs-snapshot"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        Flake inputs snapshot
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.flakeInputsSnapshot}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+
+                  {shouldShowAppLogs(feedbackType, step, mainWindowError) && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="share-app-logs"
+                        checked={shareOptions.appLogs}
+                        onCheckedChange={(checked: boolean | "indeterminate") =>
+                          setShareOptions({
+                            ...shareOptions,
+                            appLogs: checked === true,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor="share-app-logs"
+                        className="cursor-pointer font-medium text-sm text-foreground flex-1"
+                      >
+                        App logs
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
+                            aria-label="More information"
+                          >
+                            <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-sm text-sm">
+                          {shareOptionTooltips.appLogs}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+            </>
           )}
-
-          {/* Share with team */}
-          <div className="space-y-2">
-            <Label className="text-foreground">SHARE WITH THE TEAM</Label>
-            <div className="space-y-2 max-h-[28vh] overflow-y-auto pr-2">
-              {shouldShowCurrentAppState(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-app-state"
-                    checked={shareOptions.currentAppState}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        currentAppState: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-app-state"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    Current app state
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.currentAppState}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowSystemInfo(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-system-info"
-                    checked={shareOptions.systemInfo}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        systemInfo: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-system-info"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    System info
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.systemInfo}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowUsageStats(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-usage-stats"
-                    checked={shareOptions.usageStats}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        usageStats: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-usage-stats"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    Usage stats
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.usageStats}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowEvolutionLog(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-evolution-log"
-                    checked={shareOptions.evolutionLog}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        evolutionLog: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-evolution-log"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    Evolution log
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.evolutionLog}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowChangedNixFiles(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-changed-nix-files"
-                    checked={shareOptions.changedNixFiles}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        changedNixFiles: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-changed-nix-files"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    Changed nix files
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.changedNixFiles}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowAiProviderModelInfo(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-ai-provider-model-info"
-                    checked={shareOptions.aiProviderModelInfo}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        aiProviderModelInfo: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-ai-provider-model-info"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    AI provider and model info
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.aiProviderModelInfo}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowBuildErrorOutput(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-build-error-output"
-                    checked={shareOptions.buildErrorOutput}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        buildErrorOutput: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-build-error-output"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    Build error output
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.buildErrorOutput}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowFlakeInputsSnapshot(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-flake-inputs-snapshot"
-                    checked={shareOptions.flakeInputsSnapshot}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        flakeInputsSnapshot: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-flake-inputs-snapshot"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    Flake inputs snapshot
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.flakeInputsSnapshot}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-
-              {shouldShowAppLogs(feedbackType, step, mainWindowError) && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="share-app-logs"
-                    checked={shareOptions.appLogs}
-                    onCheckedChange={(checked: boolean | "indeterminate") =>
-                      setShareOptions({
-                        ...shareOptions,
-                        appLogs: checked === true,
-                      })
-                    }
-                  />
-                  <Label
-                    htmlFor="share-app-logs"
-                    className="cursor-pointer font-medium text-sm text-foreground flex-1"
-                  >
-                    App logs
-                  </Label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors flex-shrink-0 group"
-                        aria-label="More information"
-                      >
-                        <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-sm text-sm">
-                      {shareOptionTooltips.appLogs}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-            </div>
-          </div>
         </div>
 
+        {!isPreviewingReport && (
+          <div className="pt-2 border-t border-border/40">
+            <div className="flex items-center justify-center gap-2">
+              <Checkbox
+                id="preview-report"
+                checked={previewReport}
+                onCheckedChange={(checked: boolean | "indeterminate") =>
+                  setPreviewReport(checked === true)
+                }
+              />
+              <Label
+                htmlFor="preview-report"
+                className="cursor-pointer font-medium text-sm text-foreground"
+              >
+                Preview report before sending
+              </Label>
+            </div>
+          </div>
+        )}
+
         <DialogFooter>
-          {showSentryDebugButton && (
+          {!isPreviewingReport && showSentryDebugButton && (
             <Button variant="secondary" onClick={handleDebugSentryEvent} disabled={submitting}>
               Send Sentry Debug Event
             </Button>
           )}
-          <Button variant="outline" onClick={handleClose} disabled={submitting}>
-            Cancel
-          </Button>
-          <Button onClick={handleSubmit} disabled={submitting} aria-label="Send feedback">
-            {submitting ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : isReportMode ? (
-              "Send Report"
-            ) : (
-              "Send Feedback"
-            )}
-          </Button>
+          {isPreviewingReport ? (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => setIsPreviewingReport(false)}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleSubmit} disabled={submitting} aria-label="Send feedback">
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Send"}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={handleClose} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button onClick={handleSubmit} disabled={submitting} aria-label="Send feedback">
+                {submitting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : isReportMode ? (
+                  "Send Report"
+                ) : (
+                  "Send Feedback"
+                )}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -405,50 +405,35 @@ export function FeedbackDialog() {
   };
 
   const submitPayload = async (payload: string) => {
-    if (submitting) return;
+    const sent = await tauriAPI.feedback.submit(payload);
 
-    setSubmitting(true);
-    let sentSuccessfully = false;
-    try {
-      const sent = await tauriAPI.feedback.submit(payload);
-
-      if (sent) {
-        toast.success("Thanks — feedback sent");
-      } else {
-        toast.info("Failed to send, we'll try again next time you open the app.");
-      }
-      sentSuccessfully = true;
-    } finally {
-      setSubmitting(false);
+    if (sent) {
+      toast.success("Thanks — feedback sent");
+    } else {
+      toast.info("Failed to send, we'll try again next time you open the app.");
     }
 
-    if (sentSuccessfully) {
-      handleClose();
-    }
+    handleClose();
   };
 
   const handleSubmit = async () => {
     if (submitting) return;
 
-    if (isPreviewingReport) {
-      await submitPayload(previewReportText);
-      return;
-    }
-
-    if (previewReport) {
-      setSubmitting(true);
-      try {
+    setSubmitting(true);
+    try {
+      if (isPreviewingReport) {
+        await submitPayload(previewReportText);
+      } else if (previewReport) {
         const payload = await buildFeedbackPayload();
         setPreviewReportText(payload);
         setIsPreviewingReport(true);
-      } finally {
-        setSubmitting(false);
+      } else {
+        const payload = await buildFeedbackPayload();
+        await submitPayload(payload);
       }
-      return;
+    } finally {
+      setSubmitting(false);
     }
-
-    const payload = await buildFeedbackPayload();
-    await submitPayload(payload);
   };
 
   const handleDebugSentryEvent = async () => {

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -239,6 +239,40 @@ ok: boolean;
  */
 message: string }
 
+export type Evolution = { id: string; createdAt: number; state: EvolutionState; prompt: string; edits: FileEdit[]; commitHash: string | null; summary: string | null; 
+/**
+ * Full message history for context
+ */
+messages: JsonValue[]; 
+/**
+ * Agent's thinking/reasoning log
+ */
+thinking: ThinkingEntry[]; 
+/**
+ * Tool call activity log
+ */
+toolCalls: ToolCallRecord[]; 
+/**
+ * Total tokens used
+ */
+totalTokens: number; 
+/**
+ * Number of iterations
+ */
+iterations: number; 
+/**
+ * Number of build attempts
+ */
+buildAttempts: number; 
+/**
+ * AI-generated summary of changes for preview
+ */
+changesSummary: string | null; 
+/**
+ * AI-generated commit message suggestion
+ */
+suggestedCommitMessage: string | null }
+
 /**
  * Evolution failure payload with partial telemetry.
  */
@@ -617,7 +651,7 @@ usageStats: FeedbackUsageStats | null;
 /**
  * Captured evolution log content.
  */
-evolutionLogContent: string | null; 
+evolutionLogContent: Evolution | null; 
 /**
  * Diff for changed Nix files at submission time.
  */
@@ -772,6 +806,8 @@ extra: JsonValue | null }
  * HEAD content vs working-tree content for a file, used by the diff tab Monaco DiffEditor.
  */
 export type FileDiffContents = { original: string; modified: string }
+
+export type FileEdit = { path: string; search: string; replace: string }
 
 /**
  * Result of a successful `finalize_apply` or `finalize_rollback` command.
@@ -1363,6 +1399,56 @@ defaults: SystemDefault[];
  * Number of defaults keys scanned.
  */
 totalScanned: number }
+
+/**
+ * A single thinking entry from the agent's reasoning process
+ */
+export type ThinkingEntry = { 
+/**
+ * When this thought occurred (ms since evolution start)
+ */
+timestampMs: number; 
+/**
+ * The iteration number when this thought occurred
+ */
+iteration: number; 
+/**
+ * Category of thinking (planning, analysis, debugging, etc.)
+ */
+category: string; 
+/**
+ * The actual thought content
+ */
+content: string }
+
+/**
+ * A tool call record for the activity log
+ */
+export type ToolCallRecord = { 
+/**
+ * When this tool was called (ms since evolution start)
+ */
+timestampMs: number; 
+/**
+ * The iteration number
+ */
+iteration: number; 
+/**
+ * Tool name
+ */
+tool: string; 
+/**
+ * Tool arguments (simplified)
+ */
+argsSummary: string; 
+/**
+ * Result summary
+ */
+resultSummary: string; 
+/**
+ * Whether the call succeeded
+ */
+success: boolean }
 
 /**
  * User interface preferences (synced to settings.json via tauri-plugin-store).

--- a/apps/native/src/types/feedback.ts
+++ b/apps/native/src/types/feedback.ts
@@ -1,4 +1,5 @@
 import type {
+  Evolution,
   FeedbackAiProviderModelInfo,
   FeedbackFlakeInputsSnapshot,
   FeedbackSystemInfo,
@@ -78,7 +79,7 @@ interface FeedbackPayload {
   /** Structured usage statistics when available */
   usageStats?: UsageStats;
   usageStatsSnapshot?: unknown;
-  evolutionLogContent?: string;
+  evolutionLogContent?: Evolution;
   changedNixFilesDiff?: string;
   aiProviderModelInfo?: AiProviderModelInfo;
   buildErrorOutput?: string;
@@ -118,7 +119,7 @@ export class Feedback {
   // Optional collected artifacts (populated later by caller)
   public lastPromptText?: string;
   public currentAppStateSnapshot?: unknown;
-  public evolutionLogContent?: string;
+  public evolutionLogContent?: Evolution;
   public changedNixFilesDiff?: string;
   public aiProviderModelInfo?: AiProviderModelInfo;
   public buildErrorOutput?: string;


### PR DESCRIPTION
## Summary

The main inspiration for this is issue 510, namely that we need a better way to provide debug info for iterated-out evolutions. The feedback system already has most of this in place since it includes the "evolution log".

For use by developers, it's easier to just look at this and copy/paste it out to analyze, rather than have to go through the full-stack feedback system.

And for non-developers, it's a useful feature to be able to preview and potentially edit (for example to further redact) feedback submissions.

Ergo, I added an optional "preview before send" to the feedback dialog. See some screenshots.

<img width="517" height="665" alt="Screenshot 2026-05-27 at 11 35 30 AM" src="https://github.com/user-attachments/assets/a23902fd-a792-496c-8360-6caaacfe92d9" />

<img width="517" height="665" alt="Screenshot 2026-05-27 at 11 36 06 AM" src="https://github.com/user-attachments/assets/3fc6e279-b34a-4bff-90bb-91ce3342ea07" />

I also changed the evolution_log content from escaped JSON to a real object because that's really how it should be and it's easier to read and work with that way.

- Updated FeedbackMetadata to use Evolution type for evolution_log_content instead of escaped JSON.
- Introduced preview functionality in FeedbackDialog for feedback payload before submission.

## Test Plan

Manual + updated affected unit tests.

## Docs

- [ ] Docs updated
- [x] No docs update needed
