### PR TITLE
fix(build): use cargoHash to avoid crates.io 403s

### DIFF
--- a/nix/pkgs/tauri-wd.nix
+++ b/nix/pkgs/tauri-wd.nix
@@ -16,9 +16,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-8pW3cGhmrkSouC+N/N3ETJxEK1zgHjR3OfMTudG9ie4=";
   };
 
-  cargoLock = {
-    lockFile = "${src}/Cargo.lock";
-  };
+  cargoHash = "sha256-UlJ+z6++0W1aHXUSQ3whAuX6sq34x9IoB9N1NlnFyh8=";
 
   cargoBuildFlags = [
     "-p"


### PR DESCRIPTION
## Summary

use `cargoHash` instead of cargoLock in `tauri-wd.nix`, because that runs `fetchCargoVendor` which [has been patched](https://github.com/NixOS/nixpkgs/pull/513551) to deal with new crates.io policies

`cargoLock` uses `fetchurl` which uses default curl UA which gets blocked leading to build issues on cold cache

## Test Plan

`devenv up` on a machine with no tauri-wd in the Nix store succeeds

## Docs

- [X] No docs update needed
