### PR TITLE
fix: generate Specta bindings via build script

### DIFF
--- a/apps/native/src-tauri/scripts/tauri-dev.sh
+++ b/apps/native/src-tauri/scripts/tauri-dev.sh
@@ -20,14 +20,14 @@ input_hash="$({
   cat examples/specta_gen_ts.rs
 } | shasum -a 256 | awk '{print $1}')"
 
-if [ ! -f ../src/types/sqlite.ts ]; then
+if [ ! -f ../src/ipc/sqlite.ts ]; then
   needs_regen=true
-  reasons+=("missing ../src/types/sqlite.ts")
+  reasons+=("missing ../src/ipc/sqlite.ts")
 fi
 
-if [ ! -f ../src/types/shared.ts ]; then
+if [ ! -f ../src/ipc/types.ts ]; then
   needs_regen=true
-  reasons+=("missing ../src/types/shared.ts")
+  reasons+=("missing ../src/ipc/types.ts")
 fi
 
 if [ ! -f "$stamp_file" ]; then

--- a/nix/pkgs/tauri-wd.nix
+++ b/nix/pkgs/tauri-wd.nix
@@ -16,9 +16,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-8pW3cGhmrkSouC+N/N3ETJxEK1zgHjR3OfMTudG9ie4=";
   };
 
-  cargoLock = {
-    lockFile = "${src}/Cargo.lock";
-  };
+  cargoHash = "sha256-UlJ+z6++0W1aHXUSQ3whAuX6sq34x9IoB9N1NlnFyh8=";
 
   cargoBuildFlags = [
     "-p"


### PR DESCRIPTION
## Summary

Somebody moved the location of the specta-generated .ts files and changed the name of one and didn't update the regeneration hashing script, as evidenced by the increased dev build startup time and the diagnostic messages that appear.

## Test Plan

Run the dev build, watch the logs.

## Docs

- [ ] Docs updated
- [x] No docs update needed
