### PR TITLE
feat: introduce git2 for faster read-only Git operations; add profiling support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -2326,6 +2328,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3093,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3233,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.4+1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,6 +3279,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3673,6 +3721,7 @@ dependencies = [
  "dirs 5.0.1",
  "fancy-regex 0.17.0",
  "fuzzy-matcher",
+ "git2",
  "glob",
  "hex",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 members = ["apps/native/src-tauri"]
 resolver = "2"
 
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ and run the app from `/target` via:
 
 ```sh
 cd ../..
-open -a "Instruments" ./target/profiling/nixmax
+open -a "Instruments" ./target/profiling/nixmac
 ```
 
 Or start `../../target/profiling/nixmac` manually to get past the startup overhead, start Instruments, and attach to the process.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ bun run dev:server     # API server at http://localhost:3000
 bun run dev:native     # Tauri desktop app
 ```
 
+### Profiling (Rust-side)
+
+You should have Xcode installed.
+
+```sh
+cd apps/native
+bunx tauri build -- --profile profiling
+```
+
+and run the app from `/target` via:
+
+```sh
+cd ../..
+open -a "Instruments" ./target/profiling/nixmax
+```
+
+Or start `../../target/profiling/nixmac` manually to get past the startup overhead, start Instruments, and attach to the process.
+
 ### Setting Up nix-darwin
 
 If you don't already have a nix-darwin configuration:

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -71,6 +71,7 @@ fuzzy-matcher = "0.3.7"
 rusqlite_migration = "1.2"
 tauri-plugin-webdriver-automation = "0.1.3"
 tiktoken-rs = "0.6"
+git2 = "0.21.0"
 
 [dependencies.tauri-plugin-sql]
 features = ["sqlite"] # or "postgres", or "mysql"

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -24,7 +24,7 @@ pub mod lifecycle;
 pub(crate) const IGNORED_DIRS: [&str; 2] = [".git", "result"];
 
 use crate::evolve::utils::{escape_user_query, format_duration_secs, short_hash};
-use crate::git::exec::repo_root;
+use crate::git::query::repo_root;
 // Re-export public API
 use crate::shared_types::EvolutionState;
 use crate::system::nix;

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -1,9 +1,18 @@
-//! Git operations for tracking and recording configuration changes.
-
+/// Git execution layer (CLI AUTHORITY)
+///
+/// This module uses `git_command()` exclusively.
+///
+/// Rules:
+/// - This layer relies on REAL Git behavior
+/// - Must preserve CLI semantics exactly
+/// - Includes hooks suppression + identity injection
+/// - May modify filesystem, index, HEAD, refs
+use crate::git::is_repo;
+use crate::git::query::{get_head_sha, has_head_commit, repo_root};
 use crate::shared_types::{GitFileStatus, GitStatus};
 use anyhow::{Context, Result};
 use std::ffi::OsStr;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 use std::process::{Command, Output};
 use tauri::AppHandle;
 
@@ -40,7 +49,25 @@ impl GitCommand {
     }
 }
 
-/// Identity and hooks injected so nixmac doesn't inherit user's config
+/// Identity + hooks injection layer (CLI boundary enforcement)
+///
+/// IMPORTANT: This cannot be meaningfully replicated with `git2`,
+/// the Rust library which doesn't require shelling out to a process.
+///
+/// The functions that call this wrapper intentionally use the Git CLI to enforce:
+/// - deterministic identity (user.name / user.email)
+/// - disabled commit signing (GPG)
+/// - disabled hooks execution (core.hooksPath=/dev/null)
+/// - controlled environment PATH resolution
+///
+/// These behaviors are part of the *Git process environment*, not the
+/// repository object model.
+///
+/// `git2` does NOT support:
+/// - per-command environment mutation equivalent to `-c` CLI overrides
+/// - hooksPath / hook suppression semantics
+/// - GPG signing configuration via execution context
+/// - PATH-based toolchain isolation
 fn git_command() -> GitCommand {
     let mut cmd = Command::new("git");
     cmd.env("PATH", crate::system::nix::get_nix_path());
@@ -55,16 +82,6 @@ fn git_command() -> GitCommand {
         "core.hooksPath=/dev/null",
     ]);
     GitCommand(cmd)
-}
-
-/// Checks if a directory is inside a git repository.
-pub fn is_repo(dir: &str) -> bool {
-    git_command()
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(dir)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
 }
 
 /// Initializes a git repo with a .gitignore for Nix projects. Call explicitly during setup only.
@@ -92,15 +109,6 @@ fn require_repo(dir: &str) -> Result<()> {
     Ok(())
 }
 
-/// Returns true when HEAD resolves to an existing commit.
-fn has_head_commit(dir: &str) -> bool {
-    git_command()
-        .args(["rev-parse", "--verify", "HEAD"])
-        .current_dir(dir)
-        .output()
-        .is_ok()
-}
-
 /// Full diff vs HEAD, including tracked changes and untracked files as diffs.
 pub fn get_full_diff(dir: &str) -> Result<String> {
     let mut diff = get_tracked_diff(dir, None)?;
@@ -113,21 +121,6 @@ pub fn get_nix_diff(dir: &str) -> Result<String> {
     let mut diff = get_tracked_diff(dir, Some("*.nix"))?;
     append_untracked_diffs(&mut diff, dir, Some("*.nix"))?;
     Ok(diff)
-}
-
-/// Gets the git repository root directory for `dir`, or `dir` if not in a repo.
-/// Used for resolving file paths for the benefit of tools and git operations.
-pub fn repo_root(dir: &str) -> PathBuf {
-    match git_command()
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(dir)
-        .output()
-    {
-        Ok(output) if output.status.success() => {
-            PathBuf::from(String::from_utf8_lossy(&output.stdout).trim().to_string())
-        }
-        _ => PathBuf::from(dir),
-    }
 }
 
 fn is_safe_repo_relative_path(filename: &str) -> bool {
@@ -288,42 +281,10 @@ fn parse_files_from_diff(diff: &str) -> Vec<GitFileStatus> {
     files
 }
 
-/// Gets the SHA of any ref (branch name, tag, or symbolic ref like HEAD).
-pub fn get_ref_sha(dir: &str, ref_name: &str) -> Option<String> {
-    let output = git_command()
-        .args(["rev-parse", ref_name])
-        .current_dir(dir)
-        .output()
-        .ok()?;
-
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
-/// Gets the SHA of the current HEAD commit.
-fn get_head_sha(dir: &str) -> Option<String> {
-    get_ref_sha(dir, "HEAD")
-}
-
-/// Returns the current branch name (None if detached HEAD)
-pub fn current_branch(dir: &str) -> Option<String> {
-    let output = git_command()
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(dir)
-        .output()
-        .ok()?;
-
-    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if branch != "HEAD" {
-        Some(branch)
-    } else {
-        None
-    }
-}
-
 /// Comprehensive git status against HEAD.
 pub fn status(dir: &str) -> Result<GitStatus> {
     require_repo(dir)?;
-    let branch = current_branch(dir);
+    let branch = super::current_branch(dir);
 
     let diff = get_full_diff(dir)?;
     let (additions, deletions) = count_diff_changes(&diff);
@@ -542,22 +503,6 @@ pub fn restore_all(dir: &str) -> Result<()> {
     Ok(())
 }
 
-/// Returns all tags for `hash`.
-pub fn read_tags(dir: &str, hash: &str) -> Vec<String> {
-    let Ok(output) = git_command()
-        .args(["tag", "--points-at", hash])
-        .current_dir(dir)
-        .output()
-    else {
-        return vec![];
-    };
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(str::to_owned)
-        .collect()
-}
-
 /// Git tags (any ref or hash) `target`, `force = true` overwrites.
 pub fn tag_commit(dir: &str, tag: &str, target: &str, force: bool) -> Result<()> {
     let mut args = vec!["tag"];
@@ -629,6 +574,20 @@ pub fn create_evolution_backup(
 
 /// Restore working tree to the content of a specific branch ref.
 /// Replaces the current index with the branch's tree, then checks out the working tree.
+///
+/// NOTE that this would be harder to implement in git2 because:
+/// - git2 does NOT expose “plumbing-level” commands like `read-tree` or
+///   `checkout-index` as direct APIs.
+/// - The closest primitive is `repo.reset(ResetType::Hard)`, which combines
+///   index + working tree updates, but does NOT include untracked file cleanup.
+/// - `git clean -fd` is not implemented in git2 because it is inherently
+///   a filesystem operation driven by ignore rules and user policy, not just
+///   Git object model state.
+///
+/// Therefore a full equivalent would require:
+/// - resolving the ref → commit → tree (via revparse + peel)
+/// - performing a hard reset (tracked files)
+/// - manually walking the filesystem to delete untracked files/dirs
 pub fn restore_from_branch_ref(repo_path: &str, ref_name: &str) -> Result<()> {
     git_command()
         .args(["read-tree", ref_name])
@@ -663,6 +622,8 @@ pub fn delete_backup_branch(repo_path: &str, branch_name: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::git::current_branch;
+
     use super::*;
     use std::fs;
     use std::path::Path;
@@ -689,7 +650,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let repo_dir = temp_dir.path().join("repo");
         init_repo(&repo_dir.to_string_lossy()).unwrap();
-        assert!(is_repo(&repo_dir.to_string_lossy()));
+        assert!(super::is_repo(&repo_dir.to_string_lossy()));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -2,13 +2,16 @@
 
 pub mod changes_from_diff;
 pub mod exec;
+pub mod query;
 
-// Re-export the entire public surface of exec so callers keep using
+// Re-export the entire public surface of exec and query so callers keep using
 // `crate::git::some_fn()` without change.
 #[allow(unused_imports)]
 pub use exec::{
-    cache_status, checkout_files_at_commit, commit_all, commit_diff,
-    create_evolution_backup, current_branch, delete_backup_branch, get_full_diff, get_nix_diff,
-    get_ref_sha, init_repo, intent_add_untracked, is_repo, log, read_tags, restore_all,
-    restore_from_branch_ref, stash, status, status_and_cache, tag_commit, CommitInfo,
+    cache_status, checkout_files_at_commit, commit_all, commit_diff, create_evolution_backup,
+    delete_backup_branch, get_full_diff, get_nix_diff, init_repo, intent_add_untracked, log,
+    restore_all, restore_from_branch_ref, stash, status, status_and_cache, tag_commit, CommitInfo,
 };
+
+#[allow(unused_imports)]
+pub use query::{current_branch, get_ref_sha, is_repo, read_tags};

--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -1,0 +1,385 @@
+/// Git query layer (SAFE)
+///
+/// This module uses git2 exclusively.
+///
+/// Rules:
+/// - NO filesystem modification
+/// - NO index mutation
+/// - NO working tree changes
+/// - ONLY Git object graph inspection
+///
+/// Basically, only things that don't depend on git porcelain output and/or
+/// git CLI semantics.
+use std::path::PathBuf;
+
+/// Gets the git repository root directory for `dir`, or `dir` if not in a repo.
+/// Used for resolving file paths for the benefit of tools and git operations.
+pub fn repo_root(dir: &str) -> PathBuf {
+    match git2::Repository::discover(dir) {
+        Ok(repo) => {
+            // workdir() is the equivalent of "show-toplevel"
+            // but returns None for bare repositories
+            repo.workdir()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| PathBuf::from(dir))
+        }
+        Err(_) => PathBuf::from(dir),
+    }
+}
+
+/// Returns true if `dir` is inside a non-bare Git working tree.
+/// This behaves similarly to:
+///     git rev-parse --is-inside-work-tree
+///
+/// The key point is that a bare repository does not have a working tree.
+pub fn is_repo(dir: &str) -> bool {
+    git2::Repository::discover(dir)
+        .map(|repo| repo.workdir().is_some())
+        .unwrap_or(false)
+}
+
+/// Returns the current branch name (None if detached HEAD or not a repo).
+///
+/// This is equivalent to:
+///     git rev-parse --abbrev-ref HEAD
+pub fn current_branch(dir: &str) -> Option<String> {
+    let repo = git2::Repository::discover(dir).ok()?;
+
+    let head = repo.head().ok()?;
+
+    let name = head.shorthand().ok()?;
+
+    match name {
+        "HEAD" => None,
+        other => Some(other.to_string()),
+    }
+}
+
+/// Resolves a Git reference (branch, tag, HEAD, or full ref name) to its commit SHA.
+///
+/// This is the git2 equivalent of:
+///     git rev-parse <ref_name>
+///
+/// Behavior:
+/// - Returns `Some(sha)` if the reference resolves successfully
+/// - Returns `None` if:
+///   - the directory is not a Git repository
+///   - the reference does not exist
+///   - the reference cannot be resolved to an object
+pub fn get_ref_sha(dir: &str, ref_name: &str) -> Option<String> {
+    let repo = git2::Repository::discover(dir).ok()?;
+
+    let obj = repo.revparse_single(ref_name).ok()?;
+
+    // id is the sha that we want.
+    Some(obj.id().to_string())
+}
+
+/// Gets the SHA of the current HEAD commit.
+pub fn get_head_sha(dir: &str) -> Option<String> {
+    get_ref_sha(dir, "HEAD")
+}
+
+/// Returns true if HEAD can be resolved to a commit object.
+///
+/// This is stricter than "HEAD exists":
+/// it ensures HEAD ultimately points to a commit that can be diffed.
+/// Therefore it fixes a bug in the old version that used GitCommand.
+///
+/// Equivalent intent:
+///     git rev-parse --verify HEAD
+/// but with explicit commit resolution instead of string-level validation.
+pub fn has_head_commit(dir: &str) -> bool {
+    match git2::Repository::discover(dir) {
+        Ok(repo) => repo
+            .head()
+            .ok()
+            .and_then(|h| h.peel_to_commit().ok())
+            .is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Returns all tags pointing at `hash`.
+///
+/// Replaces:
+///   git tag --points-at <hash>
+///
+/// Semantics:
+/// - Returns tag names whose resolved object matches the given commit/object hash
+/// - Includes both lightweight and annotated tags (annotated tags are peeled)
+///
+/// QUERY LAYER (git2, read-only)
+pub fn read_tags(dir: &str, hash: &str) -> Vec<String> {
+    let Ok(repo) = git2::Repository::discover(dir) else {
+        return vec![];
+    };
+
+    let Ok(oid) = git2::Oid::from_str(hash) else {
+        return vec![];
+    };
+
+    let Ok(target_obj) = repo.find_object(oid, None) else {
+        return vec![];
+    };
+
+    let Ok(references) = repo.references() else {
+        return vec![];
+    };
+
+    let mut tags = Vec::new();
+
+    for reference in references.flatten() {
+        let Ok(name) = reference.name() else {
+            continue;
+        };
+
+        if !name.starts_with("refs/tags/") {
+            continue;
+        }
+
+        let Ok(resolved) = reference.peel(git2::ObjectType::Any) else {
+            continue;
+        };
+
+        if resolved.id() == target_obj.id() {
+            if let Ok(name) = reference.shorthand() {
+                tags.push(name.to_string());
+            }
+        }
+    }
+
+    tags
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn repo_with_initial_commit() -> (TempDir, git2::Oid) {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = git2::Repository::init(temp.path()).expect("init repo");
+
+        fs::write(temp.path().join("README.md"), "hello\n").expect("write file");
+
+        let mut index = repo.index().expect("open index");
+        index.add_path(Path::new("README.md")).expect("stage file");
+        index.write().expect("write index");
+
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let sig = git2::Signature::now("nixmac", "nixmac@local").expect("signature");
+
+        let commit_id = repo
+            .commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .expect("create commit");
+
+        (temp, commit_id)
+    }
+
+    #[test]
+    fn repo_root_returns_repo_toplevel_for_nested_path() {
+        let (temp, _) = repo_with_initial_commit();
+        let nested = temp.path().join("a/b/c");
+        fs::create_dir_all(&nested).expect("create nested dir");
+
+        let root = repo_root(&nested.to_string_lossy());
+        let root_canon = root.canonicalize().expect("canonicalize repo root");
+        let expected_canon = temp.path().canonicalize().expect("canonicalize temp path");
+        assert_eq!(root_canon, expected_canon);
+    }
+
+    #[test]
+    fn repo_root_returns_input_when_not_a_repo() {
+        let temp = TempDir::new().expect("create temp dir");
+        let input = temp.path().join("not-a-repo");
+
+        let root = repo_root(&input.to_string_lossy());
+        assert_eq!(root, input);
+    }
+
+    #[test]
+    fn is_repo_detects_nested_worktree_path() {
+        let (temp, _) = repo_with_initial_commit();
+        let nested = temp.path().join("nested");
+        fs::create_dir_all(&nested).expect("create nested dir");
+
+        assert!(is_repo(&nested.to_string_lossy()));
+    }
+
+    #[test]
+    fn is_repo_false_for_non_repo_and_bare_repo() {
+        let temp = TempDir::new().expect("create temp dir");
+        assert!(!is_repo(&temp.path().to_string_lossy()));
+
+        let bare_dir = temp.path().join("bare.git");
+        git2::Repository::init_bare(&bare_dir).expect("init bare repo");
+        assert!(!is_repo(&bare_dir.to_string_lossy()));
+    }
+
+    #[test]
+    fn repo_root_returns_input_for_bare_repo() {
+        let temp = TempDir::new().expect("create temp dir");
+        let bare_dir = temp.path().join("bare.git");
+        git2::Repository::init_bare(&bare_dir).expect("init bare repo");
+
+        assert_eq!(repo_root(&bare_dir.to_string_lossy()), bare_dir);
+    }
+
+    #[test]
+    fn current_branch_some_on_branch_and_none_when_detached() {
+        let (temp, commit_id) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+
+        let branch = current_branch(&path);
+        assert!(
+            branch.is_some(),
+            "expected branch name when HEAD is attached"
+        );
+
+        let repo = git2::Repository::discover(&path).expect("discover repo");
+        repo.set_head_detached(commit_id).expect("detach head");
+
+        assert_eq!(current_branch(&path), None);
+    }
+
+    #[test]
+    fn current_branch_none_for_non_repo() {
+        let temp = TempDir::new().expect("create temp dir");
+        assert_eq!(current_branch(&temp.path().to_string_lossy()), None);
+    }
+
+    #[test]
+    fn get_ref_sha_and_head_sha_resolve_head_commit() {
+        let (temp, commit_id) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+
+        assert_eq!(get_ref_sha(&path, "HEAD"), Some(commit_id.to_string()));
+        assert_eq!(get_head_sha(&path), Some(commit_id.to_string()));
+        assert_eq!(get_ref_sha(&path, "does-not-exist"), None);
+    }
+
+    #[test]
+    fn get_ref_sha_and_head_sha_none_for_non_repo() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().to_string_lossy().to_string();
+
+        assert_eq!(get_ref_sha(&path, "HEAD"), None);
+        assert_eq!(get_head_sha(&path), None);
+    }
+
+    #[test]
+    fn get_ref_sha_resolves_tag_refs() {
+        let (temp, commit_id) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+        let repo = git2::Repository::discover(&path).expect("discover repo");
+
+        let commit = repo.find_commit(commit_id).expect("find commit");
+        repo.tag_lightweight("v2.0.0", commit.as_object(), false)
+            .expect("create lightweight tag");
+
+        assert_eq!(
+            get_ref_sha(&path, "refs/tags/v2.0.0"),
+            Some(commit_id.to_string())
+        );
+        assert_eq!(get_ref_sha(&path, "v2.0.0"), Some(commit_id.to_string()));
+    }
+
+    #[test]
+    fn has_head_commit_reflects_unborn_and_committed_repo() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = git2::Repository::init(temp.path()).expect("init repo");
+        let path = temp.path().to_string_lossy().to_string();
+
+        assert!(!has_head_commit(&path));
+
+        fs::write(temp.path().join("flake.nix"), "{ }\n").expect("write file");
+        let mut index = repo.index().expect("open index");
+        index.add_path(Path::new("flake.nix")).expect("stage file");
+        index.write().expect("write index");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let sig = git2::Signature::now("nixmac", "nixmac@local").expect("signature");
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .expect("create commit");
+
+        assert!(has_head_commit(&path));
+    }
+
+    #[test]
+    fn has_head_commit_false_for_non_repo() {
+        let temp = TempDir::new().expect("create temp dir");
+        assert!(!has_head_commit(&temp.path().to_string_lossy()));
+    }
+
+    #[test]
+    fn read_tags_returns_lightweight_and_annotated_tags_for_commit() {
+        let (temp, commit_id) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+        let repo = git2::Repository::discover(&path).expect("discover repo");
+
+        let commit = repo.find_commit(commit_id).expect("find commit");
+        repo.tag_lightweight("v1.0.0", commit.as_object(), false)
+            .expect("create lightweight tag");
+
+        let obj = repo
+            .find_object(commit_id, None)
+            .expect("find commit object");
+        let sig = git2::Signature::now("nixmac", "nixmac@local").expect("signature");
+        repo.tag("v1.0.1", &obj, &sig, "annotated", false)
+            .expect("create annotated tag");
+
+        let mut tags = read_tags(&path, &commit_id.to_string());
+        tags.sort();
+        assert_eq!(tags, vec!["v1.0.0".to_string(), "v1.0.1".to_string()]);
+
+        assert!(read_tags(&path, "not-a-sha").is_empty());
+    }
+
+    #[test]
+    fn read_tags_empty_when_repo_has_no_tags_or_mismatched_target() {
+        let (temp, first_commit_id) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+        let repo = git2::Repository::discover(&path).expect("discover repo");
+
+        assert!(read_tags(&path, &first_commit_id.to_string()).is_empty());
+
+        fs::write(temp.path().join("README.md"), "hello again\n").expect("write file");
+        let mut index = repo.index().expect("open index");
+        index.add_path(Path::new("README.md")).expect("stage file");
+        index.write().expect("write index");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let sig = git2::Signature::now("nixmac", "nixmac@local").expect("signature");
+        let parent = repo
+            .find_commit(first_commit_id)
+            .expect("find parent commit");
+        let second_commit_id = repo
+            .commit(Some("HEAD"), &sig, &sig, "second", &tree, &[&parent])
+            .expect("create second commit");
+
+        let second_commit = repo
+            .find_commit(second_commit_id)
+            .expect("find second commit");
+        repo.tag_lightweight("v9.9.9", second_commit.as_object(), false)
+            .expect("create lightweight tag");
+
+        let tags_for_first = read_tags(&path, &first_commit_id.to_string());
+        assert!(
+            tags_for_first.is_empty(),
+            "first commit should not include tags pointing at second commit"
+        );
+    }
+
+    #[test]
+    fn read_tags_empty_when_hash_oid_is_valid_but_object_missing() {
+        let (temp, _) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+
+        let missing_oid = "0000000000000000000000000000000000000001";
+        assert!(read_tags(&path, missing_oid).is_empty());
+    }
+}

--- a/apps/native/src-tauri/src/storage/store.rs
+++ b/apps/native/src-tauri/src/storage/store.rs
@@ -3,7 +3,7 @@
 //! Settings are stored in a JSON file managed by tauri-plugin-store.
 //! This provides a simple key-value interface for preferences.
 
-use crate::git::exec::repo_root;
+use crate::git::query::repo_root;
 use crate::shared_types;
 use crate::storage::credential_store::{
     get_with_lazy_migration, set_with_cleanup, CredentialStoreError, KeychainStore,


### PR DESCRIPTION
## Summary

Introduces a git2 dependency and moves the most-clearly-safe git utilities from exec.rs into a new file query.rs with clear comments at the top of each file as to what should go where and why. I also introduced profiling support and docs.

The reason is this profile, which demonstrates that of the things we can actually control (without major architectural changes) during evolution, the git operations are pretty much the most expensive:

<img width="816" height="155" alt="before" src="https://github.com/user-attachments/assets/c889d9ea-c172-4ba4-aee4-0f127f22ea09" />

Afterwards it looks more like:

<img width="1049" height="125" alt="after" src="https://github.com/user-attachments/assets/cd61ece3-5b89-47c4-acad-7619f72368b4" />

where the individual functions migrated to git2 show up elsewhere but generally are more like:

<img width="655" height="136" alt="Screenshot 2026-05-29 at 4 44 04 PM" src="https://github.com/user-attachments/assets/a4b661ed-165c-4949-a072-63fbff5145e3" />

There are a couple of reasons why it's not immediately clear that it's possible to just blanket-migrate everything in exec.rs to git2, and I won't go into all that here (although I added some clues in comments in the code)...but I will continue looking at opportunities.

## Test Plan

Manual testing, profiling, added a bunch of new unit tests for the migrated functions.

## Docs

- [x] Docs updated
- [ ] No docs update needed
