### PR TITLE
refactor: nix-files feedback reusing git status, eliminate resulting dead code

### DIFF
--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -27,7 +27,7 @@ pub(crate) const IGNORED_DIRS: [&str; 2] = [".git", "result"];
 use crate::evolve::utils::{escape_user_query, format_duration_secs, short_hash};
 use crate::git::query::repo_root;
 // Re-export public API
-use crate::shared_types::EvolutionState;
+use crate::shared_types::{Evolution, EvolutionState, FileEdit};
 use crate::system::nix;
 use anyhow::{anyhow, Result};
 use chrono::Utc;
@@ -39,10 +39,9 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Runtime};
 use tokio::time::sleep;
 use tools::{create_tools, execute_tool, is_editing_tool, ToolResult};
-pub use crate::shared_types::Evolution;
 pub use types::{EvolutionProgress, EvolutionRunError};
 
 use crate::{
@@ -56,8 +55,6 @@ pub(crate) use chat_memory::session_chat_memory_store;
 use config_dir_context::format_config_dir_context;
 use messages::Message;
 use providers::{AiProvider, CliProvider, OllamaProvider, OpenAIProvider, ProviderError};
-
-use crate::shared_types::FileEdit;
 
 /// Strategy for retaining evolution messages in the conversation history for provider context.
 /// This is used to balance keeping important context visible to the model with limiting token usage
@@ -101,7 +98,6 @@ struct EvolutionMessage {
 fn normalize_max_output_tokens(value: usize) -> u32 {
     value.max(1).min(u32::MAX as usize) as u32
 }
-
 
 /// Return short hex prefix for correlation of error messages without risking sensitive content exposure.
 
@@ -595,23 +591,8 @@ pub async fn generate_evolution<R: Runtime>(
     info!("📝 Prompt: {}", prompt);
 
     let store_model = store::get_evolve_model(app).ok().flatten();
-
-    // Read configurable limits from the repo-scoped slice. Falls back to defaults
-    // when the slice isn't managed yet (e.g. during onboarding before config_dir
-    // is set).
-    let limits = app
-        .try_state::<crate::state::slice::Slice<config::EvolutionLimits>>()
-        .map(|slice| slice.read_sync().clone())
-        .unwrap_or_else(|| {
-            warn!("EvolutionLimits slice is not managed; using defaults");
-            config::EvolutionLimits::default()
-        });
-    let config::EvolutionLimits {
-        max_iterations: legacy_max_iterations,
-        max_token_budget,
-        max_build_attempts,
-        max_output_tokens,
-    } = limits;
+    let max_output_tokens =
+        store::get_max_output_tokens(app).unwrap_or(store::DEFAULT_MAX_OUTPUT_TOKENS);
     let max_output_tokens_for_request = normalize_max_output_tokens(max_output_tokens);
 
     // Select provider implementation
@@ -706,18 +687,27 @@ pub async fn generate_evolution<R: Runtime>(
         EvolveEvent::info(start_time, None, &format!("Target host: {}", host_attr)),
     );
 
+    // Read configurable limits from store (hot-reloaded on every run).
+    let config::EvolutionLimits {
+        max_build_attempts, ..
+    } = config::EvolutionLimits::load(app)
+        .inspect_err(|e| warn!("EvolutionLimits::load failed ({e}); using defaults"))
+        .unwrap_or_default();
+    let legacy_max_iterations =
+        store::get_max_iterations(app).unwrap_or(store::DEFAULT_MAX_ITERATIONS);
+    let max_token_budget =
+        store::get_max_token_budget(app).unwrap_or(store::DEFAULT_MAX_TOKEN_BUDGET);
     let max_tokens_before_edit = std::cmp::max(
         1,
         (max_token_budget * MAX_TOKEN_BUDGET_BEFORE_EDIT_PERCENT) / 100,
     );
     info!(
-        "Limits: max_token_budget={}, max_tokens_before_edit={} ({}%), max_build_attempts={}, legacy_max_iterations={}, max_output_tokens={}",
+        "Limits: max_token_budget={}, max_tokens_before_edit={} ({}%), max_build_attempts={}, legacy_max_iterations={}",
         max_token_budget,
         max_tokens_before_edit,
         MAX_TOKEN_BUDGET_BEFORE_EDIT_PERCENT,
         max_build_attempts,
         legacy_max_iterations,
-        max_output_tokens,
     );
 
     let tools = create_tools(banned_tools);
@@ -1719,7 +1709,7 @@ fn process_tool_result(
             );
             evolution.edits.push(FileEdit {
                 path: edit.path.clone(),
-                // Preserve semantic edit events in the existing edit telemetry list.
+                // Preserve semantic edit events in the legacy edits list.
                 search: String::new(),
                 replace: format!("semantic:{:?}", edit.action),
             });

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -293,10 +293,11 @@ fn get_nix_diff(dir: &str) -> Result<String> {
         .collect::<String>())
 }
 
-/// Gather a diff-like summary containing only .nix file changes (including untracked).
+/// Gather a git diff containing only .nix file changes (including untracked).
 ///
-/// Note: this is assembled from the structured git status change list; it is not a raw `git diff` patch.
-/// It will be empty when there are no changes, or if the repo hasn't been initialized.
+/// Note: this depends on git status/diff; it will be empty when there are no
+/// changes, or if the repo hasn't been initialized.
+pub fn gather_changed_nix_files_diff(app: &AppHandle) -> Option<String> {
     let config_dir = store::get_config_dir(app).ok()?;
     let diff = get_nix_diff(&config_dir).ok()?;
     if diff.trim().is_empty() {

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -4,10 +4,11 @@
 //! from the frontend.
 //! All collection respects the ShareOptions flags provided by the user.
 
+use crate::git::status;
 use crate::shared_types::Evolution;
 use crate::storage::store;
 use crate::system::{nix, secret_scanner};
-use crate::{git, types};
+use crate::types;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use log::{debug, warn};
@@ -275,17 +276,35 @@ pub fn gather_ai_provider_model_info(
     })
 }
 
-/// Gather a git diff containing only .nix file changes (including untracked).
+/// Gets a diff containing only .nix files (including untracked .nix files).
+fn get_nix_diff(dir: &str) -> Result<String> {
+    let status = status(dir)?;
+
+    Ok(status
+        .changes
+        .iter()
+        .filter(|c| c.filename.ends_with(".nix"))
+        .map(|c| {
+            format!(
+                "file: {}\nlines: {}\ndiff:\n{}\n\n",
+                c.filename, c.line_count, c.diff
+            )
+        })
+        .collect::<String>())
+}
+
+/// Gather a diff-like summary containing only .nix file changes (including untracked).
 ///
-/// Note: this depends on git status/diff; it will be empty when there are no
-/// changes, or if the repo hasn't been initialized.
-pub fn gather_changed_nix_files_diff(app: &AppHandle) -> Option<String> {
+/// Note: this is assembled from the structured git status change list; it is not a raw `git diff` patch.
+/// It will be empty when there are no changes, or if the repo hasn't been initialized.
     let config_dir = store::get_config_dir(app).ok()?;
-    let diff = git::get_nix_diff(&config_dir).ok()?;
+    let diff = get_nix_diff(&config_dir).ok()?;
     if diff.trim().is_empty() {
         None
     } else {
-        // Will be redacted in gather_metadata
+        // The status diff is already somewhat scrubbed for sensitive files by
+        // the changelist system, but for this purpose the diff will be further
+        // redacted by gather_metadata
         Some(diff)
     }
 }
@@ -742,9 +761,17 @@ pub fn gather_metadata(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::{redact_metadata_with_scanner, types};
-    use crate::{shared_types::Evolution, system::secret_scanner::SecretScanner};
+    use crate::{
+        feedback::get_nix_diff,
+        git::{commit_all, init::init_repo},
+        shared_types::Evolution,
+        system::secret_scanner::SecretScanner,
+    };
     use serde_json::json;
+    use tempfile::TempDir;
 
     fn test_scanner() -> SecretScanner {
         let toml = r#"
@@ -924,5 +951,70 @@ regex = "token=([A-Za-z0-9]+)"
         std::env::set_var("VITE_SERVER_URL", "");
         std::env::set_var("SUBMITTED_FEEDBACK_DSN", "");
         assert!(super::get_feedback_url().is_err());
+    }
+
+    #[test]
+    fn test_get_nix_diff_includes_tracked_nix() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        fs::write(repo_dir.join("flake.nix"), "{ }").unwrap();
+        commit_all(&repo_dir_str, "initial").unwrap();
+
+        // Now make a change to the tracked flake.nix file
+        fs::write(repo_dir.join("flake.nix"), "{ changed = true; }").unwrap();
+
+        let diff = get_nix_diff(&repo_dir_str).unwrap();
+        assert!(
+            diff.contains("flake.nix"),
+            "tracked .nix file should appear in diff"
+        );
+    }
+
+    #[test]
+    fn test_get_nix_diff_excludes_non_nix_untracked() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        fs::write(repo_dir.join("flake.nix"), "{ }").unwrap();
+        commit_all(&repo_dir_str, "initial").unwrap();
+
+        // Make some changes.
+        fs::write(repo_dir.join("config.nix"), "{ }").unwrap();
+        fs::write(repo_dir.join("readme.txt"), "hello").unwrap();
+
+        let diff = get_nix_diff(&repo_dir_str).unwrap();
+
+        assert!(
+            diff.contains("config.nix"),
+            ".nix untracked file should appear"
+        );
+        assert!(
+            !diff.contains("readme.txt"),
+            "non-.nix file should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_get_nix_diff_excludes_gitignored_nix_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        fs::write(repo_dir.join(".gitignore"), "secret.nix\n").unwrap();
+        fs::write(repo_dir.join("flake.nix"), "{ }").unwrap();
+        commit_all(&repo_dir_str, "initial").unwrap();
+        fs::write(repo_dir.join("secret.nix"), "{ password = \"123\"; }").unwrap();
+
+        let diff = get_nix_diff(&repo_dir_str).unwrap();
+        assert!(
+            !diff.contains("secret.nix"),
+            "gitignored .nix file must not appear in diff"
+        );
     }
 }

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -81,13 +81,6 @@ fn git_command() -> GitCommand {
     GitCommand(cmd)
 }
 
-/// Gets a diff containing only .nix files (including untracked .nix files).
-pub fn get_nix_diff(dir: &str) -> Result<String> {
-    let mut diff = get_tracked_diff(dir, Some("*.nix"))?;
-    append_untracked_diffs(&mut diff, dir, Some("*.nix"))?;
-    Ok(diff)
-}
-
 fn is_safe_repo_relative_path(filename: &str) -> bool {
     let path = Path::new(filename);
     !path.is_absolute()
@@ -111,74 +104,6 @@ pub fn file_diff_contents(dir: &str, filename: &str) -> (String, String) {
         String::new()
     };
     (original, modified)
-}
-
-/// Returns a diff of tracked changes, optionally restricted to a path glob.
-/// Falls back to staged+unstaged when HEAD is unborn (fresh repo with no commits).
-fn get_tracked_diff(dir: &str, path_filter: Option<&str>) -> Result<String> {
-    let extra: Vec<&str> = match path_filter {
-        Some(f) => vec!["--", f],
-        None => vec![],
-    };
-
-    if has_head_commit(dir) {
-        let mut args = vec!["diff", "HEAD"];
-        args.extend(&extra);
-        let output = git_command().args(&args).current_dir(dir).output()?;
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    } else {
-        let mut staged_args = vec!["diff", "--cached"];
-        staged_args.extend(&extra);
-        let mut unstaged_args = vec!["diff"];
-        unstaged_args.extend(&extra);
-
-        let staged = git_command().args(&staged_args).current_dir(dir).output()?;
-        let unstaged = git_command()
-            .args(&unstaged_args)
-            .current_dir(dir)
-            .output()?;
-
-        let mut result = String::from_utf8_lossy(&staged.stdout).to_string();
-        result.push_str(&String::from_utf8_lossy(&unstaged.stdout));
-        Ok(result)
-    }
-}
-
-/// Appends untracked files to `diff` as synthetic new-file diff blocks.
-/// `path_filter` restricts to a glob (e.g. `Some("*.nix")`); `None` includes all files.
-fn append_untracked_diffs(diff: &mut String, dir: &str, path_filter: Option<&str>) -> Result<()> {
-    // --exclude-standard omits gitignored files — hiding them from git status and summarize.
-    let mut args = vec!["ls-files", "--others", "--exclude-standard"];
-    if let Some(filter) = path_filter {
-        args.extend(["--", filter]);
-    }
-
-    let repo_root_dir = repo_root(dir);
-    let untracked_output = git_command()
-        .args(&args)
-        .current_dir(&repo_root_dir)
-        .output()?;
-    let untracked_files = String::from_utf8_lossy(&untracked_output.stdout);
-
-    for file in untracked_files.lines() {
-        if file.is_empty() {
-            continue;
-        }
-        let file_path = repo_root_dir.join(file);
-        if let Ok(contents) = std::fs::read_to_string(&file_path) {
-            diff.push_str(&format!("\ndiff --git a/{} b/{}\n", file, file));
-            diff.push_str("new file mode 100644\n");
-            diff.push_str("--- /dev/null\n");
-            diff.push_str(&format!("+++ b/{}\n", file));
-            let line_count = contents.lines().count();
-            diff.push_str(&format!("@@ -0,0 +1,{} @@\n", line_count));
-            for line in contents.lines() {
-                diff.push_str(&format!("+{}\n", line));
-            }
-        }
-    }
-
-    Ok(())
 }
 
 /// Registers all untracked files as intent-to-add in the git index.
@@ -527,48 +452,6 @@ mod tests {
 
         let (_, modified) = file_diff_contents(&repo_dir_str, "flake.nix");
         assert_eq!(modified, "{ inputs = {}; }");
-    }
-
-    #[test]
-    fn test_get_nix_diff_excludes_non_nix_untracked() {
-        let temp_dir = TempDir::new().unwrap();
-        let repo_dir = temp_dir.path().join("repo");
-        let repo_dir_str = repo_dir.to_string_lossy().to_string();
-        init_repo(&repo_dir_str).unwrap();
-
-        fs::write(repo_dir.join("flake.nix"), "{ }").unwrap();
-        commit_all(&repo_dir_str, "initial").unwrap();
-        fs::write(repo_dir.join("config.nix"), "{ }").unwrap();
-        fs::write(repo_dir.join("readme.txt"), "hello").unwrap();
-
-        let diff = get_nix_diff(&repo_dir_str).unwrap();
-        assert!(
-            diff.contains("config.nix"),
-            ".nix untracked file should appear"
-        );
-        assert!(
-            !diff.contains("readme.txt"),
-            "non-.nix file should be excluded"
-        );
-    }
-
-    #[test]
-    fn test_get_nix_diff_excludes_gitignored_nix_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let repo_dir = temp_dir.path().join("repo");
-        let repo_dir_str = repo_dir.to_string_lossy().to_string();
-        init_repo(&repo_dir_str).unwrap();
-
-        fs::write(repo_dir.join(".gitignore"), "secret.nix\n").unwrap();
-        fs::write(repo_dir.join("flake.nix"), "{ }").unwrap();
-        commit_all(&repo_dir_str, "initial").unwrap();
-        fs::write(repo_dir.join("secret.nix"), "{ password = \"123\"; }").unwrap();
-
-        let diff = get_nix_diff(&repo_dir_str).unwrap();
-        assert!(
-            !diff.contains("secret.nix"),
-            "gitignored .nix file must not appear in diff"
-        );
     }
 
     #[test]

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -10,8 +10,7 @@ pub mod query;
 #[allow(unused_imports)]
 pub use exec::{
     checkout_files_at_commit, commit_all, create_evolution_backup, delete_backup_branch,
-    get_nix_diff, intent_add_untracked, log, restore_all, restore_from_branch_ref, stash,
-    tag_commit, CommitInfo,
+    intent_add_untracked, log, restore_all, restore_from_branch_ref, stash, tag_commit, CommitInfo,
 };
 
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

Rewrite the feedback gathering for nix file diffs to reuse the revamped git::query::status, then get rid of all the code that deads, thereby avoiding having to port it to git2.

<!-- What does this PR do? Why? -->

## Test Plan

Updated and added unit tests.

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->