### PR TITLE
refactor: port the git log function from CLI to git2

### DIFF
--- a/apps/native/src-tauri/src/commands/settings_io.rs
+++ b/apps/native/src-tauri/src/commands/settings_io.rs
@@ -100,7 +100,6 @@ pub async fn settings_export(
     app: AppHandle,
     include_secrets: bool,
 ) -> Result<Option<ExportResult>, String> {
-
     let (tx, rx) = tokio::sync::oneshot::channel();
     app.dialog()
         .file()
@@ -139,7 +138,6 @@ pub async fn settings_export(
 /// cancelled the dialog.
 #[tauri::command]
 pub async fn settings_import(app: AppHandle) -> Result<Option<ImportResult>, String> {
-
     let Some(file_path) = app
         .dialog()
         .file()

--- a/apps/native/src-tauri/src/evolve/providers/ollama.rs
+++ b/apps/native/src-tauri/src/evolve/providers/ollama.rs
@@ -16,7 +16,7 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
-    pub fn new(base_url: String, model: String) -> Self {
+    pub fn new(base_url: String, model: String, max_output_tokens: u32) -> Self {
         let record_chat_logs =
             crate::state::completion_log::init_recording("evolve_provider_chat", "evolve provider");
         Self {

--- a/apps/native/src-tauri/src/evolve/providers/ollama.rs
+++ b/apps/native/src-tauri/src/evolve/providers/ollama.rs
@@ -16,7 +16,7 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
-    pub fn new(base_url: String, model: String, max_output_tokens: u32) -> Self {
+    pub fn new(base_url: String, model: String) -> Self {
         let record_chat_logs =
             crate::state::completion_log::init_recording("evolve_provider_chat", "evolve provider");
         Self {

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -26,11 +26,6 @@ impl GitCommand {
         self
     }
 
-    fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
-        self.0.arg(arg);
-        self
-    }
-
     fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
         self.0.current_dir(dir);
         self
@@ -148,49 +143,6 @@ pub fn intent_add_untracked(dir: &str) -> Result<()> {
 pub struct CommitInfo {
     pub hash: String,
     pub tree_hash: String,
-}
-
-/// Returns commits as Row Type (id = 0), from `start_hash` for `limit`(None for all)
-pub fn log(
-    dir: &str,
-    start_hash: &str,
-    limit: Option<usize>,
-) -> Result<Vec<crate::sqlite_types::Commit>> {
-    let mut cmd = git_command();
-    cmd.arg("log").arg("--format=%H%n%T%n%at%n%s");
-    if let Some(n) = limit {
-        cmd.arg("-n").arg(n.to_string());
-    }
-    cmd.arg(start_hash);
-    let output = cmd.current_dir(dir).output()?;
-
-    let text = String::from_utf8_lossy(&output.stdout);
-    let mut commits = Vec::new();
-    let mut lines = text.lines();
-
-    loop {
-        let hash = match lines.next() {
-            Some(h) if !h.is_empty() => h.to_string(),
-            _ => break,
-        };
-        let tree_hash = lines.next().unwrap_or("").to_string();
-        let timestamp: i64 = lines.next().unwrap_or("0").trim().parse().unwrap_or(0);
-        let subject = lines.next().unwrap_or("").to_string();
-
-        commits.push(crate::sqlite_types::Commit {
-            id: 0,
-            hash,
-            tree_hash,
-            message: if subject.is_empty() {
-                None
-            } else {
-                Some(subject)
-            },
-            created_at: timestamp,
-        });
-    }
-
-    Ok(commits)
 }
 
 /// Stages all and commits with msg, returns hash and tree hash.

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -10,7 +10,7 @@ pub mod query;
 #[allow(unused_imports)]
 pub use exec::{
     checkout_files_at_commit, commit_all, create_evolution_backup, delete_backup_branch,
-    intent_add_untracked, log, restore_all, restore_from_branch_ref, stash, tag_commit, CommitInfo,
+    intent_add_untracked, restore_all, restore_from_branch_ref, stash, tag_commit, CommitInfo,
 };
 
 #[allow(unused_imports)]

--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -192,6 +192,39 @@ pub fn read_tags(dir: &str, hash: &str) -> Vec<String> {
     tags
 }
 
+/// Returns commits as Row Type (id = 0), from `start_hash` for `limit` (None for all).
+///
+/// Equivalent CLI:
+///   git log --format=%H%n%T%n%at%n%s [-n <limit>] <start_hash>
+pub fn log(
+    dir: &str,
+    start_hash: &str,
+    limit: Option<usize>,
+) -> Result<Vec<crate::sqlite_types::Commit>> {
+    let repo = Repository::discover(dir)?;
+    let commit = repo.revparse_single(start_hash)?.peel_to_commit()?;
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.set_sorting(git2::Sort::TIME)?;
+    revwalk.push(commit.id())?;
+
+    let mut commits = Vec::new();
+    for oid in revwalk.take(limit.unwrap_or(usize::MAX)) {
+        let commit = repo.find_commit(oid?)?;
+        let subject = commit.summary().unwrap_or_default().unwrap_or_default();
+
+        commits.push(crate::sqlite_types::Commit {
+            id: 0,
+            hash: commit.id().to_string(),
+            tree_hash: commit.tree_id().to_string(),
+            message: (!subject.is_empty()).then(|| subject.to_string()),
+            created_at: commit.time().seconds(),
+        });
+    }
+
+    Ok(commits)
+}
+
 /// Gets the current git status of the repo including
 /// the structured list of changes for summarization and the full diff string for clients that need it.
 pub fn status(dir: &str) -> Result<GitStatus> {
@@ -473,6 +506,34 @@ mod tests {
         (temp, commit_id)
     }
 
+    fn commit_readme(
+        repo: &git2::Repository,
+        repo_path: &Path,
+        message: &str,
+        timestamp: i64,
+        parent: Option<git2::Oid>,
+    ) -> git2::Oid {
+        fs::write(repo_path.join("README.md"), format!("{message}\n")).expect("write file");
+
+        let mut index = repo.index().expect("open index");
+        index.add_path(Path::new("README.md")).expect("stage file");
+        index.write().expect("write index");
+
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let time = git2::Time::new(timestamp, 0);
+        let sig = git2::Signature::new("nixmac", "nixmac@local", &time).expect("signature");
+
+        if let Some(parent_id) = parent {
+            let parent_commit = repo.find_commit(parent_id).expect("find parent");
+            repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent_commit])
+                .expect("create commit")
+        } else {
+            repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[])
+                .expect("create commit")
+        }
+    }
+
     #[test]
     fn repo_root_returns_repo_toplevel_for_nested_path() {
         let (temp, _) = repo_with_initial_commit();
@@ -672,6 +733,32 @@ mod tests {
 
         let missing_oid = "0000000000000000000000000000000000000001";
         assert!(read_tags(&path, missing_oid).is_empty());
+    }
+
+    #[test]
+    fn log_returns_commits_from_start_hash_with_limit() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = git2::Repository::init(temp.path()).expect("init repo");
+        let path = temp.path().to_string_lossy().to_string();
+
+        let first_id = commit_readme(&repo, temp.path(), "initial", 100, None);
+        let second_id = commit_readme(&repo, temp.path(), "second", 200, Some(first_id));
+        let third_id = commit_readme(&repo, temp.path(), "third", 300, Some(second_id));
+
+        let commits = log(&path, &third_id.to_string(), Some(2)).expect("read log");
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].hash, third_id.to_string());
+        assert_eq!(commits[0].message, Some("third".to_string()));
+        assert_eq!(commits[0].created_at, 300);
+        assert_eq!(
+            commits[0].tree_hash,
+            repo.find_commit(third_id).unwrap().tree_id().to_string()
+        );
+
+        assert_eq!(commits[1].hash, second_id.to_string());
+        assert_eq!(commits[1].message, Some("second".to_string()));
+        assert_eq!(commits[1].created_at, 200);
     }
 
     #[test]

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -11,7 +11,7 @@ pub async fn get_history<R: Runtime>(
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let db_path = crate::db::get_db_path(app)?;
 
-    let git_commits = crate::git::log(&config_dir, "HEAD", None)?;
+    let git_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
 
     let build_state = crate::state::build_state::get(app).unwrap_or_default();
     let last_built_sha = if build_state.unknown_build() {

--- a/apps/native/src-tauri/src/summarize/pipelines/history.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/history.rs
@@ -13,7 +13,7 @@ pub async fn from_commit_times_number<R: Runtime>(
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let db_path = crate::db::get_db_path(app)?;
 
-    let all_commits = crate::git::log(&config_dir, "HEAD", None)?;
+    let all_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
     let start = match all_commits.iter().position(|c| c.hash == commit_hash) {
         Some(i) => i,
         None => return Ok(()),


### PR DESCRIPTION
## Summary

Moved the `log` function for git from the CLI subprocess to modern git2 native rust code.

It also seems like there are a bunch of rustfmt errors on the `develop` branch right now that got auto-fixed.

<!-- What does this PR do? Why? -->

## Test Plan

New unit testing for this.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->