### PR TITLE
refactor: update file_diff_contents to use git2 instead of CLI, make path helper more robust

### DIFF
--- a/apps/native/src-tauri/src/commands/git.rs
+++ b/apps/native/src-tauri/src/commands/git.rs
@@ -14,7 +14,7 @@ pub async fn git_file_diff_contents(
     Ok(filenames
         .into_iter()
         .map(|f| {
-            let (original, modified) = git::exec::file_diff_contents(&dir, &f);
+            let (original, modified) = git::query::file_diff_contents(&dir, &f);
             (f, shared_types::FileDiffContents { original, modified })
         })
         .collect())

--- a/apps/native/src-tauri/src/evolve/providers/ollama.rs
+++ b/apps/native/src-tauri/src/evolve/providers/ollama.rs
@@ -16,7 +16,7 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
-    pub fn new(base_url: String, model: String) -> Self {
+    pub fn new(base_url: String, model: String, max_output_tokens: u32) -> Self {
         let record_chat_logs =
             crate::state::completion_log::init_recording("evolve_provider_chat", "evolve provider");
         Self {

--- a/apps/native/src-tauri/src/evolve/providers/ollama.rs
+++ b/apps/native/src-tauri/src/evolve/providers/ollama.rs
@@ -16,7 +16,7 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
-    pub fn new(base_url: String, model: String, max_output_tokens: u32) -> Self {
+    pub fn new(base_url: String, model: String) -> Self {
         let record_chat_logs =
             crate::state::completion_log::init_recording("evolve_provider_chat", "evolve provider");
         Self {

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -10,7 +10,7 @@
 use crate::git::query::{get_head_sha, has_head_commit, repo_root};
 use anyhow::{Context, Result};
 use std::ffi::OsStr;
-use std::path::{Component, Path};
+use std::path::Path;
 use std::process::{Command, Output};
 
 /// Wraps git commands, errs with Stderr on exit with non-zero status
@@ -74,31 +74,6 @@ fn git_command() -> GitCommand {
         "core.hooksPath=/dev/null",
     ]);
     GitCommand(cmd)
-}
-
-fn is_safe_repo_relative_path(filename: &str) -> bool {
-    let path = Path::new(filename);
-    !path.is_absolute()
-        && path
-            .components()
-            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
-}
-
-/// Returns (original, modified) file content for a single file: HEAD content and working-tree content.
-/// Returns empty strings for new files (no HEAD) or deleted files (not on disk).
-pub fn file_diff_contents(dir: &str, filename: &str) -> (String, String) {
-    let original = git_command()
-        .args(["show", &format!("HEAD:{filename}")])
-        .current_dir(dir)
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default();
-    let modified = if is_safe_repo_relative_path(filename) {
-        std::fs::read_to_string(repo_root(dir).join(filename)).unwrap_or_default()
-    } else {
-        String::new()
-    };
-    (original, modified)
 }
 
 /// Registers all untracked files as intent-to-add in the git index.
@@ -376,34 +351,6 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
         String::from_utf8_lossy(&output.stdout).to_string()
-    }
-
-    #[test]
-    fn test_file_diff_contents_rejects_parent_traversal() {
-        let temp_dir = TempDir::new().unwrap();
-        let outside_file = temp_dir.path().join("outside.txt");
-        fs::write(&outside_file, "outside").unwrap();
-
-        let repo_dir = temp_dir.path().join("repo");
-        let repo_dir_str = repo_dir.to_string_lossy().to_string();
-        init_repo(&repo_dir_str).unwrap();
-
-        let (original, modified) = file_diff_contents(&repo_dir_str, "../outside.txt");
-        assert!(original.is_empty());
-        assert!(modified.is_empty());
-    }
-
-    #[test]
-    fn test_file_diff_contents_reads_safe_relative_path() {
-        let temp_dir = TempDir::new().unwrap();
-        let repo_dir = temp_dir.path().join("repo");
-        let repo_dir_str = repo_dir.to_string_lossy().to_string();
-        init_repo(&repo_dir_str).unwrap();
-
-        fs::write(repo_dir.join("flake.nix"), "{ inputs = {}; }").unwrap();
-
-        let (_, modified) = file_diff_contents(&repo_dir_str, "flake.nix");
-        assert_eq!(modified, "{ inputs = {}; }");
     }
 
     #[test]

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -4,6 +4,7 @@ pub mod changes_from_diff;
 pub mod exec;
 pub mod init;
 pub mod query;
+mod repo_files;
 
 // Re-export the entire public surface of exec and query so callers keep using
 // `crate::git::some_fn()` without change.

--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use git2::{DiffOptions, Oid, Repository};
-use std::path::PathBuf;
 use tauri::AppHandle;
 
 use crate::{
@@ -476,6 +477,25 @@ fn run_diff_engine(diff: git2::Diff) -> Result<Vec<FileDiff>> {
     Ok(result)
 }
 
+/// Returns (original, modified) file content for a single file: HEAD content and working-tree content.
+/// Returns empty strings for new files (no HEAD) or deleted files (not on disk).
+pub fn file_diff_contents(dir: &str, filename: &str) -> (String, String) {
+    // Make sure that the path cannot escape the repository, even with weird path components like ".." or symlinks.
+    // If it does, we fail closed and return empty content to avoid potential security issues.
+    let Some(path) = super::repo_files::normalize_repo_relative_path_lexically(filename) else {
+        return (String::new(), String::new());
+    };
+
+    let Ok(repo) = Repository::discover(dir) else {
+        return (String::new(), String::new());
+    };
+
+    (
+        super::repo_files::head_file_contents(&repo, &path),
+        super::repo_files::workdir_file_contents(&repo, &path),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use crate::git::init::init_repo;
@@ -861,5 +881,50 @@ mod tests {
         assert_eq!(map_change_type(git2::Delta::Copied), ChangeType::Renamed);
         // Other types should default to Edited
         assert_eq!(map_change_type(git2::Delta::Unmodified), ChangeType::Edited);
+    }
+
+    #[test]
+    fn test_file_diff_contents_rejects_parent_traversal() {
+        let temp_dir = TempDir::new().unwrap();
+        let outside_file = temp_dir.path().join("outside.txt");
+        fs::write(&outside_file, "outside").unwrap();
+
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        let (original, modified) = file_diff_contents(&repo_dir_str, "../outside.txt");
+        assert!(original.is_empty());
+        assert!(modified.is_empty());
+    }
+
+    #[test]
+    fn test_file_diff_contents_reads_safe_relative_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        fs::write(repo_dir.join("flake.nix"), "{ inputs = {}; }").unwrap();
+
+        let (_, modified) = file_diff_contents(&repo_dir_str, "flake.nix");
+        assert_eq!(modified, "{ inputs = {}; }");
+    }
+
+    #[test]
+    fn test_file_diff_contents_reads_head_and_worktree_with_git2() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        fs::write(repo_dir.join("flake.nix"), "{ }\n").unwrap();
+        crate::git::commit_all(&repo_dir_str, "initial").unwrap();
+        fs::write(repo_dir.join("flake.nix"), "{ inputs = {}; }\n").unwrap();
+
+        let (original, modified) = file_diff_contents(&repo_dir_str, "./flake.nix");
+
+        assert_eq!(original, "{ }\n");
+        assert_eq!(modified, "{ inputs = {}; }\n");
     }
 }

--- a/apps/native/src-tauri/src/git/repo_files.rs
+++ b/apps/native/src-tauri/src/git/repo_files.rs
@@ -1,0 +1,192 @@
+use std::path::{Component, Path, PathBuf};
+
+use git2::Repository;
+
+/// Normalizes a repository-relative file path, ensuring it is not absolute and does not escape the repository.
+/// NOTE that it checks the path/string components only, not the actual filesystem under a repo.
+pub fn normalize_repo_relative_path_lexically(filename: &str) -> Option<PathBuf> {
+    let path = Path::new(filename);
+    if path.is_absolute() {
+        return None;
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => normalized.push(segment),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::Prefix(_) | Component::RootDir => return None,
+        }
+    }
+
+    Some(normalized)
+}
+
+/// Reads the contents of a file at the given path from the HEAD commit of the repository.
+/// Returns an empty string if the file does not exist in HEAD or if there is no HEAD commit.
+pub fn head_file_contents(repo: &Repository, path: &Path) -> String {
+    repo.head()
+        .ok()
+        .and_then(|head| head.peel_to_commit().ok())
+        .and_then(|commit| commit.tree().ok())
+        .and_then(|tree| tree.get_path(path).ok().map(|entry| entry.id()))
+        .and_then(|id| repo.find_blob(id).ok())
+        .map(|blob| String::from_utf8_lossy(blob.content()).into_owned())
+        .unwrap_or_default()
+}
+
+/// Reads the contents of a file at the given path from the working directory of the repository.
+/// Returns an empty string if the file does not exist on disk.
+pub fn workdir_file_contents(repo: &Repository, path: &Path) -> String {
+    let Some(workdir) = repo.workdir() else {
+        return String::new();
+    };
+
+    let full_path = workdir.join(path);
+    let Ok(metadata) = std::fs::symlink_metadata(&full_path) else {
+        return String::new();
+    };
+
+    if metadata.file_type().is_symlink() {
+        return std::fs::read_link(&full_path)
+            .map(|target| target.to_string_lossy().into_owned())
+            .unwrap_or_default();
+    }
+
+    let Ok(workdir_canonical) = workdir.canonicalize() else {
+        return String::new();
+    };
+    let Ok(full_path_canonical) = full_path.canonicalize() else {
+        return String::new();
+    };
+
+    if !full_path_canonical.starts_with(workdir_canonical) {
+        return String::new();
+    }
+
+    std::fs::read_to_string(full_path_canonical).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn commit_file(repo: &Repository, path: &Path, contents: &str, message: &str) -> git2::Oid {
+        let repo_path = repo.workdir().expect("repo workdir");
+        let full_path = repo_path.join(path);
+
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).expect("create parent dirs");
+        }
+        fs::write(&full_path, contents).expect("write file");
+
+        let mut index = repo.index().expect("open index");
+        index.add_path(path).expect("stage file");
+        index.write().expect("write index");
+
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        let sig = git2::Signature::now("nixmac", "nixmac@local").expect("signature");
+        let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+        let parents = parent.iter().collect::<Vec<_>>();
+
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents)
+            .expect("create commit")
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_lexically_accepts_and_collapses_safe_paths() {
+        assert_eq!(
+            normalize_repo_relative_path_lexically("flake.nix"),
+            Some(PathBuf::from("flake.nix"))
+        );
+        assert_eq!(
+            normalize_repo_relative_path_lexically("./modules/../flake.nix"),
+            Some(PathBuf::from("flake.nix"))
+        );
+        assert_eq!(
+            normalize_repo_relative_path_lexically("modules/./darwin/default.nix"),
+            Some(PathBuf::from("modules/darwin/default.nix"))
+        );
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_lexically_rejects_escaping_paths() {
+        assert_eq!(
+            normalize_repo_relative_path_lexically("../secret.txt"),
+            None
+        );
+        assert_eq!(
+            normalize_repo_relative_path_lexically("modules/../../secret.txt"),
+            None
+        );
+        assert_eq!(
+            normalize_repo_relative_path_lexically("/tmp/secret.txt"),
+            None
+        );
+    }
+
+    #[test]
+    fn head_file_contents_reads_blob_from_head() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+
+        commit_file(&repo, Path::new("flake.nix"), "{ }\n", "initial");
+        fs::write(temp.path().join("flake.nix"), "{ inputs = {}; }\n").expect("modify file");
+
+        assert_eq!(head_file_contents(&repo, Path::new("flake.nix")), "{ }\n");
+    }
+
+    #[test]
+    fn head_file_contents_returns_empty_for_missing_head_or_file() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+
+        assert_eq!(head_file_contents(&repo, Path::new("flake.nix")), "");
+
+        commit_file(&repo, Path::new("README.md"), "hello\n", "initial");
+
+        assert_eq!(head_file_contents(&repo, Path::new("flake.nix")), "");
+    }
+
+    #[test]
+    fn workdir_file_contents_reads_existing_worktree_file() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+
+        fs::write(temp.path().join("flake.nix"), "{ inputs = {}; }\n").expect("write file");
+
+        assert_eq!(
+            workdir_file_contents(&repo, Path::new("flake.nix")),
+            "{ inputs = {}; }\n"
+        );
+    }
+
+    #[test]
+    fn workdir_file_contents_returns_empty_for_missing_file() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+
+        assert_eq!(workdir_file_contents(&repo, Path::new("missing.nix")), "");
+    }
+
+    #[test]
+    fn workdir_file_contents_rejects_path_that_resolves_outside_workdir() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+        let outside = temp.path().join("../outside.txt");
+        fs::write(&outside, "outside").expect("write outside file");
+
+        assert_eq!(
+            workdir_file_contents(&repo, Path::new("../outside.txt")),
+            ""
+        );
+    }
+}

--- a/apps/native/src-tauri/src/git/repo_files.rs
+++ b/apps/native/src-tauri/src/git/repo_files.rs
@@ -42,25 +42,16 @@ pub fn head_file_contents(repo: &Repository, path: &Path) -> String {
 
 /// Reads the contents of a file at the given path from the working directory of the repository.
 /// Returns an empty string if the file does not exist on disk.
+/// Symlinks are followed, but only if the resolved target remains inside the repository workdir.
 pub fn workdir_file_contents(repo: &Repository, path: &Path) -> String {
     let Some(workdir) = repo.workdir() else {
         return String::new();
     };
 
-    let full_path = workdir.join(path);
-    let Ok(metadata) = std::fs::symlink_metadata(&full_path) else {
-        return String::new();
-    };
-
-    if metadata.file_type().is_symlink() {
-        return std::fs::read_link(&full_path)
-            .map(|target| target.to_string_lossy().into_owned())
-            .unwrap_or_default();
-    }
-
     let Ok(workdir_canonical) = workdir.canonicalize() else {
         return String::new();
     };
+    let full_path = workdir.join(path);
     let Ok(full_path_canonical) = full_path.canonicalize() else {
         return String::new();
     };
@@ -188,5 +179,35 @@ mod tests {
             workdir_file_contents(&repo, Path::new("../outside.txt")),
             ""
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workdir_file_contents_follows_symlink_inside_workdir() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+
+        fs::write(temp.path().join("target.txt"), "inside\n").expect("write target file");
+        std::os::unix::fs::symlink("target.txt", temp.path().join("link.txt"))
+            .expect("create symlink");
+
+        assert_eq!(
+            workdir_file_contents(&repo, Path::new("link.txt")),
+            "inside\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workdir_file_contents_rejects_symlink_outside_workdir() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init(temp.path()).expect("init repo");
+        let outside = temp.path().join("../outside.txt");
+        fs::write(&outside, "outside").expect("write outside file");
+
+        std::os::unix::fs::symlink(&outside, temp.path().join("link.txt"))
+            .expect("create symlink");
+
+        assert_eq!(workdir_file_contents(&repo, Path::new("link.txt")), "");
     }
 }


### PR DESCRIPTION
## Summary

Port `file_diff_contents` over to git2 in the `query` submodule, also move associated tests. Create required new file operations in a new `repo_files.rs` file and add independent unit tests for them, Also make the path normalization helper more robust since the one that was there before looked like it might have a few robustness issues.

<!-- What does this PR do? Why? -->

## Test Plan

Added and updated unit tests, run evolve manually to trigger the diffing command.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->