### PR TITLE
ci(storybook): deploy previews before snapshot tests

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -2,7 +2,7 @@ name: Storybook Snapshots
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     branches: [main]
 
@@ -17,6 +17,8 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      deployments: write
+      issues: write
       pull-requests: write
     steps:
       - name: Checkout code
@@ -81,20 +83,6 @@ jobs:
         working-directory: apps/native
         run: bunx playwright install --with-deps chromium
 
-      - name: Run Storybook snapshot tests
-        working-directory: apps/native
-        run: bun run test:storybook
-
-      - name: Check for snapshot staleness
-        if: always() && !cancelled()
-        working-directory: apps/native
-        run: |
-          if git diff --name-only | grep -q '__snapshots__'; then
-            echo "::error::Storybook snapshots are out of date. Run 'bun run test:update-snapshots' locally and commit the changes."
-            git diff --stat -- '*/__snapshots__/*'
-            exit 1
-          fi
-
       - name: Build Storybook
         working-directory: apps/native
         run: bun run build-storybook
@@ -118,10 +106,48 @@ jobs:
             --commit-dirty=true \
             --branch="$BRANCH" 2>&1 | tee /dev/stderr)
           url=$(echo "$output" | grep -oE 'https://[a-zA-Z0-9.-]+\.pages\.dev' | head -n1 || true)
+          if [ -z "$url" ]; then
+            echo "::error::Cloudflare Pages deploy completed without a detectable preview URL"
+            exit 1
+          fi
+          echo "Storybook preview: $url"
           echo "deployment-url=$url" >> "$GITHUB_OUTPUT"
 
+      - name: Publish Storybook deployment link
+        if: steps.deploy.outputs.deployment-url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          deployment_id=$(gh api --method POST "repos/${REPO}/deployments" --jq '.id' --input - <<EOF
+          {
+            "ref": "${REF}",
+            "environment": "storybook-preview",
+            "description": "Storybook preview",
+            "auto_merge": false,
+            "required_contexts": [],
+            "transient_environment": true,
+            "production_environment": false
+          }
+          EOF
+          )
+
+          gh api --method POST "repos/${REPO}/deployments/${deployment_id}/statuses" --input - <<EOF >/dev/null
+          {
+            "state": "success",
+            "environment_url": "${DEPLOY_URL}",
+            "log_url": "${RUN_URL}",
+            "description": "Storybook preview is ready",
+            "auto_inactive": false
+          }
+          EOF
+
       - name: Comment Storybook preview URL on PR
-        if: github.event_name == 'pull_request' && steps.deploy.outputs.deployment-url != ''
+        if: always() && !cancelled() && github.event_name == 'pull_request' && steps.deploy.outputs.deployment-url != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -135,7 +161,7 @@ jobs:
           ${MARKER}
           ### 🎨 Storybook preview
 
-          ${DEPLOY_URL}
+          [Open Storybook preview](${DEPLOY_URL})
 
           Updated for ${SHA}
           EOF
@@ -155,6 +181,20 @@ jobs:
             echo "Created sticky comment"
           fi
 
+      - name: Run Storybook snapshot tests
+        working-directory: apps/native
+        run: bun run test:storybook
+
+      - name: Check for snapshot staleness
+        if: always() && !cancelled()
+        working-directory: apps/native
+        run: |
+          if git diff --name-only | grep -q '__snapshots__'; then
+            echo "::error::Storybook snapshots are out of date. Run 'bun run test:update-snapshots' locally and commit the changes."
+            git diff --stat -- '*/__snapshots__/*'
+            exit 1
+          fi
+
       - name: Upload snapshot diffs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -169,12 +209,12 @@ jobs:
         if: always()
         run: |
           echo "### Storybook Snapshot Tests" >> "$GITHUB_STEP_SUMMARY"
+          DEPLOY_URL="${{ steps.deploy.outputs.deployment-url }}"
+          if [ -n "$DEPLOY_URL" ]; then
+            echo "[Open Storybook preview]($DEPLOY_URL)" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "${{ job.status }}" == "success" ]; then
             echo "All Storybook snapshot tests passed" >> "$GITHUB_STEP_SUMMARY"
-            DEPLOY_URL="${{ steps.deploy.outputs.deployment-url }}"
-            if [ -n "$DEPLOY_URL" ]; then
-              echo "Storybook: $DEPLOY_URL" >> "$GITHUB_STEP_SUMMARY"
-            fi
           else
             echo "Storybook snapshot tests failed" >> "$GITHUB_STEP_SUMMARY"
             echo "Check the 'storybook-snapshot-diffs' artifact for visual diffs." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Fixes Storybook preview URLs not being posted to pull requests.

### Root Cause

The `storybook.yaml` workflow on `main` had **snapshot tests running BEFORE** the build, deploy, and PR comment steps. When snapshot tests failed (which they do frequently due to snapshot drift), all subsequent steps—including the Cloudflare Pages deploy and the PR comment—were **skipped**. Result: no preview URL posted.

### Fix

Reorder the workflow so build → deploy → comment → then snapshot tests. The comment step uses `if: always()` so it posts even if snapshot tests later fail.

### Changes (cherry-picked from `develop`)

- **Reorder steps**: Build → Deploy → Comment → Snapshot Tests (was: Snapshot Tests → Build → Deploy → Comment)
- **Add permissions**: `deployments: write` + `issues: write` for GitHub Deployments API
- **Add deploy URL validation**: Fail loudly if Cloudflare Pages deploy produces no detectable URL
- **Add "Publish Storybook deployment link" step**: Creates a GitHub Deployment with the preview URL
- **Fix comment step condition**: `if: always() && !cancelled()` so preview is posted even when snapshot tests fail
- **Fix comment body**: Use markdown link `[Open Storybook preview](url)` instead of bare URL
- **Add `develop` to push triggers**: Also run on pushes to develop
- **Fix summary**: Show preview link regardless of test outcome

### Test Case

PR #273 is a test case: it has a snapshot mismatch in `rebuild-overlay-panel.stories.tsx` that causes the old workflow to fail before reaching the comment step. After this fix merges to main, re-running the Storybook workflow on #273 should post the preview URL.

## Test Plan

- [ ] Merge this PR to `main`
- [ ] Re-run the Storybook Snapshots workflow on PR #273 (or push a new commit to it)
- [ ] Verify the Storybook preview comment appears on the PR
- [ ] Verify that even if snapshot tests fail, the preview URL is still posted

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #___)
- [x] No docs update needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/darkmatter/codesmith/nixmac/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783051588&installation_id=137091173&pr_number=285&repository=darkmatter%2Fnixmac&return_to=https%3A%2F%2Fgithub.com%2Fdarkmatter%2Fnixmac%2Fpull%2F285&signature=df61d534dacda2550ad46eddae66161d41a460193f517a70dd135f9a1f3ba01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->