### PR TITLE
refactor: remove git stash command and related functionality

### DIFF
--- a/apps/native/.storybook/mocks/tauri-runtime.ts
+++ b/apps/native/.storybook/mocks/tauri-runtime.ts
@@ -263,7 +263,6 @@ export const storybookTauriAPI = {
     },
     cached: async () => baseGitStatus(),
     commit: async () => ({ hash: "mock123", evolveState: baseEvolveState() }),
-    stash: async () => okResult(),
     fileDiffContents: async (_filenames: string[]) => ({}),
     stageAll: async () => undefined,
     unstageAll: async () => undefined,

--- a/apps/native/src-tauri/src/commands/git.rs
+++ b/apps/native/src-tauri/src/commands/git.rs
@@ -95,11 +95,3 @@ pub async fn git_commit(
         evolve_state,
     })
 }
-
-/// Stashes all uncommitted changes with the given message.
-#[tauri::command]
-pub async fn git_stash(app: AppHandle, message: String) -> Result<shared_types::OkResult, String> {
-    let dir = store::ensure_git_repo_folder(&app).map_err(|e| capture_err("git_stash", e))?;
-    git::stash(&dir, &message).map_err(|e| capture_err("git_stash", e))?;
-    Ok(shared_types::OkResult::yes())
-}

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -173,21 +173,6 @@ pub fn checkout_files_at_commit(dir: &str, commit_hash: &str) -> Result<()> {
     Ok(())
 }
 
-/// Stages all changes and stashes with msg.
-pub fn stash(dir: &str, message: &str) -> Result<()> {
-    git_command()
-        .args(["add", "-A"])
-        .current_dir(dir)
-        .output()?;
-
-    git_command()
-        .args(["stash", "push", "-m", message])
-        .current_dir(dir)
-        .output()?;
-
-    Ok(())
-}
-
 /// Restore all uncommitted, discard untracked.
 pub fn restore_all(dir: &str) -> Result<()> {
     git_command()

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -4,13 +4,14 @@ pub mod changes_from_diff;
 pub mod exec;
 pub mod init;
 pub mod query;
+mod repo_files;
 
 // Re-export the entire public surface of exec and query so callers keep using
 // `crate::git::some_fn()` without change.
 #[allow(unused_imports)]
 pub use exec::{
-    checkout_files_at_commit, commit_all, create_evolution_backup, delete_backup_branch,
-    intent_add_untracked, restore_all, restore_from_branch_ref, stash, tag_commit, CommitInfo,
+    checkout_files_at_commit, commit_all, create_evolution_backup, intent_add_untracked,
+    restore_all, restore_from_branch_ref, tag_commit, CommitInfo,
 };
 
 #[allow(unused_imports)]

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -508,7 +508,6 @@ fn run_gui_mode(
             commands::git::git_status,
             commands::git::git_status_and_cache,
             commands::git::git_commit,
-            commands::git::git_stash,
             commands::git::git_file_diff_contents,
             // Darwin/Nix
             commands::evolve::darwin_evolve,

--- a/apps/native/src/hooks/use-git-operations.ts
+++ b/apps/native/src/hooks/use-git-operations.ts
@@ -10,7 +10,7 @@ let fileDiffContentsRequestId = 0;
 
 /**
  * Hook for git operations.
- * Provides functions for refreshing git status and stashing changes.
+ * Provides functions for refreshing git status changes.
  */
 export const prefetchFileDiffContents = async (status: { changes: { filename: string }[] } | null) => {
   const requestId = ++fileDiffContentsRequestId;
@@ -76,16 +76,6 @@ const getInitialStatus = async () => {
   }
 };
 
-const gitStash = async () => {
-  try {
-    await tauriAPI.git.stash("stashed changes from nixmac");
-    const status = await refreshGitStatus();
-    return status;
-  } catch {
-    return null;
-  }
-};
-
 const handleCommit = async ({ message }: { message: string }) => {
   const store = useWidgetStore.getState();
   store.setProcessing(true, "merge");
@@ -109,5 +99,5 @@ const handleCommit = async ({ message }: { message: string }) => {
 };
 
 export function useGitOperations() {
-  return { refreshGitStatus, getInitialStatus, gitStash, handleCommit };
+  return { refreshGitStatus, getInitialStatus, handleCommit };
 }

--- a/apps/native/src/ipc/api.ts
+++ b/apps/native/src/ipc/api.ts
@@ -51,7 +51,6 @@ export const tauriAPI = {
     status: () => invoke<GitStatus>("git_status"),
     statusAndCache: () => invoke<GitStatus>("git_status_and_cache"),
     commit: (message: string) => invoke<CommitResult>("git_commit", { message }),
-    stash: (message: string) => invoke<OkResult>("git_stash", { message }),
     fileDiffContents: (filenames: string[]) => invoke<Record<string, FileDiffContents>>("git_file_diff_contents", { filenames }),
   },
   darwin: {


### PR DESCRIPTION
## Summary

`git stash` functionality and wiring appears to not be used, which is really good because I think this was going to be a big roadblock if we want to be able to get rid of command-line git deps.

<!-- What does this PR do? Why? -->

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->