### PR TITLE
refactor: migrate DB handling to Diesel and r2d2 pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,18 +1892,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3859,6 +3847,7 @@ dependencies = [
  "glob",
  "hex",
  "ignore",
+ "libsqlite3-sys",
  "log",
  "mockall",
  "objc",
@@ -3868,7 +3857,6 @@ dependencies = [
  "reqwest 0.12.28",
  "rnix",
  "rowan",
- "rusqlite",
  "sentry",
  "serde",
  "serde_json",
@@ -5454,20 +5442,6 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
-dependencies = [
- "bitflags 2.11.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -51,10 +51,12 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 once_cell = "1.21.3"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rusqlite = { version = "0.31", features = ["bundled"] }
 diesel = { version = "2", features = ["sqlite", "r2d2"] }
 diesel_migrations = "2"
 r2d2 = "0.8"
+# Pin libsqlite3-sys with bundled so Diesel uses a self-contained sqlite
+# rather than a system one — rusqlite previously carried this flag.
+libsqlite3-sys = { version = "0.28", features = ["bundled"] }
 tauri-plugin-upload = "2.0.0"
 tauri-plugin-macos-permissions = "2.3.0"
 sentry = "0.42.0"

--- a/apps/native/src-tauri/src/commands/git.rs
+++ b/apps/native/src-tauri/src/commands/git.rs
@@ -58,7 +58,7 @@ pub async fn git_commit(
     }
 
     let now = crate::utils::unix_now();
-    match db::commits::upsert_commit_in_pool(
+    match db::commits::upsert_commit(
         &db_pool,
         &commit_info.hash,
         &commit_info.tree_hash,

--- a/apps/native/src-tauri/src/commands/rollback.rs
+++ b/apps/native/src-tauri/src/commands/rollback.rs
@@ -2,7 +2,7 @@ use super::helpers::capture_err;
 use crate::state::evolve_state;
 use crate::storage::store;
 use crate::{db, git, rebuild, shared_types};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 /// Restore uncommitted changes.
 #[tauri::command]
@@ -36,11 +36,10 @@ pub async fn darwin_adopt_manual_changes(app: AppHandle) -> Result<i64, String> 
         .map_err(|e| capture_err("darwin_adopt_manual_changes", e))?;
     let git_status =
         git::status(&config_dir).map_err(|e| capture_err("darwin_adopt_manual_changes", e))?;
-    let db_path =
-        db::get_db_path(&app).map_err(|e| capture_err("darwin_adopt_manual_changes", e))?;
     let branch = git_status.branch.as_deref().unwrap_or("unknown");
     let existing_id = evolve_state::get(&app).ok().and_then(|s| s.evolution_id);
-    let evolution_id = db::evolutions::upsert(&db_path, existing_id, branch)
+    let pool = app.state::<db::DbPool>();
+    let evolution_id = db::evolutions::upsert(&pool, existing_id, branch)
         .map_err(|e| capture_err("darwin_adopt_manual_changes", e))?;
 
     evolve_state::set(

--- a/apps/native/src-tauri/src/commands/summarize.rs
+++ b/apps/native/src-tauri/src/commands/summarize.rs
@@ -7,10 +7,9 @@ use tauri::{AppHandle, Manager};
 pub async fn find_change_map(
     app: AppHandle,
 ) -> Result<crate::shared_types::SemanticChangeMap, String> {
-    let db_path = db::get_db_path(&app).map_err(|e| capture_err("find_change_map", e))?;
     let dir = store::get_config_dir(&app).map_err(|e| capture_err("find_change_map", e))?;
     let pool = app.state::<db::DbPool>();
-    let change_sets = crate::summarize::find_existing::for_current_state(&pool, &db_path, &dir)
+    let change_sets = crate::summarize::find_existing::for_current_state(&pool, &dir)
         .map_err(|e| capture_err("find_change_map", e))?;
     Ok(crate::summarize::group_existing::from_change_sets(
         change_sets,
@@ -40,10 +39,9 @@ pub async fn summarize_current(
     crate::summarize::new_changeset(&app, None)
         .await
         .map_err(|e| capture_err("summarize_current", e))?;
-    let db_path = db::get_db_path(&app).map_err(|e| capture_err("summarize_current", e))?;
     let dir = store::get_config_dir(&app).map_err(|e| capture_err("summarize_current", e))?;
     let pool = app.state::<db::DbPool>();
-    let change_sets = crate::summarize::find_existing::for_current_state(&pool, &db_path, &dir)
+    let change_sets = crate::summarize::find_existing::for_current_state(&pool, &dir)
         .map_err(|e| capture_err("summarize_current", e))?;
     Ok(crate::summarize::group_existing::from_change_sets(
         change_sets,

--- a/apps/native/src-tauri/src/commands/summarize.rs
+++ b/apps/native/src-tauri/src/commands/summarize.rs
@@ -1,7 +1,7 @@
 use super::helpers::capture_err;
 use crate::storage::store;
 use crate::{db, git, rebuild};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 #[tauri::command]
 pub async fn find_change_map(
@@ -9,7 +9,8 @@ pub async fn find_change_map(
 ) -> Result<crate::shared_types::SemanticChangeMap, String> {
     let db_path = db::get_db_path(&app).map_err(|e| capture_err("find_change_map", e))?;
     let dir = store::get_config_dir(&app).map_err(|e| capture_err("find_change_map", e))?;
-    let change_sets = crate::summarize::find_existing::for_current_state(&db_path, &dir)
+    let pool = app.state::<db::DbPool>();
+    let change_sets = crate::summarize::find_existing::for_current_state(&pool, &db_path, &dir)
         .map_err(|e| capture_err("find_change_map", e))?;
     Ok(crate::summarize::group_existing::from_change_sets(
         change_sets,
@@ -41,7 +42,8 @@ pub async fn summarize_current(
         .map_err(|e| capture_err("summarize_current", e))?;
     let db_path = db::get_db_path(&app).map_err(|e| capture_err("summarize_current", e))?;
     let dir = store::get_config_dir(&app).map_err(|e| capture_err("summarize_current", e))?;
-    let change_sets = crate::summarize::find_existing::for_current_state(&db_path, &dir)
+    let pool = app.state::<db::DbPool>();
+    let change_sets = crate::summarize::find_existing::for_current_state(&pool, &db_path, &dir)
         .map_err(|e| capture_err("summarize_current", e))?;
     Ok(crate::summarize::group_existing::from_change_sets(
         change_sets,

--- a/apps/native/src-tauri/src/db/changesets.rs
+++ b/apps/native/src-tauri/src/db/changesets.rs
@@ -1,89 +1,100 @@
 //! Change-set persistence helpers.
 //!
-//! Write helpers take `&Transaction` to participate in the caller's transaction.
-//! Read helpers take `&Connection` — reads don't need a transaction.
+//! All helpers take `&mut diesel::SqliteConnection`. Atomic groups are wrapped
+//! at the caller via `conn.transaction(|conn| ...)`.
 
 use anyhow::Result;
-use rusqlite::{Connection, Transaction};
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Nullable, Text};
 
+use crate::db::tables::{
+    change_sets, change_summaries, changes, group_summaries, queued_summaries, set_changes,
+};
 use crate::shared_types::{SummarizedChange, SummarizedChangeSet};
 use crate::sqlite_types::{Change, ChangeSet, ChangeSummary, QueuedSummary};
 use crate::summarize::assignments::PendingChange;
 
 pub fn insert_change_summary(
-    tx: &Transaction,
+    conn: &mut SqliteConnection,
     title: &str,
     description: &str,
     status: &str,
     created_at: i64,
 ) -> Result<i64> {
-    tx.execute(
-        "INSERT INTO change_summaries (title, description, status, created_at) VALUES (?1, ?2, ?3, ?4)",
-        rusqlite::params![title, description, status, created_at],
-    )?;
-    Ok(tx.last_insert_rowid())
+    diesel::insert_into(change_summaries::table)
+        .values((
+            change_summaries::title.eq(title),
+            change_summaries::description.eq(description),
+            change_summaries::status.eq(status),
+            change_summaries::created_at.eq(created_at),
+        ))
+        .execute(conn)?;
+    last_insert_rowid(conn)
 }
 
-pub fn upsert_change(tx: &Transaction, change: &Change, own_summary_id: Option<i64>) -> Result<()> {
-    tx.execute(
-        "INSERT OR IGNORE INTO changes \
-         (hash, filename, diff, line_count, created_at, own_summary_id) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        rusqlite::params![
-            &change.hash,
-            &change.filename,
-            &change.diff,
-            change.line_count,
-            change.created_at,
-            own_summary_id,
-        ],
-    )?;
-    tx.execute(
-        "UPDATE changes SET own_summary_id = ?1 WHERE hash = ?2",
-        rusqlite::params![own_summary_id, &change.hash],
-    )?;
+pub fn upsert_change(
+    conn: &mut SqliteConnection,
+    change: &Change,
+    own_summary_id: Option<i64>,
+) -> Result<()> {
+    diesel::insert_into(changes::table)
+        .values((
+            changes::hash.eq(&change.hash),
+            changes::filename.eq(&change.filename),
+            changes::diff.eq(&change.diff),
+            changes::line_count.eq(change.line_count),
+            changes::created_at.eq(change.created_at),
+            changes::own_summary_id.eq(own_summary_id),
+        ))
+        .on_conflict(changes::hash)
+        .do_nothing()
+        .execute(conn)?;
+    diesel::update(changes::table.filter(changes::hash.eq(&change.hash)))
+        .set(changes::own_summary_id.eq(own_summary_id))
+        .execute(conn)?;
     Ok(())
 }
 
 pub fn insert_change_or_ignore(
-    tx: &Transaction,
+    conn: &mut SqliteConnection,
     change: &Change,
     own_summary_id: Option<i64>,
 ) -> Result<i64> {
-    tx.execute(
-        "INSERT OR IGNORE INTO changes \
-         (hash, filename, diff, line_count, created_at, own_summary_id) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        rusqlite::params![
-            &change.hash,
-            &change.filename,
-            &change.diff,
-            change.line_count,
-            change.created_at,
-            own_summary_id,
-        ],
-    )?;
-    Ok(tx.query_row(
-        "SELECT id FROM changes WHERE hash = ?1",
-        [&change.hash],
-        |row| row.get(0),
-    )?)
+    diesel::insert_into(changes::table)
+        .values((
+            changes::hash.eq(&change.hash),
+            changes::filename.eq(&change.filename),
+            changes::diff.eq(&change.diff),
+            changes::line_count.eq(change.line_count),
+            changes::created_at.eq(change.created_at),
+            changes::own_summary_id.eq(own_summary_id),
+        ))
+        .on_conflict(changes::hash)
+        .do_nothing()
+        .execute(conn)?;
+    Ok(changes::table
+        .filter(changes::hash.eq(&change.hash))
+        .select(changes::id)
+        .first::<i64>(conn)?)
 }
 
 pub fn link_change_to_group_summary(
-    tx: &Transaction,
+    conn: &mut SqliteConnection,
     change_id: i64,
     change_summary_id: i64,
 ) -> Result<()> {
-    tx.execute(
-        "INSERT INTO group_summaries (change_id, change_summary_id) VALUES (?1, ?2)",
-        rusqlite::params![change_id, change_summary_id],
-    )?;
+    diesel::insert_into(group_summaries::table)
+        .values((
+            group_summaries::change_id.eq(change_id),
+            group_summaries::change_summary_id.eq(change_summary_id),
+        ))
+        .execute(conn)?;
     Ok(())
 }
 
 pub fn insert_change_set(
-    tx: &Transaction,
+    conn: &mut SqliteConnection,
     commit_id: Option<i64>,
     base_commit_id: i64,
     commit_message: Option<&str>,
@@ -91,92 +102,132 @@ pub fn insert_change_set(
     created_at: i64,
     evolution_id: Option<i64>,
 ) -> Result<i64> {
-    tx.execute(
-        "INSERT INTO change_sets \
-         (commit_id, base_commit_id, commit_message, generated_commit_message, created_at, evolution_id) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        rusqlite::params![
-            commit_id, base_commit_id, commit_message, generated_commit_message, created_at,
-            evolution_id,
-        ],
-    )?;
-    Ok(tx.last_insert_rowid())
+    diesel::insert_into(change_sets::table)
+        .values((
+            change_sets::commit_id.eq(commit_id),
+            change_sets::base_commit_id.eq(base_commit_id),
+            change_sets::commit_message.eq(commit_message),
+            change_sets::generated_commit_message.eq(generated_commit_message),
+            change_sets::created_at.eq(created_at),
+            change_sets::evolution_id.eq(evolution_id),
+        ))
+        .execute(conn)?;
+    last_insert_rowid(conn)
 }
 
-pub fn get_change_id_by_hash(tx: &Transaction, hash: &str) -> Result<i64> {
-    Ok(
-        tx.query_row("SELECT id FROM changes WHERE hash = ?1", [hash], |row| {
-            row.get("id")
-        })?,
-    )
+pub fn get_change_id_by_hash(conn: &mut SqliteConnection, hash: &str) -> Result<i64> {
+    Ok(changes::table
+        .filter(changes::hash.eq(hash))
+        .select(changes::id)
+        .first::<i64>(conn)?)
 }
 
-pub fn link_change_to_set(tx: &Transaction, change_set_id: i64, change_id: i64) -> Result<()> {
-    tx.execute(
-        "INSERT OR IGNORE INTO set_changes (change_set_id, change_id) VALUES (?1, ?2)",
-        rusqlite::params![change_set_id, change_id],
-    )?;
+pub fn link_change_to_set(
+    conn: &mut SqliteConnection,
+    change_set_id: i64,
+    change_id: i64,
+) -> Result<()> {
+    diesel::insert_into(set_changes::table)
+        .values((
+            set_changes::change_set_id.eq(change_set_id),
+            set_changes::change_id.eq(change_id),
+        ))
+        .on_conflict((set_changes::change_set_id, set_changes::change_id))
+        .do_nothing()
+        .execute(conn)?;
     Ok(())
 }
 
 pub fn insert_queued_summary(
-    tx: &Transaction,
+    conn: &mut SqliteConnection,
     prompt: &str,
     summary_type: &str,
     group_summary_id: Option<i64>,
     hash_own_summary_id_pairs: Option<&str>,
 ) -> Result<i64> {
-    tx.execute(
-        "INSERT INTO queued_summaries \
-         (status, prompt, type, group_summary_id, hash_own_summary_id_pairs) \
-         VALUES ('QUEUED', ?1, ?2, ?3, ?4)",
-        rusqlite::params![
-            prompt,
-            summary_type,
-            group_summary_id,
-            hash_own_summary_id_pairs
-        ],
-    )?;
-    Ok(tx.last_insert_rowid())
+    diesel::insert_into(queued_summaries::table)
+        .values((
+            queued_summaries::status.eq("QUEUED"),
+            queued_summaries::prompt.eq(prompt),
+            queued_summaries::type_.eq(summary_type),
+            queued_summaries::group_summary_id.eq(group_summary_id),
+            queued_summaries::hash_own_summary_id_pairs.eq(hash_own_summary_id_pairs),
+        ))
+        .execute(conn)?;
+    last_insert_rowid(conn)
 }
 
-fn map_summarized_change(row: &rusqlite::Row) -> rusqlite::Result<SummarizedChange> {
-    let change = Change {
-        id: row.get("c_id")?,
-        hash: row.get("c_hash")?,
-        filename: row.get("c_filename")?,
-        diff: row.get("c_diff")?,
-        line_count: row.get("c_line_count")?,
-        created_at: row.get("c_created_at")?,
-        own_summary_id: row.get("c_own_summary_id")?,
-    };
-    let own_summary = if row.get::<_, Option<i64>>("os_id")?.is_some() {
-        Some(ChangeSummary {
-            id: row.get("os_id")?,
-            title: row.get("os_title")?,
-            description: row.get("os_description")?,
-            status: row.get("os_status")?,
-            created_at: row.get("os_created_at")?,
-        })
-    } else {
-        None
-    };
-    let group_summary = if row.get::<_, Option<i64>>("gs_id")?.is_some() {
-        Some(ChangeSummary {
-            id: row.get("gs_id")?,
-            title: row.get("gs_title")?,
-            description: row.get("gs_description")?,
-            status: row.get("gs_status")?,
-            created_at: row.get("gs_created_at")?,
-        })
-    } else {
-        None
-    };
-    Ok(SummarizedChange {
-        change,
-        own_summary,
-        group_summary,
-    })
+// ── Big aliased row used by the JOIN read queries ────────────────────────────
+
+#[derive(QueryableByName)]
+struct SummarizedChangeRow {
+    #[diesel(sql_type = BigInt)]
+    c_id: i64,
+    #[diesel(sql_type = Text)]
+    c_hash: String,
+    #[diesel(sql_type = Text)]
+    c_filename: String,
+    #[diesel(sql_type = Text)]
+    c_diff: String,
+    #[diesel(sql_type = BigInt)]
+    c_line_count: i64,
+    #[diesel(sql_type = BigInt)]
+    c_created_at: i64,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    c_own_summary_id: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    os_id: Option<i64>,
+    #[diesel(sql_type = Nullable<Text>)]
+    os_title: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    os_description: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    os_status: Option<String>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    os_created_at: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    gs_id: Option<i64>,
+    #[diesel(sql_type = Nullable<Text>)]
+    gs_title: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    gs_description: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    gs_status: Option<String>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    gs_created_at: Option<i64>,
+}
+
+impl From<SummarizedChangeRow> for SummarizedChange {
+    fn from(row: SummarizedChangeRow) -> Self {
+        let change = Change {
+            id: row.c_id,
+            hash: row.c_hash,
+            filename: row.c_filename,
+            diff: row.c_diff,
+            line_count: row.c_line_count,
+            created_at: row.c_created_at,
+            own_summary_id: row.c_own_summary_id,
+        };
+        let own_summary = row.os_id.map(|id| ChangeSummary {
+            id,
+            title: row.os_title.unwrap_or_default(),
+            description: row.os_description.unwrap_or_default(),
+            status: row.os_status.unwrap_or_default(),
+            created_at: row.os_created_at.unwrap_or(0),
+        });
+        let group_summary = row.gs_id.map(|id| ChangeSummary {
+            id,
+            title: row.gs_title.unwrap_or_default(),
+            description: row.gs_description.unwrap_or_default(),
+            status: row.gs_status.unwrap_or_default(),
+            created_at: row.gs_created_at.unwrap_or(0),
+        });
+        SummarizedChange {
+            change,
+            own_summary,
+            group_summary,
+        }
+    }
 }
 
 const CHANGE_SELECT: &str = "SELECT \
@@ -188,40 +239,62 @@ const CHANGE_SELECT: &str = "SELECT \
         gs.id AS gs_id, gs.title AS gs_title, gs.description AS gs_description, \
         gs.status AS gs_status, gs.created_at AS gs_created_at";
 
+#[derive(QueryableByName)]
+struct ChangeSetRow {
+    #[diesel(sql_type = BigInt)]
+    id: i64,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    commit_id: Option<i64>,
+    #[diesel(sql_type = BigInt)]
+    base_commit_id: i64,
+    #[diesel(sql_type = Nullable<Text>)]
+    commit_message: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    generated_commit_message: Option<String>,
+    #[diesel(sql_type = BigInt)]
+    created_at: i64,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    evolution_id: Option<i64>,
+}
+
+impl From<ChangeSetRow> for ChangeSet {
+    fn from(row: ChangeSetRow) -> Self {
+        Self {
+            id: row.id,
+            commit_id: row.commit_id,
+            base_commit_id: row.base_commit_id,
+            commit_message: row.commit_message,
+            generated_commit_message: row.generated_commit_message,
+            created_at: row.created_at,
+            evolution_id: row.evolution_id,
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub fn query_change_set_for_commit_pair(
-    conn: &Connection,
+    conn: &mut SqliteConnection,
     commit_id: i64,
     base_commit_id: i64,
 ) -> Result<Option<SummarizedChangeSet>> {
-    let cs_result = conn.query_row(
-        "SELECT id, commit_id, base_commit_id, commit_message, generated_commit_message, created_at, evolution_id
-         FROM change_sets WHERE commit_id = ?1 AND base_commit_id = ?2
+    let cs: Option<ChangeSetRow> = sql_query(
+        "SELECT id, commit_id, base_commit_id, commit_message, generated_commit_message, \
+         created_at, evolution_id \
+         FROM change_sets WHERE commit_id = ?1 AND base_commit_id = ?2 \
          ORDER BY created_at DESC LIMIT 1",
-        rusqlite::params![commit_id, base_commit_id],
-        |row| {
-            Ok(ChangeSet {
-                id: row.get("id")?,
-                commit_id: row.get("commit_id")?,
-                base_commit_id: row.get("base_commit_id")?,
-                commit_message: row.get("commit_message")?,
-                generated_commit_message: row.get("generated_commit_message")?,
-                created_at: row.get("created_at")?,
-                evolution_id: row.get("evolution_id")?,
-            })
-        },
-    );
+    )
+    .bind::<BigInt, _>(commit_id)
+    .bind::<BigInt, _>(base_commit_id)
+    .get_result(conn)
+    .optional()?;
 
-    let change_set = match cs_result {
-        Ok(cs) => cs,
-        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
-        Err(e) => return Err(e.into()),
-    };
-
+    let Some(cs) = cs else { return Ok(None) };
+    let change_set: ChangeSet = cs.into();
     let change_set_id = change_set.id;
+
     // Subquery picks at most one group summary per change: only summaries whose
     // entire member set is present in this change_set (no orphaned members).
-    let mut stmt = conn.prepare(&format!(
+    let rows: Vec<SummarizedChangeRow> = sql_query(format!(
         "{CHANGE_SELECT}
          FROM set_changes sc
          JOIN changes c ON c.id = sc.change_id
@@ -240,11 +313,11 @@ pub fn query_change_set_for_commit_pair(
          ) best_gs ON best_gs.change_id = c.id
          LEFT JOIN change_summaries gs ON gs.id = best_gs.change_summary_id
          WHERE sc.change_set_id = ?1"
-    ))?;
-    let changes: Vec<SummarizedChange> = stmt
-        .query_map([change_set_id], map_summarized_change)?
-        .collect::<rusqlite::Result<_>>()?;
+    ))
+    .bind::<BigInt, _>(change_set_id)
+    .load(conn)?;
 
+    let changes = rows.into_iter().map(Into::into).collect();
     Ok(Some(SummarizedChangeSet {
         change_set,
         changes,
@@ -253,33 +326,21 @@ pub fn query_change_set_for_commit_pair(
 }
 
 pub fn query_change_set_for_base_with_hashes(
-    conn: &Connection,
+    conn: &mut SqliteConnection,
     base_commit_id: i64,
     hashes: &[String],
 ) -> Result<Option<SummarizedChangeSet>> {
-    let cs_result: rusqlite::Result<ChangeSet> = conn.query_row(
+    let cs: Option<ChangeSetRow> = sql_query(
         "SELECT id, commit_id, base_commit_id, commit_message, generated_commit_message, \
          created_at, evolution_id FROM change_sets WHERE base_commit_id = ?1 \
          ORDER BY created_at DESC LIMIT 1",
-        [base_commit_id],
-        |row| {
-            Ok(ChangeSet {
-                id: row.get("id")?,
-                commit_id: row.get("commit_id")?,
-                base_commit_id: row.get("base_commit_id")?,
-                commit_message: row.get("commit_message")?,
-                generated_commit_message: row.get("generated_commit_message")?,
-                created_at: row.get("created_at")?,
-                evolution_id: row.get("evolution_id")?,
-            })
-        },
-    );
+    )
+    .bind::<BigInt, _>(base_commit_id)
+    .get_result(conn)
+    .optional()?;
 
-    let change_set = match cs_result {
-        Ok(cs) => cs,
-        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
-        Err(e) => return Err(e.into()),
-    };
+    let Some(cs) = cs else { return Ok(None) };
+    let change_set: ChangeSet = cs.into();
 
     let matched = query_changes_by_hashes_for_base(conn, base_commit_id, hashes)?;
     let matched_set: std::collections::HashSet<&str> =
@@ -298,7 +359,7 @@ pub fn query_change_set_for_base_with_hashes(
 }
 
 fn query_changes_by_hashes_for_base(
-    conn: &Connection,
+    conn: &mut SqliteConnection,
     base_commit_id: i64,
     hashes: &[String],
 ) -> Result<Vec<SummarizedChange>> {
@@ -306,12 +367,12 @@ fn query_changes_by_hashes_for_base(
         return Ok(vec![]);
     }
 
+    // Numbered params (?2, ?3, …) are bound once and referenced twice in the
+    // generated SQL, so the bind list is base_commit_id followed by the hashes.
     let placeholders = (2..=hashes.len() + 1)
         .map(|i| format!("?{i}"))
         .collect::<Vec<_>>()
         .join(", ");
-    // {placeholders} is reused in both IN clauses; rusqlite numbered params (?2, ?3, ...)
-    // are bound once and referenced twice, so no extra entries in the params vec are needed.
     let sql = format!(
         "{CHANGE_SELECT}
          FROM changes c
@@ -334,136 +395,141 @@ fn query_changes_by_hashes_for_base(
          WHERE cs.base_commit_id = ?1 AND c.hash IN ({placeholders})"
     );
 
-    use rusqlite::types::ToSql;
-    let params: Vec<Box<dyn ToSql>> = std::iter::once(Box::new(base_commit_id) as Box<dyn ToSql>)
-        .chain(hashes.iter().map(|h| Box::new(h.clone()) as Box<dyn ToSql>))
-        .collect();
-    let mut stmt = conn.prepare(&sql)?;
-    let result = stmt
-        .query_map(
-            rusqlite::params_from_iter(params.iter()),
-            map_summarized_change,
-        )?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(result)
+    let mut q = sql_query(sql).into_boxed::<diesel::sqlite::Sqlite>();
+    q = q.bind::<BigInt, _>(base_commit_id);
+    for hash in hashes {
+        q = q.bind::<Text, _>(hash.clone());
+    }
+    let rows: Vec<SummarizedChangeRow> = q.load(conn)?;
+    Ok(rows.into_iter().map(Into::into).collect())
 }
 
 // ── Queue-processing helpers ───────────────────────────────────────────────────
 
-fn map_queued_summary(row: &rusqlite::Row) -> rusqlite::Result<QueuedSummary> {
-    Ok(QueuedSummary {
-        id: row.get("id")?,
-        status: row.get("status")?,
-        attempted_count: row.get("attempted_count")?,
-        prompt: row.get("prompt")?,
-        model_response: row.get("model_response")?,
-        group_summary_id: row.get("group_summary_id")?,
-        hash_own_summary_id_pairs: row.get("hash_own_summary_id_pairs")?,
-        summary_type: row.get("type")?,
-    })
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = queued_summaries)]
+struct QueuedRow {
+    id: i64,
+    status: String,
+    attempted_count: i64,
+    prompt: String,
+    model_response: Option<String>,
+    group_summary_id: Option<i64>,
+    hash_own_summary_id_pairs: Option<String>,
+    type_: String,
 }
 
-const QUEUED_SUMMARY_SELECT: &str = "SELECT id, status, attempted_count, prompt, model_response, \
-     group_summary_id, hash_own_summary_id_pairs, type FROM queued_summaries";
+impl From<QueuedRow> for QueuedSummary {
+    fn from(row: QueuedRow) -> Self {
+        Self {
+            id: row.id,
+            status: row.status,
+            attempted_count: row.attempted_count,
+            prompt: row.prompt,
+            model_response: row.model_response,
+            group_summary_id: row.group_summary_id,
+            hash_own_summary_id_pairs: row.hash_own_summary_id_pairs,
+            summary_type: row.type_,
+        }
+    }
+}
 
 /// Fetch specific QUEUED rows by ID, preserving the order of the `ids` slice.
-pub fn fetch_queued_summaries_by_ids(conn: &Connection, ids: &[i64]) -> Result<Vec<QueuedSummary>> {
+pub fn fetch_queued_summaries_by_ids(
+    conn: &mut SqliteConnection,
+    ids: &[i64],
+) -> Result<Vec<QueuedSummary>> {
     if ids.is_empty() {
         return Ok(vec![]);
     }
-    let placeholders = (1..=ids.len())
-        .map(|i| format!("?{i}"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let sql = format!("{QUEUED_SUMMARY_SELECT} WHERE status = 'QUEUED' AND id IN ({placeholders})");
-    use rusqlite::types::ToSql;
-    let params: Vec<Box<dyn ToSql>> = ids
-        .iter()
-        .map(|&id| Box::new(id) as Box<dyn ToSql>)
-        .collect();
-    let mut stmt = conn.prepare(&sql)?;
-    let mut rows: Vec<QueuedSummary> = stmt
-        .query_map(
-            rusqlite::params_from_iter(params.iter()),
-            map_queued_summary,
-        )?
-        .collect::<rusqlite::Result<_>>()?;
+    let rows = queued_summaries::table
+        .filter(queued_summaries::status.eq("QUEUED"))
+        .filter(queued_summaries::id.eq_any(ids))
+        .select(QueuedRow::as_select())
+        .load::<QueuedRow>(conn)?;
+
     let id_order: std::collections::HashMap<i64, usize> =
         ids.iter().enumerate().map(|(i, &id)| (id, i)).collect();
-    rows.sort_by_key(|r| id_order.get(&r.id).copied().unwrap_or(usize::MAX));
-    Ok(rows)
+    let mut summaries: Vec<QueuedSummary> = rows.into_iter().map(Into::into).collect();
+    summaries.sort_by_key(|r| id_order.get(&r.id).copied().unwrap_or(usize::MAX));
+    Ok(summaries)
 }
 
 /// Fetch all rows with status = 'QUEUED'.
-pub fn fetch_all_queued_summaries(conn: &Connection) -> Result<Vec<QueuedSummary>> {
-    let sql = format!("{QUEUED_SUMMARY_SELECT} WHERE status = 'QUEUED'");
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt
-        .query_map([], map_queued_summary)?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(rows)
+pub fn fetch_all_queued_summaries(conn: &mut SqliteConnection) -> Result<Vec<QueuedSummary>> {
+    let rows = queued_summaries::table
+        .filter(queued_summaries::status.eq("QUEUED"))
+        .select(QueuedRow::as_select())
+        .load::<QueuedRow>(conn)?;
+    Ok(rows.into_iter().map(Into::into).collect())
 }
 
 /// Atomically increment attempted_count.
-pub fn increment_queued_attempts(tx: &Transaction, id: i64) -> Result<()> {
-    tx.execute(
-        "UPDATE queued_summaries SET attempted_count = attempted_count + 1 WHERE id = ?1",
-        [id],
-    )?;
+pub fn increment_queued_attempts(conn: &mut SqliteConnection, id: i64) -> Result<()> {
+    diesel::update(queued_summaries::table.find(id))
+        .set(queued_summaries::attempted_count.eq(queued_summaries::attempted_count + 1))
+        .execute(conn)?;
     Ok(())
 }
 
 /// Mark queued_summary DONE, saving the raw model JSON.
-pub fn mark_queued_done(tx: &Transaction, id: i64, model_response: &str) -> Result<()> {
-    tx.execute(
-        "UPDATE queued_summaries SET status = 'DONE', model_response = ?1 WHERE id = ?2",
-        rusqlite::params![model_response, id],
-    )?;
+pub fn mark_queued_done(
+    conn: &mut SqliteConnection,
+    id: i64,
+    model_response: &str,
+) -> Result<()> {
+    diesel::update(queued_summaries::table.find(id))
+        .set((
+            queued_summaries::status.eq("DONE"),
+            queued_summaries::model_response.eq(model_response),
+        ))
+        .execute(conn)?;
     Ok(())
 }
 
 /// Mark queued_summary FAILED.
-pub fn mark_queued_failed(tx: &Transaction, id: i64) -> Result<()> {
-    tx.execute(
-        "UPDATE queued_summaries SET status = 'FAILED' WHERE id = ?1",
-        [id],
-    )?;
+pub fn mark_queued_failed(conn: &mut SqliteConnection, id: i64) -> Result<()> {
+    diesel::update(queued_summaries::table.find(id))
+        .set(queued_summaries::status.eq("FAILED"))
+        .execute(conn)?;
     Ok(())
 }
 
 /// Write title + description into a change_summaries row, set status = 'DONE'.
 pub fn update_change_summary_content(
-    tx: &Transaction,
+    conn: &mut SqliteConnection,
     summary_id: i64,
     title: &str,
     description: &str,
 ) -> Result<()> {
-    tx.execute(
-        "UPDATE change_summaries SET title = ?1, description = ?2, status = 'DONE' WHERE id = ?3",
-        rusqlite::params![title, description, summary_id],
-    )?;
+    diesel::update(change_summaries::table.find(summary_id))
+        .set((
+            change_summaries::title.eq(title),
+            change_summaries::description.eq(description),
+            change_summaries::status.eq("DONE"),
+        ))
+        .execute(conn)?;
     Ok(())
 }
 
 /// Set a change_summaries row to status = 'FAILED'.
-pub fn mark_change_summary_failed(tx: &Transaction, summary_id: i64) -> Result<()> {
-    tx.execute(
-        "UPDATE change_summaries SET status = 'FAILED' WHERE id = ?1",
-        [summary_id],
-    )?;
+pub fn mark_change_summary_failed(conn: &mut SqliteConnection, summary_id: i64) -> Result<()> {
+    diesel::update(change_summaries::table.find(summary_id))
+        .set(change_summaries::status.eq("FAILED"))
+        .execute(conn)?;
     Ok(())
 }
 
 /// Fetch the change hashes stored in a changeset.
-pub fn fetch_hashes_for_changeset(conn: &Connection, changeset_id: i64) -> Result<Vec<String>> {
-    let mut stmt = conn.prepare(
-        "SELECT c.hash FROM changes c \
-         JOIN set_changes sc ON sc.change_id = c.id \
-         WHERE sc.change_set_id = ?1",
-    )?;
-    let hashes = stmt
-        .query_map([changeset_id], |row| row.get(0))?
-        .collect::<rusqlite::Result<Vec<String>>>()?;
+pub fn fetch_hashes_for_changeset(
+    conn: &mut SqliteConnection,
+    changeset_id: i64,
+) -> Result<Vec<String>> {
+    let hashes = changes::table
+        .inner_join(set_changes::table.on(set_changes::change_id.eq(changes::id)))
+        .filter(set_changes::change_set_id.eq(changeset_id))
+        .select(changes::hash)
+        .load::<String>(conn)?;
     Ok(hashes)
 }
 
@@ -480,4 +546,8 @@ pub fn build_pairs_json(changes: &[PendingChange]) -> String {
         })
         .collect();
     serde_json::to_string(&pairs).unwrap_or_default()
+}
+
+fn last_insert_rowid(conn: &mut SqliteConnection) -> Result<i64> {
+    Ok(diesel::select(diesel::dsl::sql::<BigInt>("last_insert_rowid()")).get_result(conn)?)
 }

--- a/apps/native/src-tauri/src/db/commits.rs
+++ b/apps/native/src-tauri/src/db/commits.rs
@@ -1,15 +1,7 @@
 //! Commit persistence operations.
-//!
-//! This module has two parallel code paths for the same logical operations:
-//! raw `rusqlite::Connection` calls and managed `DbPool` (Diesel r2d2) calls.
-//! The pool-backed variants (`*_in_pool`) are the long-term direction; the
-//! raw-connection variants remain until all call sites are migrated onto the
-//! shared pool. New code should use the pool-backed functions exclusively.
 
 use anyhow::Result;
 use diesel::prelude::*;
-use rusqlite::Connection;
-use std::path::Path;
 
 use crate::db::tables::commits;
 use crate::db::DbPool;
@@ -25,7 +17,6 @@ struct NewCommit<'a> {
 
 #[derive(Debug, Queryable, Selectable)]
 #[diesel(table_name = commits)]
-#[cfg(test)]
 struct CommitRow {
     id: i64,
     hash: String,
@@ -34,7 +25,6 @@ struct CommitRow {
     created_at: i64,
 }
 
-#[cfg(test)]
 impl From<CommitRow> for crate::sqlite_types::Commit {
     fn from(row: CommitRow) -> Self {
         Self {
@@ -47,34 +37,7 @@ impl From<CommitRow> for crate::sqlite_types::Commit {
     }
 }
 
-/// Insert a commit into the database, returns id
-pub fn upsert_commit(
-    db_path: &Path,
-    hash: &str,
-    tree_hash: &str,
-    message: Option<&str>,
-    created_at: i64,
-) -> Result<i64> {
-    let conn = Connection::open(db_path)?;
-
-    if let Ok(existing_id) =
-        conn.query_row("SELECT id FROM commits WHERE hash = ?1", [hash], |row| {
-            row.get::<_, i64>("id")
-        })
-    {
-        return Ok(existing_id);
-    }
-
-    conn.execute(
-        "INSERT INTO commits (hash, tree_hash, message, created_at) VALUES (?1, ?2, ?3, ?4)",
-        (hash, tree_hash, message, created_at),
-    )?;
-
-    Ok(conn.last_insert_rowid())
-}
-
 /// Insert a commit through the managed Diesel pool, returning its id.
-#[allow(dead_code)]
 pub fn upsert_commit_in_pool(
     pool: &DbPool,
     hash: &str,
@@ -111,9 +74,24 @@ pub fn upsert_commit_in_pool(
         .first::<i64>(&mut conn)?)
 }
 
+/// Returns the full commit row for a given hash through the managed Diesel pool.
+pub fn get_commit_by_hash_in_pool(
+    pool: &DbPool,
+    hash: &str,
+) -> Result<Option<crate::sqlite_types::Commit>> {
+    let mut conn = pool.get()?;
+    let row = commits::table
+        .filter(commits::hash.eq(hash))
+        .select(CommitRow::as_select())
+        .first::<CommitRow>(&mut conn)
+        .optional()?;
+
+    Ok(row.map(Into::into))
+}
+
 /// Passes through `existing` if `Some`; otherwise resolves HEAD from git and upserts it.
-pub fn store_head_commit(
-    db_path: &Path,
+pub fn store_head_commit_in_pool(
+    pool: &DbPool,
     config_dir: &str,
     existing: Option<i64>,
 ) -> Result<Option<i64>> {
@@ -127,49 +105,9 @@ pub fn store_head_commit(
         return Ok(None);
     };
     let now = crate::utils::unix_now();
-    Ok(Some(upsert_commit(db_path, &hash, &tree_hash, None, now)?))
-}
-
-/// Returns the full commit row for a given hash, or `None` if not in the DB.
-pub fn get_commit_by_hash(
-    db_path: &Path,
-    hash: &str,
-) -> Result<Option<crate::sqlite_types::Commit>> {
-    let conn = Connection::open(db_path)?;
-    let result = conn.query_row(
-        "SELECT id, hash, tree_hash, message, created_at FROM commits WHERE hash = ?1",
-        [hash],
-        |row| {
-            Ok(crate::sqlite_types::Commit {
-                id: row.get("id")?,
-                hash: row.get("hash")?,
-                tree_hash: row.get("tree_hash")?,
-                message: row.get("message")?,
-                created_at: row.get("created_at")?,
-            })
-        },
-    );
-    match result {
-        Ok(row) => Ok(Some(row)),
-        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-        Err(e) => Err(e.into()),
-    }
-}
-
-/// Returns the full commit row for a given hash through the managed Diesel pool.
-#[cfg(test)]
-pub fn get_commit_by_hash_in_pool(
-    pool: &DbPool,
-    hash: &str,
-) -> Result<Option<crate::sqlite_types::Commit>> {
-    let mut conn = pool.get()?;
-    let row = commits::table
-        .filter(commits::hash.eq(hash))
-        .select(CommitRow::as_select())
-        .first::<CommitRow>(&mut conn)
-        .optional()?;
-
-    Ok(row.map(Into::into))
+    Ok(Some(upsert_commit_in_pool(
+        pool, &hash, &tree_hash, None, now,
+    )?))
 }
 
 #[cfg(test)]

--- a/apps/native/src-tauri/src/db/commits.rs
+++ b/apps/native/src-tauri/src/db/commits.rs
@@ -38,7 +38,7 @@ impl From<CommitRow> for crate::sqlite_types::Commit {
 }
 
 /// Insert a commit through the managed Diesel pool, returning its id.
-pub fn upsert_commit_in_pool(
+pub fn upsert_commit(
     pool: &DbPool,
     hash: &str,
     tree_hash: &str,
@@ -75,7 +75,7 @@ pub fn upsert_commit_in_pool(
 }
 
 /// Returns the full commit row for a given hash through the managed Diesel pool.
-pub fn get_commit_by_hash_in_pool(
+pub fn get_commit_by_hash(
     pool: &DbPool,
     hash: &str,
 ) -> Result<Option<crate::sqlite_types::Commit>> {
@@ -90,7 +90,7 @@ pub fn get_commit_by_hash_in_pool(
 }
 
 /// Passes through `existing` if `Some`; otherwise resolves HEAD from git and upserts it.
-pub fn store_head_commit_in_pool(
+pub fn store_head_commit(
     pool: &DbPool,
     config_dir: &str,
     existing: Option<i64>,
@@ -105,7 +105,7 @@ pub fn store_head_commit_in_pool(
         return Ok(None);
     };
     let now = crate::utils::unix_now();
-    Ok(Some(upsert_commit_in_pool(
+    Ok(Some(upsert_commit(
         pool, &hash, &tree_hash, None, now,
     )?))
 }
@@ -121,10 +121,10 @@ mod tests {
         let pool = crate::db::init_pool_at_path(&db_path).await.unwrap();
 
         let first_id =
-            upsert_commit_in_pool(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
+            upsert_commit(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
         let second_id =
-            upsert_commit_in_pool(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
-        let commit = get_commit_by_hash_in_pool(&pool, "abc123")
+            upsert_commit(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
+        let commit = get_commit_by_hash(&pool, "abc123")
             .unwrap()
             .unwrap();
 

--- a/apps/native/src-tauri/src/db/evolutions.rs
+++ b/apps/native/src-tauri/src/db/evolutions.rs
@@ -1,27 +1,59 @@
 //! Evolution persistence helpers.
 
 use anyhow::Result;
-use std::path::Path;
+use diesel::prelude::*;
+
+use crate::db::tables::evolutions;
+use crate::db::DbPool;
 
 /// Upsert an evolution by id: if `existing_id` is Some and exists in the DB, return it.
 /// Otherwise insert a new evolution record and return its id.
-pub fn upsert(db_path: &Path, existing_id: Option<i64>, origin_branch: &str) -> Result<i64> {
-    let conn = rusqlite::Connection::open(db_path)?;
+pub fn upsert(pool: &DbPool, existing_id: Option<i64>, origin_branch: &str) -> Result<i64> {
+    let mut conn = pool.get()?;
+
     if let Some(id) = existing_id {
-        let exists = conn
-            .query_row(
-                "SELECT 1 FROM evolutions WHERE id = ?1",
-                rusqlite::params![id],
-                |_| Ok(()),
-            )
-            .is_ok();
+        let exists = evolutions::table
+            .find(id)
+            .select(evolutions::id)
+            .first::<i64>(&mut conn)
+            .optional()?
+            .is_some();
         if exists {
             return Ok(id);
         }
     }
-    conn.execute(
-        "INSERT INTO evolutions (origin_branch, merged, builds) VALUES (?1, 0, 0)",
-        rusqlite::params![origin_branch],
-    )?;
-    Ok(conn.last_insert_rowid())
+
+    diesel::insert_into(evolutions::table)
+        .values((
+            evolutions::origin_branch.eq(origin_branch),
+            evolutions::merged.eq(0),
+            evolutions::builds.eq(0),
+        ))
+        .execute(&mut conn)?;
+
+    let id = diesel::select(diesel::dsl::sql::<diesel::sql_types::BigInt>(
+        "last_insert_rowid()",
+    ))
+    .get_result::<i64>(&mut conn)?;
+
+    Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn upsert_inserts_new_evolution_then_reuses_existing_id() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("nixmac.db");
+        let pool = crate::db::init_pool_at_path(&db_path).await.unwrap();
+
+        let first_id = upsert(&pool, None, "feature").unwrap();
+        let same_id = upsert(&pool, Some(first_id), "feature").unwrap();
+        let other_id = upsert(&pool, Some(9999), "feature").unwrap();
+
+        assert_eq!(first_id, same_id);
+        assert_ne!(first_id, other_id);
+    }
 }

--- a/apps/native/src-tauri/src/db/pool.rs
+++ b/apps/native/src-tauri/src/db/pool.rs
@@ -1,9 +1,7 @@
 //! Diesel connection pool for the application SQLite database.
 //!
-//! Phase 2 starts by centralizing connection ownership here. Existing query
-//! modules can then move from `rusqlite::Connection::open` to
-//! `tauri::State<DbPool>` incrementally, without changing the schema and
-//! without giving each call site responsibility for opening SQLite.
+//! Every query path acquires its connection from this pool via
+//! `tauri::State<DbPool>`; no module opens SQLite directly.
 
 use anyhow::{Context, Result};
 use diesel::{r2d2::ConnectionManager, sqlite::SqliteConnection};

--- a/apps/native/src-tauri/src/db/restore_commits.rs
+++ b/apps/native/src-tauri/src/db/restore_commits.rs
@@ -5,29 +5,51 @@
 //! copy the origin changeset rather than triggering a fresh summarization run.
 
 use anyhow::Result;
-use rusqlite::Connection;
-use std::path::Path;
+use diesel::prelude::*;
+
+use crate::db::tables::restore_commits;
+use crate::db::DbPool;
 
 /// Record that `commit_hash` is a restore of `origin_hash`.
-pub fn insert(db_path: &Path, commit_hash: &str, origin_hash: &str) -> Result<()> {
-    let conn = Connection::open(db_path)?;
-    conn.execute(
-        "INSERT OR REPLACE INTO restore_commits (commit_hash, origin_hash) VALUES (?1, ?2)",
-        (commit_hash, origin_hash),
-    )?;
+pub fn insert(pool: &DbPool, commit_hash: &str, origin_hash: &str) -> Result<()> {
+    let mut conn = pool.get()?;
+    diesel::replace_into(restore_commits::table)
+        .values((
+            restore_commits::commit_hash.eq(commit_hash),
+            restore_commits::origin_hash.eq(origin_hash),
+        ))
+        .execute(&mut conn)?;
     Ok(())
 }
 
 /// Return the origin hash for `commit_hash`, or `None` if it is not a restore commit.
-pub fn get_origin_hash(db_path: &Path, commit_hash: &str) -> Result<Option<String>> {
-    let conn = Connection::open(db_path)?;
-    match conn.query_row(
-        "SELECT origin_hash FROM restore_commits WHERE commit_hash = ?1",
-        [commit_hash],
-        |row| row.get::<_, String>(0),
-    ) {
-        Ok(hash) => Ok(Some(hash)),
-        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-        Err(e) => Err(e.into()),
+pub fn get_origin_hash(pool: &DbPool, commit_hash: &str) -> Result<Option<String>> {
+    let mut conn = pool.get()?;
+    Ok(restore_commits::table
+        .find(commit_hash)
+        .select(restore_commits::origin_hash)
+        .first::<String>(&mut conn)
+        .optional()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn insert_and_get_origin_hash_round_trips() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("nixmac.db");
+        let pool = crate::db::init_pool_at_path(&db_path).await.unwrap();
+
+        insert(&pool, "abc", "origin-1").unwrap();
+        // REPLACE: the second insert overwrites the origin
+        insert(&pool, "abc", "origin-2").unwrap();
+
+        assert_eq!(
+            get_origin_hash(&pool, "abc").unwrap(),
+            Some("origin-2".to_string())
+        );
+        assert_eq!(get_origin_hash(&pool, "missing").unwrap(), None);
     }
 }

--- a/apps/native/src-tauri/src/db/schema.rs
+++ b/apps/native/src-tauri/src/db/schema.rs
@@ -84,6 +84,7 @@ mod tests {
             .unwrap();
         assert_eq!(row_count, 0);
 
-        crate::db::evolutions::upsert(&db_path, None, "feature").unwrap();
+        let pool = rt.block_on(crate::db::init_pool_at_path(&db_path)).unwrap();
+        crate::db::evolutions::upsert(&pool, None, "feature").unwrap();
     }
 }

--- a/apps/native/src-tauri/src/db/schema.rs
+++ b/apps/native/src-tauri/src/db/schema.rs
@@ -1,16 +1,15 @@
 //! Database schema initialization.
 
-use anyhow::Result;
-use rusqlite::Connection;
+use anyhow::{anyhow, Result};
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+use diesel::sql_types::BigInt;
+use diesel::sqlite::SqliteConnection;
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use std::path::Path;
 
-const SCHEMA_VERSION: i32 = 1;
-const CURRENT_SCHEMA_SQL: &str = concat!(
-    include_str!("../../migrations/01-initial/up.sql"),
-    "\n",
-    include_str!("../../migrations/02-restore-commits/up.sql"),
-    "\nPRAGMA user_version = 1;\n",
-);
+const SCHEMA_VERSION: i64 = 1;
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
 
 /// Initialize schema.
 ///
@@ -22,10 +21,13 @@ const CURRENT_SCHEMA_SQL: &str = concat!(
 pub async fn init_schema(db_path: &Path) -> Result<()> {
     let path = db_path.to_path_buf();
 
-    tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || -> Result<()> {
         recreate_stale_database(&path)?;
-        let conn = Connection::open(&path)?;
-        conn.execute_batch(CURRENT_SCHEMA_SQL)?;
+        let database_url = path.to_string_lossy().into_owned();
+        let mut conn = SqliteConnection::establish(&database_url)?;
+        conn.run_pending_migrations(MIGRATIONS)
+            .map_err(|e| anyhow!("failed to run diesel migrations: {e}"))?;
+        conn.batch_execute(&format!("PRAGMA user_version = {SCHEMA_VERSION};"))?;
         Ok(())
     })
     .await?
@@ -36,8 +38,10 @@ fn recreate_stale_database(path: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let conn = Connection::open(path)?;
-    let version: i32 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    let database_url = path.to_string_lossy().into_owned();
+    let mut conn = SqliteConnection::establish(&database_url)?;
+    let version: i64 = diesel::select(diesel::dsl::sql::<BigInt>("user_version FROM pragma_user_version"))
+        .get_result(&mut conn)?;
     drop(conn);
     if version != SCHEMA_VERSION {
         std::fs::remove_file(path)?;
@@ -48,42 +52,48 @@ fn recreate_stale_database(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rusqlite::Connection;
 
     #[test]
     fn init_schema_recreates_stale_databases_without_migration() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("stale.db");
-        let conn = Connection::open(&db_path).unwrap();
-        conn.execute_batch(
-            r#"
-            CREATE TABLE evolutions (
-                id INTEGER PRIMARY KEY,
-                branch TEXT NOT NULL,
-                merged INTEGER NOT NULL DEFAULT 0,
-                builds INTEGER NOT NULL DEFAULT 0
-            );
-            INSERT INTO evolutions (id, branch, merged, builds) VALUES (1, 'main', 0, 0);
-            PRAGMA user_version = 3;
-            "#,
-        )
-        .unwrap();
-        drop(conn);
+
+        // Seed a stale database (user_version = 3, plus a row that would survive).
+        let database_url = db_path.to_string_lossy().into_owned();
+        {
+            let mut conn = SqliteConnection::establish(&database_url).unwrap();
+            conn.batch_execute(
+                r#"
+                CREATE TABLE evolutions (
+                    id INTEGER PRIMARY KEY,
+                    branch TEXT NOT NULL,
+                    merged INTEGER NOT NULL DEFAULT 0,
+                    builds INTEGER NOT NULL DEFAULT 0
+                );
+                INSERT INTO evolutions (id, branch, merged, builds) VALUES (1, 'main', 0, 0);
+                PRAGMA user_version = 3;
+                "#,
+            )
+            .unwrap();
+        }
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(init_schema(&db_path)).unwrap();
 
-        let conn = Connection::open(&db_path).unwrap();
-        let version: i32 = conn
-            .query_row("PRAGMA user_version", [], |row| row.get(0))
-            .unwrap();
+        let mut conn = SqliteConnection::establish(&database_url).unwrap();
+        let version: i64 =
+            diesel::select(diesel::dsl::sql::<BigInt>("user_version FROM pragma_user_version"))
+                .get_result(&mut conn)
+                .unwrap();
         assert_eq!(version, SCHEMA_VERSION);
 
-        let row_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM evolutions", [], |row| row.get(0))
+        let row_count = crate::db::tables::evolutions::table
+            .count()
+            .get_result::<i64>(&mut conn)
             .unwrap();
         assert_eq!(row_count, 0);
 
+        drop(conn);
         let pool = rt.block_on(crate::db::init_pool_at_path(&db_path)).unwrap();
         crate::db::evolutions::upsert(&pool, None, "feature").unwrap();
     }

--- a/apps/native/src-tauri/src/db/store_bare_changeset.rs
+++ b/apps/native/src-tauri/src/db/store_bare_changeset.rs
@@ -1,30 +1,31 @@
 //! Lightweight changeset persistence — no AI, no queued summaries.
 
 use anyhow::Result;
-use std::path::Path;
+use diesel::connection::Connection;
 
 use crate::db::changesets::{insert_change_or_ignore, insert_change_set, link_change_to_set};
+use crate::db::DbPool;
 use crate::sqlite_types::Change;
 use crate::utils::unix_now;
 
 /// Insert `changes` as bare rows where absent, create a new changeset.
-pub fn store(db_path: &Path, base_commit_id: i64, changes: &[Change]) -> Result<i64> {
-    let mut conn = rusqlite::Connection::open(db_path)?;
+pub fn store(pool: &DbPool, base_commit_id: i64, changes: &[Change]) -> Result<i64> {
+    let mut conn = pool.get()?;
     let now = unix_now();
-    let tx = conn.transaction()?;
 
-    let mut change_ids = Vec::with_capacity(changes.len());
-    for change in changes {
-        let id = insert_change_or_ignore(&tx, change, None)?;
-        change_ids.push(id);
-    }
+    conn.transaction::<i64, anyhow::Error, _>(|conn| {
+        let mut change_ids = Vec::with_capacity(changes.len());
+        for change in changes {
+            let id = insert_change_or_ignore(conn, change, None)?;
+            change_ids.push(id);
+        }
 
-    let change_set_id = insert_change_set(&tx, None, base_commit_id, None, None, now, None)?;
+        let change_set_id = insert_change_set(conn, None, base_commit_id, None, None, now, None)?;
 
-    for id in change_ids {
-        link_change_to_set(&tx, change_set_id, id)?;
-    }
+        for id in change_ids {
+            link_change_to_set(conn, change_set_id, id)?;
+        }
 
-    tx.commit()?;
-    Ok(change_set_id)
+        Ok(change_set_id)
+    })
 }

--- a/apps/native/src-tauri/src/db/store_evolved_changeset.rs
+++ b/apps/native/src-tauri/src/db/store_evolved_changeset.rs
@@ -1,20 +1,21 @@
 //! Persists an evolved summarization pipeline result to the database.
 
 use anyhow::Result;
-use rusqlite::Transaction;
-use std::path::Path;
+use diesel::connection::Connection;
+use diesel::sqlite::SqliteConnection;
 
 use crate::db::changesets::{
     build_pairs_json, get_change_id_by_hash, insert_change_set, insert_change_summary,
     insert_queued_summary, link_change_to_group_summary, link_change_to_set, upsert_change,
 };
+use crate::db::DbPool;
 use crate::shared_types::SemanticChangeMap;
 use crate::summarize::assignments::{
     Assignments, EvolvedGroupAssignment, NewGroupAssignment, NewSingleAssignment,
 };
 
 pub fn store(
-    db_path: &Path,
+    pool: &DbPool,
     commit_id: Option<i64>,
     base_commit_id: i64,
     commit_message: Option<&str>,
@@ -22,87 +23,91 @@ pub fn store(
     semantic_map: &SemanticChangeMap,
     evolution_id: Option<i64>,
 ) -> Result<(i64, Vec<i64>)> {
-    let mut conn = rusqlite::Connection::open(db_path)?;
+    let mut conn = pool.get()?;
     let now = crate::utils::unix_now();
-    let tx = conn.transaction()?;
 
-    let mut queued_ids = Vec::new();
-    for a in &mut assignments.evolved {
-        queued_ids.push(store_evolved(&tx, a, now)?);
-    }
-    for a in &mut assignments.new_groups {
-        queued_ids.push(store_new_group(&tx, a, now)?);
-    }
-    for a in &mut assignments.new_singles {
-        queued_ids.push(store_new_single(&tx, a, now)?);
-    }
-
-    let change_set_id = insert_change_set(
-        &tx,
-        commit_id,
-        base_commit_id,
-        commit_message,
-        None,
-        now,
-        evolution_id,
-    )?;
-
-    // Collect all change IDs — HashSet deduplicates existing + new overlaps.
-    let mut all_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
-    for a in &assignments.evolved {
-        for &id in &a.change_ids {
-            all_ids.insert(id);
+    conn.transaction::<(i64, Vec<i64>), anyhow::Error, _>(|conn| {
+        let mut queued_ids = Vec::new();
+        for a in &mut assignments.evolved {
+            queued_ids.push(store_evolved(conn, a, now)?);
         }
-    }
-    for a in &assignments.new_groups {
-        for &id in &a.change_ids {
-            all_ids.insert(id);
+        for a in &mut assignments.new_groups {
+            queued_ids.push(store_new_group(conn, a, now)?);
         }
-    }
-    for a in &assignments.new_singles {
-        if let Some(id) = a.pending.change_id {
-            all_ids.insert(id);
+        for a in &mut assignments.new_singles {
+            queued_ids.push(store_new_single(conn, a, now)?);
         }
-    }
-    // Include all existing changes from the map (groups/singles with no new placements).
-    for group in &semantic_map.groups {
-        for c in &group.changes {
-            all_ids.insert(c.id);
-        }
-    }
-    for single in &semantic_map.singles {
-        all_ids.insert(single.id);
-    }
 
-    for &id in &all_ids {
-        link_change_to_set(&tx, change_set_id, id)?;
-    }
+        let change_set_id = insert_change_set(
+            conn,
+            commit_id,
+            base_commit_id,
+            commit_message,
+            None,
+            now,
+            evolution_id,
+        )?;
 
-    tx.commit()?;
-    Ok((change_set_id, queued_ids))
+        // Collect all change IDs — HashSet deduplicates existing + new overlaps.
+        let mut all_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
+        for a in &assignments.evolved {
+            for &id in &a.change_ids {
+                all_ids.insert(id);
+            }
+        }
+        for a in &assignments.new_groups {
+            for &id in &a.change_ids {
+                all_ids.insert(id);
+            }
+        }
+        for a in &assignments.new_singles {
+            if let Some(id) = a.pending.change_id {
+                all_ids.insert(id);
+            }
+        }
+        // Include all existing changes from the map (groups/singles with no new placements).
+        for group in &semantic_map.groups {
+            for c in &group.changes {
+                all_ids.insert(c.id);
+            }
+        }
+        for single in &semantic_map.singles {
+            all_ids.insert(single.id);
+        }
+
+        for &id in &all_ids {
+            link_change_to_set(conn, change_set_id, id)?;
+        }
+
+        Ok((change_set_id, queued_ids))
+    })
 }
 
-fn store_evolved(tx: &Transaction, a: &mut EvolvedGroupAssignment, now: i64) -> Result<i64> {
+fn store_evolved(
+    conn: &mut SqliteConnection,
+    a: &mut EvolvedGroupAssignment,
+    now: i64,
+) -> Result<i64> {
     for nc in &mut a.new_changes {
-        nc.own_summary_id = Some(insert_change_summary(tx, "", "", "QUEUED", now)?);
+        nc.own_summary_id = Some(insert_change_summary(conn, "", "", "QUEUED", now)?);
     }
-    let group_summary_id = insert_change_summary(tx, "", "", "QUEUED", now)?;
+    let group_summary_id = insert_change_summary(conn, "", "", "QUEUED", now)?;
     a.group_summary_id = Some(group_summary_id);
 
     for nc in &mut a.new_changes {
-        upsert_change(tx, &nc.change, nc.own_summary_id)?;
-        let change_id = get_change_id_by_hash(tx, &nc.change.hash)?;
+        upsert_change(conn, &nc.change, nc.own_summary_id)?;
+        let change_id = get_change_id_by_hash(conn, &nc.change.hash)?;
         nc.change_id = Some(change_id);
         a.change_ids.push(change_id);
     }
 
     for &id in &a.change_ids {
-        link_change_to_group_summary(tx, id, group_summary_id)?;
+        link_change_to_group_summary(conn, id, group_summary_id)?;
     }
 
     let pairs = build_pairs_json(&a.new_changes);
     let queued_id = insert_queued_summary(
-        tx,
+        conn,
         &a.prompt,
         "EVOLVED_GROUP",
         Some(group_summary_id),
@@ -112,27 +117,31 @@ fn store_evolved(tx: &Transaction, a: &mut EvolvedGroupAssignment, now: i64) -> 
     Ok(queued_id)
 }
 
-fn store_new_group(tx: &Transaction, a: &mut NewGroupAssignment, now: i64) -> Result<i64> {
+fn store_new_group(
+    conn: &mut SqliteConnection,
+    a: &mut NewGroupAssignment,
+    now: i64,
+) -> Result<i64> {
     for c in &mut a.changes {
-        c.own_summary_id = Some(insert_change_summary(tx, "", "", "QUEUED", now)?);
+        c.own_summary_id = Some(insert_change_summary(conn, "", "", "QUEUED", now)?);
     }
-    let group_summary_id = insert_change_summary(tx, "", "", "QUEUED", now)?;
+    let group_summary_id = insert_change_summary(conn, "", "", "QUEUED", now)?;
     a.group_summary_id = Some(group_summary_id);
 
     for c in &mut a.changes {
-        upsert_change(tx, &c.change, c.own_summary_id)?;
-        let change_id = get_change_id_by_hash(tx, &c.change.hash)?;
+        upsert_change(conn, &c.change, c.own_summary_id)?;
+        let change_id = get_change_id_by_hash(conn, &c.change.hash)?;
         c.change_id = Some(change_id);
         a.change_ids.push(change_id);
     }
 
     for &id in &a.change_ids {
-        link_change_to_group_summary(tx, id, group_summary_id)?;
+        link_change_to_group_summary(conn, id, group_summary_id)?;
     }
 
     let pairs = build_pairs_json(&a.changes);
     let queued_id = insert_queued_summary(
-        tx,
+        conn,
         &a.prompt,
         "NEW_GROUP",
         Some(group_summary_id),
@@ -142,10 +151,14 @@ fn store_new_group(tx: &Transaction, a: &mut NewGroupAssignment, now: i64) -> Re
     Ok(queued_id)
 }
 
-fn store_new_single(tx: &Transaction, a: &mut NewSingleAssignment, now: i64) -> Result<i64> {
-    a.pending.own_summary_id = Some(insert_change_summary(tx, "", "", "QUEUED", now)?);
-    upsert_change(tx, &a.pending.change, a.pending.own_summary_id)?;
-    let change_id = get_change_id_by_hash(tx, &a.pending.change.hash)?;
+fn store_new_single(
+    conn: &mut SqliteConnection,
+    a: &mut NewSingleAssignment,
+    now: i64,
+) -> Result<i64> {
+    a.pending.own_summary_id = Some(insert_change_summary(conn, "", "", "QUEUED", now)?);
+    upsert_change(conn, &a.pending.change, a.pending.own_summary_id)?;
+    let change_id = get_change_id_by_hash(conn, &a.pending.change.hash)?;
     a.pending.change_id = Some(change_id);
 
     let pairs = serde_json::to_string(&[serde_json::json!({
@@ -153,7 +166,7 @@ fn store_new_single(tx: &Transaction, a: &mut NewSingleAssignment, now: i64) -> 
         "summary_id": a.pending.own_summary_id.expect("own_summary_id set on line above")
     })])
     .unwrap_or_default();
-    let queued_id = insert_queued_summary(tx, &a.prompt, "NEW_SINGLE", None, Some(&pairs))?;
+    let queued_id = insert_queued_summary(conn, &a.prompt, "NEW_SINGLE", None, Some(&pairs))?;
 
     Ok(queued_id)
 }

--- a/apps/native/src-tauri/src/db/store_new_changeset.rs
+++ b/apps/native/src-tauri/src/db/store_new_changeset.rs
@@ -1,86 +1,91 @@
 //! Persists a new summarization pipeline result to the database.
 
 use anyhow::Result;
-use rusqlite::Transaction;
-use std::path::Path;
+use diesel::connection::Connection;
+use diesel::sqlite::SqliteConnection;
 
 use crate::db::changesets::{
     build_pairs_json, get_change_id_by_hash, insert_change_set, insert_change_summary,
     insert_queued_summary, link_change_to_group_summary, link_change_to_set, upsert_change,
 };
+use crate::db::DbPool;
 use crate::summarize::assignments::{Assignments, NewGroupAssignment, NewSingleAssignment};
 
 pub fn store(
-    db_path: &Path,
+    pool: &DbPool,
     commit_id: Option<i64>,
     base_commit_id: i64,
     commit_message: Option<&str>,
     assignments: &mut Assignments,
     evolution_id: Option<i64>,
 ) -> Result<(i64, Vec<i64>)> {
-    let mut conn = rusqlite::Connection::open(db_path)?;
+    let mut conn = pool.get()?;
     let now = crate::utils::unix_now();
-    let tx = conn.transaction()?;
 
-    let mut queued_ids = Vec::new();
-    for a in &mut assignments.new_groups {
-        queued_ids.push(store_new_group(&tx, a, now)?);
-    }
-    for a in &mut assignments.new_singles {
-        queued_ids.push(store_new_single(&tx, a, now)?);
-    }
-
-    let change_set_id = insert_change_set(
-        &tx,
-        commit_id,
-        base_commit_id,
-        commit_message,
-        None,
-        now,
-        evolution_id,
-    )?;
-
-    let mut all_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
-    for a in &assignments.new_groups {
-        for &id in &a.change_ids {
-            all_ids.insert(id);
+    conn.transaction::<(i64, Vec<i64>), anyhow::Error, _>(|conn| {
+        let mut queued_ids = Vec::new();
+        for a in &mut assignments.new_groups {
+            queued_ids.push(store_new_group(conn, a, now)?);
         }
-    }
-    for a in &assignments.new_singles {
-        if let Some(id) = a.pending.change_id {
-            all_ids.insert(id);
+        for a in &mut assignments.new_singles {
+            queued_ids.push(store_new_single(conn, a, now)?);
         }
-    }
 
-    for &id in &all_ids {
-        link_change_to_set(&tx, change_set_id, id)?;
-    }
+        let change_set_id = insert_change_set(
+            conn,
+            commit_id,
+            base_commit_id,
+            commit_message,
+            None,
+            now,
+            evolution_id,
+        )?;
 
-    tx.commit()?;
-    Ok((change_set_id, queued_ids))
+        let mut all_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
+        for a in &assignments.new_groups {
+            for &id in &a.change_ids {
+                all_ids.insert(id);
+            }
+        }
+        for a in &assignments.new_singles {
+            if let Some(id) = a.pending.change_id {
+                all_ids.insert(id);
+            }
+        }
+
+        for &id in &all_ids {
+            link_change_to_set(conn, change_set_id, id)?;
+        }
+
+        Ok((change_set_id, queued_ids))
+    })
 }
 
-fn store_new_group(tx: &Transaction, a: &mut NewGroupAssignment, now: i64) -> Result<i64> {
+fn store_new_group(
+    conn: &mut SqliteConnection,
+    a: &mut NewGroupAssignment,
+    now: i64,
+) -> Result<i64> {
     for c in &mut a.changes {
-        c.own_summary_id = Some(insert_change_summary(tx, "", "", "QUEUED", now)?);
+        c.own_summary_id = Some(insert_change_summary(conn, "", "", "QUEUED", now)?);
     }
-    let group_summary_id = insert_change_summary(tx, "", "", "QUEUED", now)?;
+    let group_summary_id = insert_change_summary(conn, "", "", "QUEUED", now)?;
     a.group_summary_id = Some(group_summary_id);
 
     for c in &mut a.changes {
-        upsert_change(tx, &c.change, c.own_summary_id)?;
-        let change_id = get_change_id_by_hash(tx, &c.change.hash)?;
+        upsert_change(conn, &c.change, c.own_summary_id)?;
+        let change_id = get_change_id_by_hash(conn, &c.change.hash)?;
         c.change_id = Some(change_id);
         a.change_ids.push(change_id);
     }
 
     for &id in &a.change_ids {
-        link_change_to_group_summary(tx, id, group_summary_id)?;
+        link_change_to_group_summary(conn, id, group_summary_id)?;
     }
 
     let pairs = build_pairs_json(&a.changes);
     let queued_id = insert_queued_summary(
-        tx,
+        conn,
         &a.prompt,
         "NEW_GROUP",
         Some(group_summary_id),
@@ -90,10 +95,14 @@ fn store_new_group(tx: &Transaction, a: &mut NewGroupAssignment, now: i64) -> Re
     Ok(queued_id)
 }
 
-fn store_new_single(tx: &Transaction, a: &mut NewSingleAssignment, now: i64) -> Result<i64> {
-    a.pending.own_summary_id = Some(insert_change_summary(tx, "", "", "QUEUED", now)?);
-    upsert_change(tx, &a.pending.change, a.pending.own_summary_id)?;
-    let change_id = get_change_id_by_hash(tx, &a.pending.change.hash)?;
+fn store_new_single(
+    conn: &mut SqliteConnection,
+    a: &mut NewSingleAssignment,
+    now: i64,
+) -> Result<i64> {
+    a.pending.own_summary_id = Some(insert_change_summary(conn, "", "", "QUEUED", now)?);
+    upsert_change(conn, &a.pending.change, a.pending.own_summary_id)?;
+    let change_id = get_change_id_by_hash(conn, &a.pending.change.hash)?;
     a.pending.change_id = Some(change_id);
 
     let pairs = serde_json::to_string(&[serde_json::json!({
@@ -101,7 +110,7 @@ fn store_new_single(tx: &Transaction, a: &mut NewSingleAssignment, now: i64) -> 
         "summary_id": a.pending.own_summary_id.expect("own_summary_id set on line above")
     })])
     .unwrap_or_default();
-    let queued_id = insert_queued_summary(tx, &a.prompt, "NEW_SINGLE", None, Some(&pairs))?;
+    let queued_id = insert_queued_summary(conn, &a.prompt, "NEW_SINGLE", None, Some(&pairs))?;
 
     Ok(queued_id)
 }

--- a/apps/native/src-tauri/src/db/tables.rs
+++ b/apps/native/src-tauri/src/db/tables.rs
@@ -9,3 +9,111 @@ diesel::table! {
         created_at -> BigInt,
     }
 }
+
+diesel::table! {
+    evolutions (id) {
+        id -> BigInt,
+        origin_branch -> Text,
+        merged -> Integer,
+        builds -> Integer,
+    }
+}
+
+diesel::table! {
+    change_summaries (id) {
+        id -> BigInt,
+        title -> Text,
+        description -> Text,
+        status -> Text,
+        created_at -> BigInt,
+    }
+}
+
+diesel::table! {
+    changes (id) {
+        id -> BigInt,
+        hash -> Text,
+        filename -> Text,
+        diff -> Text,
+        line_count -> Integer,
+        created_at -> BigInt,
+        own_summary_id -> Nullable<BigInt>,
+    }
+}
+
+diesel::table! {
+    group_summaries (change_id, change_summary_id) {
+        change_id -> BigInt,
+        change_summary_id -> BigInt,
+    }
+}
+
+diesel::table! {
+    change_sets (id) {
+        id -> BigInt,
+        commit_id -> Nullable<BigInt>,
+        base_commit_id -> BigInt,
+        commit_message -> Nullable<Text>,
+        generated_commit_message -> Nullable<Text>,
+        created_at -> BigInt,
+        evolution_id -> Nullable<BigInt>,
+    }
+}
+
+diesel::table! {
+    set_changes (change_set_id, change_id) {
+        change_set_id -> BigInt,
+        change_id -> BigInt,
+    }
+}
+
+diesel::table! {
+    queued_summaries (id) {
+        id -> BigInt,
+        status -> Text,
+        attempted_count -> Integer,
+        prompt -> Text,
+        model_response -> Nullable<Text>,
+        group_summary_id -> Nullable<BigInt>,
+        hash_own_summary_id_pairs -> Nullable<Text>,
+        #[sql_name = "type"]
+        type_ -> Text,
+    }
+}
+
+diesel::table! {
+    prompts (id) {
+        id -> BigInt,
+        text -> Text,
+        commit_id -> Nullable<BigInt>,
+        created_at -> BigInt,
+    }
+}
+
+diesel::table! {
+    restore_commits (commit_hash) {
+        commit_hash -> Text,
+        origin_hash -> Text,
+    }
+}
+
+diesel::joinable!(changes -> change_summaries (own_summary_id));
+diesel::joinable!(group_summaries -> changes (change_id));
+diesel::joinable!(group_summaries -> change_summaries (change_summary_id));
+diesel::joinable!(change_sets -> evolutions (evolution_id));
+diesel::joinable!(set_changes -> change_sets (change_set_id));
+diesel::joinable!(set_changes -> changes (change_id));
+diesel::joinable!(prompts -> commits (commit_id));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    change_sets,
+    change_summaries,
+    changes,
+    commits,
+    evolutions,
+    group_summaries,
+    prompts,
+    queued_summaries,
+    restore_commits,
+    set_changes,
+);

--- a/apps/native/src-tauri/src/db/tables.rs
+++ b/apps/native/src-tauri/src/db/tables.rs
@@ -35,7 +35,7 @@ diesel::table! {
         hash -> Text,
         filename -> Text,
         diff -> Text,
-        line_count -> Integer,
+        line_count -> BigInt,
         created_at -> BigInt,
         own_summary_id -> Nullable<BigInt>,
     }
@@ -71,7 +71,7 @@ diesel::table! {
     queued_summaries (id) {
         id -> BigInt,
         status -> Text,
-        attempted_count -> Integer,
+        attempted_count -> BigInt,
         prompt -> Text,
         model_response -> Nullable<Text>,
         group_summary_id -> Nullable<BigInt>,

--- a/apps/native/src-tauri/src/evolve/lifecycle.rs
+++ b/apps/native/src-tauri/src/evolve/lifecycle.rs
@@ -295,9 +295,12 @@ pub async fn backup_evolve_and_record_changeset(
     .unwrap_or_default();
 
     // Build the change map from whatever is now stored in the DB.
+    let pool = app.state::<db::DbPool>();
     let change_map = db::get_db_path(app)
         .ok()
-        .and_then(|db_path| summarize::find_existing::for_current_state(&db_path, &repo_root).ok())
+        .and_then(|db_path| {
+            summarize::find_existing::for_current_state(&pool, &db_path, &repo_root).ok()
+        })
         .map(summarize::group_existing::from_change_sets)
         .unwrap_or_default();
 

--- a/apps/native/src-tauri/src/evolve/lifecycle.rs
+++ b/apps/native/src-tauri/src/evolve/lifecycle.rs
@@ -7,7 +7,7 @@
 //! All steps are atomic from the frontend's perspective - one call does everything.
 
 use log::info;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 use crate::state::{build_state, evolve_state};
 use crate::storage::store;
@@ -350,18 +350,11 @@ pub async fn store_metadata(
     app: &AppHandle,
     status: &crate::shared_types::GitStatus,
 ) -> (Option<i64>, Option<i64>) {
-    let db_path = match db::get_db_path(app) {
-        Ok(p) => p,
-        Err(e) => {
-            log::error!("[evolution] failed to get db path: {}", e);
-            return (None, None);
-        }
-    };
-
     // Reuse an in-progress evolution (e.g. after adopt-then-evolve); otherwise insert fresh.
     let existing_id = evolve_state::get(app).ok().and_then(|s| s.evolution_id);
+    let pool = app.state::<db::DbPool>();
     let evolution_id = match db::evolutions::upsert(
-        &db_path,
+        &pool,
         existing_id,
         status.branch.as_deref().unwrap_or("unknown"),
     ) {

--- a/apps/native/src-tauri/src/evolve/lifecycle.rs
+++ b/apps/native/src-tauri/src/evolve/lifecycle.rs
@@ -296,11 +296,8 @@ pub async fn backup_evolve_and_record_changeset(
 
     // Build the change map from whatever is now stored in the DB.
     let pool = app.state::<db::DbPool>();
-    let change_map = db::get_db_path(app)
+    let change_map = summarize::find_existing::for_current_state(&pool, &repo_root)
         .ok()
-        .and_then(|db_path| {
-            summarize::find_existing::for_current_state(&pool, &db_path, &repo_root).ok()
-        })
         .map(summarize::group_existing::from_change_sets)
         .unwrap_or_default();
 

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -9,7 +9,6 @@ pub async fn get_history<R: Runtime>(
     app: &AppHandle<R>,
 ) -> Result<Vec<crate::shared_types::HistoryItem>> {
     let config_dir = crate::storage::store::get_config_dir(app)?;
-    let db_path = crate::db::get_db_path(app)?;
     let pool = app.state::<crate::db::DbPool>();
 
     let git_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
@@ -58,7 +57,7 @@ pub async fn get_history<R: Runtime>(
         let (change_map, unsummarized_hashes) = if let Some(ref parent) = parent_db {
             let diff_hashes: Vec<String> = raw_changes.iter().map(|c| c.hash.clone()).collect();
             match crate::summarize::find_existing::by_base_with_hashes(
-                &db_path,
+                &pool,
                 parent.id,
                 &diff_hashes,
             ) {

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -25,10 +25,10 @@ pub async fn get_history<R: Runtime>(
 
     for (i, git_commit) in git_commits.iter().enumerate() {
         let db_commit =
-            crate::db::commits::get_commit_by_hash_in_pool(&pool, &git_commit.hash).unwrap_or(None);
+            crate::db::commits::get_commit_by_hash(&pool, &git_commit.hash).unwrap_or(None);
 
         let parent_db = git_commits.get(i + 1).and_then(|parent| {
-            crate::db::commits::get_commit_by_hash_in_pool(&pool, &parent.hash)
+            crate::db::commits::get_commit_by_hash(&pool, &parent.hash)
                 .ok()
                 .flatten()
         });

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -3,13 +3,14 @@
 use anyhow::Result;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Manager, Runtime};
 
 pub async fn get_history<R: Runtime>(
     app: &AppHandle<R>,
 ) -> Result<Vec<crate::shared_types::HistoryItem>> {
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let db_path = crate::db::get_db_path(app)?;
+    let pool = app.state::<crate::db::DbPool>();
 
     let git_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
 
@@ -78,7 +79,7 @@ pub async fn get_history<R: Runtime>(
         };
 
         let origin_hash = if change_map.is_none() {
-            crate::db::restore_commits::get_origin_hash(&db_path, &git_commit.hash)
+            crate::db::restore_commits::get_origin_hash(&pool, &git_commit.hash)
                 .ok()
                 .flatten()
         } else {

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -26,10 +26,10 @@ pub async fn get_history<R: Runtime>(
 
     for (i, git_commit) in git_commits.iter().enumerate() {
         let db_commit =
-            crate::db::commits::get_commit_by_hash(&db_path, &git_commit.hash).unwrap_or(None);
+            crate::db::commits::get_commit_by_hash_in_pool(&pool, &git_commit.hash).unwrap_or(None);
 
         let parent_db = git_commits.get(i + 1).and_then(|parent| {
-            crate::db::commits::get_commit_by_hash(&db_path, &parent.hash)
+            crate::db::commits::get_commit_by_hash_in_pool(&pool, &parent.hash)
                 .ok()
                 .flatten()
         });

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -607,17 +607,12 @@ fn run_gui_mode(
             app.manage(evolve::config::load_slice(handle)?);
             evolve::config::register_slice_config(&app.state::<state::slice::SliceRegistry>())?;
             app.manage(state::evolve_state::load_slice(handle)?);
-            app.manage(summarize::queue_summarizer::start_worker(handle)?);
 
-            // Initialize SQLite database
-            let db_handle = handle.clone();
-            tauri::async_runtime::spawn(async move {
-                if let Err(e) = db::init(&db_handle).await {
-                    log::error!("Failed to initialize database: {}", e);
-                } else {
-                    log::info!("Database initialized successfully");
-                }
-            });
+            // Initialize SQLite database before any consumer that reads the
+            // managed DbPool from app state (e.g. the queue summarizer worker).
+            tauri::async_runtime::block_on(db::init(handle))?;
+
+            app.manage(summarize::queue_summarizer::start_worker(handle)?);
 
             // Background initialize the scanner singleton; the returned &'static ref is not
             // needed right now. fire-and-forget is intentional here.

--- a/apps/native/src-tauri/src/managed_edits/managed_edit.rs
+++ b/apps/native/src-tauri/src/managed_edits/managed_edit.rs
@@ -19,7 +19,7 @@ pub fn prepare_managed_edit(app: &AppHandle) -> Result<ManagedEditContext> {
         git::status(&dir).context("Failed to get pre-edit working tree status")?;
 
     let pool = app.state::<db::DbPool>();
-    let _base_commit_id = db::commits::store_head_commit_in_pool(&pool, &dir, None)
+    let _base_commit_id = db::commits::store_head_commit(&pool, &dir, None)
         .context("Failed to store HEAD commit")?;
 
     let pre_state = evolve_state::get(app).unwrap_or_default();

--- a/apps/native/src-tauri/src/managed_edits/managed_edit.rs
+++ b/apps/native/src-tauri/src/managed_edits/managed_edit.rs
@@ -20,12 +20,12 @@ pub fn prepare_managed_edit(app: &AppHandle) -> Result<ManagedEditContext> {
     let pre_edit_status =
         git::status(&dir).context("Failed to get pre-edit working tree status")?;
 
-    let _base_commit_id = db::commits::store_head_commit(&db_path, &dir, None)
+    let pool = app.state::<db::DbPool>();
+    let _base_commit_id = db::commits::store_head_commit_in_pool(&pool, &dir, None)
         .context("Failed to store HEAD commit")?;
 
     let pre_state = evolve_state::get(app).unwrap_or_default();
     let branch = git::current_branch(&dir).unwrap_or_else(|| "main".to_string());
-    let pool = app.state::<db::DbPool>();
     let evolution_id = db::evolutions::upsert(&pool, pre_state.evolution_id, &branch)
         .context("Failed to upsert evolution")?;
 
@@ -102,9 +102,13 @@ pub async fn finalize_managed_edit(
         }
     }
 
-    let change_sets =
-        summarize::find_existing::for_current_state(context.db_path.as_path(), &context.dir)
-            .unwrap_or_default();
+    let pool = app.state::<db::DbPool>();
+    let change_sets = summarize::find_existing::for_current_state(
+        &pool,
+        context.db_path.as_path(),
+        &context.dir,
+    )
+    .unwrap_or_default();
 
     let change_map = summarize::group_existing::from_change_sets(change_sets);
     let git_status =

--- a/apps/native/src-tauri/src/managed_edits/managed_edit.rs
+++ b/apps/native/src-tauri/src/managed_edits/managed_edit.rs
@@ -1,7 +1,7 @@
 //! Reusable managed review helpers for non-AI edits.
 
 use anyhow::{Context, Result};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 use crate::state::{build_state, evolve_state};
 use crate::storage::store;
@@ -25,7 +25,8 @@ pub fn prepare_managed_edit(app: &AppHandle) -> Result<ManagedEditContext> {
 
     let pre_state = evolve_state::get(app).unwrap_or_default();
     let branch = git::current_branch(&dir).unwrap_or_else(|| "main".to_string());
-    let evolution_id = db::evolutions::upsert(&db_path, pre_state.evolution_id, &branch)
+    let pool = app.state::<db::DbPool>();
+    let evolution_id = db::evolutions::upsert(&pool, pre_state.evolution_id, &branch)
         .context("Failed to upsert evolution")?;
 
     let changeset_id = pre_state.current_changeset_id.unwrap_or(0);

--- a/apps/native/src-tauri/src/managed_edits/managed_edit.rs
+++ b/apps/native/src-tauri/src/managed_edits/managed_edit.rs
@@ -9,14 +9,12 @@ use crate::{db, git, shared_types, summarize};
 
 pub struct ManagedEditContext {
     pub dir: String,
-    pub db_path: std::path::PathBuf,
     pub evolution_id: i64,
     pub evolve_state: shared_types::EvolveState,
 }
 
 pub fn prepare_managed_edit(app: &AppHandle) -> Result<ManagedEditContext> {
     let dir = store::ensure_config_dir_exists(app).context("Failed to get config directory")?;
-    let db_path = db::get_db_path(app).context("Failed to get DB path")?;
     let pre_edit_status =
         git::status(&dir).context("Failed to get pre-edit working tree status")?;
 
@@ -71,7 +69,6 @@ pub fn prepare_managed_edit(app: &AppHandle) -> Result<ManagedEditContext> {
 
     Ok(ManagedEditContext {
         dir,
-        db_path,
         evolution_id,
         evolve_state,
     })
@@ -103,12 +100,8 @@ pub async fn finalize_managed_edit(
     }
 
     let pool = app.state::<db::DbPool>();
-    let change_sets = summarize::find_existing::for_current_state(
-        &pool,
-        context.db_path.as_path(),
-        &context.dir,
-    )
-    .unwrap_or_default();
+    let change_sets =
+        summarize::find_existing::for_current_state(&pool, &context.dir).unwrap_or_default();
 
     let change_map = summarize::group_existing::from_change_sets(change_sets);
     let git_status =

--- a/apps/native/src-tauri/src/rebuild/finalize_restore.rs
+++ b/apps/native/src-tauri/src/rebuild/finalize_restore.rs
@@ -1,7 +1,7 @@
 //! Post-restore finalization: commit, tag, record in DB, then record build state.
 
 use anyhow::{Context, Result};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 use crate::state::build_state;
 use crate::storage::store;
@@ -30,21 +30,20 @@ pub async fn finalize_restore(app: &AppHandle, target_hash: String) -> Result<Gi
     }
 
     // Record restore origin in DB
-    if let Ok(db_path) = db::get_db_path(app) {
-        let commit_hash = info.hash.clone();
-        let origin = target_hash.clone();
-        match tokio::task::spawn_blocking(move || {
-            db::restore_commits::insert(&db_path, &commit_hash, &origin)
-        })
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => log::warn!("[finalize_restore] Failed to record restore origin: {}", e),
-            Err(e) => log::warn!(
-                "[finalize_restore] Failed to record restore origin (panic): {}",
-                e
-            ),
-        }
+    let pool = app.state::<db::DbPool>().inner().clone();
+    let commit_hash = info.hash.clone();
+    let origin = target_hash.clone();
+    match tokio::task::spawn_blocking(move || {
+        db::restore_commits::insert(&pool, &commit_hash, &origin)
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => log::warn!("[finalize_restore] Failed to record restore origin: {}", e),
+        Err(e) => log::warn!(
+            "[finalize_restore] Failed to record restore origin (panic): {}",
+            e
+        ),
     }
 
     let git_status = git::status(&config_dir).context("Failed to get git status after restore")?;

--- a/apps/native/src-tauri/src/state/build_state.rs
+++ b/apps/native/src-tauri/src/state/build_state.rs
@@ -120,7 +120,7 @@ pub fn record_build<R: Runtime>(app: &AppHandle<R>, git_status: &GitStatus) -> R
     let pool = app.state::<crate::db::DbPool>();
 
     let build_changeset_id = if !git_status.changes.is_empty() {
-        let base_id = crate::db::commits::store_head_commit_in_pool(&pool, &config_dir, None)?
+        let base_id = crate::db::commits::store_head_commit(&pool, &config_dir, None)?
             .ok_or_else(|| anyhow::anyhow!("missing HEAD commit while recording build state"))?;
         Some(crate::db::store_bare_changeset::store(
             &pool,

--- a/apps/native/src-tauri/src/state/build_state.rs
+++ b/apps/native/src-tauri/src/state/build_state.rs
@@ -77,13 +77,12 @@ pub fn current_state_built<R: Runtime>(app: &AppHandle<R>, current_changes: &[Ch
     match state.changeset_id {
         None => current_changes.is_empty(),
         Some(id) => {
-            let Ok(db_path) = crate::db::get_db_path(app) else {
+            let pool = app.state::<crate::db::DbPool>();
+            let Ok(mut conn) = pool.get() else {
                 return false;
             };
-            let Ok(conn) = rusqlite::Connection::open(&db_path) else {
-                return false;
-            };
-            let Ok(stored_hashes) = crate::db::changesets::fetch_hashes_for_changeset(&conn, id)
+            let Ok(stored_hashes) =
+                crate::db::changesets::fetch_hashes_for_changeset(&mut conn, id)
             else {
                 return false;
             };
@@ -117,7 +116,6 @@ pub fn set_active_build<R: Runtime>(
 
 /// Compute build state with a "bare" changeset to verify it
 pub fn record_build<R: Runtime>(app: &AppHandle<R>, git_status: &GitStatus) -> Result<()> {
-    let db_path = crate::db::get_db_path(app)?;
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let pool = app.state::<crate::db::DbPool>();
 
@@ -125,7 +123,7 @@ pub fn record_build<R: Runtime>(app: &AppHandle<R>, git_status: &GitStatus) -> R
         let base_id = crate::db::commits::store_head_commit_in_pool(&pool, &config_dir, None)?
             .ok_or_else(|| anyhow::anyhow!("missing HEAD commit while recording build state"))?;
         Some(crate::db::store_bare_changeset::store(
-            &db_path,
+            &pool,
             base_id,
             &git_status.changes,
         )?)

--- a/apps/native/src-tauri/src/state/build_state.rs
+++ b/apps/native/src-tauri/src/state/build_state.rs
@@ -5,7 +5,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_store::StoreExt;
 
 use crate::shared_types::GitStatus;
@@ -119,9 +119,10 @@ pub fn set_active_build<R: Runtime>(
 pub fn record_build<R: Runtime>(app: &AppHandle<R>, git_status: &GitStatus) -> Result<()> {
     let db_path = crate::db::get_db_path(app)?;
     let config_dir = crate::storage::store::get_config_dir(app)?;
+    let pool = app.state::<crate::db::DbPool>();
 
     let build_changeset_id = if !git_status.changes.is_empty() {
-        let base_id = crate::db::commits::store_head_commit(&db_path, &config_dir, None)?
+        let base_id = crate::db::commits::store_head_commit_in_pool(&pool, &config_dir, None)?
             .ok_or_else(|| anyhow::anyhow!("missing HEAD commit while recording build state"))?;
         Some(crate::db::store_bare_changeset::store(
             &db_path,

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -105,14 +105,8 @@ where
 
                         if current_json != cached_json || external_build_detected {
                             let pool = app_handle.state::<db::DbPool>();
-                            let change_map = db::get_db_path(&app_handle)
+                            let change_map = summarize::find_existing::for_current_state(&pool, dir)
                                 .ok()
-                                .and_then(|db_path| {
-                                    summarize::find_existing::for_current_state(
-                                        &pool, &db_path, dir,
-                                    )
-                                    .ok()
-                                })
                                 .map(summarize::group_existing::from_change_sets)
                                 .unwrap_or_default();
                             // Side-effect: refresh the evolve slice. The slice write-guard

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -11,7 +11,7 @@ use crate::{db, git, summarize};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 /// Set to `false` by `start_watching` to stop the old thread before starting a new one.
 static WATCHER_ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -104,10 +104,14 @@ where
                         let current_json = serde_json::to_string(&status).ok();
 
                         if current_json != cached_json || external_build_detected {
+                            let pool = app_handle.state::<db::DbPool>();
                             let change_map = db::get_db_path(&app_handle)
                                 .ok()
                                 .and_then(|db_path| {
-                                    summarize::find_existing::for_current_state(&db_path, dir).ok()
+                                    summarize::find_existing::for_current_state(
+                                        &pool, &db_path, dir,
+                                    )
+                                    .ok()
                                 })
                                 .map(summarize::group_existing::from_change_sets)
                                 .unwrap_or_default();

--- a/apps/native/src-tauri/src/summarize/find_existing.rs
+++ b/apps/native/src-tauri/src/summarize/find_existing.rs
@@ -1,8 +1,6 @@
 //! Orchestrators for querying change sets and summarized changes from the DB.
 
 use anyhow::Result;
-use rusqlite::Connection;
-use std::path::Path;
 
 use crate::db::DbPool;
 use crate::shared_types::{SummarizedChange, SummarizedChangeSet};
@@ -29,13 +27,13 @@ impl From<SummarizedChangeSet> for FoundSetForCurrent {
 
 /// Looks up changes for hashes against a known base commit
 pub fn by_base_with_hashes(
-    db_path: &Path,
+    pool: &DbPool,
     base_commit_id: i64,
     hashes: &[String],
 ) -> Result<FoundSetForCurrent> {
-    let conn = Connection::open(db_path)?;
+    let mut conn = pool.get()?;
     match crate::db::changesets::query_change_set_for_base_with_hashes(
-        &conn,
+        &mut conn,
         base_commit_id,
         hashes,
     )? {
@@ -49,11 +47,7 @@ pub fn by_base_with_hashes(
 }
 
 /// Retuns existing summaries for head and missed hashes for unsummarized
-pub fn for_current_state(
-    pool: &DbPool,
-    db_path: &Path,
-    dir: &str,
-) -> Result<Vec<FoundSetForCurrent>> {
+pub fn for_current_state(pool: &DbPool, dir: &str) -> Result<Vec<FoundSetForCurrent>> {
     let status = crate::git::status(dir)?;
 
     let Some(head_hash) = status.head_commit_hash.as_deref() else {
@@ -76,10 +70,11 @@ pub fn for_current_state(
         commit_id: commit.id,
         hashes: &diff_hashes,
     });
-    let conn = Connection::open(db_path)?;
+
+    let mut conn = pool.get()?;
     let result: Vec<FoundSetForCurrent> =
         match crate::db::changesets::query_change_set_for_base_with_hashes(
-            &conn,
+            &mut conn,
             commit.id,
             &diff_hashes,
         )? {

--- a/apps/native/src-tauri/src/summarize/find_existing.rs
+++ b/apps/native/src-tauri/src/summarize/find_existing.rs
@@ -56,7 +56,7 @@ pub fn for_current_state(pool: &DbPool, dir: &str) -> Result<Vec<FoundSetForCurr
 
     let diff_hashes: Vec<String> = status.changes.iter().map(|c| c.hash.clone()).collect();
 
-    let Some(commit) = crate::db::commits::get_commit_by_hash_in_pool(pool, head_hash)? else {
+    let Some(commit) = crate::db::commits::get_commit_by_hash(pool, head_hash)? else {
         // DB has no record for this commit — surface all hashes as missed
         return Ok(vec![FoundSetForCurrent {
             change_set: None,

--- a/apps/native/src-tauri/src/summarize/find_existing.rs
+++ b/apps/native/src-tauri/src/summarize/find_existing.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 use std::path::Path;
 
+use crate::db::DbPool;
 use crate::shared_types::{SummarizedChange, SummarizedChangeSet};
 use crate::sqlite_types::ChangeSet;
 use crate::summarize::sumlog as dbg;
@@ -48,7 +49,11 @@ pub fn by_base_with_hashes(
 }
 
 /// Retuns existing summaries for head and missed hashes for unsummarized
-pub fn for_current_state(db_path: &Path, dir: &str) -> Result<Vec<FoundSetForCurrent>> {
+pub fn for_current_state(
+    pool: &DbPool,
+    db_path: &Path,
+    dir: &str,
+) -> Result<Vec<FoundSetForCurrent>> {
     let status = crate::git::status(dir)?;
 
     let Some(head_hash) = status.head_commit_hash.as_deref() else {
@@ -57,7 +62,7 @@ pub fn for_current_state(db_path: &Path, dir: &str) -> Result<Vec<FoundSetForCur
 
     let diff_hashes: Vec<String> = status.changes.iter().map(|c| c.hash.clone()).collect();
 
-    let Some(commit) = crate::db::commits::get_commit_by_hash(db_path, head_hash)? else {
+    let Some(commit) = crate::db::commits::get_commit_by_hash_in_pool(pool, head_hash)? else {
         // DB has no record for this commit — surface all hashes as missed
         return Ok(vec![FoundSetForCurrent {
             change_set: None,

--- a/apps/native/src-tauri/src/summarize/mod.rs
+++ b/apps/native/src-tauri/src/summarize/mod.rs
@@ -13,7 +13,7 @@ pub mod sumlog;
 pub mod token_budgets;
 
 use anyhow::Result;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Manager, Runtime};
 
 pub async fn new_changeset<R: Runtime>(
     app: &AppHandle<R>,
@@ -21,6 +21,7 @@ pub async fn new_changeset<R: Runtime>(
 ) -> Result<Option<i64>> {
     let db_path = crate::db::get_db_path(app)?;
     let config_dir = crate::storage::store::get_config_dir(app)?;
+    let pool = app.state::<crate::db::DbPool>();
 
     let status = crate::git::status(&config_dir)?;
 
@@ -29,7 +30,7 @@ pub async fn new_changeset<R: Runtime>(
         return Ok(None);
     }
 
-    let existing = find_existing::for_current_state(&db_path, &config_dir)?;
+    let existing = find_existing::for_current_state(&pool, &db_path, &config_dir)?;
 
     if !existing.iter().any(|e| e.change_set.is_some()) {
         return pipelines::fresh_changeset::analyze(
@@ -68,7 +69,8 @@ pub async fn new_changeset<R: Runtime>(
         return Ok(existing_id);
     }
 
-    let Some(base_commit_id) = crate::db::commits::store_head_commit(&db_path, &config_dir, None)?
+    let Some(base_commit_id) =
+        crate::db::commits::store_head_commit_in_pool(&pool, &config_dir, None)?
     else {
         return Ok(None);
     };

--- a/apps/native/src-tauri/src/summarize/mod.rs
+++ b/apps/native/src-tauri/src/summarize/mod.rs
@@ -68,7 +68,7 @@ pub async fn new_changeset<R: Runtime>(
     }
 
     let Some(base_commit_id) =
-        crate::db::commits::store_head_commit_in_pool(&pool, &config_dir, None)?
+        crate::db::commits::store_head_commit(&pool, &config_dir, None)?
     else {
         return Ok(None);
     };

--- a/apps/native/src-tauri/src/summarize/mod.rs
+++ b/apps/native/src-tauri/src/summarize/mod.rs
@@ -19,7 +19,6 @@ pub async fn new_changeset<R: Runtime>(
     app: &AppHandle<R>,
     evolution_id: Option<i64>,
 ) -> Result<Option<i64>> {
-    let db_path = crate::db::get_db_path(app)?;
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let pool = app.state::<crate::db::DbPool>();
 
@@ -30,13 +29,12 @@ pub async fn new_changeset<R: Runtime>(
         return Ok(None);
     }
 
-    let existing = find_existing::for_current_state(&pool, &db_path, &config_dir)?;
+    let existing = find_existing::for_current_state(&pool, &config_dir)?;
 
     if !existing.iter().any(|e| e.change_set.is_some()) {
         return pipelines::fresh_changeset::analyze(
             all_changes,
             app,
-            &db_path,
             None,
             None,
             None,
@@ -79,7 +77,6 @@ pub async fn new_changeset<R: Runtime>(
         semantic_map,
         missed_changes,
         app,
-        &db_path,
         None,
         base_commit_id,
         None,

--- a/apps/native/src-tauri/src/summarize/pipelines/commit_message.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/commit_message.rs
@@ -6,11 +6,10 @@ use tauri::{AppHandle, Manager, Runtime};
 use crate::summarize::{build_prompt, find_existing, group_existing, model_calls};
 
 pub async fn generate<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
-    let db_path = crate::db::get_db_path(app)?;
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let pool = app.state::<crate::db::DbPool>();
 
-    let change_sets = find_existing::for_current_state(&pool, &db_path, &config_dir)?;
+    let change_sets = find_existing::for_current_state(&pool, &config_dir)?;
     let map = group_existing::from_change_sets(change_sets);
 
     if map.groups.is_empty() && map.singles.is_empty() {

--- a/apps/native/src-tauri/src/summarize/pipelines/commit_message.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/commit_message.rs
@@ -1,15 +1,16 @@
 //! Commit message pipeline — generates a conventional commit message from the current semantic map.
 
 use anyhow::Result;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Manager, Runtime};
 
 use crate::summarize::{build_prompt, find_existing, group_existing, model_calls};
 
 pub async fn generate<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
     let db_path = crate::db::get_db_path(app)?;
     let config_dir = crate::storage::store::get_config_dir(app)?;
+    let pool = app.state::<crate::db::DbPool>();
 
-    let change_sets = find_existing::for_current_state(&db_path, &config_dir)?;
+    let change_sets = find_existing::for_current_state(&pool, &db_path, &config_dir)?;
     let map = group_existing::from_change_sets(change_sets);
 
     if map.groups.is_empty() && map.singles.is_empty() {

--- a/apps/native/src-tauri/src/summarize/pipelines/evolved_changeset.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/evolved_changeset.rs
@@ -1,7 +1,6 @@
 //! Iterative pipeline — adapts an existing semantic map with new hunks from a changeset.
 
 use anyhow::Result;
-use std::path::Path;
 use tauri::{AppHandle, Manager, Runtime};
 
 use crate::shared_types::SemanticChangeMap;
@@ -14,7 +13,6 @@ pub async fn analyze<R: Runtime>(
     semantic_map: SemanticChangeMap,
     missed_changes: Vec<Change>,
     app: &AppHandle<R>,
-    db_path: &Path,
     commit_id: Option<i64>,
     base_commit_id: i64,
     commit_message: Option<&str>,
@@ -75,8 +73,9 @@ pub async fn analyze<R: Runtime>(
 
     dbg::grouped_log_assignments(&assignments);
 
+    let pool = app.state::<crate::db::DbPool>();
     let (change_set_id, queued_ids) = crate::db::store_evolved_changeset::store(
-        db_path,
+        &pool,
         commit_id,
         base_commit_id,
         commit_message,
@@ -94,7 +93,7 @@ pub async fn analyze<R: Runtime>(
             crate::summarize::queue_summarizer::process(
                 Some(queued_ids),
                 app.clone(),
-                db_path.to_path_buf(),
+                pool.inner().clone(),
             )
             .await?;
         }

--- a/apps/native/src-tauri/src/summarize/pipelines/fresh_changeset.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/fresh_changeset.rs
@@ -25,7 +25,7 @@ pub async fn analyze<R: Runtime>(
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let pool = app.state::<crate::db::DbPool>();
     let Some(base_commit_id) =
-        crate::db::commits::store_head_commit_in_pool(&pool, &config_dir, base_commit_id)?
+        crate::db::commits::store_head_commit(&pool, &config_dir, base_commit_id)?
     else {
         return Ok(None);
     };

--- a/apps/native/src-tauri/src/summarize/pipelines/fresh_changeset.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/fresh_changeset.rs
@@ -25,8 +25,9 @@ pub async fn analyze<R: Runtime>(
     }
 
     let config_dir = crate::storage::store::get_config_dir(app)?;
+    let pool = app.state::<crate::db::DbPool>();
     let Some(base_commit_id) =
-        crate::db::commits::store_head_commit(db_path, &config_dir, base_commit_id)?
+        crate::db::commits::store_head_commit_in_pool(&pool, &config_dir, base_commit_id)?
     else {
         return Ok(None);
     };

--- a/apps/native/src-tauri/src/summarize/pipelines/fresh_changeset.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/fresh_changeset.rs
@@ -1,7 +1,6 @@
 //! Fresh changeset pipeline — groups incoming hunks from scratch into a new semantic map.
 
 use anyhow::Result;
-use std::path::Path;
 use tauri::{AppHandle, Manager, Runtime};
 
 use crate::sqlite_types::Change;
@@ -12,7 +11,6 @@ use crate::summarize::sumlog as dbg;
 pub async fn analyze<R: Runtime>(
     changes: Vec<Change>,
     app: &AppHandle<R>,
-    db_path: &Path,
     commit_id: Option<i64>,
     base_commit_id: Option<i64>,
     commit_message: Option<&str>,
@@ -63,7 +61,7 @@ pub async fn analyze<R: Runtime>(
     }
 
     let (change_set_id, queued_ids) = crate::db::store_new_changeset::store(
-        db_path,
+        &pool,
         commit_id,
         base_commit_id,
         commit_message,
@@ -80,7 +78,7 @@ pub async fn analyze<R: Runtime>(
             crate::summarize::queue_summarizer::process(
                 Some(queued_ids),
                 app.clone(),
-                db_path.to_path_buf(),
+                pool.inner().clone(),
             )
             .await?;
         }

--- a/apps/native/src-tauri/src/summarize/pipelines/history.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/history.rs
@@ -1,7 +1,7 @@
 //! Pipeline entry point for generating summaries over a historical commit range.
 
 use anyhow::Result;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Manager, Runtime};
 
 use crate::sqlite_types::Change;
 
@@ -12,6 +12,7 @@ pub async fn from_commit_times_number<R: Runtime>(
 ) -> Result<()> {
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let db_path = crate::db::get_db_path(app)?;
+    let pool = app.state::<crate::db::DbPool>();
 
     let all_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
     let start = match all_commits.iter().position(|c| c.hash == commit_hash) {
@@ -30,8 +31,8 @@ pub async fn from_commit_times_number<R: Runtime>(
 
     let mut db_ids: Vec<i64> = Vec::with_capacity(commits.len());
     for commit in &commits {
-        let id = crate::db::commits::upsert_commit(
-            &db_path,
+        let id = crate::db::commits::upsert_commit_in_pool(
+            &pool,
             &commit.hash,
             &commit.tree_hash,
             commit.message.as_deref(),

--- a/apps/native/src-tauri/src/summarize/pipelines/history.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/history.rs
@@ -11,7 +11,6 @@ pub async fn from_commit_times_number<R: Runtime>(
     number: usize,
 ) -> Result<()> {
     let config_dir = crate::storage::store::get_config_dir(app)?;
-    let db_path = crate::db::get_db_path(app)?;
     let pool = app.state::<crate::db::DbPool>();
 
     let all_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
@@ -59,7 +58,7 @@ pub async fn from_commit_times_number<R: Runtime>(
         let diff_hashes: Vec<String> = all_changes.iter().map(|c| c.hash.clone()).collect();
 
         let found = crate::summarize::find_existing::by_base_with_hashes(
-            &db_path,
+            &pool,
             base_commit_id,
             &diff_hashes,
         )?;
@@ -87,7 +86,6 @@ pub async fn from_commit_times_number<R: Runtime>(
                 semantic_map,
                 missed_changes,
                 app,
-                &db_path,
                 Some(commit_id),
                 base_commit_id,
                 commits[i].message.as_deref(),
@@ -106,7 +104,6 @@ pub async fn from_commit_times_number<R: Runtime>(
             if let Err(e) = super::fresh_changeset::analyze(
                 all_changes,
                 app,
-                &db_path,
                 Some(commit_id),
                 Some(base_commit_id),
                 commits[i].message.as_deref(),

--- a/apps/native/src-tauri/src/summarize/pipelines/history.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/history.rs
@@ -30,7 +30,7 @@ pub async fn from_commit_times_number<R: Runtime>(
 
     let mut db_ids: Vec<i64> = Vec::with_capacity(commits.len());
     for commit in &commits {
-        let id = crate::db::commits::upsert_commit_in_pool(
+        let id = crate::db::commits::upsert_commit(
             &pool,
             &commit.hash,
             &commit.tree_hash,

--- a/apps/native/src-tauri/src/summarize/queue_summarizer.rs
+++ b/apps/native/src-tauri/src/summarize/queue_summarizer.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{Context, Result};
 use std::path::Path;
-use tauri::{AppHandle, Emitter, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tokio::sync::mpsc;
 
 use crate::sqlite_types::QueuedSummary;
@@ -444,7 +444,9 @@ fn serialize_group_response(
 fn emit_update<R: Runtime>(app: &AppHandle<R>, db_path: &Path) {
     let result = (|| -> Result<()> {
         let config_dir = crate::storage::store::get_config_dir(app)?;
-        let change_sets = crate::summarize::find_existing::for_current_state(db_path, &config_dir)?;
+        let pool = app.state::<crate::db::DbPool>();
+        let change_sets =
+            crate::summarize::find_existing::for_current_state(&pool, db_path, &config_dir)?;
         let semantic_map = crate::summarize::group_existing::from_change_sets(change_sets);
         app.emit("change_map_changed", semantic_map)?;
         Ok(())

--- a/apps/native/src-tauri/src/summarize/queue_summarizer.rs
+++ b/apps/native/src-tauri/src/summarize/queue_summarizer.rs
@@ -5,10 +5,12 @@
 //! worker drains the durable SQLite queue at a time.
 
 use anyhow::{Context, Result};
-use std::path::Path;
+use diesel::connection::Connection;
+use diesel::sqlite::SqliteConnection;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tokio::sync::mpsc;
 
+use crate::db::DbPool;
 use crate::sqlite_types::QueuedSummary;
 use crate::summarize::model_output_types::HunkSummary;
 
@@ -59,13 +61,13 @@ struct HashSummaryPair {
 pub fn start_worker<R: Runtime>(app: &AppHandle<R>) -> Result<SummarizerState> {
     let (tx, rx) = mpsc::channel(SUMMARIZER_QUEUE_DEPTH);
     let app = app.clone();
-    let db_path = crate::db::get_db_path(&app)?;
+    let pool = app.state::<DbPool>().inner().clone();
 
     tauri::async_runtime::spawn(worker_loop(rx, move |job| {
         let app = app.clone();
-        let db_path = db_path.clone();
+        let pool = pool.clone();
         async move {
-            if let Err(error) = process(job.ids, app, db_path).await {
+            if let Err(error) = process(job.ids, app, pool).await {
                 log::warn!("[queue_summarizer] worker job failed: {error:#}");
             }
         }
@@ -87,7 +89,7 @@ where
 pub async fn process<R: Runtime>(
     ids: Option<Vec<i64>>,
     app: AppHandle<R>,
-    db_path: std::path::PathBuf,
+    pool: DbPool,
 ) -> Result<()> {
     if let Some(ref specific_ids) = ids {
         crate::summarize::sumlog::queue_log_started(specific_ids);
@@ -95,16 +97,17 @@ pub async fn process<R: Runtime>(
     let mut first_pass = true;
     loop {
         let items = {
-            let conn = rusqlite::Connection::open(&db_path)?;
+            let mut conn = pool.get()?;
             if first_pass {
                 match &ids {
-                    Some(specific_ids) => {
-                        crate::db::changesets::fetch_queued_summaries_by_ids(&conn, specific_ids)?
-                    }
-                    None => crate::db::changesets::fetch_all_queued_summaries(&conn)?,
+                    Some(specific_ids) => crate::db::changesets::fetch_queued_summaries_by_ids(
+                        &mut conn,
+                        specific_ids,
+                    )?,
+                    None => crate::db::changesets::fetch_all_queued_summaries(&mut conn)?,
                 }
             } else {
-                crate::db::changesets::fetch_all_queued_summaries(&conn)?
+                crate::db::changesets::fetch_all_queued_summaries(&mut conn)?
             }
         };
         first_pass = false;
@@ -116,14 +119,14 @@ pub async fn process<R: Runtime>(
         let mut passed = 0usize;
         let mut retrying = 0usize;
         for item in &items {
-            match try_process_item(item, &app, &db_path).await {
+            match try_process_item(item, &app, &pool).await {
                 Ok(_) => passed += 1,
                 Err(e) => {
                     log::warn!("[queue_summarizer] item {} error: {:#}", item.id, e);
                     retrying += 1;
                 }
             }
-            emit_update(&app, &db_path);
+            emit_update(&app);
         }
         crate::summarize::sumlog::queue_log_done(passed, retrying);
     }
@@ -135,38 +138,40 @@ pub async fn process<R: Runtime>(
 async fn try_process_item<R: Runtime>(
     item: &QueuedSummary,
     app: &AppHandle<R>,
-    db_path: &Path,
+    pool: &DbPool,
 ) -> Result<()> {
     // Already exhausted retries on a previous run — fail immediately.
     if item.attempted_count >= FAILED_AFTER_TRIES {
-        let mut conn = rusqlite::Connection::open(db_path)?;
-        let tx = conn.transaction()?;
-        crate::db::changesets::mark_queued_failed(&tx, item.id)?;
-        fail_change_summaries(&tx, item)?;
-        tx.commit()?;
+        let mut conn = pool.get()?;
+        conn.transaction::<(), anyhow::Error, _>(|conn| {
+            crate::db::changesets::mark_queued_failed(conn, item.id)?;
+            fail_change_summaries(conn, item)?;
+            Ok(())
+        })?;
         return Ok(());
     }
 
     // Optimistically increment the attempt counter before the model call.
     {
-        let mut conn = rusqlite::Connection::open(db_path)?;
-        let tx = conn.transaction()?;
-        crate::db::changesets::increment_queued_attempts(&tx, item.id)?;
-        tx.commit()?;
+        let mut conn = pool.get()?;
+        conn.transaction::<(), anyhow::Error, _>(|conn| {
+            crate::db::changesets::increment_queued_attempts(conn, item.id)?;
+            Ok(())
+        })?;
     }
     let new_count = item.attempted_count + 1;
 
     match item.summary_type.as_str() {
-        "NEW_SINGLE" => handle_new_single(item, app, db_path, new_count).await?,
+        "NEW_SINGLE" => handle_new_single(item, app, pool, new_count).await?,
         "NEW_GROUP" => {
-            handle_group(item, db_path, new_count, || {
+            handle_group(item, pool, new_count, || {
                 crate::summarize::model_calls::summarize_new_group(&item.prompt, Some(app))
             })
             .await?
         }
         "EVOLVED_GROUP" => {
             let group_summary_id = item.group_summary_id.unwrap_or(0);
-            handle_group(item, db_path, new_count, || {
+            handle_group(item, pool, new_count, || {
                 crate::summarize::model_calls::summarize_evolved_group(
                     &item.prompt,
                     group_summary_id,
@@ -186,7 +191,7 @@ async fn try_process_item<R: Runtime>(
 async fn handle_new_single<R: Runtime>(
     item: &QueuedSummary,
     app: &AppHandle<R>,
-    db_path: &Path,
+    pool: &DbPool,
     new_count: i64,
 ) -> Result<()> {
     crate::summarize::sumlog::queue_log_prompt(item.id, &item.prompt);
@@ -198,7 +203,7 @@ async fn handle_new_single<R: Runtime>(
             );
             let summary = validate_or_retry(
                 summary,
-                db_path,
+                pool,
                 item.id,
                 |s| validate_hunk_summary(s, "single"),
                 || crate::summarize::model_calls::summarize_new_single(&item.prompt, Some(app)),
@@ -209,26 +214,28 @@ async fn handle_new_single<R: Runtime>(
                 serde_json::to_string(&summary).unwrap_or_else(|_| "{}".to_string());
             let pairs = parse_pairs(item)?;
             if let Some(pair) = pairs.first() {
-                let mut conn = rusqlite::Connection::open(db_path)?;
-                let tx = conn.transaction()?;
-                crate::db::changesets::update_change_summary_content(
-                    &tx,
-                    pair.summary_id,
-                    &summary.title,
-                    &summary.description,
-                )?;
-                crate::db::changesets::mark_queued_done(&tx, item.id, &model_response)?;
-                tx.commit()?;
+                let mut conn = pool.get()?;
+                conn.transaction::<(), anyhow::Error, _>(|conn| {
+                    crate::db::changesets::update_change_summary_content(
+                        conn,
+                        pair.summary_id,
+                        &summary.title,
+                        &summary.description,
+                    )?;
+                    crate::db::changesets::mark_queued_done(conn, item.id, &model_response)?;
+                    Ok(())
+                })?;
             }
         }
         Err(e) => {
             log::warn!("[queue_summarizer] NEW_SINGLE {} failed: {:#}", item.id, e);
             if new_count >= FAILED_AFTER_TRIES {
-                let mut conn = rusqlite::Connection::open(db_path)?;
-                let tx = conn.transaction()?;
-                crate::db::changesets::mark_queued_failed(&tx, item.id)?;
-                fail_change_summaries(&tx, item)?;
-                tx.commit()?;
+                let mut conn = pool.get()?;
+                conn.transaction::<(), anyhow::Error, _>(|conn| {
+                    crate::db::changesets::mark_queued_failed(conn, item.id)?;
+                    fail_change_summaries(conn, item)?;
+                    Ok(())
+                })?;
             }
         }
     }
@@ -239,7 +246,7 @@ async fn handle_new_single<R: Runtime>(
 /// `call` is invoked for both the initial model request and, if validation fails, the retry.
 async fn handle_group<F, Fut>(
     item: &QueuedSummary,
-    db_path: &Path,
+    pool: &DbPool,
     new_count: i64,
     call: F,
 ) -> Result<()>
@@ -264,7 +271,7 @@ where
             );
             let summary = validate_or_retry(
                 summary,
-                db_path,
+                pool,
                 item.id,
                 |s| validate_group_response(s, &pairs),
                 call,
@@ -273,48 +280,50 @@ where
             crate::summarize::sumlog::queue_log_validation_ok(item.id, pairs.len());
             let model_response =
                 serialize_group_response(&summary.group, &pairs, &summary.own_summaries);
-            let mut conn = rusqlite::Connection::open(db_path)?;
-            let tx = conn.transaction()?;
-            crate::db::changesets::update_change_summary_content(
-                &tx,
-                group_summary_id,
-                &summary.group.title,
-                &summary.group.description,
-            )?;
-            for pair in &pairs {
-                let own = summary.own_summaries.get(&pair.hash).ok_or_else(|| {
-                    anyhow::anyhow!("hash {} missing after validation", pair.hash)
-                })?;
+            let mut conn = pool.get()?;
+            conn.transaction::<(), anyhow::Error, _>(|conn| {
                 crate::db::changesets::update_change_summary_content(
-                    &tx,
-                    pair.summary_id,
-                    &own.title,
-                    &own.description,
+                    conn,
+                    group_summary_id,
+                    &summary.group.title,
+                    &summary.group.description,
                 )?;
-            }
-            crate::db::changesets::mark_queued_done(&tx, item.id, &model_response)?;
-            tx.commit()?;
+                for pair in &pairs {
+                    let own = summary.own_summaries.get(&pair.hash).ok_or_else(|| {
+                        anyhow::anyhow!("hash {} missing after validation", pair.hash)
+                    })?;
+                    crate::db::changesets::update_change_summary_content(
+                        conn,
+                        pair.summary_id,
+                        &own.title,
+                        &own.description,
+                    )?;
+                }
+                crate::db::changesets::mark_queued_done(conn, item.id, &model_response)?;
+                Ok(())
+            })?;
         }
         Err(e) => {
             log::warn!("[queue_summarizer] group {} failed: {:#}", item.id, e);
             if new_count >= FAILED_AFTER_TRIES {
-                let mut conn = rusqlite::Connection::open(db_path)?;
-                let tx = conn.transaction()?;
-                crate::db::changesets::mark_queued_failed(&tx, item.id)?;
-                fail_change_summaries(&tx, item)?;
-                tx.commit()?;
+                let mut conn = pool.get()?;
+                conn.transaction::<(), anyhow::Error, _>(|conn| {
+                    crate::db::changesets::mark_queued_failed(conn, item.id)?;
+                    fail_change_summaries(conn, item)?;
+                    Ok(())
+                })?;
             }
         }
     }
     Ok(())
 }
 
-fn increment_attempts_now(db_path: &Path, id: i64) -> Result<()> {
-    let mut conn = rusqlite::Connection::open(db_path)?;
-    let tx = conn.transaction()?;
-    crate::db::changesets::increment_queued_attempts(&tx, id)?;
-    tx.commit()?;
-    Ok(())
+fn increment_attempts_now(pool: &DbPool, id: i64) -> Result<()> {
+    let mut conn = pool.get()?;
+    conn.transaction::<(), anyhow::Error, _>(|conn| {
+        crate::db::changesets::increment_queued_attempts(conn, id)?;
+        Ok(())
+    })
 }
 
 // ── Retry helper ──────────────────────────────────────────────────────────────
@@ -324,7 +333,7 @@ fn increment_attempts_now(db_path: &Path, id: i64) -> Result<()> {
 /// also fails validation.
 async fn validate_or_retry<T, Retry, Fut>(
     result: T,
-    db_path: &Path,
+    pool: &DbPool,
     item_id: i64,
     validate: impl Fn(&T) -> Result<()>,
     retry: Retry,
@@ -341,7 +350,7 @@ where
                 item_id,
                 e
             );
-            increment_attempts_now(db_path, item_id)?;
+            increment_attempts_now(pool, item_id)?;
             let (result2, _) = retry().await.with_context(|| {
                 format!(
                     "failed to summarize queued item {}, retry model call failed",
@@ -349,7 +358,7 @@ where
                 )
             })?;
             if let Err(e2) = validate(&result2) {
-                increment_attempts_now(db_path, item_id)?;
+                increment_attempts_now(pool, item_id)?;
                 return Err(e2).with_context(|| {
                     format!(
                         "failed to summarize queued item {}, retry validation also failed",
@@ -403,14 +412,14 @@ fn parse_pairs(item: &QueuedSummary) -> Result<Vec<HashSummaryPair>> {
     Ok(serde_json::from_str(json)?)
 }
 
-fn fail_change_summaries(tx: &rusqlite::Transaction, item: &QueuedSummary) -> Result<()> {
+fn fail_change_summaries(conn: &mut SqliteConnection, item: &QueuedSummary) -> Result<()> {
     if let Some(group_id) = item.group_summary_id {
-        crate::db::changesets::mark_change_summary_failed(tx, group_id)?;
+        crate::db::changesets::mark_change_summary_failed(conn, group_id)?;
     }
     if let Some(pairs_json) = &item.hash_own_summary_id_pairs {
         if let Ok(pairs) = serde_json::from_str::<Vec<HashSummaryPair>>(pairs_json) {
             for pair in pairs {
-                crate::db::changesets::mark_change_summary_failed(tx, pair.summary_id)?;
+                crate::db::changesets::mark_change_summary_failed(conn, pair.summary_id)?;
             }
         }
     }
@@ -441,12 +450,11 @@ fn serialize_group_response(
     .unwrap_or_else(|_| "{}".to_string())
 }
 
-fn emit_update<R: Runtime>(app: &AppHandle<R>, db_path: &Path) {
+fn emit_update<R: Runtime>(app: &AppHandle<R>) {
     let result = (|| -> Result<()> {
         let config_dir = crate::storage::store::get_config_dir(app)?;
         let pool = app.state::<crate::db::DbPool>();
-        let change_sets =
-            crate::summarize::find_existing::for_current_state(&pool, db_path, &config_dir)?;
+        let change_sets = crate::summarize::find_existing::for_current_state(&pool, &config_dir)?;
         let semantic_map = crate::summarize::group_existing::from_change_sets(change_sets);
         app.emit("change_map_changed", semantic_map)?;
         Ok(())

--- a/docs/2026-06-03-pr-review-followups.md
+++ b/docs/2026-06-03-pr-review-followups.md
@@ -1,0 +1,605 @@
+# PR #228, #244–#255 Review Follow-ups
+
+- Date: 2026-06-03
+- Status: Draft for review
+- Reviewer of the reviewed PRs: @arximboldi (Juan Pedro Bolívar Puente)
+- Author: synthesized from review comments on PRs #228, #244–#255 with critical commentary
+- Relates to: `docs/2026-05-29-state-management-migration-plan.md` (Phases 1, 2, 5, 7, 8)
+
+This document collects the post-merge review remarks left on PRs #228 and
+#244–#255, analyzes them, pushes back where the proposed remedy looks like it
+trades clarity for over-abstraction, and proposes a refined plan. Several of
+these items revise the design described in the 2026-05-29 migration plan —
+that document was written before the slice infrastructure existed; this one
+reacts to what shipped.
+
+## 1. Comments collected, by source PR
+
+Of the 13 PRs in scope, only five carry actionable feedback. The others were
+either docs/process PRs or were approved without comment.
+
+| PR | Title | Review | Inline comments |
+| --- | -------------------------------------------------- | ---------- | ------------------------------------------------------- |
+| 228 | implement derive(Configurable) macro | — | — |
+| 244 | docs(state): add migration plan issues | — | — |
+| 245 | refactor(configurable): split derive and generated UI | CHANGES_REQUESTED | `configurable/src/lib.rs:91`, `commands/dev_configs.rs:33` |
+| 246 | feat(state): add scoped slice persistence | CHANGES_REQUESTED | `state/slice/registry.rs:32`, `state/slice/persistence.rs:4`, `state/slice/mod.rs:101` |
+| 247 | feat(db): add Diesel pool and table models | — | — |
+| 248 | feat(state): wire runtime slices and summarizer | APPROVED | `commands/git.rs:61`, `evolve/mod.rs:657`, `commands/git.rs:45` |
+| 249 | chore(credentials): remove legacy plaintext fallback | COMMENTED | (only meta-note about PR slicing) |
+| 250 | feat(settings): split backup and tuning panels | — | — |
+| 251 | fix(theme): scope Minted to Monaco diffs | — | — |
+| 252 | feat(console): add resizable log panel | — | — |
+| 253 | chore(fmt): add treefmt wiring | — | — |
+| 254 | chore(beads): update state migration issues | — | — |
+| 255 | refactor(frontend): move backend mirrors to viewmodel | APPROVED | (review summary only) |
+
+The substantive remarks distill to eight themes, addressed below.
+
+## 2. Themes, analysis, and pushback
+
+The header "Verdict" below each theme is my synthesized recommendation —
+agreement, disagreement, or partial agreement — not a restatement of the
+review comment.
+
+### 2.1 The `state/slice` module is a misnamed reinvention of `tauri::State`
+
+**Review:** "This whole notion of 'state slice' is misleading. The persistence
+layer should be tied to configurables. The registry is not needed. The whole
+`state/slice` should go away. 'State slice' is a Tauri concept, it's
+`tauri::State`, we should not reinvent it or abuse the term." (PR #246)
+
+**Verdict: agree on the name, partially agree on the registry.**
+
+The naming criticism is correct without qualification. The Tauri docs and
+the Rust ecosystem use "state" and "slice" to mean exactly what `tauri::State`
+already provides; using the same noun for our local primitive collides on the
+first read. The `state/slice` module name should go.
+
+The "registry is not needed" claim is more subtle and worth pushing back on.
+`tauri::State<T>` is keyed by `TypeId` and is *not enumerable* — you cannot
+ask Tauri "give me every state that implements `Configurable`." The
+`dev_configs_list` command needs that enumeration. So *some* registry exists
+either way; the only design choice is whether it is **built at compile time**
+(linker-section magic via the [`inventory`](https://docs.rs/inventory/) crate,
+populated by the derive macro) or **at runtime** (the current
+`SliceRegistry`).
+
+Compile-time registration via `inventory` is genuinely nicer when it works.
+It does not work on every target — `inventory` uses linker-section tricks
+that fail on Wasm targets and on Miri, and can be debugging puzzles when
+linker GC strips symbols. None of those constraints currently apply to this
+project (we ship a desktop Tauri binary on macOS/Linux/Windows), so it is the
+right call here — but it is worth stating that as a constraint rather than
+calling Tauri's state map "the registry."
+
+### 2.2 Rename `Slice<T>` to `Observable<T>`
+
+**Review:** "Perhaps it could be renamed into `Observable`, as the main feature
+is actually observing changes (via emitters, or indirectly via the persistence
+callback)." (PR #246)
+
+**Verdict: agree the rename is needed, push back on `Observable`.**
+
+The current type is doing three things: it owns a typed value, it notifies on
+write (via `SliceEventEmitter`), and it persists on write (via `Persistence`).
+"Observable" captures the notification axis but hides the persistence axis,
+and in the JS/RxJS-influenced corner of the field it strongly suggests a
+*stream you subscribe to*, not a *cell you read and write*.
+
+Better candidates, roughly ranked:
+
+- **`Persisted<T>`** — emphasizes the load-bearing property (state survives
+  restarts) and makes the change-event a secondary detail. Read sites that
+  do not subscribe never care about emission anyway.
+- **`WatchedCell<T>`** / **`SyncedCell<T>`** — keeps the "cell" mental model
+  from `std::cell::Cell` and friends, adds the notification verb.
+- **`Signal<T>`** — accurate but heavily overloaded (Solid.js, Preact, Leptos,
+  Sycamore, Tokio all use this name for related-but-different things).
+- **`Observable<T>`** — what the review proposed; my objection above.
+
+My recommendation is `Persisted<T>`, with `PersistedWriteGuard` and a
+`PersistedEventEmitter` trait. The rename is mechanical (12 call-sites in
+two crates), but worth doing once.
+
+### 2.3 Split `Configurable`'s schema from its current value; decouple from Serde
+
+**Review:** "Ideally we would have two separate concerns: fetching the schema
+for a configurable (just meta-data, has static lifetime and can be cached) vs.
+reading the current value (can't be cached). Also, I'm not sure I vibe with
+having `default` be stored in JSON. JSON-serialization is orthogonal to the
+configurable infrastructure. One could imagine using the Configurable stuff in
+a different app that doesn't use Tauri and is all Rust and doesn't necessarily
+use Serde." (PR #245)
+
+**Verdict: agree on the schema/value split. Push back on the
+Serde decoupling.**
+
+The schema/value split is a real correctness and clarity win. `schema()`
+today takes an `AppHandle` only because the static schema and the dynamic
+current value were merged into one struct (`ConfigField`). Splitting these
+into `ConfigFieldSchema` (static, no `app`, equatable, hashable, the same
+value every call) and `ConfigFieldValue` (dynamic, joined with the schema
+only at the IPC boundary) is the right shape. It also opens the door to
+caching the schema once at startup, which is cheap and pays for itself the
+moment anyone opens the dev settings panel twice.
+
+The Serde decoupling is where I want to push back. The motivation given is
+"one could imagine using the Configurable stuff in a different app that
+doesn't use Tauri and is all Rust and doesn't necessarily use Serde." That is
+a hypothetical second consumer. There is none planned. The cost of the
+decoupling is real:
+
+- The derive needs to materialize defaults from typed Rust values. If `T`
+  must not be `Serialize`, then the default cannot be a `serde_json::Value`;
+  it has to be either `Box<dyn Any>` (which forces downcasts at every use
+  site), `T` itself (which leaks into every type that wants to enumerate
+  schemas, requiring HKT-style workarounds), or a const-fn-evaluated
+  placeholder that the derive constructs (which constrains `T` to types
+  expressible in const).
+- The on-disk format is JSON. Removing Serde from the core crate just pushes
+  the same dependency into a thin `configurable-json` wrapper, with the same
+  total complexity but more crates.
+
+I would do the *type-level* split (separate `ConfigFieldSchema` from value)
+without doing the *crate-level* decoupling. Keep `serde` as a hard dependency
+of `configurable`. If a second non-Serde consumer ever shows up, splitting
+crates is a mechanical extraction at that point.
+
+The "default in JSON" sub-complaint resolves naturally with the type split:
+`ConfigFieldSchema::default` becomes a typed value, and only the IPC payload
+(which is built in the Tauri command, not in the schema) carries it as
+`serde_json::Value`.
+
+### 2.4 Whole-Configurable setter, not field-by-field
+
+**Review:** "Why do we need to set the individual fields separately instead of
+setting the whole `Configurable` in one?" (PR #245)
+
+**Verdict: agree, with one tradeoff to surface.**
+
+Validation via `serde::Deserialize` of the whole struct is cleaner than
+per-field dispatch by name. It also kills the type-erased `set_field_fn`
+function pointer and the `struct_name` string parameter, both of which only
+exist to compensate for the current per-field shape.
+
+The tradeoff to surface is partial-update semantics. Whole-struct writes
+clobber concurrent edits — if a background process bumps field B while the
+dev-settings UI is editing field A, the UI's POST overwrites B with whatever
+stale value the panel started with. For a single-user dev-settings panel this
+is fine. It would not be fine if the same primitive grew into a multi-actor
+config surface (concurrent edits across tabs, syncing across a fleet, etc).
+None of that is on the roadmap, but worth flagging because the field-by-field
+setter does avoid this category of bug essentially by accident.
+
+### 2.5 `upsert_commit_in_pool` is wordy
+
+**Review:** "The `in_pool` thing in the name feels unnecessarily wordy.
+Probably the LLM doing LLM things but just saying :)" (PR #248)
+
+**Verdict: agree, but not yet.**
+
+The `_in_pool` suffix exists right now precisely because the old rusqlite
+`upsert_commit(db_path, ...)` and the new Diesel `upsert_commit_in_pool(pool, ...)`
+coexist during the in-flight Diesel migration. Renaming today produces
+ambiguous overloads. The right ordering is: delete the rusqlite twin of
+each function (a sub-goal of Phase 2 in the migration plan, lines 80–98 of
+`docs/2026-05-29-state-management-migration-plan.md`, though not currently
+called out as an explicit milestone — see open question O5), then drop the
+suffix from every Diesel function in `db/commits.rs` in one rename pass.
+Same treatment for `get_commit_by_hash_in_pool`.
+
+### 2.6 Panic when an expected `Persisted<T>` is unmanaged
+
+**Review:** "I think it should be ok to `panic()` if we forget to manage the
+Slice, but this doesn't hurt." (PR #248, `evolve/mod.rs:657`)
+
+**Verdict: agree, but investigate the load-bearing comment first.**
+
+`app.state::<T>()` already panics if the state is not managed; the current
+`try_state` + default fallback is actively suppressing that panic. The
+relevant code path is the evolve loop reading `EvolutionLimits`. The
+suppression looks defensive (`"slice is not managed; using defaults"`), but
+the defensive fallback is exactly what masks a real misconfiguration.
+
+Before flipping to a panic, check whether any test or CLI path runs the
+evolve loop without managing the slice. If yes, fix that setup. If no, drop
+the fallback.
+
+### 2.7 Widget-store trails on the frontend
+
+**Review (#255 summary):** "There seems to be still some trails of the
+widget-store that would be nice to get rid of in later commits."
+
+**Verdict: agree, this is already Phase 8.**
+
+The migration plan slates `widget-store.impl.ts` deletion for Phase 8
+("Decommission"). The current state is ~30 import sites in
+`apps/native/src/components/widget/**` and a couple of utility files. Some
+of those imports are for *types* (`WidgetStep`, `EvolveEvent`, `GitStatus`,
+`RebuildErrorType`, `RebuildLine`) that legitimately still need a home; the
+rest are uses of `useWidgetStore` that should already be reading from the
+ViewModel or `useUiState`.
+
+Action: before Phase 8 deletion, split the cleanup into two passes —
+(a) move all type-only imports to `@/ipc/types` or `@/viewmodel/types`,
+(b) replace `useWidgetStore` call sites with the appropriate ViewModel
+selectors. Phase 8 then becomes a pure deletion.
+
+### 2.8 ViewModel slice regularity
+
+**Review (#255 summary):** "There is certain level of regularity in the
+ViewModel slices that could perhaps be extracted away."
+
+**Verdict: agree, with the rule of three honored.**
+
+Every slice in `apps/native/src/viewmodel/{evolve,git,change-map}.ts` follows
+the same skeleton: fetch initial state via a tauri command, register one
+`ipcRenderer.on` listener that calls a `mirror*` function, return an
+unlisten. Three repetitions of an identical pattern justify a helper:
+
+```ts
+function bindBackendSlice<TPayload>({
+  initial,
+  event,
+  mirror,
+}: {
+  initial: () => Promise<TPayload>;
+  event: string;
+  mirror: (payload: TPayload) => void;
+}): Promise<() => void>;
+```
+
+Caveat: the current `git.ts` slice does slightly more (it triggers a history
+snapshot refresh and listens on a second `git_state_error` event). Keep the
+helper composable enough that `git.ts` can use it for the main subscription
+and stack an extra `ipcRenderer.on` next to it, rather than forcing every
+slice through a one-size-fits-all interface. Over-fitted abstractions for
+three call sites that might diverge again are worse than two helper calls
+plus one ad-hoc subscriber.
+
+## 3. Refined plan
+
+Each item below has a motivation, a scope, risks, and an acceptance
+criterion. Items are numbered B (backend) and F (frontend).
+
+### B1. Delete `SliceRegistry`; switch to compile-time registration via `inventory`
+
+- **Motivation:** Remove the runtime registry whose only job is to enumerate
+  configurables; let the derive submit each configurable to a static
+  `inventory` collection.
+- **Scope:**
+  - `apps/native/src-tauri/configurable-derive/src/codegen.rs` — emit
+    `inventory::submit! { ConfigurableMeta { … } }` next to the impl block,
+    where `ConfigurableMeta` carries the static schema and a typed handle
+    that can be downcast to set the whole `T` via `tauri::State`.
+  - `apps/native/src-tauri/configurable/src/lib.rs` — `inventory::collect!`
+    declaration; expose `ConfigurableRegistry::iter()` that just walks it.
+  - Delete `apps/native/src-tauri/src/state/slice/registry.rs`.
+  - Delete `evolve::config::register_slice_config` and the corresponding
+    `register_slice_config(&app.state::<SliceRegistry>())?` call in
+    `main.rs`. Delete the `app.manage(SliceRegistry::default())` line.
+  - Rewrite `src/commands/dev_configs.rs` to use the static registry.
+- **Risks:** `inventory` requires the metadata be `Sync + 'static`. The
+  current `set_field_fn` pointer takes `&AppHandle<Wry>`, which is fine.
+  Watch for Wry-vs-generic-Runtime split (the codegen currently emits
+  `__configurable_*_wry` monomorphizations for that reason; keep that).
+- **Acceptance:** `grep -rn "SliceRegistry\|RegisteredSliceConfig" apps/`
+  returns nothing; `main.rs` mentions no specific `Configurable` struct.
+
+### B2. Rename `Slice<T>` to `Persisted<T>`; dissolve `src/state/slice/`
+
+- **Motivation:** Stop colliding with Tauri's "state" / "slice" terminology;
+  surface the load-bearing property (persistence) in the type name.
+- **Scope:**
+  - Move `src/state/slice/{mod,persistence,json_io}.rs` to `src/persisted/`
+    (or `src/observed/` — see open question O2).
+  - Rename `Slice<T>` → `Persisted<T>`, `SliceWriteGuard` →
+    `PersistedWriteGuard`, `SliceEventEmitter` → `PersistedEventEmitter`.
+  - Rename the existing event names (`*_changed`) — they currently echo
+    "slice"; nothing user-facing needs to change.
+  - Update all ~12 call sites.
+- **Risks:** Touches a lot of files but every edit is mechanical.
+- **Acceptance:** No file under `apps/native/src-tauri/src/` is named
+  `slice*`; `cargo build` and `cargo test` pass.
+
+### B3. Split `Configurable`'s schema from its current value
+
+- **Motivation:** Make the schema a static, cacheable value; remove the
+  spurious `app` parameter from `schema()`. Stops `ConfigField` from being a
+  conflation of metadata and runtime state.
+- **Scope:**
+  - In `configurable/src/lib.rs`, split `ConfigField` into
+    `ConfigFieldSchema { key, label, help, ty, default }` (static) and
+    `ConfigFieldValue { key, current }` (dynamic, used only on the IPC wire).
+  - `ConfigurableSchema` becomes purely static; a new
+    `ConfigurableSnapshot` joins schema + values for the
+    `dev_configs_list` response.
+  - In the derive (`configurable-derive/src/codegen.rs`), emit a
+    `const FIELD_SCHEMAS: &'static [ConfigFieldSchema] = …;` per struct, and
+    a `fn current_values(app) -> Vec<ConfigFieldValue>` that returns the
+    runtime state.
+- **Risks:** The TypeScript types regenerated via `specta` will change shape.
+  Frontend mirror (`apps/native/src/components/.../developer-tab.tsx`) needs
+  to update its mapping.
+- **Pushback on the review:** The reviewer also asked to **decouple from
+  Serde / `serde_json::Value`** so a non-Tauri consumer could use the crate.
+  This document recommends *not* doing the crate-level decoupling, because
+  there is no second consumer and the cost is real. The schema/value
+  type-level split delivers the clarity benefit without the
+  speculative-future-proofing cost. See §2.3 for the full reasoning. If
+  agreement is not reached here, this item splits in two and B3b
+  (Serde-decoupling) becomes a follow-up.
+- **Acceptance:** `EvolutionLimits::schema()` is callable without an
+  `AppHandle` and returns the same value every call; the IPC payload of
+  `dev_configs_list` joins schema and values at the command boundary.
+
+### B4. Setter takes the whole `Configurable`, not `(struct_name, key, value)`
+
+- **Motivation:** Single-shot Serde validation; drop the per-field dispatch
+  table; the IPC command becomes one strongly-typed call per configurable.
+- **Scope:**
+  - Replace `dev_config_set(struct_name, key, value)` with one of:
+    - A generic `dev_config_set(struct_name, value: serde_json::Value)`
+      that deserializes the whole struct via the static registry; OR
+    - One `set_<configurable>(value: T)` command per configurable, emitted
+      by the derive. Better static typing on both sides, more commands.
+  - Frontend `developer-tab` posts the entire panel state on save (or on
+    blur of any field) rather than one field at a time.
+- **Risks:** Concurrent-edit clobbering (see §2.4). Acceptable for the
+  dev-settings UI.
+- **Acceptance:** No `set_field_fn` function pointer in the registry; one
+  command per configurable (or one generic command keyed by struct name) on
+  the IPC surface.
+
+### B5. Drop `_in_pool` suffix once the rusqlite twins are gone
+
+- **Motivation:** Naming hygiene; the suffix exists only because the
+  rusqlite path is still alive.
+- **Gate (precise):** For each `*_in_pool` function in
+  `apps/native/src-tauri/src/db/commits.rs`, the corresponding rusqlite
+  twin (same root name, takes `db_path: &Path`) has been deleted. This
+  belongs inside Phase 2 of the migration plan (lines 80–98 of
+  `docs/2026-05-29-state-management-migration-plan.md`), which commits to
+  porting `rusqlite::Connection::open` sites "incrementally" but does not
+  explicitly call out the deletion of the rusqlite twins as a milestone.
+  See open question O5 below — the migration plan should add that
+  milestone, or B5 should explicitly migrate to Phase 8 "Decommission."
+- **Scope:** Rename in `apps/native/src-tauri/src/db/commits.rs` and call
+  sites:
+  - `upsert_commit_in_pool` → `upsert_commit`
+  - `get_commit_by_hash_in_pool` → `get_commit_by_hash`
+  - Any sibling `*_in_pool` functions.
+- **Risks:** Trivial.
+- **Acceptance:** `grep -rn "_in_pool" apps/native/src-tauri/src/` returns
+  nothing.
+
+### B6. Drop the silent default fallback on missing `Persisted<EvolutionLimits>`
+
+- **Motivation:** Misconfiguration should fail loudly at startup, not
+  silently swap in defaults at runtime.
+- **Scope:**
+  - In `src/evolve/mod.rs` near line 657, replace the `try_state` +
+    fallback with `app.state::<Persisted<config::EvolutionLimits>>().read_sync().clone()`.
+  - Verify no test or CLI entry point reaches that code path without
+    managing the state. If one does, fix the setup; do not restore the
+    fallback.
+- **Risks:** Hidden test setup that depends on the fallback. Investigate
+  before flipping.
+- **Acceptance:** No call to `try_state::<Persisted<EvolutionLimits>>()` in
+  the evolve loop; the production binary panics on startup if the state is
+  not managed.
+
+### F1. Sweep widget-store import surface ahead of Phase 8 deletion
+
+- **Motivation:** Phase 8 calls for deleting `widget-store.impl.ts`. The
+  deletion is currently blocked by ~30 callers. Two-step the cleanup.
+- **Scope:**
+  - Step F1a: relocate type-only imports (`WidgetStep`, `EvolveEvent`,
+    `GitStatus`, `RebuildErrorType`, `RebuildLine`, …) from
+    `@/stores/widget-store` to `@/ipc/types` or `@/viewmodel/types`.
+  - Step F1b: replace each `useWidgetStore` call site with the appropriate
+    ViewModel selector or `useUiState` field. Stories and mocks last.
+- **Risks:** The Storybook `__mocks__/widget-store.ts` needs equivalent
+  mocks under the new homes; do not delete it until stories are migrated.
+- **Acceptance:** Phase 8 deletion of `widget-store{,.impl,.test}.ts` is a
+  pure file removal with no follow-up edits.
+
+### F2. Extract `bindBackendSlice` helper used by ViewModel slices
+
+- **Motivation:** Three near-identical slice subscribers in
+  `apps/native/src/viewmodel/{evolve,git,change-map}.ts` justify one helper.
+- **Scope:**
+  - Add `bindBackendSlice` to `apps/native/src/viewmodel/_helpers.ts` (new
+    file).
+  - Each slice exports `startEvolveSync` / `startGitSync` /
+    `startChangeMapSync` as a one-liner around the helper. `git.ts` keeps
+    its extra `git_state_error` listener alongside the helper call.
+- **Risks:** Premature abstraction is the danger; keep the helper minimal
+  (one event, one hydrate, one mirror) and let slices that need more do it
+  inline next to the helper call.
+- **Acceptance:** Each `start*Sync` is under 10 lines; the helper is under
+  20\.
+
+## 4. Sequencing
+
+### 4.1 Dependency table
+
+| Item | Depends on | External wait | Size | Risk |
+| ---- | ------------- | -------------------------- | ---- | ------ |
+| B2 | — | — | M | low |
+| B3 | — | — | M | medium |
+| B1 | B2, B3 | — | L | medium |
+| B4 | B1, B3 | — | M | medium |
+| B5 | — | rusqlite twins deleted (sub-goal of Phase 2; see §B5) | XS | low |
+| B6 | — | Investigation (§2.6) | XS | low |
+| F1a | — | — | S | low |
+| F1b | — | — | M | low |
+| F1c | F1a, F1b | Phase 8 of migration plan | XS | low |
+| F2 | — | — | S | low |
+
+Sizes are rough PR scale: XS ≤ 50 LOC, S ≤ 200, M ≤ 600, L ≤ 1500.
+
+### 4.2 Wave structure
+
+Three waves, organized so each wave can be parallelized across PRs and so no
+PR has to be rebased on top of another in-flight PR from the same wave.
+
+**Wave 1 — independent quick wins (parallel PRs).** These can all open
+simultaneously; none touches the same files as another.
+
+- B2: rename `Slice<T>` → `Persisted<T>`, move `src/state/slice/` →
+  `src/persisted/`.
+- B6: investigate the `try_state` fallback and drop it if nothing depends on
+  it.
+- F1a: relocate type-only imports out of `@/stores/widget-store`.
+- F2: extract `bindBackendSlice` and rewrite the three ViewModel slices over
+  it.
+
+Wave 1 lands first because it is the lowest risk and clears the surface for
+Wave 2 — in particular, B2 has to land before B1, or the `inventory` entries
+introduced in B1 would reference the old `Slice<T>` and need to be renamed
+twice.
+
+**Wave 2 — the Configurable redesign (sequential, one PR per step).** This
+is the chain B3 → B1 → B4. Each step is reviewable in isolation; doing them
+as one PR would push past the ~1500 LOC line and lose reviewability.
+
+- B3: split `ConfigField` into `ConfigFieldSchema` (static) +
+  `ConfigFieldValue` (dynamic). Update the derive to emit a
+  `const FIELD_SCHEMAS: &'static [ConfigFieldSchema]`. The IPC payload joins
+  the two at the command boundary. Frontend mirror in `developer-tab.tsx`
+  follows the regenerated specta types.
+- B1: delete `SliceRegistry`, `RegisteredSliceConfig`, and the
+  `register_slice_config` boilerplate. Replace with `inventory::submit!` in
+  the derive and `inventory::collect!` in the `configurable` crate.
+  Rewrite `dev_configs_list` to walk the static registry.
+- B4: change the setter from `(struct_name, key, value)` to a whole-struct
+  write. Either one generic command keyed by struct name or one command per
+  configurable — see open question O3.
+
+Wave 2 cannot start until Wave 1 B2 ships, because B1 introduces inventory
+entries that hold references to `Persisted<T>` slices. If B1 were attempted
+on top of `Slice<T>`, the rename in B2 would force a second pass through
+the same code.
+
+**Wave 3 — externally gated cleanup.** These wait for prior phases of the
+2026-05-29 migration plan to complete.
+
+- B5: drop the `_in_pool` suffix from every Diesel function in
+  `db/commits.rs`. Gated on the rusqlite twins being deleted — a sub-goal
+  of Phase 2 ("port `rusqlite::Connection::open` sites incrementally", line
+  91 of the migration plan) but not currently called out as an explicit
+  milestone in that document. The suffix is load-bearing as a
+  disambiguator until then.
+- F1b: replace `useWidgetStore` call sites with ViewModel selectors or
+  `useUiState`. Can technically start anytime after F1a, but the cleanest
+  scheduling is to do it together with Phase 8 prep.
+- F1c: delete `widget-store.ts`, `widget-store.impl.ts`,
+  `widget-store.test.ts`, and the Storybook `__mocks__/widget-store.ts`.
+  Gated on F1a and F1b being complete. This is the Phase 8 deletion bullet
+  already in the migration plan.
+
+### 4.3 Diagram
+
+```
+Wave 1 (parallel)        Wave 2 (sequential)         Wave 3 (gated)
+───────────────────      ────────────────────        ─────────────────────
+
+B2  Persisted<T> ──┐                                 B5  drop _in_pool
+                   │                                     (after rusqlite
+                   │                                      twins deleted)
+B6  drop fallback  │     ┌── B3  schema/value
+                   ├───► │                           F1b useWidgetStore
+F1a type imports   │     ├── B1  inventory               replacement
+                   │     │
+F2  bindBackendSlice     └── B4  whole-struct set    F1c delete files
+                                                         (after F1a+F1b,
+                                                         = Phase 8)
+```
+
+### 4.4 Why this ordering
+
+- **B2 before B1/B4** because B1 introduces new references to the type; we
+  do not want to rename twice.
+- **B3 before B1** because B1's `inventory` entries hold static schemas,
+  and the static schemas are exactly what B3 introduces.
+- **B4 last in Wave 2** because the whole-struct setter is the cleanest
+  expression *after* the registry is static and the schema is decoupled
+  from runtime values. Doing it earlier would mean designing it around the
+  per-field dispatch table that B1 deletes.
+- **B5 deferred** because the rename collides with the still-living
+  rusqlite function of the same name. Phase 2 removes the collision; B5
+  then becomes a one-line rename per call site.
+- **F2 in Wave 1** because it has no backend dependencies and unblocks the
+  three ViewModel slices from accumulating further drift in the meantime.
+- **F1 split across waves** because Phase 8 of the migration plan owns the
+  file deletion; F1a and F1b just trim the surface so that deletion is
+  truly a deletion.
+
+### 4.5 Stopping points
+
+If the work has to halt midway, these are the safe halt points:
+
+- After Wave 1: code is internally consistent (renames done, helper
+  extracted, fallback either fixed or documented as load-bearing). No
+  functional change.
+- After Wave 2 B3: type split is in place but the registry is still
+  runtime; acceptable indefinitely if B1 turns out to be unwanted.
+- After Wave 2 B1: the static registry is live and the runtime
+  `SliceRegistry` is gone; the field-by-field setter remains. Functional
+  and reviewable; B4 can wait.
+- Wave 3 items are individually independent and can be picked up at any
+  time once their external gate clears.
+
+## 5. Open questions for the reviewer
+
+- **O1.** Should B3 include the crate-level Serde decoupling (this document
+  recommends *no*), or only the type-level schema/value split?
+- **O2.** Final name for the renamed primitive in B2. This document proposes
+  `Persisted<T>`; the original review proposed `Observable<T>`. Other
+  candidates: `WatchedCell<T>`, `SyncedCell<T>`.
+- **O3.** For B4, do we want one generic `dev_config_set(struct_name, value)`
+  command or one `set_<configurable>(value: T)` per configurable? The latter
+  gives better static typing but multiplies the IPC surface.
+- **O4.** B6: is the `try_state` fallback actually load-bearing for any test
+  or CLI path? Worth confirming before deleting.
+- **O5.** B5: the migration plan (Phase 2, line 91) says rusqlite call
+  sites are "ported incrementally" but never names a milestone where the
+  rusqlite twins are deleted. Two options: (a) amend Phase 2 to require
+  twin-deletion as its exit criterion; (b) move the twin-deletion (and
+  therefore B5's gate) into Phase 8 "Decommission." Option (a) is cleaner
+  — it keeps Phase 2 self-contained — but it broadens the Phase 2 scope.
+
+## 6. Process notes (not code work)
+
+Two PR-slicing observations from the reviewer worth fixing in the workflow,
+not in code:
+
+- **PR #245 / #246 ordering.** The reviewer noted that types used in #245
+  were "in fact introduced here [in #246] for the first time." The
+  `SliceRegistry` import in `src/commands/dev_configs.rs` (PR #245) refers
+  to a type defined in `src/state/slice/registry.rs`, which only existed in
+  PR #246. The first PR cannot have compiled in isolation. This is a
+  stacked-PR slicing error — the rebase that produced #245 included #246's
+  files. Fix in process: rebase each PR in the stack onto its parent
+  *after* the parent is approved, never before.
+- **PR #249 "includes the previous one."** The base of #249 was the #246
+  branch; when GitHub renders the diff of #249 against the wrong base, the
+  parent's content reappears. The fix is the same: rebase stacked branches
+  onto `develop` as soon as their parent merges, and confirm the PR base
+  matches.
+
+## 7. Tracking
+
+These items should land as new sub-issues under `nixmac-h85`:
+
+- `nixmac-h85.5.1` — B1, B2, B3, B4 (the Configurable redesign)
+- `nixmac-h85.5.2` — B6
+- `nixmac-h85.2.1` — B5
+- `nixmac-h85.8.1` — F1
+- `nixmac-h85.7.1` — F2
+
+The 2026-05-29 migration plan should be amended in Phase 1 ("slice
+registry") and Phase 5 ("slice registry / `set_field` path") to reflect the
+revised design before any of these issues are picked up.


### PR DESCRIPTION
## Summary

- Completes Phase 2 of `docs/2026-05-29-state-management-migration-plan.md` proposed by @czxtm : every `rusqlite::Connection::open` is gone, replaced by a Diesel `r2d2` pool + DSL/sql_query.
- Schema bootstrap now uses `diesel_migrations::embed_migrations!`; `db/schema.rs` is the migration harness, not raw DDL.
- Resolves the B5 `_in_pool` rename item from `docs/2026-06-03-pr-review-followups.md`.
- Adds the followup doc itself (`docs/2026-06-03-pr-review-followups.md`), which collects @arximboldi's review comments on PRs #228, #244–#255 and proposes the rest of the work.

## Behavior preserved

- Stale-DB recreation semantics in `db/schema.rs` are kept (PRAGMA `user_version` check + remove + run migrations).
- Same `SCHEMA_VERSION = 1` value, stamped after migrations apply.
- The two multi-JOIN read queries (`query_change_set_for_commit_pair`, `query_change_set_for_base_with_hashes`) keep their original SQL text; only the Diesel harness changes.
- libsqlite3-sys keeps the `bundled` feature so we still ship a self-contained sqlite — rusqlite was carrying that flag transitively.

## Test plan

- [x] `cargo test --manifest-path apps/native/src-tauri/Cargo.toml` — **374 passed / 2 ignored / 0 failed** at every commit
- [ ] Smoke-launch the desktop app on a fresh app-data directory (verifies first-run migration path)
- [ ] Smoke-launch on an existing 0.22.0 database (verifies user_version-based stale recreate still works)
- [ ] Trigger one evolve cycle end-to-end so all three changeset writers + queue summarizer exercise the new pool