### PR TITLE
refactor: migrate macOS Objective-C bindings from `objc`/`cocoa` to `objc2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,12 +644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,35 +949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "cocoa-foundation",
- "core-foundation 0.10.1",
- "core-graphics 0.24.0",
- "foreign-types 0.5.0",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-foundation 0.10.1",
- "core-graphics-types",
- "objc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,19 +1088,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "core-graphics-types",
- "foreign-types 0.5.0",
- "libc",
-]
 
 [[package]]
 name = "core-graphics"
@@ -3464,15 +3416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3836,7 +3779,6 @@ dependencies = [
  "backtrace",
  "chrono",
  "clap",
- "cocoa",
  "configurable",
  "diesel",
  "diesel_migrations",
@@ -3849,7 +3791,9 @@ dependencies = [
  "ignore",
  "log",
  "mockall",
- "objc",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "once_cell",
  "r2d2",
  "regex",
@@ -4003,15 +3947,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
 ]
 
 [[package]]
@@ -6712,7 +6647,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
- "core-graphics 0.25.0",
+ "core-graphics",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -85,8 +85,9 @@ tauri-plugin-updater = "2.0.0"
 url = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26"
-objc = "0.2"
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSWindow"] }
+objc2-foundation = "0.3.2"
 
 [dev-dependencies]
 mockall = "0.14.0"

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -853,7 +853,8 @@ pub async fn generate_evolution<R: Runtime>(
 
     // Read configurable limits from store (hot-reloaded on every run).
     let config::EvolutionLimits {
-        mut max_build_attempts, ..
+        mut max_build_attempts,
+        ..
     } = config::EvolutionLimits::load(app)
         .inspect_err(|e| warn!("EvolutionLimits::load failed ({e}); using defaults"))
         .unwrap_or_default();
@@ -1101,7 +1102,13 @@ pub async fn generate_evolution<R: Runtime>(
             );
             emit_evolve_event(
                 app,
-                EvolveEvent::api_response(start_time, iteration, usage.total, total_tokens, max_token_budget),
+                EvolveEvent::api_response(
+                    start_time,
+                    iteration,
+                    usage.total,
+                    total_tokens,
+                    max_token_budget,
+                ),
             );
         }
 

--- a/apps/native/src-tauri/src/git/repo_files.rs
+++ b/apps/native/src-tauri/src/git/repo_files.rs
@@ -205,8 +205,7 @@ mod tests {
         let outside = temp.path().join("../outside.txt");
         fs::write(&outside, "outside").expect("write outside file");
 
-        std::os::unix::fs::symlink(&outside, temp.path().join("link.txt"))
-            .expect("create symlink");
+        std::os::unix::fs::symlink(&outside, temp.path().join("link.txt")).expect("create symlink");
 
         assert_eq!(workdir_file_contents(&repo, Path::new("link.txt")), "");
     }

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -810,18 +810,15 @@ fn run_gui_mode(
 
             #[cfg(target_os = "macos")]
             if e2e_opaque_window {
-                use objc::msg_send;
-                use objc::runtime::Object;
-                use objc::sel;
-                use objc::sel_impl;
+                use objc2_app_kit::NSWindow;
 
                 match main_window.ns_window() {
                     Ok(ns_window) => unsafe {
-                        let ns_window = ns_window as *mut Object;
-                        let is_opaque: bool = msg_send![ns_window, isOpaque];
-                        let alpha_value: f64 = msg_send![ns_window, alphaValue];
-                        let level: i64 = msg_send![ns_window, level];
-                        let has_shadow: bool = msg_send![ns_window, hasShadow];
+                        let ns_window = &*(ns_window.cast::<NSWindow>());
+                        let is_opaque = ns_window.isOpaque();
+                        let alpha_value = ns_window.alphaValue();
+                        let level = ns_window.level();
+                        let has_shadow = ns_window.hasShadow();
                         log::info!(
                             "NIXMAC_E2E_OPAQUE_WINDOW native window diagnostics: isOpaque={} alphaValue={:.3} level={} hasShadow={}",
                             is_opaque,

--- a/apps/native/src-tauri/src/peek.rs
+++ b/apps/native/src-tauri/src/peek.rs
@@ -523,32 +523,26 @@ pub fn create_preview_indicator_window<R: Runtime>(app: &AppHandle<R>) -> Result
     // Disable shadow and set as utility panel (prevents grouping with main window)
     #[cfg(target_os = "macos")]
     {
-        use cocoa::appkit::{NSWindow, NSWindowCollectionBehavior};
-        use cocoa::base::id;
-        use objc::msg_send;
-        use objc::sel;
-        use objc::sel_impl;
+        use objc2_app_kit::{NSFloatingWindowLevel, NSWindow, NSWindowCollectionBehavior};
 
         let _ = window.set_shadow(false);
 
         // Get the native NSWindow and configure it as an independent panel
         if let Ok(ns_window) = window.ns_window() {
-            let ns_win = ns_window as id;
             unsafe {
+                let ns_win = &*(ns_window.cast::<NSWindow>());
                 // Set collection behavior to be independent (not grouped with other windows)
                 // NSWindowCollectionBehaviorStationary keeps it from moving with spaces
                 // NSWindowCollectionBehaviorCanJoinAllSpaces makes it visible on all spaces
                 // NSWindowCollectionBehaviorIgnoresCycle prevents Cmd+` from cycling to it
-                ns_win.setCollectionBehavior_(
-                    NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
-                        | NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary
-                        | NSWindowCollectionBehavior::NSWindowCollectionBehaviorIgnoresCycle,
+                ns_win.setCollectionBehavior(
+                    NSWindowCollectionBehavior::CanJoinAllSpaces
+                        | NSWindowCollectionBehavior::Stationary
+                        | NSWindowCollectionBehavior::IgnoresCycle,
                 );
 
                 // Set as a floating panel level (above regular windows but independent)
-                // kCGFloatingWindowLevel = 5 (or we can use NSFloatingWindowLevel = 3)
-                let floating_level: i64 = 3; // NSFloatingWindowLevel
-                let _: () = msg_send![ns_win, setLevel: floating_level];
+                ns_win.setLevel(NSFloatingWindowLevel);
             }
         }
     }

--- a/apps/native/src-tauri/src/state/drift_notifications.rs
+++ b/apps/native/src-tauri/src/state/drift_notifications.rs
@@ -78,36 +78,35 @@ fn notification_for_event(
 
 #[cfg(target_os = "macos")]
 fn send_native_notification(title: &str, body: &str) -> Result<(), String> {
-    use cocoa::base::{id, nil};
-    use cocoa::foundation::{NSAutoreleasePool, NSString};
-    use objc::{class, msg_send, sel, sel_impl};
+    use objc2::ffi::nil;
+    use objc2::rc::Retained;
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::{NSAutoreleasePool, NSString};
 
     unsafe {
-        let pool = NSAutoreleasePool::new(nil);
-        let content: id = msg_send![class!(UNMutableNotificationContent), new];
-        let title = NSString::alloc(nil).init_str(title);
-        let body = NSString::alloc(nil).init_str(body);
-        let identifier =
-            NSString::alloc(nil).init_str(&format!("nixmac-drift-{}", uuid::Uuid::new_v4()));
+        let pool = NSAutoreleasePool::new();
+        let content: Retained<AnyObject> = msg_send![class!(UNMutableNotificationContent), new];
+        let title = NSString::from_str(title);
+        let body = NSString::from_str(body);
+        let identifier = NSString::from_str(&format!("nixmac-drift-{}", uuid::Uuid::new_v4()));
 
-        let _: () = msg_send![content, setTitle: title];
-        let _: () = msg_send![content, setBody: body];
+        let _: () = msg_send![&content, setTitle: &*title];
+        let _: () = msg_send![&content, setBody: &*body];
 
-        let request: id = msg_send![
+        let request: Retained<AnyObject> = msg_send![
             class!(UNNotificationRequest),
-            requestWithIdentifier: identifier
-            content: content
+            requestWithIdentifier: &*identifier,
+            content: &*content,
             trigger: nil
         ];
 
-        let center: id = msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
-        let _: () = msg_send![center, addNotificationRequest: request withCompletionHandler: nil];
+        let center: Retained<AnyObject> =
+            msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
+        let _: () =
+            msg_send![&center, addNotificationRequest: &*request, withCompletionHandler: nil];
 
-        let _: () = msg_send![title, release];
-        let _: () = msg_send![body, release];
-        let _: () = msg_send![identifier, release];
-        let _: () = msg_send![content, release];
-        let _: () = msg_send![pool, drain];
+        pool.drain();
     }
 
     Ok(())
@@ -135,7 +134,6 @@ mod tests {
             changes: Vec::new(),
         }
     }
-
 
     #[test]
     fn no_notification_without_drift() {

--- a/apps/native/src-tauri/src/state/drift_notifications.rs
+++ b/apps/native/src-tauri/src/state/drift_notifications.rs
@@ -79,13 +79,12 @@ fn notification_for_event(
 #[cfg(target_os = "macos")]
 fn send_native_notification(title: &str, body: &str) -> Result<(), String> {
     use objc2::ffi::nil;
-    use objc2::rc::Retained;
+    use objc2::rc::{autoreleasepool, Retained};
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
-    use objc2_foundation::{NSAutoreleasePool, NSString};
+    use objc2_foundation::NSString;
 
-    unsafe {
-        let pool = NSAutoreleasePool::new();
+    autoreleasepool(|_| unsafe {
         let content: Retained<AnyObject> = msg_send![class!(UNMutableNotificationContent), new];
         let title = NSString::from_str(title);
         let body = NSString::from_str(body);
@@ -94,20 +93,17 @@ fn send_native_notification(title: &str, body: &str) -> Result<(), String> {
         let _: () = msg_send![&content, setTitle: &*title];
         let _: () = msg_send![&content, setBody: &*body];
 
-        let request: Retained<AnyObject> = msg_send![
+        let request: *mut AnyObject = msg_send![
             class!(UNNotificationRequest),
             requestWithIdentifier: &*identifier,
             content: &*content,
             trigger: nil
         ];
 
-        let center: Retained<AnyObject> =
+        let center: *mut AnyObject =
             msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
-        let _: () =
-            msg_send![&center, addNotificationRequest: &*request, withCompletionHandler: nil];
-
-        pool.drain();
-    }
+        let _: () = msg_send![center, addNotificationRequest: request, withCompletionHandler: nil];
+    });
 
     Ok(())
 }

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -117,7 +117,10 @@ where
                                 let _ = evolve_state::set(&app_handle, es, &status.changes);
                             }
                             // Native drift notification (config drift / external build).
-                            drift_notifications::maybe_notify(Some(&status), external_build_detected);
+                            drift_notifications::maybe_notify(
+                                Some(&status),
+                                external_build_detected,
+                            );
                             // One emit per slice — frontend listens on its dedicated channel.
                             // fire-and-forget: window may not be connected yet.
                             let _ = app_handle.emit(


### PR DESCRIPTION
## Summary

Fixes a bunch of deprecation warnings that got introduced today on `develop` that were blocking builds.

<!-- What does this PR do? Why? -->

## Test Plan

Build and start the app.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed