### PR TITLE
feat: replace cocoa/objc notifications with tauri-plugin-notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,6 +3882,7 @@ dependencies = [
  "tauri-plugin-http",
  "tauri-plugin-keyring",
  "tauri-plugin-macos-permissions",
+ "tauri-plugin-notification",
  "tauri-plugin-positioner",
  "tauri-plugin-process",
  "tauri-plugin-sentry",
@@ -3909,6 +3922,20 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -4686,7 +4713,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -4896,6 +4923,15 @@ name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -6995,6 +7031,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-positioner"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7308,6 +7363,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -42,6 +42,7 @@
     "test:wdio:onboarding": "npm run build:e2e && wdio run e2e-tauri/wdio.onboarding.conf.mjs"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@nixmac/ui": "workspace:*",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
@@ -67,8 +68,8 @@
     "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",
     "execa": "^9.6.0",
+    "lottie-react": "^2.4.1",
     "lucide-react": "^1.14.0",
-    "@monaco-editor/react": "^4.7.0",
     "monaco-editor": "^0.55.1",
     "monaco-editor-textmate": "^4.0.0",
     "monaco-textmate": "^3.0.1",

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-process = "2.0.0"
 tauri-plugin-single-instance = "2.0.0"
 tauri-plugin-websocket = "2.0.0"
 tauri-plugin-window-state = "2.0.0"
+tauri-plugin-notification = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/native/src-tauri/capabilities/default.json
+++ b/apps/native/src-tauri/capabilities/default.json
@@ -26,6 +26,7 @@
     "updater:default",
     "updater:allow-check",
     "updater:allow-download-and-install",
-    "process:allow-restart"
+    "process:allow-restart",
+    "notification:default"
   ]
 }

--- a/apps/native/src-tauri/src/commands/debug.rs
+++ b/apps/native/src-tauri/src/commands/debug.rs
@@ -73,6 +73,20 @@ pub async fn debug_sentry_event() -> Result<shared_types::DebugSentryResult, Str
     })
 }
 
+/// Sends a test drift notification from the developer settings.
+/// Exercises the same code path as the watcher's drift notifications.
+#[tauri::command]
+pub async fn developer_send_test_notification(app: AppHandle) -> Result<(), String> {
+    let developer_mode =
+        store::get_bool_pref(&app, store::DEVELOPER_MODE_KEY, false).map_err(|e| e.to_string())?;
+    if !developer_mode {
+        return Err("Developer mode is required to send test notifications".to_string());
+    }
+
+    crate::state::drift_notifications::maybe_notify(None, true);
+    Ok(())
+}
+
 /// Clears the app's Tauri plugin-store files.
 #[tauri::command]
 pub async fn developer_clear_tauri_state(app: AppHandle) -> Result<(), String> {

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -53,6 +53,11 @@ use tauri::{
 };
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+/// Global app handle, set during GUI setup so background threads (such as the
+/// drift watcher) can access plugins like notifications without threading an
+/// `AppHandle` through every call site.
+pub static APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
+
 fn e2e_opaque_window_enabled() -> bool {
     cfg!(debug_assertions) && crate::e2e_runtime::enabled("NIXMAC_E2E_OPAQUE_WINDOW")
 }
@@ -328,6 +333,7 @@ fn run_cli_mode(context: tauri::Context<tauri::Wry>) -> i32 {
                     // Ensure store plugin (and its managed state) is initialized so we can load settings
                     .plugin(tauri_plugin_store::Builder::default().build())
                     .plugin(tauri_plugin_keyring::init())
+                    .plugin(tauri_plugin_notification::init())
                     .invoke_handler(tauri::generate_handler![])
                     .setup(|app| {
                         app.manage(state::preferences::load_global_slice(app.handle())?);
@@ -476,6 +482,7 @@ fn run_gui_mode(
         .plugin(tauri_plugin_sql::Builder::new().build())
         .plugin(tauri_plugin_upload::init())
         .plugin(tauri_plugin_macos_permissions::init())
+        .plugin(tauri_plugin_notification::init())
         // Configurable slices register here during setup so dev settings
         // commands can update typed state without opening store files directly.
         .manage(state::slice::SliceRegistry::default())
@@ -497,6 +504,7 @@ fn run_gui_mode(
             #[cfg(debug_assertions)]
             commands::debug::debug_sentry_event,
             commands::debug::developer_clear_tauri_state,
+            commands::debug::developer_send_test_notification,
             #[cfg(debug_assertions)]
             commands::debug::e2e_log_breadcrumb,
             #[cfg(debug_assertions)]
@@ -588,6 +596,8 @@ fn run_gui_mode(
         ])
         .setup(move |app| {
             let handle = app.handle();
+            // Expose the app handle globally so background threads can use plugins.
+            let _ = crate::APP_HANDLE.set(handle.clone());
             log::debug!("Tauri setup started");
 
             // Set up panic handler to catch crashes and show feedback dialog

--- a/apps/native/src-tauri/src/state/drift_notifications.rs
+++ b/apps/native/src-tauri/src/state/drift_notifications.rs
@@ -6,10 +6,6 @@ use crate::shared_types::GitStatus;
 
 static LAST_DRIFT_NOTIFICATION_ID: Mutex<Option<String>> = Mutex::new(None);
 
-#[cfg(target_os = "macos")]
-#[link(name = "UserNotifications", kind = "framework")]
-extern "C" {}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DriftNotification {
     id: String,
@@ -76,46 +72,22 @@ fn notification_for_event(
     })
 }
 
-#[cfg(target_os = "macos")]
 fn send_native_notification(title: &str, body: &str) -> Result<(), String> {
-    use cocoa::base::{id, nil};
-    use cocoa::foundation::{NSAutoreleasePool, NSString};
-    use objc::{class, msg_send, sel, sel_impl};
+    use tauri_plugin_notification::NotificationExt;
 
-    unsafe {
-        let pool = NSAutoreleasePool::new(nil);
-        let content: id = msg_send![class!(UNMutableNotificationContent), new];
-        let title = NSString::alloc(nil).init_str(title);
-        let body = NSString::alloc(nil).init_str(body);
-        let identifier =
-            NSString::alloc(nil).init_str(&format!("nixmac-drift-{}", uuid::Uuid::new_v4()));
+    // The notification plugin is registered during GUI startup, so the global
+    // app handle is available by the time the watcher emits drift notifications.
+    let app_handle = crate::APP_HANDLE
+        .get()
+        .ok_or("App handle not initialized")?;
 
-        let _: () = msg_send![content, setTitle: title];
-        let _: () = msg_send![content, setBody: body];
-
-        let request: id = msg_send![
-            class!(UNNotificationRequest),
-            requestWithIdentifier: identifier
-            content: content
-            trigger: nil
-        ];
-
-        let center: id = msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
-        let _: () = msg_send![center, addNotificationRequest: request withCompletionHandler: nil];
-
-        let _: () = msg_send![title, release];
-        let _: () = msg_send![body, release];
-        let _: () = msg_send![identifier, release];
-        let _: () = msg_send![content, release];
-        let _: () = msg_send![pool, drain];
-    }
-
-    Ok(())
-}
-
-#[cfg(not(target_os = "macos"))]
-fn send_native_notification(_title: &str, _body: &str) -> Result<(), String> {
-    Ok(())
+    app_handle
+        .notification()
+        .builder()
+        .title(title)
+        .body(body)
+        .show()
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/apps/native/src/components/widget/settings/developer-tab.tsx
+++ b/apps/native/src/components/widget/settings/developer-tab.tsx
@@ -12,6 +12,7 @@ import {
   DatabaseZap,
   Download,
   GitBranch,
+  Bell,
   Eraser,
   History,
   Pin,
@@ -136,6 +137,17 @@ export function DeveloperTab() {
     setStatusMessage("Cleared local UI debug buffers.");
     setErrorMessage(null);
   };
+
+  const handleSendTestNotification = async () => {
+    setErrorMessage(null);
+    try {
+      await tauriAPI.debug.sendTestNotification();
+      setStatusMessage("Test notification sent.");
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : String(err));
+    }
+  };
+
 
   const handleDisableDeveloper = async () => {
     try {
@@ -276,6 +288,10 @@ export function DeveloperTab() {
             <Button onClick={handleClearUiBuffers} size="sm" variant="outline">
               <Eraser className="mr-2 h-3.5 w-3.5" />
               Clear UI buffers
+            </Button>
+            <Button onClick={handleSendTestNotification} size="sm" variant="outline">
+              <Bell className="mr-2 h-3.5 w-3.5" />
+              Test notification
             </Button>
           </div>
         </div>

--- a/apps/native/src/ipc/api.ts
+++ b/apps/native/src/ipc/api.ts
@@ -110,6 +110,7 @@ export const tauriAPI = {
       }),
     sentryEvent: () => invoke<void>("debug_sentry_event"),
     clearTauriState: () => invoke<void>("developer_clear_tauri_state"),
+    sendTestNotification: () => invoke<void>("developer_send_test_notification"),
   },
   ui: {
     getPrefs: getCachedPrefs,

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "class-variance-authority": "^0.7.1",
         "cmdk": "^1.1.1",
         "execa": "^9.6.0",
+        "lottie-react": "^2.4.1",
         "lucide-react": "^1.14.0",
         "monaco-editor": "^0.55.1",
         "monaco-editor-textmate": "^4.0.0",
@@ -1768,6 +1769,10 @@
     "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "loglevel-plugin-prefix": ["loglevel-plugin-prefix@0.8.4", "", {}, "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="],
+
+    "lottie-react": ["lottie-react@2.4.1", "", { "dependencies": { "lottie-web": "^5.10.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LQrH7jlkigIIv++wIyrOYFLHSKQpEY4zehPicL9bQsrt1rnoKRYCYgpCUe5maqylNtacy58/sQDZTkwMcTRxZw=="],
+
+    "lottie-web": ["lottie-web@5.13.0", "", {}, "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 


### PR DESCRIPTION
Replace raw UNUserNotificationCenter calls in drift_notifications.rs with tauri-plugin-notification, which handles cross-platform native notifications via Tauri's plugin system.

- Add tauri-plugin-notification = "2" to Cargo deps
- Rewrite send_native_notification() to use NotificationExt via global APP_HANDLE (OnceLock, matching existing codebase pattern)
- Remove #[link(UserNotifications)] extern block and platform-gated cocoa/objc code (cocoa/objc deps kept — used by main.rs, peek.rs)
- Register plugin in both GUI and CLI builder paths
- Add notification:default capability permission
- Add developer_send_test_notification command (developer_mode gated)
- Add "Test notification" button in Developer settings

## Summary

<!-- What does this PR do? Why? -->

## Test Plan

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [ ] No docs update needed
