### PR TITLE
fix(evolve): four correctness fixes in the evolve loop

### DIFF
--- a/apps/native/src-tauri/src/evolve/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/edit_nix_file.rs
@@ -675,6 +675,17 @@ fn add(content: &str, attrpath: &str, values: &[String]) -> Result<String> {
         return append_values_to_existing_list(content, &list_node, &values_to_append);
     }
 
+    // No list was found at this attrpath. If the attrpath already exists as a
+    // non-list assignment (e.g. `programs.git = { enable = true; };`), inserting
+    // a fresh `attrpath = [ ... ];` would produce two assignments to the same
+    // attribute — invalid Nix. Refuse rather than silently corrupt the file.
+    if find_assignment_value_range(content, attrpath).is_some() {
+        return Err(anyhow::anyhow!(
+            "Cannot add list values to '{}': it already exists and is not a list",
+            attrpath
+        ));
+    }
+
     // not found -> insert new attr assignment in top-level attrset
     let insert_pos = find_top_level_attrset_end(&root_node)
         .context("Cannot find top-level attribute set to insert new attr")?;
@@ -1005,6 +1016,20 @@ environment.systemPackages = with pkgs; [
             edited.matches("environment.systemPackages =").count(),
             1,
             "should not insert duplicate environment.systemPackages assignment"
+        );
+    }
+
+    #[test]
+    fn add_refuses_to_duplicate_non_list_attr() {
+        // `programs.git` already exists as an attrset, not a list. Adding list
+        // values must error rather than insert a second `programs.git = [ ... ];`
+        // assignment (which would be invalid, duplicated Nix).
+        let src = "{\n  programs.git = { enable = true; };\n}\n";
+        let err = add(src, "programs.git", &["foo".to_string()])
+            .expect_err("add to a non-list attr should error, not duplicate it");
+        assert!(
+            err.to_string().contains("not a list"),
+            "unexpected error: {err:#}"
         );
     }
 

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -174,20 +174,29 @@ fn path_scope_error(input: &str, base: &Path, resolved: &Path, operation: &str) 
 /// even for complete junk, which isn't helpful for our use case of validating AI-generated edits.
 /// Instead, we check basic structural validity: balanced braces/brackets/parens, closed strings.
 fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
-    // Simple validation: track bracket/brace/paren balance across the content,
-    // respecting string contexts. This catches obvious errors like unmatched braces.
-
-    let mut brace_depth = 0;
-    let mut bracket_depth = 0;
-    let mut paren_depth = 0;
-    let mut in_string = false;
-    let mut in_multiline_string = false;
-    let mut in_line_comment = false;
-    let mut in_block_comment = false;
-    let mut escape_next = false;
+    // Track structural balance (braces/brackets/parens) and string contexts.
+    // `${ ... }` antiquotation re-enters code context *inside* a string, so a
+    // single shared stack is used: an interpolation pushes a code frame and its
+    // matching `}` pops back to the string. This lets interpolations contain
+    // nested strings, braces, and further interpolations without desyncing the
+    // string state (which the old flag-based scanner got wrong, falsely
+    // rejecting valid Nix like `"${if a then "}" else "y"}"`).
+    #[derive(PartialEq)]
+    enum Frame {
+        Brace,    // `{ ... }` in code, and `${ ... }` interpolation bodies
+        Bracket,  // `[ ... ]`
+        Paren,    // `( ... )`
+        Str,      // `"..."`
+        Indented, // `''...''`
+    }
 
     let chars: Vec<char> = content.chars().collect();
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
     let mut i = 0;
+
+    let err = |msg: String| anyhow::anyhow!("Syntax error in {}: {}", file_path, msg);
 
     while i < chars.len() {
         let ch = chars[i];
@@ -204,137 +213,124 @@ fn validate_nix_syntax(content: &str, file_path: &str) -> anyhow::Result<()> {
             if i + 1 < chars.len() && ch == '*' && chars[i + 1] == '/' {
                 in_block_comment = false;
                 i += 2;
-                continue;
-            }
-            i += 1;
-            continue;
-        }
-
-        if escape_next {
-            escape_next = false;
-            i += 1;
-            continue;
-        }
-
-        // Check for multiline strings: '' ... ''
-        if !in_string && i + 1 < chars.len() && ch == '\'' && chars[i + 1] == '\'' {
-            if in_multiline_string {
-                // In an indented string, '' introduces either an escape sequence
-                // (e.g. ''', ''$, ''\) or the closing delimiter.
-                // Only treat it as closing when it is not an escape prefix.
-                if i + 2 < chars.len()
-                    && (chars[i + 2] == '\'' || chars[i + 2] == '$' || chars[i + 2] == '\\')
-                {
-                    i += 3;
-                    continue;
-                }
-            }
-
-            in_multiline_string = !in_multiline_string;
-            i += 2;
-            continue;
-        }
-
-        if in_multiline_string {
-            i += 1;
-            continue;
-        }
-
-        if !in_string {
-            if ch == '#' {
-                in_line_comment = true;
+            } else {
                 i += 1;
-                continue;
             }
-            if i + 1 < chars.len() && ch == '/' && chars[i + 1] == '*' {
-                in_block_comment = true;
-                i += 2;
-                continue;
-            }
+            continue;
         }
 
-        match ch {
-            '\\' if in_string => escape_next = true,
-            '"' => in_string = !in_string,
-            '{' if !in_string => brace_depth += 1,
-            '}' if !in_string => {
-                brace_depth -= 1;
-                if brace_depth < 0 {
-                    return Err(anyhow::anyhow!(
-                        "Syntax error in {}: unmatched closing brace '}}'",
-                        file_path
-                    ));
+        let is_interp_start = ch == '$' && i + 1 < chars.len() && chars[i + 1] == '{';
+
+        match stack.last() {
+            // Inside a normal "..." string.
+            Some(Frame::Str) => {
+                if ch == '\\' {
+                    i += 2; // escape: skip the escaped char too
+                } else if ch == '"' {
+                    stack.pop();
+                    i += 1;
+                } else if is_interp_start {
+                    stack.push(Frame::Brace); // antiquotation -> code context
+                    i += 2;
+                } else {
+                    i += 1;
                 }
             }
-            '[' if !in_string => bracket_depth += 1,
-            ']' if !in_string => {
-                bracket_depth -= 1;
-                if bracket_depth < 0 {
-                    return Err(anyhow::anyhow!(
-                        "Syntax error in {}: unmatched closing bracket ']'",
-                        file_path
-                    ));
+            // Inside an indented ''...'' string.
+            Some(Frame::Indented) => {
+                if ch == '\'' && i + 1 < chars.len() && chars[i + 1] == '\'' {
+                    // '' escape sequences (''', ''$, ''\) stay in the string;
+                    // a bare '' closes it.
+                    if i + 2 < chars.len()
+                        && (chars[i + 2] == '\'' || chars[i + 2] == '$' || chars[i + 2] == '\\')
+                    {
+                        i += 3;
+                    } else {
+                        stack.pop();
+                        i += 2;
+                    }
+                } else if is_interp_start {
+                    stack.push(Frame::Brace);
+                    i += 2;
+                } else {
+                    i += 1;
                 }
             }
-            '(' if !in_string => paren_depth += 1,
-            ')' if !in_string => {
-                paren_depth -= 1;
-                if paren_depth < 0 {
-                    return Err(anyhow::anyhow!(
-                        "Syntax error in {}: unmatched closing parenthesis ')'",
-                        file_path
-                    ));
+            // Code context: top is None / Brace / Bracket / Paren.
+            _ => {
+                if ch == '#' {
+                    in_line_comment = true;
+                    i += 1;
+                } else if ch == '/' && i + 1 < chars.len() && chars[i + 1] == '*' {
+                    in_block_comment = true;
+                    i += 2;
+                } else if ch == '"' {
+                    stack.push(Frame::Str);
+                    i += 1;
+                } else if ch == '\'' && i + 1 < chars.len() && chars[i + 1] == '\'' {
+                    stack.push(Frame::Indented);
+                    i += 2;
+                } else if ch == '{' {
+                    stack.push(Frame::Brace);
+                    i += 1;
+                } else if ch == '[' {
+                    stack.push(Frame::Bracket);
+                    i += 1;
+                } else if ch == '(' {
+                    stack.push(Frame::Paren);
+                    i += 1;
+                } else if ch == '}' {
+                    if stack.last() == Some(&Frame::Brace) {
+                        stack.pop();
+                        i += 1;
+                    } else {
+                        return Err(err("unmatched closing brace '}'".to_string()));
+                    }
+                } else if ch == ']' {
+                    if stack.last() == Some(&Frame::Bracket) {
+                        stack.pop();
+                        i += 1;
+                    } else {
+                        return Err(err("unmatched closing bracket ']'".to_string()));
+                    }
+                } else if ch == ')' {
+                    if stack.last() == Some(&Frame::Paren) {
+                        stack.pop();
+                        i += 1;
+                    } else {
+                        return Err(err("unmatched closing parenthesis ')'".to_string()));
+                    }
+                } else {
+                    i += 1;
                 }
             }
-            _ => {}
         }
-
-        i += 1;
-    }
-
-    if in_string {
-        return Err(anyhow::anyhow!(
-            "Syntax error in {}: unclosed string literal",
-            file_path
-        ));
-    }
-
-    if in_multiline_string {
-        return Err(anyhow::anyhow!(
-            "Syntax error in {}: unclosed multiline string ''...''",
-            file_path
-        ));
     }
 
     if in_block_comment {
-        return Err(anyhow::anyhow!(
-            "Syntax error in {}: unclosed block comment /*...*/",
-            file_path
-        ));
+        return Err(err("unclosed block comment /*...*/".to_string()));
+    }
+    if stack.iter().any(|f| *f == Frame::Str) {
+        return Err(err("unclosed string literal".to_string()));
+    }
+    if stack.iter().any(|f| *f == Frame::Indented) {
+        return Err(err("unclosed multiline string ''...''".to_string()));
     }
 
-    if brace_depth != 0 {
-        return Err(anyhow::anyhow!(
-            "Syntax error in {}: {} unmatched opening brace(s)",
-            file_path,
-            brace_depth
-        ));
+    let braces = stack.iter().filter(|f| **f == Frame::Brace).count();
+    if braces != 0 {
+        return Err(err(format!("{} unmatched opening brace(s)", braces)));
     }
-
-    if bracket_depth != 0 {
-        return Err(anyhow::anyhow!(
-            "Syntax error in {}: {} unmatched opening bracket(s)",
-            file_path,
-            bracket_depth
-        ));
+    let brackets = stack.iter().filter(|f| **f == Frame::Bracket).count();
+    if brackets != 0 {
+        return Err(err(format!("{} unmatched opening bracket(s)", brackets)));
     }
-
-    if paren_depth != 0 {
-        return Err(anyhow::anyhow!(
-            "Syntax error in {}: {} unmatched opening parenthesis/parentheses",
-            file_path,
-            paren_depth
-        ));
+    let parens = stack.iter().filter(|f| **f == Frame::Paren).count();
+    if parens != 0 {
+        return Err(err(format!(
+            "{} unmatched opening parenthesis/parentheses",
+            parens
+        )));
     }
 
     Ok(())
@@ -683,6 +679,46 @@ mod tests {
         let err = super::validate_nix_syntax(invalid_nix, "test.nix")
             .expect_err("should reject unclosed block comment");
         assert!(err.to_string().contains("unclosed block comment"));
+    }
+
+    #[test]
+    fn validate_nix_syntax_accepts_antiquotation_with_nested_strings() {
+        // `${ ... }` re-enters code context, so nested strings inside the
+        // interpolation that contain `{`/`}` must not desync string tracking.
+        // The old scanner falsely rejected all but the first of these.
+        let cases = [
+            r#"{ x = "${cfg.name}"; }"#,
+            r#"{ x = "${if a then "}" else "y"}"; }"#,
+            r#"{ x = "${if a then "{" else "y"}"; }"#,
+            r#"{ x = "pre ${f "a" "}"} post"; }"#,
+        ];
+        for src in cases {
+            super::validate_nix_syntax(src, "test.nix")
+                .unwrap_or_else(|e| panic!("should accept `{src}`: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_nix_syntax_accepts_interpolation_in_indented_string() {
+        let valid = r#"
+{
+  script = ''
+    ${pkgs.coreutils}/bin/ls {a} [b]
+  '';
+}
+"#;
+        super::validate_nix_syntax(valid, "test.nix")
+            .expect("antiquotation inside an indented string should be accepted");
+    }
+
+    #[test]
+    fn validate_nix_syntax_rejects_unbalanced_inside_interpolation() {
+        // The `}` closes the interpolation while a `(` is still open: still a
+        // real syntax error, and still caught.
+        let invalid = r#"{ x = "${ f ( }"; }"#;
+        let err = super::validate_nix_syntax(invalid, "test.nix")
+            .expect_err("unbalanced delimiters inside an interpolation should be rejected");
+        assert!(err.to_string().contains("Syntax error"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -1738,6 +1738,10 @@ fn process_tool_result(
                 edit.replace.len()
             );
             evolution.edits.push(edit.clone());
+            // A new edit invalidates any prior successful build: the verified
+            // state no longer matches the files, so `done` must require a fresh
+            // build_check.
+            *build_verified = false;
             let msg = Message::Tool {
                 tool_call_id: tool_call_id.to_string(),
                 content:
@@ -1759,6 +1763,8 @@ fn process_tool_result(
                 search: String::new(),
                 replace: format!("semantic:{:?}", edit.action),
             });
+            // A new edit invalidates any prior successful build verification.
+            *build_verified = false;
 
             let msg = Message::Tool {
                 tool_call_id: tool_call_id.to_string(),
@@ -1776,6 +1782,8 @@ fn process_tool_result(
                 search: String::new(),
                 replace: format!("ensure_secret:{}", result.name),
             });
+            // A new edit invalidates any prior successful build verification.
+            *build_verified = false;
             let content = serde_json::to_string(result)
                 .unwrap_or_else(|_| format!("{{\"name\":\"{}\"}}", result.name));
             let msg = Message::Tool {
@@ -1832,6 +1840,9 @@ fn process_tool_result(
                 };
                 (msg, Some(false))
             } else {
+                // A failing build invalidates any earlier successful verification,
+                // otherwise `done` could still accept the (now broken) config.
+                *build_verified = false;
                 warn!(
                     "❌ BUILD CHECK FAILED (attempt {}/{})",
                     build_attempts, max_build_attempts
@@ -1909,9 +1920,113 @@ fn process_tool_result(
 #[cfg(test)]
 mod tests {
     use super::{
-        filter_evolution_messages, read_file_dedup_key, store_tool_result, EvolutionMessage,
-        Message, Retention,
+        filter_evolution_messages, process_tool_result, read_file_dedup_key, store_tool_result,
+        Evolution, EvolutionMessage, EvolutionState, FileEdit, Message, Retention, ToolResult,
     };
+
+    fn build_result(success: bool) -> ToolResult {
+        ToolResult::BuildResult {
+            success,
+            output: String::new(),
+            stdout: String::new(),
+            stderr: if success {
+                String::new()
+            } else {
+                "boom".to_string()
+            },
+        }
+    }
+
+    fn run_tool_result(result: &ToolResult, evolution: &mut Evolution, build_verified: &mut bool) {
+        let mut build_attempts = 0usize;
+        process_tool_result(
+            "tool-call-id",
+            result,
+            evolution,
+            build_verified,
+            &mut build_attempts,
+            5,
+            "host",
+            0,
+            0,
+        )
+        .expect("process_tool_result should not error in these cases");
+    }
+
+    // Bug 1: build_verified latched true on the first passing build and was never
+    // cleared, so a later failing build_check (or an edit) still let `done`
+    // complete an unbuildable config. A failing build must clear verification.
+    #[test]
+    fn failing_build_check_clears_prior_verification() {
+        let mut evolution = Evolution::new("prompt");
+        let mut build_verified = false;
+
+        run_tool_result(&build_result(true), &mut evolution, &mut build_verified);
+        assert!(
+            build_verified,
+            "a passing build_check should set build_verified"
+        );
+
+        run_tool_result(&build_result(false), &mut evolution, &mut build_verified);
+        assert!(
+            !build_verified,
+            "a failing build_check must clear the prior verification"
+        );
+    }
+
+    // End-to-end consequence: with edits present, calling done after a build that
+    // failed (following an earlier pass) must NOT mark the evolution Generated.
+    #[test]
+    fn done_is_rejected_after_a_failing_build() {
+        let mut evolution = Evolution::new("prompt");
+        evolution.edits.push(FileEdit {
+            path: "configuration.nix".to_string(),
+            search: "a".to_string(),
+            replace: "b".to_string(),
+        });
+        let mut build_verified = false;
+
+        run_tool_result(&build_result(true), &mut evolution, &mut build_verified);
+        run_tool_result(&build_result(false), &mut evolution, &mut build_verified);
+        run_tool_result(
+            &ToolResult::Done("done".to_string()),
+            &mut evolution,
+            &mut build_verified,
+        );
+
+        assert!(
+            !matches!(evolution.state, EvolutionState::Generated),
+            "done must not complete an evolution whose last build_check failed"
+        );
+    }
+
+    // A new edit after a passing build_check must clear verification, so the
+    // agent cannot call done on files that were changed since the last build.
+    #[test]
+    fn edit_after_passing_build_clears_verification() {
+        let mut evolution = Evolution::new("prompt");
+        let mut build_verified = false;
+
+        run_tool_result(&build_result(true), &mut evolution, &mut build_verified);
+        assert!(
+            build_verified,
+            "a passing build_check should set build_verified"
+        );
+
+        run_tool_result(
+            &ToolResult::Edit(FileEdit {
+                path: "configuration.nix".to_string(),
+                search: "a".to_string(),
+                replace: "b".to_string(),
+            }),
+            &mut evolution,
+            &mut build_verified,
+        );
+        assert!(
+            !build_verified,
+            "an edit after a passing build must clear the prior verification"
+        );
+    }
 
     fn set_memory_strategy_for_test(
         value: &str,

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -158,13 +158,17 @@ pub(crate) fn quote_homebrew_list_values(path: &str, values: Vec<String>) -> Vec
     }
 }
 
-// Truncate string for logging (single line preview)
+// Truncate string for logging (single line preview).
+// `max_len` is a character budget: slicing by byte index would panic when the
+// cut lands inside a multi-byte UTF-8 char (e.g. an accented letter or emoji in
+// an agent thought), so truncate on a char boundary instead.
 pub(crate) fn truncate_for_log(s: &str, max_len: usize) -> String {
     let s = s.replace('\n', " ").replace('\r', "");
-    if s.len() <= max_len {
+    if s.chars().count() <= max_len {
         s
     } else {
-        format!("{}...", &s[..max_len])
+        let truncated: String = s.chars().take(max_len).collect();
+        format!("{}...", truncated)
     }
 }
 
@@ -199,11 +203,34 @@ pub(crate) fn ensure_nixmac_edit_allowed(tool: &str, path: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_tool, ToolResult};
+    use super::{execute_tool, truncate_for_log, ToolResult};
     use crate::evolve::gitignore::load_gitignore_matcher;
     use serde_json::json;
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn truncate_for_log_passes_short_strings_through() {
+        assert_eq!(truncate_for_log("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_for_log_collapses_newlines() {
+        assert_eq!(truncate_for_log("a\nb\r\nc", 100), "a b c");
+    }
+
+    #[test]
+    fn truncate_for_log_truncates_to_char_budget() {
+        assert_eq!(truncate_for_log("abcdefghij", 4), "abcd...");
+    }
+
+    #[test]
+    fn truncate_for_log_does_not_panic_on_multibyte_boundary() {
+        // 3-byte chars: a byte-index slice at max_len would land mid-char and
+        // panic (the original bug). Truncation must happen on a char boundary.
+        let s = "→".repeat(50);
+        assert_eq!(truncate_for_log(&s, 10), format!("{}...", "→".repeat(10)));
+    }
 
     #[test]
     fn read_file_rejects_base_gitignored_files() {


### PR DESCRIPTION
## Summary

Four independent correctness fixes in the `evolve` agentic loop, one per commit, each with its own test. Stacked on current `develop`.

### 1. reset `build_verified` on edit and on failed build_check (`mod.rs`)
`build_verified` latched `true` on the first passing `build_check` and was never cleared. Two ways this let `done` complete an **unbuildable** config:
- build passes → agent edits again → `done` accepted, though the new edit was never built.
- build passes → a later build fails → `done` accepted as "complete" despite the failing build.

Now cleared whenever an edit is applied (`Edit` / `EditSemantic` / `EnsureSecret` arms) and whenever a `build_check` fails, so the done-gate requires a fresh, passing build.

### 2. handle `${ }` antiquotation in `validate_nix_syntax` (`file_ops.rs`)
The structural validator scanned strings with a flat `in_string` flag and never recognized `${ … }` antiquotation. A nested string inside an interpolation — e.g. `"${if a then "}" else "y"}"` — toggled the flag and mis-counted the braces, so the validator **rejected valid Nix and blocked legitimate agent edits**. Rewritten around a single context stack: `${` inside a string pushes a code frame, its matching `}` pops back. All prior behavior and error messages preserved.

### 3. don't duplicate a non-list attr in `edit_nix_file` `add()` (`edit_nix_file.rs`)
When `add()` targeted an attrpath that already existed as a **non-list** assignment (e.g. `programs.git = { … }`), it fell through and inserted a second `attrpath = [ … ];`, producing two assignments to the same attribute — **invalid Nix**. Now returns a clear error instead.

### 4. make `truncate_for_log` UTF-8 safe (`tools.rs`)
`truncate_for_log` sliced with `&s[..max_len]` (a byte index). A multi-byte char (accented letters, emoji, arrows — common in agent thoughts, truncated at 200 for logging) straddling that index **panicked** with "byte index N is not a char boundary." Now truncates on a char boundary, treating `max_len` as a character budget.

## Test Plan

- [ ] No test plan needed

Each commit adds its own test. Verified **red-green**: reverting each fix to develop's code (keeping the test) makes exactly that test fail — and only those tests, no collateral.

```
cargo test evolve::      # 166 passed / 0 failed
cargo clippy --tests     # clean for all four files
```

Tests added:
- Bug 1: `failing_build_check_clears_prior_verification`, `done_is_rejected_after_a_failing_build`, `edit_after_passing_build_clears_verification` (drive `process_tool_result` directly)
- Bug 2: accept/reject tests for nested-string and indented-string interpolation
- Bug 3: `add_refuses_to_duplicate_non_list_attr`
- Bug 4: short-string, newline-collapse, ASCII, and multi-byte-boundary cases

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed

These are internal correctness fixes with no new user-facing behavior — they make already-valid configs work (2, 3) and stop a logging panic (4), and tighten an internal completion gate (1).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
