### PR TITLE
fix: add corrective error messages for common `edit_nix_file` agent mistakes

### DIFF
--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -370,6 +370,116 @@ mod tests {
     }
 
     #[test]
+    fn edit_nix_file_reports_attr_path_used_as_top_level_path() {
+        let tmp = tempdir().expect("tempdir");
+
+        let result = execute_tool(
+            tmp.path(),
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_nix_file",
+            &json!({
+                "action": "set_attrs",
+                "path": "launchd.user.agents",
+                "attrs": {
+                    "raycast": {
+                        "serviceConfig": {
+                            "Label": "com.raycast.macos",
+                            "RunAtLoad": true
+                        }
+                    }
+                }
+            }),
+            None,
+        );
+
+        let err = result.expect_err("attr path in top-level path should be corrective");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("top-level 'path' must be the relative .nix file"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            msg.contains(r#""path": "modules/darwin/services.nix""#),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            msg.contains(r#""set_attrs": { "path": "launchd.user.agents", "attrs": {...} }"#),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn edit_nix_file_reports_string_action_with_corrective_shape() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join("services.nix"), "{ ... }: { }\n").expect("write nix file");
+
+        let result = execute_tool(
+            tmp.path(),
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_nix_file",
+            &json!({
+                "path": "services.nix",
+                "action": "set_attrs",
+                "attrs": {
+                    "raycast": {
+                        "serviceConfig": {
+                            "Label": "com.raycast.macos",
+                            "RunAtLoad": true
+                        }
+                    }
+                }
+            }),
+            None,
+        );
+
+        let err = result.expect_err("string action should get a corrective error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("action must be an object, not string 'set_attrs'"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            msg.contains("Wrap sibling payload fields under action.set_attrs"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            msg.contains(
+                r#""action": { "set_attrs": { "path": "<attribute.path>", "attrs": {...} } }"#
+            ),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn edit_nix_file_reports_non_object_action_payload() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join("services.nix"), "{ ... }: { }\n").expect("write nix file");
+
+        let result = execute_tool(
+            tmp.path(),
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_nix_file",
+            &json!({
+                "path": "services.nix",
+                "action": {
+                    "set_attrs": "launchd.user.agents"
+                }
+            }),
+            None,
+        );
+
+        let err = result.expect_err("non-object set_attrs payload should be corrective");
+        assert!(
+            err.to_string()
+                .contains("edit_nix_file.set_attrs: action payload must be an object"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
     fn edit_nix_file_quotes_homebrew_add_values() {
         let tmp = tempdir().expect("tempdir");
         fs::write(

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -140,16 +140,112 @@ IMPORTANT: The generated Nix code is syntax-validated before writing. Edits with
     }
 }
 
+/// Determines if the given string presumably from "path" looks like an actual
+/// file path or if it looks like an attribute path that was mistakenly put in the
+/// file path field, which is a common agent mistake.
+/// This is a heuristic check to provide a helpful error message, but it's not a guarantee.
+fn looks_like_attr_path(path: &str) -> bool {
+    path.contains('.') && !path.contains('/') && !path.ends_with(".nix")
+}
+
+/// Return a known edit action name when `action` was provided as a shorthand string.
+fn action_name(value: &serde_json::Value) -> Option<&str> {
+    let name = value.as_str()?;
+    matches!(name, "add" | "remove" | "set" | "set_attrs").then_some(name)
+}
+
+/// Build a compact example call that shows where the file path and action path belong.
+fn corrective_action_shape(action: &str, attr_path: &str) -> String {
+    let payload = match action {
+        "add" | "remove" => format!(r#""path": "{}", "values": [...]"#, attr_path),
+        "set" => format!(r#""path": "{}", "value": ..."#, attr_path),
+        "set_attrs" => format!(r#""path": "{}", "attrs": {{...}}"#, attr_path),
+        _ => format!(r#""path": "{}""#, attr_path),
+    };
+
+    format!(
+        r#"{{ "path": "modules/darwin/services.nix", "action": {{ "{}": {{ {} }} }} }}"#,
+        action, payload
+    )
+}
+
+/// Explain the common mistake of putting a Nix option path in the top-level file path field.
+fn explain_attr_path_used_as_file_path(args: &serde_json::Value, path: &str) -> anyhow::Error {
+    let action = action_name(&args["action"]);
+    let correction = action
+        .map(|name| corrective_action_shape(name, path))
+        .unwrap_or_else(|| {
+            format!(
+                r#"{{ "path": "modules/darwin/services.nix", "action": {{ "set_attrs": {{ "path": "{}", "attrs": {{...}} }} }} }}"#,
+                path
+            )
+        });
+
+    anyhow!(
+        "edit_nix_file: top-level 'path' must be the relative .nix file to edit, but got attribute path '{}'. Put '{}' inside the action object as the action path, choose a file path for top-level 'path', and call the tool like: {}",
+        path,
+        path,
+        correction
+    )
+}
+
+/// Explain the shorthand action shape without executing it, so the agent can retry correctly.
+fn explain_string_action(args: &serde_json::Value, action: &str) -> anyhow::Error {
+    let payload_fields = match action {
+        "add" | "remove" => "path and values",
+        "set" => "path and value",
+        "set_attrs" => "path and attrs",
+        _ => "the required payload fields",
+    };
+    let likely_attr_path = args["path"]
+        .as_str()
+        .filter(|path| looks_like_attr_path(path));
+    let attr_path = likely_attr_path.unwrap_or("<attribute.path>");
+    let correction = corrective_action_shape(action, attr_path);
+
+    anyhow!(
+        "edit_nix_file: action must be an object, not string '{}'. Wrap sibling payload fields under action.{} with {}. Top-level 'path' must remain the .nix file path. Correct shape: {}",
+        action,
+        action,
+        payload_fields,
+        correction
+    )
+}
+
+/// Ensure the selected action contains the expected object payload before reading fields from it.
+fn ensure_action_payload_is_object<'a>(
+    action_val: &'a serde_json::Value,
+    action_name: &str,
+) -> Result<&'a serde_json::Value> {
+    let payload = action_val
+        .get(action_name)
+        .ok_or_else(|| anyhow!("edit_nix_file.{}: missing action payload", action_name))?;
+    if !payload.is_object() {
+        return Err(anyhow!(
+            "edit_nix_file.{}: action payload must be an object. Correct shape: {{ \"action\": {{ \"{}\": {{ \"path\": \"<attribute.path>\", ... }} }}, \"path\": \"modules/darwin/services.nix\" }}",
+            action_name,
+            action_name
+        ));
+    }
+    Ok(payload)
+}
+
 pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     let args = ctx.args;
     let path = args["path"]
         .as_str()
         .ok_or_else(|| anyhow!("edit_nix_file: missing path"))?;
+    if looks_like_attr_path(path) {
+        return Err(explain_attr_path_used_as_file_path(args, path));
+    }
     ensure_nixmac_edit_allowed("edit_nix_file", path)?;
 
     // Expect `action` to be an object like { "add": { "path": "a.b", "values": ["v"] } }
     let action_val = &args["action"];
     if !action_val.is_object() {
+        if let Some(action) = action_name(action_val) {
+            return Err(explain_string_action(args, action));
+        }
         return Err(anyhow!("edit_nix_file: action must be an object"));
     }
 
@@ -188,10 +284,14 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     }
 
     let action = if has_add {
-        let add_obj = &action_val["add"];
+        let add_obj = ensure_action_payload_is_object(action_val, "add")?;
         let attr_path = add_obj["path"]
             .as_str()
-            .ok_or_else(|| anyhow!("edit_nix_file.add: missing path"))?;
+            .ok_or_else(|| {
+                anyhow!(
+                    "edit_nix_file.add: missing action path. Put the list attribute path inside action.add.path, e.g. {{ \"action\": {{ \"add\": {{ \"path\": \"environment.systemPackages\", \"values\": [...] }} }}, \"path\": \"modules/darwin/packages.nix\" }}"
+                )
+            })?;
         let values = quote_homebrew_list_values(
             attr_path,
             parse_values(&add_obj["values"], "edit_nix_file.add")?,
@@ -201,10 +301,14 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             values,
         }
     } else if action_val.get("remove").is_some() {
-        let rem_obj = &action_val["remove"];
+        let rem_obj = ensure_action_payload_is_object(action_val, "remove")?;
         let attr_path = rem_obj["path"]
             .as_str()
-            .ok_or_else(|| anyhow!("edit_nix_file.remove: missing path"))?;
+            .ok_or_else(|| {
+                anyhow!(
+                    "edit_nix_file.remove: missing action path. Put the list attribute path inside action.remove.path, e.g. {{ \"action\": {{ \"remove\": {{ \"path\": \"environment.systemPackages\", \"values\": [...] }} }}, \"path\": \"modules/darwin/packages.nix\" }}"
+                )
+            })?;
         let values = quote_homebrew_list_values(
             attr_path,
             parse_values(&rem_obj["values"], "edit_nix_file.remove")?,
@@ -214,10 +318,14 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             values,
         }
     } else if action_val.get("set").is_some() {
-        let set_obj = &action_val["set"];
+        let set_obj = ensure_action_payload_is_object(action_val, "set")?;
         let attr_path = set_obj["path"]
             .as_str()
-            .ok_or_else(|| anyhow!("edit_nix_file.set: missing path"))?;
+            .ok_or_else(|| {
+                anyhow!(
+                    "edit_nix_file.set: missing action path. Put the scalar option path inside action.set.path, e.g. {{ \"action\": {{ \"set\": {{ \"path\": \"services.tailscale.enable\", \"value\": true }} }}, \"path\": \"modules/darwin/services.nix\" }}"
+                )
+            })?;
         let value = set_obj
             .get("value")
             .ok_or_else(|| anyhow!("edit_nix_file.set: missing value"))?
@@ -240,10 +348,14 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             value,
         }
     } else if has_set_attrs {
-        let set_attrs_obj = &action_val["set_attrs"];
+        let set_attrs_obj = ensure_action_payload_is_object(action_val, "set_attrs")?;
         let attr_path = set_attrs_obj["path"]
             .as_str()
-            .ok_or_else(|| anyhow!("edit_nix_file.set_attrs: missing path"))?;
+            .ok_or_else(|| {
+                anyhow!(
+                    "edit_nix_file.set_attrs: missing action path. Put the attrset option path inside action.set_attrs.path, e.g. {{ \"action\": {{ \"set_attrs\": {{ \"path\": \"launchd.user.agents\", \"attrs\": {{...}} }} }}, \"path\": \"modules/darwin/services.nix\" }}"
+                )
+            })?;
         let attrs_val = set_attrs_obj
             .get("attrs")
             .ok_or_else(|| anyhow!("edit_nix_file.set_attrs: missing attrs"))?;

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -148,10 +148,19 @@ fn looks_like_attr_path(path: &str) -> bool {
     path.contains('.') && !path.contains('/') && !path.ends_with(".nix")
 }
 
-/// Return a known edit action name when `action` was provided as a shorthand string.
 fn action_name(value: &serde_json::Value) -> Option<&str> {
-    let name = value.as_str()?;
-    matches!(name, "add" | "remove" | "set" | "set_attrs").then_some(name)
+    if let Some(name) = value.as_str() {
+        return matches!(name, "add" | "remove" | "set" | "set_attrs").then_some(name);
+    }
+
+    let obj = value.as_object()?;
+    for key in ["add", "remove", "set", "set_attrs"] {
+        if obj.contains_key(key) {
+            return Some(key);
+        }
+    }
+
+    None
 }
 
 /// Build a compact example call that shows where the file path and action path belong.


### PR DESCRIPTION
## Summary

Return more specific, agent-actionable errors from `edit_nix_file`. While testing "track changes" functionality, some of the edit-nix-file actions from the usual test models especially flub up the usage of "path" which is supposed to be a file path, not a nix attribute "path". Previously we'd return a generic "action must be an object" error, and what I saw is that the agent would then just retry the same thing forever until I killed the evolve. With the better error messages, this gets immediately corrected in my testing.

<!-- What does this PR do? Why? -->

## Test Plan

Added a number of new unit tests in additon to the manual testing I mentioned above.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed