### PR TITLE
chore: enable rustfmt and apply formatting fixes across the codebase

### DIFF
--- a/apps/native/src-tauri/configurable-derive/src/attrs.rs
+++ b/apps/native/src-tauri/configurable-derive/src/attrs.rs
@@ -78,7 +78,7 @@ pub(crate) fn parse_struct_config(attrs: &[Attribute]) -> syn::Result<StructConf
                         return Err(syn::Error::new_spanned(
                             lit,
                             format!("Configurable: unsupported scope `{other}`"),
-                        ))
+                        ));
                     }
                 });
                 Ok(())
@@ -181,7 +181,7 @@ pub(crate) fn parse_field_config(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use syn::{parse_quote, DeriveInput};
+    use syn::{DeriveInput, parse_quote};
 
     #[test]
     fn parse_struct_config_accepts_repo_scope() {

--- a/apps/native/src-tauri/configurable-derive/src/codegen.rs
+++ b/apps/native/src-tauri/configurable-derive/src/codegen.rs
@@ -10,8 +10,8 @@
 //! mapping live in sibling modules so this file can read like the macro's
 //! high-level pipeline.
 
-use crate::attrs::{parse_struct_config, StoreScope};
-use crate::fields::{generate_fields, named_fields, GeneratedFields};
+use crate::attrs::{StoreScope, parse_struct_config};
+use crate::fields::{GeneratedFields, generate_fields, named_fields};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::DeriveInput;

--- a/apps/native/src-tauri/configurable-derive/src/lib.rs
+++ b/apps/native/src-tauri/configurable-derive/src/lib.rs
@@ -20,7 +20,7 @@ mod strings;
 mod types;
 
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{DeriveInput, parse_macro_input};
 
 /// Proc-macro entrypoint called by the compiler for each annotated struct.
 ///

--- a/apps/native/src-tauri/configurable-derive/src/types.rs
+++ b/apps/native/src-tauri/configurable-derive/src/types.rs
@@ -31,7 +31,7 @@ pub(crate) fn field_type_expr(ty: &Type, cfg: &FieldConfig) -> syn::Result<Token
                         return Err(syn::Error::new_spanned(
                             elem,
                             "#[config(options = [...])] entries must be string literals",
-                        ))
+                        ));
                     }
                 };
                 let label = humanize(&value_str);
@@ -59,8 +59,8 @@ pub(crate) fn field_type_expr(ty: &Type, cfg: &FieldConfig) -> syn::Result<Token
     })?;
 
     match name.as_str() {
-        "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize"
-        | "f32" | "f64" => {
+        "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize" | "f32"
+        | "f64" => {
             let (min_expr, max_expr) = match &cfg.range {
                 Some(range) => range_bounds(range),
                 None => (

--- a/apps/native/src-tauri/src/ai/mod.rs
+++ b/apps/native/src-tauri/src/ai/mod.rs
@@ -4,4 +4,4 @@ pub mod providers;
 
 // Re-export the most commonly used types so callers can use short paths.
 #[allow(unused_imports)]
-pub use providers::{create_provider, ChatCompletionProvider, TokenUsage};
+pub use providers::{ChatCompletionProvider, TokenUsage, create_provider};

--- a/apps/native/src-tauri/src/ai/providers/cli.rs
+++ b/apps/native/src-tauri/src/ai/providers/cli.rs
@@ -1,5 +1,5 @@
 use super::{ChatCompletionProvider, TokenUsage};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use log::debug;
 use std::process::Stdio;

--- a/apps/native/src-tauri/src/ai/providers/openai.rs
+++ b/apps/native/src-tauri/src/ai/providers/openai.rs
@@ -2,13 +2,13 @@ use super::{ChatCompletionProvider, TokenUsage};
 use crate::ai::provider_errors::{classify_openai_error, friendly_provider_error};
 use anyhow::Result;
 use async_openai::{
+    Client,
     config::OpenAIConfig,
     error::OpenAIError,
     types::{
         ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
         CreateChatCompletionRequestArgs, ResponseFormat,
     },
-    Client,
 };
 use async_trait::async_trait;
 use log::debug;

--- a/apps/native/src-tauri/src/bootstrap/import.rs
+++ b/apps/native/src-tauri/src/bootstrap/import.rs
@@ -8,7 +8,7 @@
 //! `~/.darwin`) so the rest of onboarding can proceed exactly as if the user
 //! had selected an existing flake.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use std::fs::File;
 use std::path::{Component, Path, PathBuf};
 

--- a/apps/native/src-tauri/src/commands/evolve.rs
+++ b/apps/native/src-tauri/src/commands/evolve.rs
@@ -29,7 +29,6 @@ pub async fn darwin_evolve(
         .await;
     }
 
-
     let result =
         match evolve::lifecycle::backup_evolve_and_record_changeset(&app, &description, None).await
         {

--- a/apps/native/src-tauri/src/db/changesets.rs
+++ b/apps/native/src-tauri/src/db/changesets.rs
@@ -8,9 +8,7 @@ use diesel::prelude::*;
 use diesel::sql_query;
 use diesel::sql_types::{BigInt, Nullable, Text};
 
-use crate::db::tables::{
-    change_sets, change_summaries, changes, group_summaries, set_changes,
-};
+use crate::db::tables::{change_sets, change_summaries, changes, group_summaries, set_changes};
 use crate::shared_types::{SummarizedChange, SummarizedChangeSet};
 use crate::sqlite_types::{Change, ChangeSet, ChangeSummary};
 
@@ -136,7 +134,6 @@ pub fn link_change_to_set(
         .execute(conn)?;
     Ok(())
 }
-
 
 // ── Big aliased row used by the JOIN read queries ────────────────────────────
 

--- a/apps/native/src-tauri/src/db/commits.rs
+++ b/apps/native/src-tauri/src/db/commits.rs
@@ -3,8 +3,8 @@
 use anyhow::Result;
 use diesel::prelude::*;
 
-use crate::db::tables::commits;
 use crate::db::DbPool;
+use crate::db::tables::commits;
 
 #[derive(Debug, Insertable)]
 #[diesel(table_name = commits)]
@@ -105,9 +105,7 @@ pub fn store_head_commit(
         return Ok(None);
     };
     let now = crate::utils::unix_now();
-    Ok(Some(upsert_commit(
-        pool, &hash, &tree_hash, None, now,
-    )?))
+    Ok(Some(upsert_commit(pool, &hash, &tree_hash, None, now)?))
 }
 
 #[cfg(test)]
@@ -120,13 +118,9 @@ mod tests {
         let db_path = temp_dir.path().join("nixmac.db");
         let pool = crate::db::init_pool_at_path(&db_path).await.unwrap();
 
-        let first_id =
-            upsert_commit(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
-        let second_id =
-            upsert_commit(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
-        let commit = get_commit_by_hash(&pool, "abc123")
-            .unwrap()
-            .unwrap();
+        let first_id = upsert_commit(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
+        let second_id = upsert_commit(&pool, "abc123", "tree123", Some("message"), 123).unwrap();
+        let commit = get_commit_by_hash(&pool, "abc123").unwrap().unwrap();
 
         assert_eq!(first_id, second_id);
         assert_eq!(commit.id, first_id);

--- a/apps/native/src-tauri/src/db/evolutions.rs
+++ b/apps/native/src-tauri/src/db/evolutions.rs
@@ -3,8 +3,8 @@
 use anyhow::Result;
 use diesel::prelude::*;
 
-use crate::db::tables::evolutions;
 use crate::db::DbPool;
+use crate::db::tables::evolutions;
 
 /// Upsert an evolution by id: if `existing_id` is Some and exists in the DB, return it.
 /// Otherwise insert a new evolution record and return its id.

--- a/apps/native/src-tauri/src/db/restore_commits.rs
+++ b/apps/native/src-tauri/src/db/restore_commits.rs
@@ -7,8 +7,8 @@
 use anyhow::Result;
 use diesel::prelude::*;
 
-use crate::db::tables::restore_commits;
 use crate::db::DbPool;
+use crate::db::tables::restore_commits;
 
 /// Record that `commit_hash` is a restore of `origin_hash`.
 pub fn insert(pool: &DbPool, commit_hash: &str, origin_hash: &str) -> Result<()> {

--- a/apps/native/src-tauri/src/db/schema.rs
+++ b/apps/native/src-tauri/src/db/schema.rs
@@ -1,11 +1,11 @@
 //! Database schema initialization.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use diesel::connection::SimpleConnection;
 use diesel::prelude::*;
 use diesel::sql_types::BigInt;
 use diesel::sqlite::SqliteConnection;
-use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use std::path::Path;
 
 const SCHEMA_VERSION: i64 = 1;
@@ -40,8 +40,10 @@ fn recreate_stale_database(path: &Path) -> Result<()> {
 
     let database_url = path.to_string_lossy().into_owned();
     let mut conn = SqliteConnection::establish(&database_url)?;
-    let version: i64 = diesel::select(diesel::dsl::sql::<BigInt>("user_version FROM pragma_user_version"))
-        .get_result(&mut conn)?;
+    let version: i64 = diesel::select(diesel::dsl::sql::<BigInt>(
+        "user_version FROM pragma_user_version",
+    ))
+    .get_result(&mut conn)?;
     drop(conn);
     if version != SCHEMA_VERSION {
         std::fs::remove_file(path)?;
@@ -81,10 +83,11 @@ mod tests {
         rt.block_on(init_schema(&db_path)).unwrap();
 
         let mut conn = SqliteConnection::establish(&database_url).unwrap();
-        let version: i64 =
-            diesel::select(diesel::dsl::sql::<BigInt>("user_version FROM pragma_user_version"))
-                .get_result(&mut conn)
-                .unwrap();
+        let version: i64 = diesel::select(diesel::dsl::sql::<BigInt>(
+            "user_version FROM pragma_user_version",
+        ))
+        .get_result(&mut conn)
+        .unwrap();
         assert_eq!(version, SCHEMA_VERSION);
 
         let row_count = crate::db::tables::evolutions::table

--- a/apps/native/src-tauri/src/db/store_bare_changeset.rs
+++ b/apps/native/src-tauri/src/db/store_bare_changeset.rs
@@ -3,8 +3,8 @@
 use anyhow::Result;
 use diesel::connection::Connection;
 
-use crate::db::changesets::{insert_change_or_ignore, insert_change_set, link_change_to_set};
 use crate::db::DbPool;
+use crate::db::changesets::{insert_change_or_ignore, insert_change_set, link_change_to_set};
 use crate::sqlite_types::Change;
 use crate::utils::unix_now;
 

--- a/apps/native/src-tauri/src/db/store_whole_diff_changeset.rs
+++ b/apps/native/src-tauri/src/db/store_whole_diff_changeset.rs
@@ -3,11 +3,11 @@
 use anyhow::Result;
 use diesel::connection::Connection;
 
+use crate::db::DbPool;
 use crate::db::changesets::{
     get_change_id_by_hash, insert_change_set, insert_change_summary, link_change_to_group_summary,
     link_change_to_set, upsert_change,
 };
-use crate::db::DbPool;
 use crate::sqlite_types::Change;
 
 #[allow(clippy::too_many_arguments)]

--- a/apps/native/src-tauri/src/evolve/age.rs
+++ b/apps/native/src-tauri/src/evolve/age.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
@@ -107,8 +107,8 @@ fn derive_public_key(key_path: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        find_existing_age_key_path, resolve_age_key_path, MACOS_SOPS_AGE_KEYS_RELATIVE_PATH,
-        SOPS_AGE_KEYS_RELATIVE_PATH, SOPS_AGE_KEY_FILE_ENV_VAR,
+        MACOS_SOPS_AGE_KEYS_RELATIVE_PATH, SOPS_AGE_KEY_FILE_ENV_VAR, SOPS_AGE_KEYS_RELATIVE_PATH,
+        find_existing_age_key_path, resolve_age_key_path,
     };
     use std::ffi::OsString;
     use std::path::Path;

--- a/apps/native/src-tauri/src/evolve/config.rs
+++ b/apps/native/src-tauri/src/evolve/config.rs
@@ -129,9 +129,8 @@ mod tests {
 
     #[test]
     fn missing_fields_use_defaults() {
-        let limits: EvolutionLimits = serde_json::from_value(serde_json::json!({
-        }))
-        .expect("limits deserialize");
+        let limits: EvolutionLimits =
+            serde_json::from_value(serde_json::json!({})).expect("limits deserialize");
 
         assert_eq!(limits.max_token_budget, 50_000);
         assert_eq!(limits.max_build_attempts, 5);

--- a/apps/native/src-tauri/src/evolve/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/edit_nix_file.rs
@@ -1,8 +1,8 @@
 use crate::evolve::types::SemanticFileEdit;
 use anyhow::{Context, Result};
 use log::{debug, info};
-use rnix::ast::{AttrSet, List};
 use rnix::SyntaxNode;
+use rnix::ast::{AttrSet, List};
 use rnix::{Parse, Root};
 use rowan::ast::AstNode;
 use rowan::{TextRange, TextSize};
@@ -508,7 +508,7 @@ fn find_statement_end(content: &str, start: usize) -> Option<usize> {
             '(' => paren_depth += 1,
             ')' => paren_depth = paren_depth.saturating_sub(1),
             ';' if bracket_depth == 0 && brace_depth == 0 && paren_depth == 0 => {
-                return Some(absolute)
+                return Some(absolute);
             }
             _ => {}
         }
@@ -1149,11 +1149,11 @@ environment.systemPackages = with pkgs; [
         ];"#;
 
         assert!(
-        edited.contains(expected),
-        "expected firefox to append at the end while preserving list comment/spacing structure.\nExpected:\n{}\n\nActual:\n{}",
-        expected,
-        edited
-    );
+            edited.contains(expected),
+            "expected firefox to append at the end while preserving list comment/spacing structure.\nExpected:\n{}\n\nActual:\n{}",
+            expected,
+            edited
+        );
     }
 
     #[test]

--- a/apps/native/src-tauri/src/evolve/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/ensure_secret.rs
@@ -8,7 +8,7 @@ use crate::evolve::sops::{
 };
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use ignore::gitignore::Gitignore;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};

--- a/apps/native/src-tauri/src/evolve/gitignore.rs
+++ b/apps/native/src-tauri/src/evolve/gitignore.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use log::warn;
 use std::fs;

--- a/apps/native/src-tauri/src/evolve/lifecycle.rs
+++ b/apps/native/src-tauri/src/evolve/lifecycle.rs
@@ -18,7 +18,7 @@ use crate::{
         SemanticChangeMap,
     },
     summarize,
-    types::{emit_evolve_event, EvolveEvent},
+    types::{EvolveEvent, emit_evolve_event},
 };
 
 impl EvolutionTelemetry {

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -47,8 +47,8 @@ pub use types::{EvolutionProgress, EvolutionRunError};
 use crate::{
     statistics, store,
     types::{emit_evolve_event, EvolveEvent},
-    utils::short_hash,
     utils as global_utils,
+    utils::short_hash,
 };
 use chat_memory::{to_provider_context_messages, ChatMessage, Role as ChatMemoryRole};
 
@@ -1857,12 +1857,12 @@ fn process_tool_result(
                 }
 
                 let msg = Message::Tool {
-            tool_call_id: tool_call_id.to_string(),
-            content: format!(
-                "{}\n\nUse the 'think' tool to analyze the error, then fix the issue and run build_check again.",
-                model_output
-            ),
-        };
+                    tool_call_id: tool_call_id.to_string(),
+                    content: format!(
+                        "{}\n\nUse the 'think' tool to analyze the error, then fix the issue and run build_check again.",
+                        model_output
+                    ),
+                };
                 (msg, Some(false))
             }
         }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -29,7 +29,7 @@ use crate::git::query::repo_root;
 // Re-export public API
 use crate::shared_types::{Evolution, EvolutionState, FileEdit};
 use crate::system::nix;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::Utc;
 use log::{debug, error, info, warn};
 use regex::Regex;
@@ -41,16 +41,16 @@ use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Runtime};
 use tokio::time::sleep;
-use tools::{create_tools, execute_tool, ToolResult};
+use tools::{ToolResult, create_tools, execute_tool};
 pub use types::{EvolutionProgress, EvolutionRunError};
 
 use crate::{
     statistics, store,
-    types::{emit_evolve_event, EvolveEvent},
+    types::{EvolveEvent, emit_evolve_event},
     utils as global_utils,
     utils::short_hash,
 };
-use chat_memory::{to_provider_context_messages, ChatMessage, Role as ChatMemoryRole};
+use chat_memory::{ChatMessage, Role as ChatMemoryRole, to_provider_context_messages};
 
 pub(crate) use chat_memory::session_chat_memory_store;
 use config_dir_context::format_config_dir_context;
@@ -1915,8 +1915,8 @@ fn process_tool_result(
 #[cfg(test)]
 mod tests {
     use super::{
-        filter_evolution_messages, process_tool_result, read_file_dedup_key, store_tool_result,
         Evolution, EvolutionMessage, EvolutionState, FileEdit, Message, Retention, ToolResult,
+        filter_evolution_messages, process_tool_result, read_file_dedup_key, store_tool_result,
     };
 
     fn build_result(success: bool) -> ToolResult {

--- a/apps/native/src-tauri/src/evolve/providers/cli.rs
+++ b/apps/native/src-tauri/src/evolve/providers/cli.rs
@@ -1,5 +1,5 @@
 use super::{AiProvider, ProviderError, ProviderResponse};
-use crate::ai::providers::cli::{run_cli_process, CliTool};
+use crate::ai::providers::cli::{CliTool, run_cli_process};
 use crate::evolve::messages::{Message, Tool as GenericTool, ToolCall};
 use anyhow::anyhow;
 use async_trait::async_trait;

--- a/apps/native/src-tauri/src/evolve/providers/openai.rs
+++ b/apps/native/src-tauri/src/evolve/providers/openai.rs
@@ -3,6 +3,7 @@ use crate::ai::provider_errors::classify_openai_error;
 use crate::evolve::messages::{Message, Tool as GenericTool, ToolCall};
 use anyhow::anyhow;
 use async_openai::{
+    Client,
     config::OpenAIConfig,
     error::OpenAIError,
     types::{
@@ -12,7 +13,6 @@ use async_openai::{
         ChatCompletionTool, ChatCompletionToolArgs, ChatCompletionToolType,
         CreateChatCompletionRequestArgs, FunctionCall, FunctionObjectArgs,
     },
-    Client,
 };
 use async_trait::async_trait;
 use reqwest::StatusCode;

--- a/apps/native/src-tauri/src/evolve/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/search_code.rs
@@ -1,5 +1,5 @@
 use super::utils::truncate_error;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use ignore::gitignore::Gitignore;
 use log::info;
 use serde_json::Value;

--- a/apps/native/src-tauri/src/evolve/search_docs.rs
+++ b/apps/native/src-tauri/src/evolve/search_docs.rs
@@ -1,8 +1,8 @@
 //! search_docs tool implementation for nix-darwin and home-manager documentation.
 
 use anyhow::Result;
-use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -204,10 +204,7 @@ pub fn execute_search_docs(
     };
 
     // Read mode: a specific doc key/path was requested.
-    if let Some(path) = doc_path
-        .map(str::trim)
-        .filter(|p| !p.is_empty())
-    {
+    if let Some(path) = doc_path.map(str::trim).filter(|p| !p.is_empty()) {
         return Ok(read_doc(index, path, source_filter));
     }
 
@@ -282,7 +279,8 @@ fn read_doc(index: &DocsIndex, requested: &str, source_filter: Option<DocsSource
     let child_prefix = format!("{}/", target);
 
     let mut exact: Vec<&DocsOptionEntry> = Vec::new();
-    let mut child_keys: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    let mut child_keys: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
 
     for entry in index
         .entries

--- a/apps/native/src-tauri/src/evolve/search_packages.rs
+++ b/apps/native/src-tauri/src/evolve/search_packages.rs
@@ -412,7 +412,7 @@ mod tests {
             channel: "test-channel".to_string(),
             version: "13.2".to_string(),
             description: "Extensible package for writing and formatting TeX files in GNU Emacs and XEmacs".to_string(),
-            install_via: SearchResultInstallTarget::Either,  
+            install_via: SearchResultInstallTarget::Either,
             additional_info: None,
         })), ("empty", 0, None )];
         let fake_package_classifier = |_package_name: &str| SearchResultInstallTarget::Either;

--- a/apps/native/src-tauri/src/evolve/session_control.rs
+++ b/apps/native/src-tauri/src/evolve/session_control.rs
@@ -26,8 +26,8 @@ static ONGOING_QUESTION: std::sync::OnceLock<
     tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<String>>>,
 > = std::sync::OnceLock::new();
 
-fn ongoing_question_slot(
-) -> &'static tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<String>>> {
+fn ongoing_question_slot()
+-> &'static tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<String>>> {
     ONGOING_QUESTION.get_or_init(|| tokio::sync::Mutex::new(None))
 }
 

--- a/apps/native/src-tauri/src/evolve/sops.rs
+++ b/apps/native/src-tauri/src/evolve/sops.rs
@@ -1,5 +1,5 @@
 use crate::evolve::file_ops::resolve_path_in_dir_allow_create;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde_yaml::{Mapping, Sequence, Value};
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -28,7 +28,7 @@ use crate::evolve::types::SemanticFileEdit;
 use crate::evolve::utils::normalize_relative_path;
 use crate::shared_types::FileEdit;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use ignore::gitignore::Gitignore;
 use std::path::{Component, Path};
 
@@ -203,7 +203,7 @@ pub(crate) fn ensure_nixmac_edit_allowed(tool: &str, path: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_tool, truncate_for_log, ToolResult};
+    use super::{ToolResult, execute_tool, truncate_for_log};
     use crate::evolve::gitignore::load_gitignore_matcher;
     use serde_json::json;
     use std::fs;

--- a/apps/native/src-tauri/src/evolve/tools/ask_user.rs
+++ b/apps/native/src-tauri/src/evolve/tools/ask_user.rs
@@ -1,6 +1,6 @@
 //! `ask_user` tool: ask the user a question and wait for a response.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use log::info;
 
 use crate::evolve::messages::Tool;
@@ -13,7 +13,8 @@ pub(crate) fn definition() -> Tool {
         description: "Ask the user a question and wait for their response. Use this when you \
                      need clarification, want to confirm a destructive action, or need the user \
                      to choose between options. The question should be clear and specific. \
-                     Optionally provide a list of choices for the user to pick from.".to_string(),
+                     Optionally provide a list of choices for the user to pick from."
+            .to_string(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {

--- a/apps/native/src-tauri/src/evolve/tools/build_check.rs
+++ b/apps/native/src-tauri/src/evolve/tools/build_check.rs
@@ -13,7 +13,8 @@ pub(crate) fn definition() -> Tool {
         description: "Validate the Nix flake by running a dry-run build. This checks for syntax \
                      errors and evaluation errors WITHOUT actually building derivations. \
                      Call this BEFORE calling 'done' to ensure your changes are valid. \
-                     If the build fails, analyze the error and fix it before trying again.".to_string(),
+                     If the build fails, analyze the error and fix it before trying again."
+            .to_string(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {

--- a/apps/native/src-tauri/src/evolve/tools/done.rs
+++ b/apps/native/src-tauri/src/evolve/tools/done.rs
@@ -11,7 +11,8 @@ pub(crate) fn definition() -> Tool {
     Tool {
         name: "done".to_string(),
         description: "Signal that all changes are complete. IMPORTANT: Only call this AFTER \
-                     you have verified your changes with build_check and are confident they work.".to_string(),
+                     you have verified your changes with build_check and are confident they work."
+            .to_string(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {

--- a/apps/native/src-tauri/src/evolve/tools/edit_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_file.rs
@@ -1,13 +1,13 @@
 //! `edit_file` tool: find-and-replace edits to a file.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use log::info;
 
 use crate::evolve::file_ops::apply_file_edits;
 use crate::evolve::messages::Tool;
 use crate::shared_types::FileEdit;
 
-use super::{ensure_nixmac_edit_allowed, ToolCtx, ToolResult};
+use super::{ToolCtx, ToolResult, ensure_nixmac_edit_allowed};
 
 pub(crate) fn definition() -> Tool {
     Tool {

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -1,6 +1,6 @@
 //! `edit_nix_file` tool: semantic Add/Remove/Set/SetAttrs edits to Nix files.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::evolve::edit_nix_file::{apply_semantic_edit, infer_single_list_attrpath};
 use crate::evolve::file_ops::resolve_existing_path_in_dir;
@@ -9,7 +9,7 @@ use crate::evolve::messages::Tool;
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 use crate::evolve::utils::normalize_relative_path;
 
-use super::{ensure_nixmac_edit_allowed, quote_homebrew_list_values, ToolCtx, ToolResult};
+use super::{ToolCtx, ToolResult, ensure_nixmac_edit_allowed, quote_homebrew_list_values};
 
 pub(crate) fn definition() -> Tool {
     Tool {

--- a/apps/native/src-tauri/src/evolve/tools/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/tools/ensure_secret.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::evolve::ensure_secret::execute_ensure_secret;
 use crate::evolve::messages::Tool;
 
-use super::{ensure_nixmac_edit_allowed, ToolCtx, ToolResult};
+use super::{ToolCtx, ToolResult, ensure_nixmac_edit_allowed};
 
 pub(crate) fn definition() -> Tool {
     Tool {

--- a/apps/native/src-tauri/src/evolve/tools/list_files.rs
+++ b/apps/native/src-tauri/src/evolve/tools/list_files.rs
@@ -1,20 +1,22 @@
 //! `list_files` tool: glob the config directory (gitignore-aware).
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use log::{debug, info};
 use std::path::Component;
 
+use crate::evolve::IGNORED_DIRS;
 use crate::evolve::file_ops::{ensure_path_under_base, join_in_dir};
 use crate::evolve::gitignore::is_ignored_by_matcher;
 use crate::evolve::messages::Tool;
-use crate::evolve::IGNORED_DIRS;
 
 use super::{ToolCtx, ToolResult};
 
 pub(crate) fn definition() -> Tool {
     Tool {
         name: "list_files".to_string(),
-        description: "List files in the config directory. Use glob patterns to find specific file types.".to_string(),
+        description:
+            "List files in the config directory. Use glob patterns to find specific file types."
+                .to_string(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {

--- a/apps/native/src-tauri/src/evolve/tools/read_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/read_file.rs
@@ -1,6 +1,6 @@
 //! `read_file` tool: read a file's contents (gitignore-aware).
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use log::info;
 use std::path::Path;
 

--- a/apps/native/src-tauri/src/evolve/tools/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/tools/search_code.rs
@@ -1,6 +1,6 @@
 //! `search_code` tool: ripgrep over the codebase.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::evolve::messages::Tool;
 use crate::evolve::search_code::execute_search_code;
@@ -13,7 +13,8 @@ pub(crate) fn definition() -> Tool {
         description: "Search for text patterns in the codebase using ripgrep. \
                      This helps locate where functions or variables are defined or used. \
                      Output format: one match per line as file:line:text, where \
-                     text is the matching line content.".to_string(),
+                     text is the matching line content."
+            .to_string(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {

--- a/apps/native/src-tauri/src/evolve/tools/search_docs.rs
+++ b/apps/native/src-tauri/src/evolve/tools/search_docs.rs
@@ -1,9 +1,9 @@
 //! `search_docs` tool: two-step nix-darwin/home-manager option docs lookup.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::evolve::messages::Tool;
-use crate::evolve::search_docs::{default_limit, execute_search_docs, max_limit, DocsSource};
+use crate::evolve::search_docs::{DocsSource, default_limit, execute_search_docs, max_limit};
 
 use super::{ToolCtx, ToolResult};
 

--- a/apps/native/src-tauri/src/evolve/tools/search_packages.rs
+++ b/apps/native/src-tauri/src/evolve/tools/search_packages.rs
@@ -1,6 +1,6 @@
 //! `search_packages` tool: wrapper around `nix search`.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::evolve::messages::Tool;
 use crate::evolve::search_packages::execute_search_packages;

--- a/apps/native/src-tauri/src/evolve/tools/think.rs
+++ b/apps/native/src-tauri/src/evolve/tools/think.rs
@@ -1,11 +1,11 @@
 //! `think` tool: structured step-by-step reasoning.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use log::{debug, info};
 
 use crate::evolve::messages::Tool;
 
-use super::{truncate_for_log, ToolCtx, ToolResult};
+use super::{ToolCtx, ToolResult, truncate_for_log};
 
 pub(crate) fn definition() -> Tool {
     Tool {

--- a/apps/native/src-tauri/src/evolve/utils.rs
+++ b/apps/native/src-tauri/src/evolve/utils.rs
@@ -1,6 +1,6 @@
 //! Common utilities for the evolve module
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::path::{Component, Path, PathBuf};
 
 /// Escape special characters in the user query to prevent them from being interpreted as markup in the system prompt.

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -816,11 +816,13 @@ regex = "token=([A-Za-z0-9]+)"
         assert!(redacted_fields.contains(&"evolution_log_content"));
         assert!(redacted_fields.contains(&"build_error_output"));
         assert!(!redacted_fields.contains(&"changed_nix_files_diff"));
-        assert!(metadata
-            .evolution_log_content
-            .unwrap()
-            .prompt
-            .contains("[REDACTED]"));
+        assert!(
+            metadata
+                .evolution_log_content
+                .unwrap()
+                .prompt
+                .contains("[REDACTED]")
+        );
         assert_eq!(metadata.changed_nix_files_diff.unwrap(), "no secrets here");
         assert!(metadata.build_error_output.unwrap().contains("[REDACTED]"));
     }
@@ -850,17 +852,21 @@ regex = "token=([A-Za-z0-9]+)"
         assert!(redacted_fields.contains(&"ai_provider_model_info"));
 
         let state = metadata.current_app_state_snapshot.unwrap();
-        assert!(state
-            .get("token")
-            .and_then(|v| v.as_str())
-            .unwrap()
-            .contains("[REDACTED]"));
-        assert!(state
-            .get("nested")
-            .and_then(|v| v.get("value"))
-            .and_then(|v| v.as_str())
-            .unwrap()
-            .contains("[REDACTED]"));
+        assert!(
+            state
+                .get("token")
+                .and_then(|v| v.as_str())
+                .unwrap()
+                .contains("[REDACTED]")
+        );
+        assert!(
+            state
+                .get("nested")
+                .and_then(|v| v.get("value"))
+                .and_then(|v| v.as_str())
+                .unwrap()
+                .contains("[REDACTED]")
+        );
 
         let info = metadata.ai_provider_model_info.unwrap();
         assert!(info.evolve_provider.unwrap().contains("[REDACTED]"));

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -1108,8 +1108,10 @@ mod tests {
             .get_path(Path::new("new.nix"), 0)
             .expect("new file should have an index entry");
 
-        assert!(git2::IndexEntryFlag::from_bits_truncate(entry.flags)
-            .contains(git2::IndexEntryFlag::EXTENDED));
+        assert!(
+            git2::IndexEntryFlag::from_bits_truncate(entry.flags)
+                .contains(git2::IndexEntryFlag::EXTENDED)
+        );
         assert!(
             git2::IndexEntryExtendedFlag::from_bits_truncate(entry.flags_extended)
                 .contains(git2::IndexEntryExtendedFlag::INTENT_TO_ADD)
@@ -1137,7 +1139,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_intent_add_untracked_preserves_unix_file_modes_without_hashing_contents() {
-        use std::os::unix::fs::{symlink, PermissionsExt};
+        use std::os::unix::fs::{PermissionsExt, symlink};
 
         let temp_dir = TempDir::new().unwrap();
         let repo_dir = temp_dir.path().join("repo");

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -9,8 +9,8 @@ mod repo_files;
 // `crate::git::some_fn()` without change.
 #[allow(unused_imports)]
 pub use exec::{
-    checkout_files_at_commit, commit_all, create_evolution_backup, intent_add_untracked,
-    restore_all, restore_from_branch_ref, tag_commit, CommitInfo,
+    CommitInfo, checkout_files_at_commit, commit_all, create_evolution_backup,
+    intent_add_untracked, restore_all, restore_from_branch_ref, tag_commit,
 };
 
 #[allow(unused_imports)]

--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -5,7 +5,7 @@ use git2::{DiffOptions, Oid, Repository};
 use tauri::AppHandle;
 
 use crate::{
-    git::{file_diff_to_change, init::require_repo, is_sensitive_or_opaque, FileDiff},
+    git::{FileDiff, file_diff_to_change, init::require_repo, is_sensitive_or_opaque},
     shared_types::{ChangeType, GitFileStatus, GitStatus},
 };
 

--- a/apps/native/src-tauri/src/git/repo_files.rs
+++ b/apps/native/src-tauri/src/git/repo_files.rs
@@ -205,8 +205,7 @@ mod tests {
         let outside = temp.path().join("../outside.txt");
         fs::write(&outside, "outside").expect("write outside file");
 
-        std::os::unix::fs::symlink(&outside, temp.path().join("link.txt"))
-            .expect("create symlink");
+        std::os::unix::fs::symlink(&outside, temp.path().join("link.txt")).expect("create symlink");
 
         assert_eq!(workdir_file_contents(&repo, Path::new("link.txt")), "");
     }

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -42,18 +42,18 @@ use storage::store;
 
 use std::env;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
 };
 use std::time::Duration;
 use tauri::{
+    Emitter, Manager, RunEvent, WebviewUrl, WebviewWindow, WebviewWindowBuilder, WindowEvent,
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
     webview::PageLoadEvent,
-    Emitter, Manager, RunEvent, WebviewUrl, WebviewWindow, WebviewWindowBuilder, WindowEvent,
 };
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Global app handle, set during GUI setup so background threads (such as the
 /// drift watcher) can access plugins like notifications without threading an

--- a/apps/native/src-tauri/src/managed_edits/managed_edit.rs
+++ b/apps/native/src-tauri/src/managed_edits/managed_edit.rs
@@ -19,8 +19,8 @@ pub fn prepare_managed_edit(app: &AppHandle) -> Result<ManagedEditContext> {
         git::status(&dir).context("Failed to get pre-edit working tree status")?;
 
     let pool = app.state::<db::DbPool>();
-    let _base_commit_id = db::commits::store_head_commit(&pool, &dir, None)
-        .context("Failed to store HEAD commit")?;
+    let _base_commit_id =
+        db::commits::store_head_commit(&pool, &dir, None).context("Failed to store HEAD commit")?;
 
     let pre_state = evolve_state::get(app).unwrap_or_default();
     let branch = git::current_branch(&dir).unwrap_or_else(|| "main".to_string());

--- a/apps/native/src-tauri/src/peek.rs
+++ b/apps/native/src-tauri/src/peek.rs
@@ -8,8 +8,8 @@
 
 pub(crate) use crate::shared_types::PreviewIndicatorState;
 use once_cell::sync::Lazy;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tauri::{
     AppHandle, Emitter, Manager, PhysicalPosition, Runtime, WebviewUrl, WebviewWindowBuilder,

--- a/apps/native/src-tauri/src/state/drift_notifications.rs
+++ b/apps/native/src-tauri/src/state/drift_notifications.rs
@@ -108,7 +108,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn no_notification_without_drift() {
         let status = clean_status();

--- a/apps/native/src-tauri/src/state/mod.rs
+++ b/apps/native/src-tauri/src/state/mod.rs
@@ -26,7 +26,7 @@ pub mod completion_log;
 pub mod drift_notifications;
 pub mod evolve_state;
 pub mod preferences;
+pub mod session_log;
 /// Generic state slices used by runtime state and scoped preferences.
 pub mod slice;
-pub mod session_log;
 pub mod watcher;

--- a/apps/native/src-tauri/src/state/slice/mod.rs
+++ b/apps/native/src-tauri/src/state/slice/mod.rs
@@ -208,7 +208,7 @@ mod tests {
     };
     use anyhow::Result;
     use serde::{Deserialize, Serialize};
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use std::sync::{Arc, Mutex};
 
     #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -336,9 +336,11 @@ mod tests {
         assert_eq!(entries[0].name, "DemoState");
         let _schema_fn = entries[0].schema_fn;
         let _set_field_fn = entries[0].set_field_fn;
-        assert!(registry
-            .get("DemoState")
-            .expect("registry lookup")
-            .is_some());
+        assert!(
+            registry
+                .get("DemoState")
+                .expect("registry lookup")
+                .is_some()
+        );
     }
 }

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -8,8 +8,8 @@ use crate::shared_types::GitState;
 use crate::state::{build_state, drift_notifications, evolve_state};
 use crate::storage::store;
 use crate::{db, git, summarize};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
@@ -105,17 +105,21 @@ where
 
                         if current_json != cached_json || external_build_detected {
                             let pool = app_handle.state::<db::DbPool>();
-                            let change_map = summarize::find_existing::for_current_state(&pool, dir)
-                                .ok()
-                                .map(summarize::group_existing::from_change_sets)
-                                .unwrap_or_default();
+                            let change_map =
+                                summarize::find_existing::for_current_state(&pool, dir)
+                                    .ok()
+                                    .map(summarize::group_existing::from_change_sets)
+                                    .unwrap_or_default();
                             // Side-effect: refresh the evolve slice. The slice write-guard
                             // emits `evolve_state_changed` on drop, so no manual emit needed.
                             if let Ok(es) = evolve_state::get(&app_handle) {
                                 let _ = evolve_state::set(&app_handle, es, &status.changes);
                             }
                             // Native drift notification (config drift / external build).
-                            drift_notifications::maybe_notify(Some(&status), external_build_detected);
+                            drift_notifications::maybe_notify(
+                                Some(&status),
+                                external_build_detected,
+                            );
                             // One emit per slice — frontend listens on its dedicated channel.
                             // fire-and-forget: window may not be connected yet.
                             let _ = app_handle.emit(

--- a/apps/native/src-tauri/src/storage/credential_store.rs
+++ b/apps/native/src-tauri/src/storage/credential_store.rs
@@ -186,7 +186,9 @@ where
                             err
                         );
                     } else {
-                        log::info!("Cleaned up stale plaintext credential from settings (already in keychain)");
+                        log::info!(
+                            "Cleaned up stale plaintext credential from settings (already in keychain)"
+                        );
                     }
                 }
                 Ok(None) => {}

--- a/apps/native/src-tauri/src/storage/store.rs
+++ b/apps/native/src-tauri/src/storage/store.rs
@@ -8,7 +8,7 @@ use crate::shared_types;
 use crate::storage::credential_store::{CredentialStore, KeychainStore};
 
 use anyhow::Result;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use std::sync::Arc;
 use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_store::{Store, StoreExt};

--- a/apps/native/src-tauri/src/summarize/group_existing.rs
+++ b/apps/native/src-tauri/src/summarize/group_existing.rs
@@ -109,10 +109,7 @@ pub fn find_in_singles_by_hash<'a>(
 }
 
 fn is_invalid(summary: &ChangeSummary) -> bool {
-    matches!(
-        summary.status.as_str(),
-        "FAILED" | "CANCELLED" | "QUEUED"
-    )
+    matches!(summary.status.as_str(), "FAILED" | "CANCELLED" | "QUEUED")
 }
 
 fn to_change_with_summary(

--- a/apps/native/src-tauri/src/summarize/model_calls.rs
+++ b/apps/native/src-tauri/src/summarize/model_calls.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Runtime};
 
-use crate::ai::providers::{create_provider, TokenUsage};
+use crate::ai::providers::{TokenUsage, create_provider};
 use crate::summarize::token_budgets::commit_message_budget;
 
 #[derive(Deserialize)]

--- a/apps/native/src-tauri/src/summarize/token_budgets.rs
+++ b/apps/native/src-tauri/src/summarize/token_budgets.rs
@@ -1,7 +1,7 @@
 //! Token budget constants and prompt-length based budget computation for model calls.
 
 use once_cell::sync::Lazy;
-use tiktoken_rs::{cl100k_base, CoreBPE};
+use tiktoken_rs::{CoreBPE, cl100k_base};
 
 const DEFAULT_MODEL_CONTEXT_WINDOW: u32 = 8192;
 const MIN_MEANINGFUL_OUTPUT_TOKENS: u32 = 128;

--- a/apps/native/src-tauri/src/sync/client.rs
+++ b/apps/native/src-tauri/src/sync/client.rs
@@ -9,10 +9,10 @@
 //! configurable base URL and will function against any backend that implements
 //! the documented endpoints.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 
-use super::signing::{authorization_header, SigningRequest};
+use super::signing::{SigningRequest, authorization_header};
 use crate::shared_types::{AuthAccount, SyncRemoteStatus};
 
 /// Secret material needed to sign authenticated sync requests.

--- a/apps/native/src-tauri/src/sync/mod.rs
+++ b/apps/native/src-tauri/src/sync/mod.rs
@@ -13,7 +13,7 @@
 pub mod client;
 pub mod signing;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use tauri::{AppHandle, Runtime};
 
 use crate::shared_types::{AuthAccount, AuthStatus, SyncRemoteStatus, SyncResult};

--- a/apps/native/src-tauri/src/system/nix_ast_lists.rs
+++ b/apps/native/src-tauri/src/system/nix_ast_lists.rs
@@ -1,7 +1,7 @@
 use rnix::ast::List;
 use rnix::{Parse, Root};
-use rowan::ast::AstNode;
 use rowan::TextSize;
+use rowan::ast::AstNode;
 use std::collections::HashMap;
 
 /// Parse all string-only list assignments from Nix source and return a map of

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -643,8 +643,7 @@ const KEY_DEFS: &[(&str, &[KeyDef])] = &[
             },
             KeyDef {
                 defaults_key: "com.apple.trackpad.enableSecondaryClick",
-                nix_key:
-                    "system.defaults.NSGlobalDomain.\"com.apple.trackpad.enableSecondaryClick\"",
+                nix_key: "system.defaults.NSGlobalDomain.\"com.apple.trackpad.enableSecondaryClick\"",
                 label: "Enable secondary click on trackpad",
                 category: "Global",
                 val_type: ValType::Bool,

--- a/apps/native/src-tauri/src/telemetry/init.rs
+++ b/apps/native/src-tauri/src/telemetry/init.rs
@@ -11,10 +11,10 @@ use std::env;
 use opentelemetry::KeyValue;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{LogExporter, Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::SdkTracerProvider;
-use opentelemetry_sdk::Resource;
 
 const SERVICE_NAME: &str = "nixmac";
 
@@ -53,7 +53,10 @@ fn parse_sentry_dsn(dsn: &str) -> Option<SentryOtlpConfig> {
     Some(SentryOtlpConfig {
         traces_url: format!("{scheme}://{host}/api/{project_id}/integration/otlp/v1/traces/"),
         logs_url: format!("{scheme}://{host}/api/{project_id}/integration/otlp/v1/logs/"),
-        headers: vec![("x-sentry-auth".to_string(), format!("sentry sentry_key={public_key}"))],
+        headers: vec![(
+            "x-sentry-auth".to_string(),
+            format!("sentry sentry_key={public_key}"),
+        )],
     })
 }
 
@@ -193,10 +196,12 @@ pub fn init_telemetry(send_diagnostics: bool) -> TelemetryGuard {
     {
         use tracing_subscriber::prelude::*;
         let log_bridge = OpenTelemetryTracingBridge::new(&logger_provider);
-        if tracing_subscriber::registry().with(log_bridge).try_init().is_err() {
-            log::debug!(
-                "OTEL log bridge not attached: a tracing subscriber is already installed"
-            );
+        if tracing_subscriber::registry()
+            .with(log_bridge)
+            .try_init()
+            .is_err()
+        {
+            log::debug!("OTEL log bridge not attached: a tracing subscriber is already installed");
         }
     }
 

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -167,7 +167,7 @@ lib.mkIf (!config.container.isBuilding) {
   treefmt.config = {
     # The commit hook runs treefmt repo-wide; enabling more formatters here
     # expands pre-commit cost and can surface unrelated formatting drift.
-    programs.rustfmt.enable = false;
+    programs.rustfmt.enable = true;
     programs.yamlfmt.enable = false;
     programs.mdformat.enable = true;
   };


### PR DESCRIPTION
## Summary

I have been getting a ton of format drift lately, which I have mostly been manually reverting...but I don't think this is a good situation to persist with. So I turned on rustfmt in treefmt and ran it and let it clean everything up. @czxtm please free free to discard this PR if you don't agree. Thanks!

<!-- What does this PR do? Why? -->

## Test Plan

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed