### PR TITLE
fix(test): unblock OpenAI provider typecheck

### DIFF
--- a/apps/native/src/lib/ai-provider-migration.test.ts
+++ b/apps/native/src/lib/ai-provider-migration.test.ts
@@ -23,6 +23,7 @@ const PREFS: UiPrefs = {
   scanHomebrewOnStartup: false,
   defaultToDiffTab: false,
   developerMode: false,
+  experimentalSpinningMascot: false,
   pinnedVersion: null,
   updateChannel: "stable",
 };

--- a/apps/native/src/lib/api-key-verification.test.ts
+++ b/apps/native/src/lib/api-key-verification.test.ts
@@ -15,7 +15,6 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 const okResponse = { ok: true } as Response;
-const unauthorizedResponse = { ok: false } as Response;
 
 describe("api key verification", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Adds the new `experimentalSpinningMascot` preference to the OpenAI provider migration test fixture.
- Removes an unused `unauthorizedResponse` test constant that was failing `noUnusedLocals`.

This is a small helper PR intended to unblock TypeScript/build failures on #351.

## Verification

- `bunx vitest run --project=unit src/lib/ai-provider-migration.test.ts src/lib/api-key-verification.test.ts`
- `bun -F native build`
- `git diff --check`

## Notes

No `codex` or `codex-automation` labels were available in this repo.