### PR TITLE
fix: defer `.nixmac/` dir creation to write time, skip repo-scoped persistence before config dir is set

### DIFF
--- a/apps/native/src-tauri/src/evolve/config.rs
+++ b/apps/native/src-tauri/src/evolve/config.rs
@@ -16,7 +16,7 @@ use tauri::{AppHandle, Runtime};
 
 use crate::state::preferences;
 use crate::state::slice::{
-    Persistence, RegisteredSliceConfig, RepoScopedJson, Slice, SliceRegistry,
+    ConfiguredRepoScopedJson, Persistence, RegisteredSliceConfig, Slice, SliceRegistry,
 };
 
 pub const EVOLUTION_LIMITS_CHANGED_EVENT: &str = "evolution_limits_changed";
@@ -72,11 +72,7 @@ impl Default for EvolutionLimits {
 }
 
 pub fn load_slice<R: Runtime>(app: &AppHandle<R>) -> Result<Slice<EvolutionLimits>> {
-    let persistence: Arc<dyn Persistence> =
-        match crate::storage::configurable_scope::repo_store_path(app) {
-            Ok(path) => Arc::new(RepoScopedJson::new(path)),
-            Err(_) => Arc::new(preferences::VolatileJson),
-        };
+    let persistence: Arc<dyn Persistence> = Arc::new(ConfiguredRepoScopedJson::new(app.clone()));
     let initial = preferences::load_or_default::<EvolutionLimits>(persistence.as_ref())?;
 
     Ok(Slice::new(

--- a/apps/native/src-tauri/src/state/preferences.rs
+++ b/apps/native/src-tauri/src/state/preferences.rs
@@ -9,7 +9,6 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use specta::Type;
 use std::sync::Arc;
 use tauri::{AppHandle, Runtime};
@@ -96,28 +95,10 @@ where
     Ok(T::default())
 }
 
-/// No-op persistence backend used when the storage path is unavailable.
-///
-/// During onboarding the config directory may not be set yet, so
-/// repo-scoped slices fall back to this. Reads return `None` (treated as
-/// "use defaults") and writes are silently discarded. Once the user selects
-/// a config dir, the slice is reloaded with a real backend.
-#[derive(Debug, Default)]
-pub(crate) struct VolatileJson;
-
-impl Persistence for VolatileJson {
-    fn load(&self) -> Result<Option<Value>> {
-        Ok(None)
-    }
-
-    fn flush(&self, _: &Value) -> Result<()> {
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
     use serde_json::json;
     use std::sync::Mutex;
 

--- a/apps/native/src-tauri/src/state/slice/mod.rs
+++ b/apps/native/src-tauri/src/state/slice/mod.rs
@@ -61,7 +61,7 @@ pub mod json_io;
 pub mod persistence;
 pub mod registry;
 
-pub use persistence::{AppDataJson, Persistence, RepoScopedJson};
+pub use persistence::{AppDataJson, ConfiguredRepoScopedJson, Persistence};
 pub use registry::{RegisteredSliceConfig, SliceRegistry};
 
 use anyhow::{Context, Result};
@@ -202,9 +202,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::persistence::RepoScopedJson;
     use super::{
-        AppDataJson, Persistence, RegisteredSliceConfig, RepoScopedJson, Slice, SliceEventEmitter,
-        SliceRegistry,
+        AppDataJson, Persistence, RegisteredSliceConfig, Slice, SliceEventEmitter, SliceRegistry,
     };
     use anyhow::Result;
     use serde::{Deserialize, Serialize};

--- a/apps/native/src-tauri/src/state/slice/persistence.rs
+++ b/apps/native/src-tauri/src/state/slice/persistence.rs
@@ -80,6 +80,8 @@ pub struct RepoScopedJson {
     path: PathBuf,
 }
 
+/// Repo-scoped persistence that waits for the app's config directory to be set
+/// before doing anything.
 impl RepoScopedJson {
     /// Build a repo-scoped persistence backend from an already resolved path.
     pub fn new(path: impl Into<PathBuf>) -> Self {
@@ -107,6 +109,51 @@ impl Persistence for RepoScopedJson {
     }
 
     fn flush(&self, value: &Value) -> Result<()> {
+        crate::storage::configurable_scope::ensure_repo_store_dir_for_path(&self.path)?;
         write_json_file(&self.path, value)
+    }
+}
+
+/// Repo-scoped JSON persistence that follows the app's explicitly configured
+/// config directory.
+///
+/// This intentionally ignores the onboarding default (`~/.darwin`) until the
+/// user has confirmed a directory. That keeps first-launch reads and accidental
+/// pre-setup writes from making a clone/import target non-empty, which is disallowed
+/// later in the UI and therefore bad.
+#[derive(Debug, Clone)]
+pub struct ConfiguredRepoScopedJson<R: Runtime> {
+    app: tauri::AppHandle<R>,
+}
+
+impl<R: Runtime> ConfiguredRepoScopedJson<R> {
+    pub fn new(app: tauri::AppHandle<R>) -> Self {
+        Self { app }
+    }
+
+    fn path(&self) -> Result<Option<PathBuf>> {
+        let Some(config_dir) = crate::storage::store::get_config_dir_if_set(&self.app)? else {
+            return Ok(None);
+        };
+        Ok(Some(PathBuf::from(
+            crate::storage::configurable_scope::repo_store_path_for_config_dir(&config_dir)?,
+        )))
+    }
+}
+
+impl<R: Runtime> Persistence for ConfiguredRepoScopedJson<R> {
+    fn load(&self) -> Result<Option<Value>> {
+        let Some(path) = self.path()? else {
+            return Ok(None);
+        };
+        read_json_file(&path)
+    }
+
+    fn flush(&self, value: &Value) -> Result<()> {
+        let Some(path) = self.path()? else {
+            return Ok(());
+        };
+        crate::storage::configurable_scope::ensure_repo_store_dir_for_path(&path)?;
+        write_json_file(&path, value)
     }
 }

--- a/apps/native/src-tauri/src/storage/configurable_scope.rs
+++ b/apps/native/src-tauri/src/storage/configurable_scope.rs
@@ -6,8 +6,10 @@
 //! machines on the next clone/pull — settings persist across reinstalls and
 //! sync across devices without any explicit backup/restore step.
 //!
-//! The first time the path is requested, the `.nixmac/` directory is created
-//! and a short README is written explaining what the file is.
+//! Callers that intend to write repo-scoped settings should ensure the
+//! `.nixmac/` directory first by using `ensure_repo_store_dir_for_path`;
+//! read-only startup paths can resolve the settings location without mutating
+//! a not-yet-confirmed config directory.
 
 use crate::storage::store;
 use anyhow::Result;
@@ -36,8 +38,11 @@ If you'd rather not commit these settings, add `.nixmac/` to your
 defaults on next launch.
 ";
 
-/// Absolute path to `<config_dir>/.nixmac/settings.json`. The `.nixmac/`
-/// directory and the explanatory `README.md` are created on first call.
+/// Absolute path to `<config_dir>/.nixmac/settings.json`.
+///
+/// This resolver is read-only: **IT DOES NOT AUTOMAGICALLY CREATE `.nixmac/`**. Use
+/// `ensure_repo_store_dir_for_path` before writes that should materialize the
+/// managed settings directory.
 pub fn repo_store_path<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
     let config_dir = store::get_config_dir(app)?;
     repo_store_path_for_config_dir(&config_dir)
@@ -45,6 +50,15 @@ pub fn repo_store_path<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
 
 pub(crate) fn repo_store_path_for_config_dir(config_dir: &str) -> Result<String> {
     let dir = Path::new(&config_dir).join(REPO_DIR_NAME);
+    Ok(dir.join(REPO_SETTINGS_FILE).to_string_lossy().to_string())
+}
+
+/// Ensure the parent `.nixmac/` directory exists for a repo-scoped settings
+/// file and create the explanatory README when missing.
+pub(crate) fn ensure_repo_store_dir_for_path(path: impl AsRef<Path>) -> Result<()> {
+    let Some(dir) = path.as_ref().parent() else {
+        return Ok(());
+    };
     std::fs::create_dir_all(&dir)?;
     let readme = dir.join(REPO_README_FILE);
     if !readme.exists() {
@@ -53,19 +67,41 @@ pub(crate) fn repo_store_path_for_config_dir(config_dir: &str) -> Result<String>
         // mount.
         let _ = std::fs::write(&readme, REPO_README_CONTENT);
     }
-    Ok(dir.join(REPO_SETTINGS_FILE).to_string_lossy().to_string())
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
-    fn repo_store_path_creates_managed_dir_and_readme() {
+    fn repo_store_path_does_not_create_managed_dir() {
         let temp = tempfile::tempdir().expect("create tempdir");
 
         let path = repo_store_path_for_config_dir(temp.path().to_str().expect("utf-8 temp path"))
             .expect("resolve repo-scoped store path");
+
+        let expected_dir = temp.path().join(REPO_DIR_NAME);
+        assert_eq!(
+            path,
+            expected_dir
+                .join(REPO_SETTINGS_FILE)
+                .to_string_lossy()
+                .to_string()
+        );
+        assert!(!expected_dir.exists());
+    }
+
+    #[test]
+    fn ensure_repo_store_dir_creates_managed_dir_and_readme() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+
+        let path = PathBuf::from(
+            repo_store_path_for_config_dir(temp.path().to_str().expect("utf-8 temp path"))
+                .expect("resolve repo-scoped store path"),
+        );
+        ensure_repo_store_dir_for_path(&path).expect("ensure repo store dir");
 
         let expected_dir = temp.path().join(REPO_DIR_NAME);
         assert_eq!(
@@ -90,12 +126,31 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("create managed dir");
         std::fs::write(dir.join(REPO_README_FILE), "custom note").expect("write custom README");
 
-        let _ = repo_store_path_for_config_dir(temp.path().to_str().expect("utf-8 temp path"))
-            .expect("resolve repo-scoped store path");
+        let path = PathBuf::from(
+            repo_store_path_for_config_dir(temp.path().to_str().expect("utf-8 temp path"))
+                .expect("resolve repo-scoped store path"),
+        );
+        ensure_repo_store_dir_for_path(&path).expect("ensure repo store dir");
 
         assert_eq!(
             std::fs::read_to_string(dir.join(REPO_README_FILE)).expect("read README"),
             "custom note"
+        );
+    }
+
+    #[test]
+    fn ensure_repo_store_dir_accepts_file_path() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let path: PathBuf = temp.path().join(REPO_DIR_NAME).join(REPO_SETTINGS_FILE);
+
+        ensure_repo_store_dir_for_path(&path).expect("ensure repo store dir");
+
+        assert!(temp.path().join(REPO_DIR_NAME).is_dir());
+        assert!(
+            temp.path()
+                .join(REPO_DIR_NAME)
+                .join(REPO_README_FILE)
+                .is_file()
         );
     }
 }

--- a/apps/native/src-tauri/src/storage/store.rs
+++ b/apps/native/src-tauri/src/storage/store.rs
@@ -97,6 +97,20 @@ pub fn get_config_dir<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
     Ok(home.join(".darwin").to_string_lossy().to_string())
 }
 
+/// Gets the flake configuration directory only when it was explicitly
+/// configured, avoiding the onboarding default of `~/.darwin`.
+pub fn get_config_dir_if_set<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>> {
+    if let Some(dir) = e2e_env_value("NIXMAC_E2E_CONFIG_DIR") {
+        return Ok(Some(dir));
+    }
+
+    let store = get_store(app)?;
+
+    Ok(store
+        .get("configDir")
+        .and_then(|dir| dir.as_str().map(ToString::to_string)))
+}
+
 /// Gets the git repository root for the current workspace.
 ///
 /// If not stored, it is derived from configDir using `git rev-parse`,


### PR DESCRIPTION
## Summary

This fixes a bug where during initial setup, the default `~/.darwin` directory ends up not being a valid target for import from git/zip due to the fact that we rush during startup to create the magic `.nixmac` directory, thereby making the directory technically non-empty. I also think this code is cleaner and easier to understand.

<!-- What does this PR do? Why? -->

## Test Plan

New/updated unit tests plus manual testing.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed