### PR TITLE
feat: default hostname to the actual local hostname during setup

### DIFF
--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -18,6 +18,26 @@ pub async fn config_get(app: AppHandle) -> Result<types::Config, String> {
     })
 }
 
+/// Gets the hostname that we're running on, does not touch config but is used
+/// for UI convenience and onboarding defaults.
+/// The name of this function is specificlly chosen to NOT get confused
+/// with an actual config read.
+#[tauri::command]
+pub async fn get_this_hostname() -> Result<String, String> {
+    // Use the system `hostname` command to get the current hostname, which is more reliable than Rust's std::env::var("HOSTNAME")
+    let output = std::process::Command::new("hostname")
+        .output()
+        .map_err(|e| capture_err("get_this_hostname", e))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to get hostname: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let hostname = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(hostname)
+}
+
 /// Sets the nix-darwin host attribute (e.g., "Coopers-MacBook-Pro").
 #[tauri::command]
 pub async fn config_set_host_attr(

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -467,6 +467,7 @@ fn run_gui_mode(
             commands::config::config_prepare_new_dir,
             commands::config::config_pick_dir,
             commands::config::flake_exists_at,
+            commands::config::get_this_hostname,
             commands::config::path_exists,
             commands::config::path_normalize,
             commands::config::config_pick_zip,

--- a/apps/native/src/components/widget/controls/bootstrap-config.tsx
+++ b/apps/native/src/components/widget/controls/bootstrap-config.tsx
@@ -14,13 +14,41 @@ interface BootstrapConfigProps {
   onSuccess?: () => void;
 }
 
+const DEFAULT_HOSTNAME = "macbook";
+
 export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
-  const [hostname, setHostname] = useState("macbook");
+  const [hostname, setHostname] = useState(DEFAULT_HOSTNAME);
+  const [hostnamePlaceholder, setHostnamePlaceholder] = useState(DEFAULT_HOSTNAME);
   const [localError, setLocalError] = useState<string | null>(null);
   const { bootstrap, isBootstrapping } = useDarwinConfig();
   const configDir = useWidgetStore((state) => state.configDir);
   const gitStatus = useViewModel((state) => state.git);
   const [flakeExists, setFlakeExists] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadThisHostname = async () => {
+      let nextHostname = DEFAULT_HOSTNAME;
+
+      try {
+        nextHostname = (await tauriAPI.config.getThisHostname()).trim() || DEFAULT_HOSTNAME;
+      } catch {}
+
+      if (cancelled) return;
+
+      setHostnamePlaceholder(nextHostname);
+      setHostname((currentHostname) =>
+        currentHostname === DEFAULT_HOSTNAME ? nextHostname : currentHostname,
+      );
+    };
+
+    void loadThisHostname();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     setLocalError(null);
@@ -73,7 +101,7 @@ export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
                 type="text"
                 value={hostname}
                 onChange={(e) => setHostname(e.target.value)}
-                placeholder="macbook"
+                placeholder={hostnamePlaceholder}
                 className="font-mono text-xs"
                 disabled={isBootstrapping}
               />

--- a/apps/native/src/ipc/api.ts
+++ b/apps/native/src/ipc/api.ts
@@ -54,6 +54,7 @@ export const tauriAPI = {
       invoke<SetDirResult>("config_import_github", { repoRef, dirName: dirName ?? null }),
     importZip: (zipPath: string, dirName?: string) =>
       invoke<SetDirResult>("config_import_zip", { zipPath, dirName: dirName ?? null }),
+    getThisHostname: () => invoke<string>("get_this_hostname"),
   },
   account: {
     status: () => invoke<AuthStatus>("account_status"),


### PR DESCRIPTION
## Summary

The hostname during Setup / onboarding was hard-coded to "macbook" as a default. I changed it to be the actual hostname you're running on. This has been annoying me for a long time and I thought I entered an issue on it, but I can't find it, so here is a proposed fix.

<!-- What does this PR do? Why? -->

## Test Plan

Manual.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed