### PR TITLE
Fix empty cloud API key routing

### DIFF
--- a/apps/native/src-tauri/src/storage/store.rs
+++ b/apps/native/src-tauri/src/storage/store.rs
@@ -280,7 +280,7 @@ pub fn set_evolve_model<R: Runtime>(app: &AppHandle<R>, model: &str) -> Result<(
 
 /// Gets the stored OpenRouter API key.
 pub fn get_openrouter_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>> {
-    get_secret_pref(app, "openrouterApiKey")
+    get_secret_pref_normalized(app, "openrouterApiKey")
 }
 
 pub fn set_openrouter_api_key<R: Runtime>(app: &AppHandle<R>, key: &str) -> Result<()> {
@@ -289,7 +289,7 @@ pub fn set_openrouter_api_key<R: Runtime>(app: &AppHandle<R>, key: &str) -> Resu
 
 /// Gets the stored OpenAI API key (for direct OpenAI access).
 pub fn get_openai_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>> {
-    get_secret_pref(app, "openaiApiKey")
+    get_secret_pref_normalized(app, "openaiApiKey")
 }
 
 pub fn set_openai_api_key<R: Runtime>(app: &AppHandle<R>, key: &str) -> Result<()> {
@@ -322,7 +322,7 @@ pub fn set_vllm_api_base_url<R: Runtime>(app: &AppHandle<R>, url: &str) -> Resul
 
 /// Gets the stored vLLM API key (optional — vllm direct endpoint may not require one).
 pub fn get_vllm_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>> {
-    get_secret_pref(app, "vllmApiKey")
+    get_secret_pref_normalized(app, "vllmApiKey")
 }
 
 pub fn set_vllm_api_key<R: Runtime>(app: &AppHandle<R>, key: &str) -> Result<()> {
@@ -496,14 +496,18 @@ fn keychain_store_for<R: Runtime>(app: &AppHandle<R>, key: &str) -> KeychainStor
 
 fn get_secret_pref<R: Runtime>(app: &AppHandle<R>, key: &'static str) -> Result<Option<String>> {
     if e2e_mock_system_enabled() {
-        return Ok(normalize_secret(get_string_pref_raw(app, key)?));
+        return get_string_pref_raw(app, key);
     }
 
     let keychain = keychain_store_for(app, key);
-    keychain
-        .get()
-        .map(normalize_secret)
-        .map_err(anyhow::Error::from)
+    keychain.get().map_err(anyhow::Error::from)
+}
+
+fn get_secret_pref_normalized<R: Runtime>(
+    app: &AppHandle<R>,
+    key: &'static str,
+) -> Result<Option<String>> {
+    Ok(normalize_secret(get_secret_pref(app, key)?))
 }
 
 fn set_secret_pref<R: Runtime>(app: &AppHandle<R>, key: &'static str, value: &str) -> Result<()> {
@@ -599,7 +603,7 @@ pub fn delete_sync_account<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
 
 /// Gets the per-device HMAC secret from the keychain.
 pub fn get_sync_secret<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>> {
-    get_secret_pref(app, SYNC_SECRET_KEYCHAIN_KEY)
+    get_secret_pref_normalized(app, SYNC_SECRET_KEYCHAIN_KEY)
 }
 
 /// Stores the per-device HMAC secret in the keychain.


### PR DESCRIPTION
## Summary

- Treat empty or whitespace cloud API key writes as clears so keychain-backed secrets are deleted instead of saved as empty strings.
- Normalize stored fallback secrets before backend credential routing so an empty OpenRouter key cannot beat a valid OpenAI key.
- Add a production-path regression test for the clear-then-route path and include minimal upstream Rust compile cleanup required on `origin/develop`.

Fixes ENG-558
Fixes #368
Supersedes draft PR #370; this keeps the same backend direction but avoids the weaker duplicated routing test and preserves Scott's committed import ordering.

## Test Plan

- [x] `rustfmt --check --edition 2021 --config style_edition=2024,skip_children=true apps/native/src-tauri/src/storage/store.rs apps/native/src-tauri/src/state/mod.rs apps/native/src-tauri/src/evolve/edit_nix_file.rs apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs`
- [x] `cargo test --manifest-path apps/native/src-tauri/Cargo.toml storage::store::tests -- --nocapture`
- [x] `cargo check --manifest-path apps/native/src-tauri/Cargo.toml`
- [x] `git diff --check`

## Docs

- [x] No docs update needed; this is a backend credential-routing bugfix with regression coverage.
