### PR TITLE
Instrument native analytics funnels

### DIFF
--- a/apps/native/src/components/widget/controls/bootstrap-config.tsx
+++ b/apps/native/src/components/widget/controls/bootstrap-config.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
+import type { TelemetrySurface } from "@/hooks/use-darwin-config";
 import { useViewModel } from "@/stores/view-model";
 import { useWidgetStore } from "@/stores/widget-store";
 import { tauriAPI } from "@/ipc/api";
@@ -12,9 +13,14 @@ import { useEffect, useState } from "react";
 interface BootstrapConfigProps {
   label: string;
   onSuccess?: () => void;
+  telemetrySurface?: TelemetrySurface;
 }
 
-export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
+export function BootstrapConfig({
+  label,
+  onSuccess,
+  telemetrySurface = "settings",
+}: BootstrapConfigProps) {
   const [hostname, setHostname] = useState("macbook");
   const [localError, setLocalError] = useState<string | null>(null);
   const { bootstrap, isBootstrapping } = useDarwinConfig();
@@ -44,7 +50,9 @@ export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
 
   const handleBootstrap = async (): Promise<void> => {
     setLocalError(null);
-    await bootstrap(needsInitialCommit ? "" : hostname);
+    await bootstrap(needsInitialCommit ? "" : hostname, {
+      telemetrySurface,
+    });
     const storeError = useWidgetStore.getState().error;
     if (storeError) {
       setLocalError(storeError);

--- a/apps/native/src/components/widget/controls/directory-picker.test.tsx
+++ b/apps/native/src/components/widget/controls/directory-picker.test.tsx
@@ -9,7 +9,9 @@ import { DirectoryPicker } from "@/components/widget/controls/directory-picker";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockPickDir = vi.fn();
+const mockPickDir = vi.fn<
+  () => Promise<{ dir: string; evolveState: never; hosts: string[] | null } | null>
+>();
 const mockNormalize = vi.fn<(p: string) => Promise<string | null>>();
 const mockExists = vi.fn<(p: string) => Promise<boolean>>();
 const mockSetDir =
@@ -155,6 +157,26 @@ describe("<DirectoryPicker>", () => {
     expect(s.configDir).toBe("/Users/me/.darwin");
     expect(s.host).toBe("");
     expect(s.hosts).toEqual(["mbp", "workbook"]);
+  });
+
+  it("does not resubmit setup directory selection when Enter blurs the input", async () => {
+    mockNormalize.mockResolvedValue("/Users/me/.darwin");
+    mockSetDir.mockResolvedValue({
+      dir: "/Users/me/.darwin",
+      evolveState: {} as never,
+      hosts: ["mbp"],
+    });
+
+    render(<DirectoryPicker flow="setup" label="Config directory" />);
+    fireEvent.click(screen.getByRole("tab", { name: "Existing" }));
+    const input = screen.getByLabelText("Config directory");
+
+    fireEvent.change(input, { target: { value: "/Users/me/.darwin" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockSetDir).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("uses empty hosts when setDir has no hosts and still persists the dir", async () => {

--- a/apps/native/src/components/widget/controls/directory-picker.tsx
+++ b/apps/native/src/components/widget/controls/directory-picker.tsx
@@ -9,7 +9,7 @@ import { ConfigDirBadge } from "@/components/widget/badges/config-dir-badge";
 import { GitignoreBadge } from "@/components/widget/badges/gitignore-badge";
 import { RepoImport } from "@/components/widget/controls/repo-import";
 import { FolderOpen, FolderPlus } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { tauriAPI } from "@/ipc/api";
 
 type DirectoryPickerProps = {
@@ -38,12 +38,16 @@ export function DirectoryPicker({
   const configDir = useWidgetStore((state) => state.configDir);
   const { pickDir, prepareNewDir, setDir } = useDarwinConfig();
   const isSetupFlow = flow === "setup";
+  const telemetryOptions = {
+    telemetrySurface: isSetupFlow ? "onboarding" : "settings",
+  } as const;
 
   const [value, setValue] = useState<string>(configDir || "");
   const [setupChoice, setSetupChoice] = useState<SetupChoice>(isSetupFlow ? "new" : "existing");
   const [directoryName, setDirectoryName] = useState<string>(() => getDirectoryName(configDir));
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
   const [showPrivacyNote, setShowPrivacyNote] = useState(false);
+  const suppressNextBlurSubmitRef = useRef(false);
 
   useEffect(() => {
     setShowPrivacyNote(Boolean(configDir && !configDir.endsWith("/.darwin")));
@@ -89,7 +93,7 @@ export function DirectoryPicker({
     if (!normalizedPath) return false;
 
     try {
-      const result = await prepareNewDir(normalizedPath);
+      const result = await prepareNewDir(normalizedPath, telemetryOptions);
       setValue(result.dir);
       setValidationMessage(null);
       onConfigured?.();
@@ -106,7 +110,7 @@ export function DirectoryPicker({
     if (!normalizedPath) return false;
     if (!(await validateDirectoryExists(normalizedPath))) return false;
     try {
-      const result = await setDir(normalizedPath);
+      const result = await setDir(normalizedPath, telemetryOptions);
       setValue(result.dir);
       onConfigured?.();
       return true;
@@ -117,11 +121,20 @@ export function DirectoryPicker({
     }
   };
 
-  const onBlur = () => { submit(); };
+  const onBlur = () => {
+    if (suppressNextBlurSubmitRef.current) {
+      suppressNextBlurSubmitRef.current = false;
+      return;
+    }
+    void submit();
+  };
   const onKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "Enter") return;
     const target = e.currentTarget;
-    if (await submit()) target.blur();
+    if (await submit()) {
+      suppressNextBlurSubmitRef.current = true;
+      target.blur();
+    }
   };
   const onNewKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== "Enter") return;
@@ -130,7 +143,7 @@ export function DirectoryPicker({
   };
 
   const onPickDir = async () => {
-    const result = await pickDir();
+    const result = await pickDir(telemetryOptions);
     if (!result) return;
     setValue(result.dir);
     onConfigured?.();
@@ -229,7 +242,10 @@ export function DirectoryPicker({
         )}
 
         {setupChoice === "import" ? (
-          <RepoImport onImported={() => onConfigured?.()} />
+          <RepoImport
+            onImported={() => onConfigured?.()}
+            telemetrySurface={telemetryOptions.telemetrySurface}
+          />
         ) : setupChoice === "new" ? (
           <div className="space-y-2 rounded-lg border border-border bg-muted/30 p-3">
             <div className="flex items-center gap-2">

--- a/apps/native/src/components/widget/controls/repo-import.tsx
+++ b/apps/native/src/components/widget/controls/repo-import.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
+import type { TelemetrySurface } from "@/hooks/use-darwin-config";
 import { FileArchive, FolderInput, GitBranch } from "lucide-react";
 import { useState } from "react";
 
@@ -12,11 +13,15 @@ type ImportSource = "github" | "zip";
 interface RepoImportProps {
   /** Called once the imported configuration has been selected as the config dir. */
   onImported?: () => void;
+  telemetrySurface?: TelemetrySurface;
 }
 
 const DEFAULT_DIR = ".darwin";
 
-export function RepoImport({ onImported }: RepoImportProps) {
+export function RepoImport({
+  onImported,
+  telemetrySurface = "settings",
+}: RepoImportProps) {
   const { importGithub, importZip, pickZip } = useDarwinConfig();
 
   const [source, setSource] = useState<ImportSource>("github");
@@ -46,7 +51,9 @@ export function RepoImport({ onImported }: RepoImportProps) {
       setError("Enter a GitHub reference like owner/repo");
       return;
     }
-    void runImport(() => importGithub(repoRef.trim(), targetName));
+    void runImport(() =>
+      importGithub(repoRef.trim(), targetName, { telemetrySurface }),
+    );
   };
 
   const onPickZip = async () => {
@@ -60,7 +67,7 @@ export function RepoImport({ onImported }: RepoImportProps) {
       setError("Choose a .zip archive to import");
       return;
     }
-    void runImport(() => importZip(zipPath, targetName));
+    void runImport(() => importZip(zipPath, targetName, { telemetrySurface }));
   };
 
   return (

--- a/apps/native/src/components/widget/settings/settings-dialog.tsx
+++ b/apps/native/src/components/widget/settings/settings-dialog.tsx
@@ -264,7 +264,9 @@ export function SettingsDialog() {
                         host={host}
                         hosts={hosts}
                         productAnalyticsField={productAnalyticsField}
-                        saveHost={saveHost}
+                        saveHost={(value) =>
+                          saveHost(value, { telemetrySurface: "settings" })
+                        }
                         sendDiagnosticsField={sendDiagnosticsField}
                         setSettingsOpen={setSettingsOpen}
                       />

--- a/apps/native/src/components/widget/steps/nix-setup-step.tsx
+++ b/apps/native/src/components/widget/steps/nix-setup-step.tsx
@@ -51,7 +51,7 @@ export function NixSetupStep() {
   // The backend handles running the prefetch directly (no Terminal).
   useEffect(() => {
     if (nixInstalled === true && darwinRebuildAvailable === false && !nixInstalling && !error) {
-      installNix();
+      installNix("automatic");
     }
   }, [nixInstalled, darwinRebuildAvailable, nixInstalling, error, installNix]);
 
@@ -98,7 +98,7 @@ export function NixSetupStep() {
                       ? "nix-darwin needs to be set up. Click below to continue."
                       : "Nix is not installed on this system. Click below to install it using the standard macOS installer."}
                   </p>
-                  <Button onClick={installNix} className="w-full">
+                  <Button onClick={() => installNix("user")} className="w-full">
                     <Download className="mr-2 h-4 w-4" />
                     {nixInstalled ? "Set up nix-darwin" : "Install Nix"}
                   </Button>
@@ -164,7 +164,11 @@ export function NixSetupStep() {
             <div className="space-y-4">
               <p className="text-destructive text-sm">{error}</p>
               <div className="flex gap-2">
-                <Button onClick={installNix} variant="default" className="flex-1">
+                <Button
+                  onClick={() => installNix("user")}
+                  variant="default"
+                  className="flex-1"
+                >
                   Try Again
                 </Button>
                 <Button onClick={checkNix} variant="outline" className="flex-1">

--- a/apps/native/src/components/widget/steps/setup-step.test.tsx
+++ b/apps/native/src/components/widget/steps/setup-step.test.tsx
@@ -53,7 +53,11 @@ describe("<SetupStep>", () => {
     const next = await screen.findByRole("button", { name: "Next" });
     fireEvent.click(next);
 
-    await waitFor(() => expect(mockSaveHost).toHaveBeenCalledWith("mbp"));
+    await waitFor(() =>
+      expect(mockSaveHost).toHaveBeenCalledWith("mbp", {
+        telemetrySurface: "onboarding",
+      }),
+    );
     expect(mockSaveHost).not.toHaveBeenCalledWith("");
   });
 });

--- a/apps/native/src/components/widget/steps/setup-step.tsx
+++ b/apps/native/src/components/widget/steps/setup-step.tsx
@@ -81,9 +81,17 @@ export function SetupStep() {
               </p>
             </>
           ) : (
-            <BootstrapConfig label="2. Configuration" />
+            <BootstrapConfig
+              label="2. Configuration"
+              telemetrySurface="onboarding"
+            />
           )}
-          <Button disabled={!effectiveHost} onClick={() => saveHost(effectiveHost)}>
+          <Button
+            disabled={!effectiveHost}
+            onClick={() =>
+              saveHost(effectiveHost, { telemetrySurface: "onboarding" })
+            }
+          >
             Next
           </Button>
         </div>

--- a/apps/native/src/hooks/use-apply.test.ts
+++ b/apps/native/src/hooks/use-apply.test.ts
@@ -1,0 +1,182 @@
+import type { EvolveState, GitStatus } from "@/ipc/types";
+import type { TelemetryEvent } from "@/lib/telemetry/types";
+import { useWidgetStore } from "@/stores/widget-store";
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useApply } from "./use-apply";
+
+const mocks = vi.hoisted(() => ({
+  captureEvent: vi.fn<(event: TelemetryEvent) => void>(),
+  consoleError: vi.fn<typeof console.error>(),
+  finalizeApply: vi.fn<
+    () => Promise<{ evolveState: EvolveState; gitStatus: GitStatus }>
+  >(),
+  triggerRebuild: vi.fn<
+    (options: {
+      onFailure?: () => Promise<void>;
+      onSuccess?: () => Promise<void>;
+    }) => Promise<void>
+  >(),
+}));
+
+vi.mock("@/lib/telemetry/instance", () => ({
+  getTelemetry: () => ({
+    captureEvent: mocks.captureEvent,
+  }),
+}));
+
+vi.mock("@/hooks/use-rebuild-stream", () => ({
+  useRebuildStream: () => ({
+    triggerRebuild: mocks.triggerRebuild,
+  }),
+}));
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    darwin: {
+      finalizeApply: mocks.finalizeApply,
+    },
+  },
+}));
+
+const gitStatus: GitStatus = {
+  additions: 0,
+  branch: "main",
+  changes: [],
+  cleanHead: true,
+  deletions: 0,
+  diff: "",
+  files: [],
+  headCommitHash: "abc123",
+};
+
+const evolveState: EvolveState = {
+  backupBranch: null,
+  committable: false,
+  currentChangesetId: 1,
+  evolutionId: 1,
+  rollbackBranch: null,
+  rollbackChangesetId: null,
+  rollbackStorePath: null,
+  step: "commit",
+};
+
+describe("useApply telemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(mocks.consoleError);
+    mocks.finalizeApply.mockResolvedValue({ evolveState, gitStatus });
+    mocks.triggerRebuild.mockResolvedValue(undefined);
+    useWidgetStore.getState().setProcessing(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits apply start and completion for the normal rebuild flow", async () => {
+    const { result } = renderHook(() => useApply());
+
+    await result.current.handleApply();
+    const onSuccess = mocks.triggerRebuild.mock.calls[0][0]
+      .onSuccess as () => Promise<void>;
+    await onSuccess();
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "apply_started",
+      props: { source: "changes" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "apply_completed",
+      props: { result: "success", source: "changes" },
+    });
+  });
+
+  it("emits apply failure exactly once when finalizeApply fails after rebuild", async () => {
+    mocks.finalizeApply.mockRejectedValue(new Error("finalize failed"));
+    const { result } = renderHook(() => useApply());
+
+    await result.current.handleApply();
+    const onSuccess = mocks.triggerRebuild.mock.calls[0][0]
+      .onSuccess as () => Promise<void>;
+    await expect(onSuccess()).rejects.toThrow("finalize failed");
+
+    expect(
+      mocks.captureEvent.mock.calls.filter(
+        ([event]) => event.name === "apply_completed",
+      ),
+    ).toEqual([
+      [
+        {
+          name: "apply_completed",
+          props: { result: "failure", source: "changes" },
+        },
+      ],
+    ]);
+  });
+
+  it("emits apply failure when the rebuild stream reports failure", async () => {
+    const { result } = renderHook(() => useApply());
+
+    await result.current.handleApply();
+    const onFailure = mocks.triggerRebuild.mock.calls[0][0]
+      .onFailure as () => Promise<void>;
+    await onFailure();
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "apply_completed",
+      props: { result: "failure", source: "changes" },
+    });
+    expect(mocks.finalizeApply).not.toHaveBeenCalled();
+  });
+
+  it("covers history rebuild and manual confirm apply paths", async () => {
+    const { result } = renderHook(() => useApply());
+
+    await result.current.handleHistoryBuild();
+    const historyOnSuccess = mocks.triggerRebuild.mock.calls[0][0]
+      .onSuccess as () => Promise<void>;
+    await historyOnSuccess();
+    await result.current.handleManualBuildConfirm();
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "apply_started",
+      props: { source: "history" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "apply_completed",
+      props: { result: "success", source: "history" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "apply_started",
+      props: { source: "manual_confirm" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "apply_completed",
+      props: { result: "success", source: "manual_confirm" },
+    });
+  });
+
+  it("propagates history finalize failures after emitting terminal telemetry", async () => {
+    mocks.finalizeApply.mockRejectedValue(new Error("history finalize failed"));
+    const { result } = renderHook(() => useApply());
+
+    await result.current.handleHistoryBuild();
+    const onSuccess = mocks.triggerRebuild.mock.calls[0][0]
+      .onSuccess as () => Promise<void>;
+    await expect(onSuccess()).rejects.toThrow("history finalize failed");
+
+    expect(
+      mocks.captureEvent.mock.calls.filter(
+        ([event]) => event.name === "apply_completed",
+      ),
+    ).toEqual([
+      [
+        {
+          name: "apply_completed",
+          props: { result: "failure", source: "history" },
+        },
+      ],
+    ]);
+  });
+});

--- a/apps/native/src/hooks/use-apply.ts
+++ b/apps/native/src/hooks/use-apply.ts
@@ -2,6 +2,8 @@ import { useWidgetStore } from "@/stores/widget-store";
 import { tauriAPI } from "@/ipc/api";
 import { useRebuildStream } from "@/hooks/use-rebuild-stream";
 import { useViewModel } from "@/stores/view-model";
+import { getTelemetry } from "@/lib/telemetry/instance";
+import type { ApplySource } from "@/lib/telemetry/events";
 import { mirrorEvolveState } from "@/viewmodel/evolve";
 import { mirrorGitState } from "@/viewmodel/git";
 
@@ -13,41 +15,21 @@ import { mirrorGitState } from "@/viewmodel/git";
 export function useApply() {
   const { triggerRebuild } = useRebuildStream();
 
-  const handleApply = async () => {
-    const store = useWidgetStore.getState();
-    store.setProcessing(true, "apply");
-
-    await triggerRebuild({
-      context: "apply",
-      onSuccess: async () => {
-        try {
-          const result = await tauriAPI.darwin.finalizeApply();
-          mirrorGitState(useViewModel.getState().git, false);
-          if (result?.gitStatus) {
-            mirrorGitState(result.gitStatus);
-          }
-          if (result?.evolveState) {
-            mirrorEvolveState(result.evolveState);
-          }
-        } catch (e) {
-          console.error("Failed to finalize apply:", e);
-        }
-      },
+  const captureApplyStarted = (source: ApplySource) => {
+    getTelemetry().captureEvent({
+      name: "apply_started",
+      props: { source },
     });
   };
 
-  const handleHistoryBuild = async () => {
-    const store = useWidgetStore.getState();
-    store.setProcessing(true, "apply");
-    await triggerRebuild({
-      context: "apply",
-      onSuccess: async () => {
-        await tauriAPI.darwin.finalizeApply();
-      },
+  const captureApplyCompleted = (source: ApplySource, ok: boolean) => {
+    getTelemetry().captureEvent({
+      name: "apply_completed",
+      props: { result: ok ? "success" : "failure", source },
     });
   };
 
-  const handleManualBuildConfirm = async () => {
+  const finalizeApply = async (source: ApplySource) => {
     try {
       const result = await tauriAPI.darwin.finalizeApply();
       mirrorGitState(useViewModel.getState().git, false);
@@ -57,6 +39,48 @@ export function useApply() {
       if (result?.evolveState) {
         mirrorEvolveState(result.evolveState);
       }
+      captureApplyCompleted(source, true);
+    } catch (e) {
+      captureApplyCompleted(source, false);
+      throw e;
+    }
+  };
+
+  const handleApply = async () => {
+    const store = useWidgetStore.getState();
+    store.setProcessing(true, "apply");
+    captureApplyStarted("changes");
+
+    await triggerRebuild({
+      context: "apply",
+      onSuccess: async () => {
+        await finalizeApply("changes");
+      },
+      onFailure: async () => {
+        captureApplyCompleted("changes", false);
+      },
+    });
+  };
+
+  const handleHistoryBuild = async () => {
+    const store = useWidgetStore.getState();
+    store.setProcessing(true, "apply");
+    captureApplyStarted("history");
+    await triggerRebuild({
+      context: "apply",
+      onSuccess: async () => {
+        await finalizeApply("history");
+      },
+      onFailure: async () => {
+        captureApplyCompleted("history", false);
+      },
+    });
+  };
+
+  const handleManualBuildConfirm = async () => {
+    captureApplyStarted("manual_confirm");
+    try {
+      await finalizeApply("manual_confirm");
     } catch (e) {
       console.error("Failed to finalize manual build:", e);
     }

--- a/apps/native/src/hooks/use-darwin-config.test.ts
+++ b/apps/native/src/hooks/use-darwin-config.test.ts
@@ -1,0 +1,150 @@
+import type { SetDirResult } from "@/ipc/types";
+import type { TelemetryEvent } from "@/lib/telemetry/types";
+import { useWidgetStore } from "@/stores/widget-store";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDarwinConfig } from "./use-darwin-config";
+
+const mocks = vi.hoisted(() => ({
+  bootstrapDefault: vi.fn<(hostname: string) => Promise<void>>(),
+  captureEvent: vi.fn<(event: TelemetryEvent) => void>(),
+  importGithub: vi.fn<
+    (repoRef: string, dirName?: string) => Promise<SetDirResult>
+  >(),
+  setDir: vi.fn<
+    (
+      dir: string,
+      options?: { telemetrySurface?: "onboarding" | "settings" },
+    ) => Promise<SetDirResult>
+  >(),
+  setHostAttr: vi.fn<(host: string) => Promise<void>>(),
+}));
+
+vi.mock("@/lib/telemetry/instance", () => ({
+  getTelemetry: () => ({
+    captureEvent: mocks.captureEvent,
+  }),
+}));
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    config: {
+      importGithub: mocks.importGithub,
+      setDir: mocks.setDir,
+      setHostAttr: mocks.setHostAttr,
+    },
+    flake: {
+      bootstrapDefault: mocks.bootstrapDefault,
+      listHosts: vi.fn<() => Promise<string[]>>().mockResolvedValue(["mbp"]),
+    },
+  },
+}));
+
+const setDirResult = {
+  dir: "/Users/me/.darwin",
+  evolveState: {
+    backupBranch: null,
+    committable: false,
+    currentChangesetId: null,
+    evolutionId: null,
+    rollbackBranch: null,
+    rollbackChangesetId: null,
+    rollbackStorePath: null,
+    step: "begin",
+  },
+  hosts: ["mbp"],
+} satisfies SetDirResult;
+
+describe("useDarwinConfig telemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.bootstrapDefault.mockResolvedValue(undefined);
+    mocks.importGithub.mockResolvedValue(setDirResult);
+    mocks.setDir.mockResolvedValue(setDirResult);
+    mocks.setHostAttr.mockResolvedValue(undefined);
+
+    const store = useWidgetStore.getState();
+    store.setConfigDir("");
+    store.setHosts([]);
+    store.setHost("");
+    store.setError(null);
+    store.setBootstrapping(false);
+  });
+
+  it("emits safe onboarding events when configuration directory and host setup succeeds", async () => {
+    const { result } = renderHook(() => useDarwinConfig());
+
+    await result.current.setDir("/Users/me/.darwin", {
+      telemetrySurface: "onboarding",
+    });
+    await result.current.saveHost("mbp", { telemetrySurface: "onboarding" });
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "onboarding_step_completed",
+      props: { source: "manual", step: "config_directory" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "onboarding_step_completed",
+      props: { step: "host_configuration" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "onboarding_completed",
+      props: { step: "host_configuration" },
+    });
+  });
+
+  it("does not emit host onboarding completion when saving the host fails", async () => {
+    mocks.setHostAttr.mockRejectedValue(new Error("nope"));
+    const { result } = renderHook(() => useDarwinConfig());
+
+    await result.current.saveHost("mbp");
+
+    expect(mocks.captureEvent).not.toHaveBeenCalledWith({
+      name: "onboarding_completed",
+      props: { step: "host_configuration" },
+    });
+  });
+
+  it("emits source-specific setup completion for imported repositories", async () => {
+    const { result } = renderHook(() => useDarwinConfig());
+
+    await result.current.importGithub("darkmatter/nixmac-config", undefined, {
+      telemetrySurface: "onboarding",
+    });
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "onboarding_step_completed",
+      props: { source: "github_import", step: "config_directory" },
+    });
+  });
+
+  it("does not double-count config-directory completion during onboarding bootstrap", async () => {
+    const { result } = renderHook(() => useDarwinConfig());
+
+    await result.current.setDir("/Users/me/.darwin", {
+      telemetrySurface: "onboarding",
+    });
+    mocks.captureEvent.mockClear();
+
+    await result.current.bootstrap("macbook", {
+      telemetrySurface: "onboarding",
+    });
+
+    expect(mocks.captureEvent).not.toHaveBeenCalledWith({
+      name: "onboarding_step_completed",
+      props: { source: "bootstrap", step: "config_directory" },
+    });
+    expect(mocks.captureEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not emit onboarding completion for Settings-surface changes", async () => {
+    const { result } = renderHook(() => useDarwinConfig());
+
+    await result.current.setDir("/Users/me/.darwin", {
+      telemetrySurface: "settings",
+    });
+    await result.current.saveHost("mbp", { telemetrySurface: "settings" });
+
+    expect(mocks.captureEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/native/src/hooks/use-darwin-config.ts
+++ b/apps/native/src/hooks/use-darwin-config.ts
@@ -1,10 +1,29 @@
 import { useWidgetStore } from "@/stores/widget-store";
 import { tauriAPI } from "@/ipc/api";
 import type { SetDirResult } from "@/ipc/types";
+import { getTelemetry } from "@/lib/telemetry/instance";
+import type { SetupSource } from "@/lib/telemetry/events";
 import { mirrorEvolveState } from "@/viewmodel/evolve";
 import { mirrorGitState } from "@/viewmodel/git";
 
-const applyDirResult = async (result: SetDirResult) => {
+export type TelemetrySurface = "onboarding" | "settings";
+
+type TelemetryOptions = {
+  telemetrySurface?: TelemetrySurface;
+};
+
+const captureConfigDirectoryCompleted = (source: SetupSource) => {
+  getTelemetry().captureEvent({
+    name: "onboarding_step_completed",
+    props: { source, step: "config_directory" },
+  });
+};
+
+const applyDirResult = async (
+  result: SetDirResult,
+  source: SetupSource,
+  options: TelemetryOptions = {},
+) => {
   const store = useWidgetStore.getState();
   store.setConfigDir(result.dir);
   if (result.evolveState) {
@@ -16,54 +35,75 @@ const applyDirResult = async (result: SetDirResult) => {
     } catch {}
     store.setHosts(result.hosts ?? []);
   }
+  if (options.telemetrySurface === "onboarding") {
+    captureConfigDirectoryCompleted(source);
+  }
 };
 
-const setDir = async (dir: string) => {
+const setDir = async (dir: string, options?: TelemetryOptions) => {
   const result = await tauriAPI.config.setDir(dir);
-  await applyDirResult(result);
+  await applyDirResult(result, "manual", options);
   return result;
 };
 
-const prepareNewDir = async (dir: string) => {
+const prepareNewDir = async (dir: string, options?: TelemetryOptions) => {
   const result = await tauriAPI.config.prepareNewDir(dir);
-  await applyDirResult(result);
+  await applyDirResult(result, "manual", options);
   return result;
 };
 
-const pickDir = async () => {
+const pickDir = async (options?: TelemetryOptions) => {
   const result = await tauriAPI.config.pickDir();
   if (!result) return;
-  await applyDirResult(result);
+  await applyDirResult(result, "picker", options);
   return result;
 };
 
-const importGithub = async (repoRef: string, dirName?: string) => {
+const importGithub = async (
+  repoRef: string,
+  dirName?: string,
+  options?: TelemetryOptions,
+) => {
   const result = await tauriAPI.config.importGithub(repoRef, dirName);
-  await applyDirResult(result);
+  await applyDirResult(result, "github_import", options);
   return result;
 };
 
-const importZip = async (zipPath: string, dirName?: string) => {
+const importZip = async (
+  zipPath: string,
+  dirName?: string,
+  options?: TelemetryOptions,
+) => {
   const result = await tauriAPI.config.importZip(zipPath, dirName);
-  await applyDirResult(result);
+  await applyDirResult(result, "zip_import", options);
   return result;
 };
 
 const pickZip = () => tauriAPI.config.pickZip();
 
-const saveHost = async (host: string) => {
+const saveHost = async (host: string, options: TelemetryOptions = {}) => {
   const store = useWidgetStore.getState();
 
   try {
     await tauriAPI.config.setHostAttr(host);
     store.setHost(host);
+    if (options.telemetrySurface === "onboarding") {
+      getTelemetry().captureEvent({
+        name: "onboarding_step_completed",
+        props: { step: "host_configuration" },
+      });
+      getTelemetry().captureEvent({
+        name: "onboarding_completed",
+        props: { step: "host_configuration" },
+      });
+    }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     store.setError(`Failed to save host: ${message}`);
   }
 };
 
-const bootstrap = async (hostname: string) => {
+const bootstrap = async (hostname: string, _options: TelemetryOptions = {}) => {
   const commitExisting = !hostname.trim();
   const store = useWidgetStore.getState();
   store.setError(null);

--- a/apps/native/src/hooks/use-evolve.test.ts
+++ b/apps/native/src/hooks/use-evolve.test.ts
@@ -1,4 +1,5 @@
 import type { EvolveState, EvolutionResult, GitStatus, SemanticChangeMap } from "@/ipc/types";
+import type { TelemetryEvent } from "@/lib/telemetry/types";
 import { useViewModel } from "@/stores/view-model";
 import { useWidgetStore } from "@/stores/widget-store";
 import { mirrorChangeMapState } from "@/viewmodel/change-map";
@@ -8,30 +9,37 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEvolve } from "./use-evolve";
 
 const mocks = vi.hoisted(() => ({
-  evolve: vi.fn(),
-  promptHistoryAdd: vi.fn(),
-  promptHistoryGet: vi.fn(),
-  on: vi.fn(),
+  captureEvent: vi.fn<(event: TelemetryEvent) => void>(),
+  evolve: vi.fn<() => Promise<EvolutionResult>>(),
+  promptHistoryAdd: vi.fn<(prompt: string) => Promise<void>>(),
+  promptHistoryGet: vi.fn<() => Promise<string[]>>(),
+  on: vi.fn<() => Promise<() => void>>(),
 }));
 
 vi.mock("@/ipc/api", () => ({
   tauriAPI: {
     darwin: {
       evolve: mocks.evolve,
-      evolveFromManual: vi.fn(),
-      buildCheck: vi.fn(),
+      evolveFromManual: vi.fn<() => Promise<void>>(),
+      buildCheck: vi.fn<() => Promise<unknown>>(),
     },
     promptHistory: {
       add: mocks.promptHistoryAdd,
       get: mocks.promptHistoryGet,
     },
     summarizedChanges: {
-      findChangeMap: vi.fn(),
+      findChangeMap: vi.fn<() => Promise<void>>(),
     },
   },
   ipcRenderer: {
     on: mocks.on,
   },
+}));
+
+vi.mock("@/lib/telemetry/instance", () => ({
+  getTelemetry: () => ({
+    captureEvent: mocks.captureEvent,
+  }),
 }));
 
 const gitStatus: GitStatus = {
@@ -109,5 +117,13 @@ describe("useEvolve", () => {
 
     expect(useViewModel.getState().changeMap).toBe(existingMap);
     expect(useWidgetStore.getState().conversationalResponse).toBe("No file changes needed.");
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "evolve_started",
+      props: { source: "prompt" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "evolve_completed",
+      props: { outcome: "conversational", step: "evolve" },
+    });
   });
 });

--- a/apps/native/src/hooks/use-evolve.ts
+++ b/apps/native/src/hooks/use-evolve.ts
@@ -72,7 +72,10 @@ const handleEvolve = async () => {
   store.appendLog(`\n> Evolving: "${store.evolvePrompt}"\n`);
 
   // Track evolution start
-  getTelemetry().captureEvent({ name: "evolve_started" });
+  getTelemetry().captureEvent({
+    name: "evolve_started",
+    props: { source: "prompt" },
+  });
   // Set up evolve event listener
   const unlistenEvolve = await ipcRenderer.on<EvolveEvent>(EVOLVE_EVENT_CHANNEL, (event) => {
     if (event.payload) {
@@ -117,7 +120,13 @@ const handleEvolve = async () => {
     // Track successful evolution
     if (result?.evolveState) {
       const step = result.evolveState.step;
-      getTelemetry().captureEvent({ name: "evolve_completed", props: { step } });
+      getTelemetry().captureEvent({
+        name: "evolve_completed",
+        props: {
+          outcome: isConversational ? "conversational" : "changes",
+          step,
+        },
+      });
     }
   } catch (e: unknown) {
     const msg = (e as Error)?.message || String(e);

--- a/apps/native/src/hooks/use-nix-install.test.ts
+++ b/apps/native/src/hooks/use-nix-install.test.ts
@@ -1,0 +1,169 @@
+import { useWidgetStore } from "@/stores/widget-store";
+import type { TelemetryEvent } from "@/lib/telemetry/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useNixInstall } from "./use-nix-install";
+
+const mocks = vi.hoisted(() => ({
+  captureEvent: vi.fn<(event: TelemetryEvent) => void>(),
+  installStart: vi.fn<() => Promise<void>>(),
+  on: vi.fn<
+    (
+      eventName: string,
+      handler: (event: { payload: Record<string, unknown> }) => void,
+    ) => Promise<() => void>
+  >(),
+  prefetchDarwinRebuild: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("@/lib/telemetry/instance", () => ({
+  getTelemetry: () => ({
+    captureEvent: mocks.captureEvent,
+  }),
+}));
+
+vi.mock("@/ipc/api", () => ({
+  ipcRenderer: {
+    on: mocks.on,
+  },
+  tauriAPI: {
+    nix: {
+      check: vi.fn<() => Promise<unknown>>(),
+      installStart: mocks.installStart,
+      prefetchDarwinRebuild: mocks.prefetchDarwinRebuild,
+    },
+  },
+}));
+
+describe("useNixInstall telemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.installStart.mockResolvedValue(undefined);
+    mocks.prefetchDarwinRebuild.mockResolvedValue(undefined);
+    mocks.on.mockResolvedValue(vi.fn());
+
+    const store = useWidgetStore.getState();
+    store.setNixInstalled(false);
+    store.setDarwinRebuildAvailable(null);
+    store.setNixInstalling(false);
+    store.setNixInstallPhase(null);
+    store.setNixDownloadProgress(null);
+    store.setError(null);
+  });
+
+  it("emits nix setup start and completion without error text", async () => {
+    const endHandlers: Array<(event: { payload: { ok: boolean } }) => void> =
+      [];
+    mocks.on.mockImplementation(async (eventName, handler) => {
+      if (eventName === "nix:install:end") {
+        endHandlers.push(handler);
+      }
+      return vi.fn<() => void>();
+    });
+
+    await useNixInstall().installNix();
+    endHandlers[0]?.({ payload: { ok: true } });
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "nix_setup_started",
+      props: { target: "nix", trigger: "user" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "nix_setup_completed",
+      props: { target: "nix" },
+    });
+  });
+
+  it("emits nix setup failure as an enum event only", async () => {
+    const endHandlers: Array<
+      (event: { payload: { error: string; ok: boolean } }) => void
+    > = [];
+    mocks.on.mockImplementation(async (eventName, handler) => {
+      if (eventName === "nix:install:end") {
+        endHandlers.push(handler);
+      }
+      return vi.fn<() => void>();
+    });
+
+    await useNixInstall().installNix();
+    endHandlers[0]?.({
+      payload: { error: "token sk-test /Users/me/.darwin", ok: false },
+    });
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "nix_setup_failed",
+      props: { target: "nix" },
+    });
+    expect(mocks.captureEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({ error: expect.any(String) }),
+      }),
+    );
+  });
+
+  it("attributes darwin-rebuild phase failures to nix-darwin setup", async () => {
+    const progressHandlers: Array<
+      (event: { payload: { phase: "prefetching" } }) => void
+    > = [];
+    const endHandlers: Array<
+      (event: {
+        payload: { error_type: "darwin_rebuild"; ok: boolean };
+      }) => void
+    > = [];
+    mocks.on.mockImplementation(async (eventName, handler) => {
+      if (eventName === "nix:install:progress") {
+        progressHandlers.push(handler);
+      }
+      if (eventName === "nix:install:end") {
+        endHandlers.push(handler);
+      }
+      return vi.fn<() => void>();
+    });
+
+    await useNixInstall().installNix();
+    progressHandlers[0]?.({ payload: { phase: "prefetching" } });
+    endHandlers[0]?.({
+      payload: { error_type: "darwin_rebuild", ok: false },
+    });
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "nix_setup_failed",
+      props: { target: "nix_darwin" },
+    });
+  });
+
+  it("tracks automatic nix-darwin setup separately from Nix installation", async () => {
+    const endHandlers: Array<(event: { payload: { ok: boolean } }) => void> =
+      [];
+    mocks.on.mockImplementation(async (eventName, handler) => {
+      if (eventName === "nix:darwin-rebuild:end") {
+        endHandlers.push(handler);
+      }
+      return vi.fn<() => void>();
+    });
+
+    await useNixInstall().prefetchDarwinRebuild();
+    endHandlers[0]?.({ payload: { ok: true } });
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "nix_setup_started",
+      props: { target: "nix_darwin", trigger: "automatic" },
+    });
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "nix_setup_completed",
+      props: { target: "nix_darwin" },
+    });
+  });
+
+  it("labels auto-triggered nix-darwin installStart flows as automatic", async () => {
+    const store = useWidgetStore.getState();
+    store.setNixInstalled(true);
+    store.setDarwinRebuildAvailable(false);
+
+    await useNixInstall().installNix("automatic");
+
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "nix_setup_started",
+      props: { target: "nix_darwin", trigger: "automatic" },
+    });
+  });
+});

--- a/apps/native/src/hooks/use-nix-install.ts
+++ b/apps/native/src/hooks/use-nix-install.ts
@@ -1,10 +1,46 @@
 import { useWidgetStore } from "@/stores/widget-store";
 import { tauriAPI, ipcRenderer } from "@/ipc/api";
+import { getTelemetry } from "@/lib/telemetry/instance";
+import type {
+  NixSetupTarget,
+  NixSetupTrigger,
+} from "@/lib/telemetry/events";
 import type {
   NixDarwinRebuildEndEvent,
   NixInstallEndEvent,
   NixInstallProgressEvent,
 } from "@/ipc/types";
+
+const captureNixSetupStarted = (
+  target: NixSetupTarget,
+  trigger: NixSetupTrigger,
+) => {
+  getTelemetry().captureEvent({
+    name: "nix_setup_started",
+    props: { target, trigger },
+  });
+};
+
+const captureNixSetupFinished = (target: NixSetupTarget, ok: boolean) => {
+  getTelemetry().captureEvent({
+    name: ok ? "nix_setup_completed" : "nix_setup_failed",
+    props: { target },
+  });
+};
+
+const resolveInstallEndTarget = (
+  startedTarget: NixSetupTarget,
+  payload: NixInstallEndEvent,
+  phase: NixInstallProgressEvent["phase"] | null,
+): NixSetupTarget => {
+  if (
+    !payload.ok &&
+    (payload.error_type === "darwin_rebuild" || phase === "prefetching")
+  ) {
+    return "nix_darwin";
+  }
+  return startedTarget;
+};
 
 const checkNix = async () => {
     try {
@@ -17,8 +53,10 @@ const checkNix = async () => {
     }
 };
 
-const installNix = async () => {
+const installNix = async (trigger: NixSetupTrigger = "user") => {
     const store = useWidgetStore.getState();
+    const target: NixSetupTarget = store.nixInstalled ? "nix_darwin" : "nix";
+    captureNixSetupStarted(target, trigger);
     store.setNixInstalling(true);
     store.setNixInstallPhase(null);
     store.setNixDownloadProgress(null);
@@ -37,11 +75,17 @@ const installNix = async () => {
 
     const unlistenEnd = await ipcRenderer.on<NixInstallEndEvent>("nix:install:end", (event) => {
       const current = useWidgetStore.getState();
+      const terminalTarget = resolveInstallEndTarget(
+        target,
+        event.payload,
+        current.nixInstallPhase,
+      );
       current.setNixInstalling(false);
       current.setNixInstallPhase(null);
       current.setNixDownloadProgress(null);
       current.setNixInstalled(event.payload.ok);
       current.setDarwinRebuildAvailable(event.payload.darwin_rebuild_available ?? false);
+      captureNixSetupFinished(terminalTarget, event.payload.ok);
 
       if (!event.payload.ok) {
         current.setError(
@@ -61,6 +105,7 @@ const installNix = async () => {
       store.setNixInstallPhase(null);
       store.setNixDownloadProgress(null);
       store.setError(msg);
+      captureNixSetupFinished(target, false);
       unlistenProgress();
       unlistenEnd();
     }
@@ -68,6 +113,7 @@ const installNix = async () => {
 
 const prefetchDarwinRebuild = async () => {
     const store = useWidgetStore.getState();
+    captureNixSetupStarted("nix_darwin", "automatic");
     store.setDarwinRebuildPrefetching(true);
     store.setError(null);
 
@@ -75,6 +121,7 @@ const prefetchDarwinRebuild = async () => {
       const current = useWidgetStore.getState();
       current.setDarwinRebuildPrefetching(false);
       current.setDarwinRebuildAvailable(event.payload.ok);
+      captureNixSetupFinished("nix_darwin", event.payload.ok);
 
       if (!event.payload.ok) {
         current.setError(event.payload.error ?? "Failed to set up nix-darwin.");
@@ -89,6 +136,7 @@ const prefetchDarwinRebuild = async () => {
       const msg = (e as Error)?.message || String(e);
       store.setDarwinRebuildPrefetching(false);
       store.setError(msg);
+      captureNixSetupFinished("nix_darwin", false);
       unlistenEnd();
     }
 };

--- a/apps/native/src/hooks/use-rebuild-stream.ts
+++ b/apps/native/src/hooks/use-rebuild-stream.ts
@@ -102,6 +102,9 @@ export function useRebuildStream() {
           } catch (e) {
             console.error("Failed to check permissions:", e);
           }
+          if (options?.onFailure) {
+            await options.onFailure();
+          }
           await refreshGitStatus({ cache: true });
           currentStore.setProcessing(false);
           return;
@@ -140,6 +143,9 @@ export function useRebuildStream() {
         useWidgetStore.getState().setRebuildError("generic_error", msg);
         useWidgetStore.getState().setRebuildComplete(false);
         useWidgetStore.getState().setProcessing(false);
+        if (options?.onFailure) {
+          await options.onFailure();
+        }
         unlistenData();
         unlistenSummary();
         unlistenEnd();

--- a/apps/native/src/hooks/use-rollback.test.ts
+++ b/apps/native/src/hooks/use-rollback.test.ts
@@ -1,4 +1,5 @@
 import type { EvolveState, GitStatus } from "@/ipc/types";
+import type { TelemetryEvent } from "@/lib/telemetry/types";
 import { useWidgetStore } from "@/stores/widget-store";
 import { mirrorEvolveState } from "@/viewmodel/evolve";
 import { mirrorGitState } from "@/viewmodel/git";
@@ -7,10 +8,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRollback } from "./use-rollback";
 
 const mocks = vi.hoisted(() => ({
-  finalizeRollback: vi.fn(),
-  findChangeMap: vi.fn(),
-  rollbackErase: vi.fn(),
-  triggerRebuild: vi.fn(),
+  captureEvent: vi.fn<(event: TelemetryEvent) => void>(),
+  finalizeRollback: vi.fn<
+    (
+      storePath: string,
+      changesetId: number | null,
+    ) => Promise<{ evolveState: EvolveState; gitStatus: GitStatus }>
+  >(),
+  findChangeMap: vi.fn<() => Promise<void>>(),
+  rollbackErase: vi.fn<
+    () => Promise<{
+      evolveState: EvolveState;
+      gitStatus: GitStatus;
+      rollbackChangesetId: number;
+      rollbackStorePath: string;
+    }>
+  >(),
+  triggerRebuild: vi.fn<
+    (options: { onSuccess?: () => Promise<void> }) => Promise<void>
+  >(),
 }));
 
 vi.mock("@/ipc/api", () => ({
@@ -31,6 +47,12 @@ vi.mock("@/hooks/use-rebuild-stream", () => ({
 vi.mock("@/hooks/use-summary", () => ({
   useSummary: () => ({
     findChangeMap: mocks.findChangeMap,
+  }),
+}));
+
+vi.mock("@/lib/telemetry/instance", () => ({
+  getTelemetry: () => ({
+    captureEvent: mocks.captureEvent,
   }),
 }));
 
@@ -106,6 +128,10 @@ describe("useRollback", () => {
     expect(mocks.triggerRebuild).toHaveBeenCalledTimes(1);
     expect(useWidgetStore.getState().isProcessing).toBe(true);
     expect(mocks.findChangeMap).not.toHaveBeenCalled();
+    expect(mocks.captureEvent).toHaveBeenCalledWith({
+      name: "rollback_performed",
+      props: { source: "changes" },
+    });
   });
 
   it("refreshes the change map after rollback rebuild finalization succeeds", async () => {

--- a/apps/native/src/hooks/use-rollback.ts
+++ b/apps/native/src/hooks/use-rollback.ts
@@ -28,7 +28,10 @@ export function useRollback() {
       store.appendLog("✓ Changes discarded\n");
 
       // Track rollback
-      getTelemetry().captureEvent({ name: "rollback_performed" });
+      getTelemetry().captureEvent({
+        name: "rollback_performed",
+        props: { source: "changes" },
+      });
 
       if (result.rollbackStorePath && wasCommittable) {
         await triggerRebuild({

--- a/apps/native/src/lib/telemetry/events.ts
+++ b/apps/native/src/lib/telemetry/events.ts
@@ -1,0 +1,83 @@
+export type OnboardingStep =
+  | "config_directory"
+  | "host_configuration";
+
+export type SetupSource =
+  | "github_import"
+  | "manual"
+  | "picker"
+  | "zip_import";
+
+export type NixSetupTarget = "nix" | "nix_darwin";
+export type NixSetupTrigger = "automatic" | "user";
+export type EvolveSource = "prompt";
+export type EvolveOutcome = "changes" | "conversational";
+export type EvolveStage = "agent" | "apply" | "build";
+export type ApplySource = "changes" | "history" | "manual_confirm";
+export type ApplyResult = "failure" | "success";
+export type RollbackSource = "changes";
+
+export type TelemetryEventProps = {
+  app_launched: { environment?: string };
+  app_ready: { boot_ms?: number };
+  apply_completed: { result: ApplyResult; source: ApplySource };
+  apply_started: { source: ApplySource };
+  diagnostics_opt_in: Record<string, never>;
+  diagnostics_opt_out: Record<string, never>;
+  evolve_completed: { outcome?: EvolveOutcome; step?: string };
+  evolve_failed: { stage?: EvolveStage };
+  evolve_started: {
+    has_custom_model?: boolean;
+    provider?: string;
+    source?: EvolveSource;
+  };
+  nix_setup_completed: { target: NixSetupTarget };
+  nix_setup_failed: { target: NixSetupTarget };
+  nix_setup_started: { target: NixSetupTarget; trigger: NixSetupTrigger };
+  onboarding_completed: { step: OnboardingStep };
+  onboarding_step_completed: { source?: SetupSource; step: OnboardingStep };
+  product_analytics_opt_in: Record<string, never>;
+  product_analytics_opt_out: Record<string, never>;
+  rollback_performed: { source?: RollbackSource };
+  settings_changed: { setting: string };
+};
+
+export type TelemetryEventName = keyof TelemetryEventProps;
+
+type RequiredKeys<T> = {
+  [Key in keyof T]-?: Record<never, never> extends Pick<T, Key> ? never : Key;
+}[keyof T];
+
+type EventForName<Name extends TelemetryEventName> =
+  keyof TelemetryEventProps[Name] extends never
+    ? { name: Name; props?: never }
+    : RequiredKeys<TelemetryEventProps[Name]> extends never
+      ? { name: Name; props?: TelemetryEventProps[Name] }
+      : { name: Name; props: TelemetryEventProps[Name] };
+
+export type TelemetryEvent = {
+  [Name in TelemetryEventName]: EventForName<Name>;
+}[TelemetryEventName];
+
+export const TELEMETRY_EVENT_PROPERTY_KEYS = {
+  app_launched: ["environment"],
+  app_ready: ["boot_ms"],
+  apply_completed: ["result", "source"],
+  apply_started: ["source"],
+  diagnostics_opt_in: [],
+  diagnostics_opt_out: [],
+  evolve_completed: ["outcome", "step"],
+  evolve_failed: ["stage"],
+  evolve_started: ["provider", "has_custom_model", "source"],
+  nix_setup_completed: ["target"],
+  nix_setup_failed: ["target"],
+  nix_setup_started: ["target", "trigger"],
+  onboarding_completed: ["step"],
+  onboarding_step_completed: ["step", "source"],
+  product_analytics_opt_in: [],
+  product_analytics_opt_out: [],
+  rollback_performed: ["source"],
+  settings_changed: ["setting"],
+} satisfies {
+  [Name in TelemetryEventName]: readonly (keyof TelemetryEventProps[Name])[];
+};

--- a/apps/native/src/lib/telemetry/provider.test.ts
+++ b/apps/native/src/lib/telemetry/provider.test.ts
@@ -99,7 +99,7 @@ describe("createTelemetryProvider", () => {
         $geoip_disable: true,
         $ip: null,
         $process_person_profile: false,
-        distinct_id: expect.stringMatching(/^nixmac-product-analytics-event-/),
+        distinct_id: expect.stringMatching(/^nixmac-product-analytics-session-/),
         environment: "test",
         release: "0.0.0-test",
         stage: "build",
@@ -175,7 +175,7 @@ describe("createTelemetryProvider", () => {
         $geoip_disable: true,
         $ip: null,
         $process_person_profile: false,
-        distinct_id: expect.stringMatching(/^nixmac-product-analytics-event-/),
+        distinct_id: expect.stringMatching(/^nixmac-product-analytics-session-/),
         environment: "production",
         release: "0.0.0-test",
         token: "phc_test",
@@ -184,28 +184,33 @@ describe("createTelemetryProvider", () => {
     expect(telemetry.diagnosticsEnabled).toBe(true);
   });
 
-  it("uses per-event anonymous PostHog IDs instead of collapsing clients into one actor", () => {
+  it("uses a per-launch anonymous PostHog session ID so funnels connect within the session", () => {
     const telemetry = createTelemetryProvider(config, {
       diagnosticsEnabled: false,
       productAnalyticsEnabled: true,
     });
 
     telemetry.captureEvent({ name: "app_launched" });
-    telemetry.captureEvent({ name: "rollback_performed" });
+    telemetry.captureEvent({
+      name: "apply_completed",
+      props: { result: "success", source: "changes" },
+    });
 
     const payloads = mocks.fetch.mock.calls.map(([, init]) =>
       JSON.parse((init as RequestInit).body as string),
     ) as Array<{ properties: Record<string, unknown> }>;
 
     expect(payloads[0]?.properties.distinct_id).toEqual(
-      expect.stringMatching(/^nixmac-product-analytics-event-/),
+      expect.stringMatching(/^nixmac-product-analytics-session-/),
     );
     expect(payloads[1]?.properties.distinct_id).toEqual(
-      expect.stringMatching(/^nixmac-product-analytics-event-/),
+      expect.stringMatching(/^nixmac-product-analytics-session-/),
     );
-    expect(payloads[0]?.properties.distinct_id).not.toBe(
+    expect(payloads[0]?.properties.distinct_id).toBe(
       payloads[1]?.properties.distinct_id,
     );
+    expect(payloads[0]?.properties).not.toHaveProperty("$session_id");
+    expect(payloads[1]?.properties).not.toHaveProperty("$session_id");
   });
 
   it("initializes PostHog with passive capture features disabled", () => {

--- a/apps/native/src/lib/telemetry/provider.ts
+++ b/apps/native/src/lib/telemetry/provider.ts
@@ -32,7 +32,7 @@ const PRIVACY_SUPER_PROPERTIES = {
   $ip: null,
   $process_person_profile: false,
 } as const;
-const PRODUCT_ANALYTICS_EVENT_ID_PREFIX = "nixmac-product-analytics-event";
+const PRODUCT_ANALYTICS_SESSION_ID_PREFIX = "nixmac-product-analytics-session";
 
 const registerPostHogSuperProperties = (config: TelemetryConfig) => {
   posthog.register({
@@ -50,17 +50,18 @@ const optInPostHogCapturing = (
 
 const postHogCaptureUrl = (host: string) => `${host.replace(/\/$/, "")}/capture/`;
 
-const createProductAnalyticsEventId = () => {
+const createProductAnalyticsSessionId = () => {
   if (globalThis.crypto?.randomUUID) {
-    return `${PRODUCT_ANALYTICS_EVENT_ID_PREFIX}-${globalThis.crypto.randomUUID()}`;
+    return `${PRODUCT_ANALYTICS_SESSION_ID_PREFIX}-${globalThis.crypto.randomUUID()}`;
   }
-  return `${PRODUCT_ANALYTICS_EVENT_ID_PREFIX}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `${PRODUCT_ANALYTICS_SESSION_ID_PREFIX}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 };
 
 const sendPostHogProductEvent = (
   config: TelemetryConfig,
   name: string,
   props: Record<string, unknown>,
+  sessionId: string,
   fetchImpl: typeof fetch = fetch,
 ) =>
   fetchImpl(postHogCaptureUrl(config.host), {
@@ -69,10 +70,10 @@ const sendPostHogProductEvent = (
       event: name,
       properties: {
         ...PRIVACY_SUPER_PROPERTIES,
-        // PostHog requires a distinct_id. Use a per-event anonymous ID so
-        // events are not linked to a persisted machine/user identity and are
-        // not collapsed into one shared actor.
-        distinct_id: createProductAnalyticsEventId(),
+        // PostHog requires a distinct_id for funnels. Use a per-launch
+        // anonymous ID held only in memory, so same-session events connect
+        // without creating a persisted machine/user identifier.
+        distinct_id: sessionId,
         environment: config.environment,
         release: config.release,
         token: config.key,
@@ -136,6 +137,7 @@ export function createTelemetryProvider(
   let diagnosticsEnabled = initialState.diagnosticsEnabled;
   let productAnalyticsEnabled = initialState.productAnalyticsEnabled;
   let posthogStarted = false;
+  const productAnalyticsSessionId = createProductAnalyticsSessionId();
 
   const tracerProvider = new WebTracerProvider({
     resource: resourceFromAttributes({
@@ -182,7 +184,12 @@ export function createTelemetryProvider(
     captureEvent(event: TelemetryEvent) {
       if (!productAnalyticsEnabled) return;
       const prepared = preparePostHogEvent(event);
-      void sendPostHogProductEvent(config, prepared.name, prepared.props);
+      void sendPostHogProductEvent(
+        config,
+        prepared.name,
+        prepared.props,
+        productAnalyticsSessionId,
+      );
     },
 
     captureError(error: Error, context?: Record<string, unknown>) {

--- a/apps/native/src/lib/telemetry/sanitize.test.ts
+++ b/apps/native/src/lib/telemetry/sanitize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { preparePostHogEvent, sanitizeDiagnosticText } from "./sanitize";
+import { TELEMETRY_EVENT_PROPERTY_KEYS } from "./events";
 import type { TelemetryEvent } from "./types";
 
 describe("telemetry product event sanitization", () => {
@@ -64,6 +65,43 @@ describe("telemetry product event sanitization", () => {
     ).toEqual({
       name: "app_ready",
       props: { boot_ms: 1234 },
+    });
+  });
+
+  it("keeps every registered product event behind explicit property allowlists", () => {
+    expect(Object.keys(TELEMETRY_EVENT_PROPERTY_KEYS).sort()).toEqual([
+      "app_launched",
+      "app_ready",
+      "apply_completed",
+      "apply_started",
+      "diagnostics_opt_in",
+      "diagnostics_opt_out",
+      "evolve_completed",
+      "evolve_failed",
+      "evolve_started",
+      "nix_setup_completed",
+      "nix_setup_failed",
+      "nix_setup_started",
+      "onboarding_completed",
+      "onboarding_step_completed",
+      "product_analytics_opt_in",
+      "product_analytics_opt_out",
+      "rollback_performed",
+      "settings_changed",
+    ]);
+
+    const prepared = preparePostHogEvent({
+      name: "apply_completed",
+      props: {
+        error: "raw failure token sk-test",
+        result: "success",
+        source: "changes",
+      },
+    } as unknown as TelemetryEvent);
+
+    expect(prepared).toEqual({
+      name: "apply_completed",
+      props: { result: "success", source: "changes" },
     });
   });
 

--- a/apps/native/src/lib/telemetry/sanitize.ts
+++ b/apps/native/src/lib/telemetry/sanitize.ts
@@ -13,6 +13,7 @@
  */
 
 import type { TelemetryEvent } from "./types";
+import { TELEMETRY_EVENT_PROPERTY_KEYS } from "./events";
 
 const REDACTED = "[REDACTED]";
 const REDACTED_APP_CONTENT = "[REDACTED_APP_CONTENT]";
@@ -141,19 +142,10 @@ export interface PreparedPostHogEvent {
   props: Record<string, boolean | number | string>;
 }
 
-const POSTHOG_ALLOWED_PROPERTIES = {
-  app_launched: ["environment"],
-  app_ready: ["boot_ms"],
-  evolve_started: ["provider", "has_custom_model"],
-  evolve_completed: ["step"],
-  evolve_failed: ["stage"],
-  rollback_performed: [],
-  settings_changed: ["setting"],
-  diagnostics_opt_in: [],
-  diagnostics_opt_out: [],
-  product_analytics_opt_in: [],
-  product_analytics_opt_out: [],
-} satisfies Record<ProductEventName, readonly string[]>;
+const POSTHOG_ALLOWED_PROPERTIES = TELEMETRY_EVENT_PROPERTY_KEYS satisfies Record<
+  ProductEventName,
+  readonly string[]
+>;
 
 const isPrimitiveProductValue = (
   value: unknown,

--- a/apps/native/src/lib/telemetry/types.ts
+++ b/apps/native/src/lib/telemetry/types.ts
@@ -5,27 +5,9 @@
  * pipeline: OTEL spans for diagnostics, PostHog for product analytics.
  */
 
-export type TelemetryEvent =
-  | { name: "app_launched"; props?: { environment: string } }
-  | { name: "app_ready"; props?: { boot_ms?: number } }
-  | {
-    name: "evolve_started";
-    props?: { provider: string; has_custom_model: boolean };
-  }
-  | {
-    name: "evolve_completed";
-    props: { step: string };
-  }
-  | {
-    name: "evolve_failed";
-    props?: { stage: "build" | "agent" | "apply" };
-  }
-  | { name: "rollback_performed" }
-  | { name: "settings_changed"; props: { setting: string } }
-  | { name: "diagnostics_opt_in" }
-  | { name: "diagnostics_opt_out" }
-  | { name: "product_analytics_opt_in" }
-  | { name: "product_analytics_opt_out" };
+import type { TelemetryEvent } from "./events";
+
+export type { TelemetryEvent } from "./events";
 
 export interface TelemetryProvider {
   /** Record a product event. Goes only to PostHog and is product-consent gated. */

--- a/docs/product-telemetry-event-contract.md
+++ b/docs/product-telemetry-event-contract.md
@@ -39,6 +39,14 @@ The provider must register these privacy super-properties for every event:
 - `$geoip_disable: true`
 - `$ip: null`
 
+PostHog requires an actor key to calculate funnels. nixmac uses an anonymous
+per-launch session ID as `distinct_id`. The value is generated in memory, is
+never persisted, and is not derived from the machine, user, config path, host
+name, account, or API credentials. This enables within-session funnels while
+preserving the no persistent user/machine identity privacy boundary. Funnels
+that span app restarts should be treated as lower bound measurements unless a
+future privacy decision explicitly introduces a persisted anonymous install ID.
+
 The provider must also register these non-user super-properties for dashboard
 filtering:
 
@@ -71,13 +79,42 @@ Initial ENG-230 product events:
 - `app_ready`
   - allowed properties: `boot_ms`
 - `evolve_started`
-  - allowed properties: `provider`, `has_custom_model`
+  - allowed properties: `provider`, `has_custom_model`, `source`
+  - allowed values: `source = prompt`
 - `evolve_completed`
-  - allowed properties: `step`
+  - allowed properties: `step`, `outcome`
+  - allowed values: `outcome = changes | conversational`
 - `evolve_failed`
   - allowed properties: `stage`
+  - allowed values: `stage = agent | apply | build`
 - `rollback_performed`
-  - allowed properties: none
+  - allowed properties: `source`
+  - allowed values: `source = changes`
+- `apply_started`
+  - allowed properties: `source`
+  - allowed values: `source = changes | history | manual_confirm`
+- `apply_completed`
+  - allowed properties: `source`, `result`
+  - allowed values: `source = changes | history | manual_confirm`,
+    `result = success | failure`
+- `onboarding_step_completed`
+  - allowed properties: `step`, `source`
+  - allowed values:
+    - `step = config_directory | host_configuration`
+    - `source = github_import | manual | picker | zip_import`
+- `onboarding_completed`
+  - allowed properties: `step`
+  - allowed values: `step = host_configuration`
+- `nix_setup_started`
+  - allowed properties: `target`, `trigger`
+  - allowed values: `target = nix | nix_darwin`,
+    `trigger = automatic | user`
+- `nix_setup_completed`
+  - allowed properties: `target`
+  - allowed values: `target = nix | nix_darwin`
+- `nix_setup_failed`
+  - allowed properties: `target`
+  - allowed values: `target = nix | nix_darwin`
 - `settings_changed`
   - allowed properties: `setting`
 - `diagnostics_opt_in`
@@ -89,8 +126,45 @@ Initial ENG-230 product events:
 - `product_analytics_opt_out`
   - allowed properties: none
 
-Richer onboarding, review/apply, and session-duration events should be added in
-follow-up work only after they have explicit allowlisted property contracts.
+Website acquisition events and starter-access events are not native app events
+yet. Track them under ENG-534/ENG-544 once those surfaces have concrete event
+boundaries and the same explicit property contracts.
+
+## Canonical PostHog Funnels
+
+Build dashboards from these event sequences. Filter all insights by
+`environment` and `release`.
+
+- Native activation:
+  `app_launched` -> `app_ready` -> `onboarding_step_completed`
+  where `step = config_directory` -> `onboarding_step_completed`
+  where `step = host_configuration` -> `onboarding_completed` ->
+  `evolve_started` -> `apply_completed` where `result = success`.
+- AI value loop:
+  `evolve_started` -> `evolve_completed` where `outcome = changes` ->
+  `apply_started` -> `apply_completed` where `result = success`.
+- Conversational follow-up loop:
+  `evolve_started` -> `evolve_completed` where `outcome = conversational`.
+- Nix setup:
+  `nix_setup_started` -> `nix_setup_completed`, with a sibling trend for
+  `nix_setup_failed` by `target`.
+- Recovery health:
+  `apply_completed` where `result = success` -> `rollback_performed`.
+- Consent health:
+  trend `product_analytics_opt_out` divided by `app_launched` for the same
+  time window. Do not model opt-out users as a segment after opt-out; once
+  product analytics is disabled, future events intentionally stop.
+
+Expected launch dashboard cards:
+
+- app launches by release/environment;
+- activation completion rate;
+- first evolve-to-successful-apply conversion;
+- evolve failure rate by stage;
+- apply success rate by source;
+- rollback rate after successful apply;
+- Nix setup completion/failure by target;
+- product analytics opt-out rate.
 
 ## Real-Send Smoke Test
 


### PR DESCRIPTION
## Summary

Stacked on #348. Adds the native product analytics funnel layer on top of the consent/privacy/allowlist work:

- Adds a typed telemetry event registry and derives `TelemetryEvent` from it.
- Uses a per-launch in-memory anonymous PostHog `distinct_id` so within-session funnels work without a persisted user or machine ID.
- Instruments durable native flow boundaries: config setup, host setup, Nix/nix-darwin setup, evolve outcomes, apply start/completion, rebuild failure terminals, and rollback.
- Keeps Settings reconfiguration out of onboarding conversion events.
- Updates the telemetry contract with canonical PostHog funnel specs and the session-identity privacy boundary.

Live PostHog dashboard creation is not claimed here: the PostHog MCP schema read currently fails with `authentication_failed: Invalid access token`, so the doc defines the dashboards/funnels but does not pretend they were created.

## Test Plan

- [x] `bun run test:unit -- src/lib/telemetry/sanitize.test.ts src/lib/telemetry/provider.test.ts src/hooks/use-darwin-config.test.ts src/hooks/use-apply.test.ts src/hooks/use-nix-install.test.ts src/hooks/use-evolve.test.ts src/hooks/use-rollback.test.ts src/components/widget/steps/setup-step.test.tsx src/components/widget/controls/directory-picker.test.tsx src/components/widget/controls/repo-import.test.tsx src/components/widget/settings/general-tab.test.tsx`
- [x] `bun run build`
- [x] `cargo check --manifest-path apps/native/src-tauri/Cargo.toml`
- [x] `bunx oxlint <touched telemetry/hook/component files>`
- [x] `claude-review` proposal pass, then implementation pass; required findings addressed.

## Docs

- [x] Docs updated
- [ ] No docs update needed
