### PR TITLE
ci: verify cachix push before caching devenv profile pointer

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -44,8 +44,13 @@ runs:
       with:
         extra-conf: ${{ inputs.extra-nix-conf }}
 
+    # continue-on-error on the cachix steps: some persistent self-hosted
+    # runners have a Nix install whose runner user is not in trusted-users,
+    # so `cachix use` cannot add substituters and exits 1. Degrading to
+    # "build without binary caches" beats failing the whole job there.
     - name: Configure darkmatter Cachix cache
       if: ${{ inputs.darkmatter-cachix-auth-token != '' }}
+      continue-on-error: true
       uses: cachix/cachix-action@v17
       with:
         name: darkmatter
@@ -55,6 +60,7 @@ runs:
     # This avoids building devenv and its deps from source.
     - name: Configure devenv Cachix cache
       if: ${{ inputs.install-devenv == 'true' }}
+      continue-on-error: true
       uses: cachix/cachix-action@v17
       with:
         name: devenv
@@ -65,6 +71,7 @@ runs:
     # (~10 minutes of gcc on GitHub-hosted runners).
     - name: Configure nixpkgs-python Cachix cache
       if: ${{ inputs.install-devenv == 'true' }}
+      continue-on-error: true
       uses: cachix/cachix-action@v17
       with:
         name: nixpkgs-python
@@ -73,16 +80,19 @@ runs:
     # The devenv profile is a plain store path. Caching that path (plus the
     # env vars devenv exports) lets warm runs skip installing the devenv CLI
     # and evaluating devenv entirely — `nix build <path>` just substitutes the
-    # closure from the configured binary caches. The closure reaches the
-    # darkmatter cache via cachix-action's post-job push from the run that
-    # built it.
+    # closure from the configured binary caches. The pointer is only saved
+    # after the closure has verifiably been pushed to the darkmatter cache
+    # (see "Push devenv profile" below), so a cache hit implies the profile
+    # is downloadable.
+    # Key namespace v2: v1 pointers were saved while cachix pushes were
+    # silently failing (403), so they reference paths no cache can serve.
     - name: Restore devenv profile pointer
       if: ${{ inputs.install-devenv == 'true' }}
       id: devenv-cache
       uses: actions/cache/restore@v4
       with:
         path: .devenv-ci
-        key: devenv-profile-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('devenv.nix', 'devenv.yaml', 'devenv.lock', 'flake.nix', 'flake.lock', 'treefmt.nix', 'nix/**') }}
+        key: devenv-profile-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('devenv.nix', 'devenv.yaml', 'devenv.lock', 'flake.nix', 'flake.lock', 'treefmt.nix', 'nix/**') }}
 
     - name: Substitute cached devenv profile
       if: ${{ inputs.install-devenv == 'true' && steps.devenv-cache.outputs.cache-hit == 'true' }}
@@ -165,8 +175,45 @@ runs:
         # store path — nix-store --realise only accepts store path roots.
         grep -oE '/nix/store/[a-z0-9]{32}-[^:/" ]+' .devenv-ci/env | sort -u > .devenv-ci/extra-paths || true
 
+    # Push the profile closure synchronously and verify it is actually
+    # downloadable before trusting it. cachix-action's post-job push is not
+    # enough: it swallows per-path API errors (e.g. 403 from a token without
+    # write permission) and reports success, which would poison the pointer
+    # cache with paths nothing can serve.
+    - name: Push devenv profile to darkmatter Cachix
+      if: ${{ inputs.install-devenv == 'true' && steps.devenv-realise.outputs.ok != 'true' }}
+      id: devenv-push
+      shell: bash
+      env:
+        CACHIX_AUTH_TOKEN: ${{ inputs.darkmatter-cachix-auth-token }}
+      run: |
+        set -euo pipefail
+
+        ok=false
+        profile_path="$(cat .devenv-ci/profile-path)"
+
+        if [ -z "${CACHIX_AUTH_TOKEN:-}" ]; then
+          echo "::warning::No darkmatter Cachix auth token; skipping devenv profile push, the profile pointer will not be cached."
+        elif ! command -v cachix > /dev/null; then
+          echo "::warning::cachix is not on PATH; skipping devenv profile push, the profile pointer will not be cached."
+        else
+          if { echo "$profile_path"; cat .devenv-ci/extra-paths; } | xargs cachix push darkmatter; then
+            # Belt and braces: confirm the profile narinfo is really served.
+            # Pushes have failed silently before while reporting success.
+            if nix path-info --store https://darkmatter.cachix.org "$profile_path" > /dev/null 2>&1; then
+              ok=true
+            else
+              echo "::warning::devenv profile push reported success but ${profile_path} is not downloadable from darkmatter.cachix.org; the profile pointer will not be cached. Check that DARKMATTER_CACHIX_AUTH_TOKEN has write permission."
+            fi
+          else
+            echo "::warning::cachix push to darkmatter failed; the profile pointer will not be cached. Check that DARKMATTER_CACHIX_AUTH_TOKEN has write permission."
+          fi
+        fi
+
+        echo "ok=$ok" >> "$GITHUB_OUTPUT"
+
     - name: Save devenv profile pointer
-      if: ${{ inputs.install-devenv == 'true' && steps.devenv-realise.outputs.ok != 'true' && steps.devenv-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.install-devenv == 'true' && steps.devenv-push.outputs.ok == 'true' && steps.devenv-cache.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v4
       with:
         path: .devenv-ci

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -137,6 +137,12 @@ runs:
       shell: bash
       env:
         NIXPKGS_ALLOW_UNFREE: 1
+        # devenv keeps home-level state (GC roots) in $XDG_DATA_HOME/devenv.
+        # Point it at a job-scoped dir: on shared persistent runners the
+        # default ~/.local/share/devenv can be unwritable (e.g. root-owned
+        # from a past sudo invocation), and per-job state is better hygiene
+        # on shared runners anyway.
+        XDG_DATA_HOME: ${{ runner.temp }}/devenv-xdg-data
       run: |
         set -euo pipefail
 
@@ -150,6 +156,8 @@ runs:
       shell: bash
       env:
         NIXPKGS_ALLOW_UNFREE: 1
+        # Must match the Build step so devenv reuses the same state dir.
+        XDG_DATA_HOME: ${{ runner.temp }}/devenv-xdg-data
       run: |
         set -euo pipefail
 


### PR DESCRIPTION
## Summary

Hardening follow-up to #384, driven by what its first production runs revealed. Two infra problems surfaced, one of which poisoned the new profile cache:

**1. `DARKMATTER_CACHIX_AUTH_TOKEN` cannot write to the cache.** Every push in the cachix-action post-job daemon fails with `403 Forbidden` on `POST /api/v1/cache/darkmatter/multipart-nar`, but cachix-action logs these as `Info` and reports the step green. This has been failing silently since before #384 — it's why nothing was ever in the darkmatter cache (and why ubuntu runners compiled CPython from source). For #384 specifically: the first develop run cached a profile pointer assuming the post-job push would upload the closure; it never did, so every later macOS run hit the pointer, failed substitution (`no substituter that can build it`), and fell back to a full rebuild.

**2. One self-hosted mac runner hard-fails every cachix job.** A persistent machine (runner user `coopermaruyama`) has a Nix install where the runner user is not in `trusted-users`, so `cachix use` exits 1 and the whole job fails. This pre-dates #384 — it's what failed the 11:57 develop push and the 12:39 merge-group run.

Changes:

- **Push-then-verify before caching the pointer**: the build path now pushes the profile closure synchronously (`cachix push darkmatter`) and then confirms the profile narinfo is actually downloadable from `darkmatter.cachix.org` before `actions/cache/save` runs. If the token is missing, the push fails, or verification fails, a `::warning::` annotation is emitted and the pointer is *not* saved — behavior degrades to exactly the pre-#384 full-build path, never a poisoned cache.
- **Key namespace bump `v1` → `v2`**: orphans the already-poisoned v1 pointers (immutable cache keys can't be overwritten).
- **`continue-on-error` on the three cachix-action steps**: the untrusted-user runner now degrades to building without binary caches instead of failing every job it picks up.

## Action items this PR cannot fix (for @czxtm / org admins)

1. **Mint a write-capable token** for the darkmatter cachix cache (app.cachix.org → darkmatter → Settings → Auth Tokens, with write permission) and replace the `DARKMATTER_CACHIX_AUTH_TOKEN` GitHub Actions secret. There is no cachix token in `ops/secrets/secrets.yaml` to fall back on — the GH secret is the only copy. Until this is done, profile caching stays dormant (with visible warnings) and every run pays the full devenv build.
2. **Fix or remove the untrusted-user mac runner**: on that machine run
   `echo "trusted-users = root coopermaruyama" | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon`
   or take it out of the `[self-hosted, macOS]` pool.

Once the token is replaced, no further changes are needed — the next cache-miss run pushes, verifies, saves the v2 pointer, and subsequent runs get the fast path #384 intended.

## Test Plan

- [x] YAML parse + shellcheck (`--severity=warning`) clean on all embedded scripts; actionlint clean on touched files
- [x] Verified the 403s and the missing narinfo directly (curl + run logs quoted above)
- [ ] After merge: first run warns `the profile pointer will not be cached` (token still read-only) and completes via the full-build path
- [ ] After the token is replaced: one cache-miss run, then setup drops to ~1–2m on macOS/ubuntu

## Docs

- [x] No docs update needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)