### PR TITLE
ci: add lean cargo-check tripwire on develop pushes (ENG-550)

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+  # Post-merge tripwire: re-run cargo check on develop itself so any compile
+  # breakage that slips past the pre-merge gate (merge-queue edge cases, the
+  # main->develop merge producing a broken tree from two green parents, a
+  # ruleset change) turns develop's commit status red quickly instead of
+  # costing the next person a confusing local build failure. Only the Rust
+  # Check job runs on push (see the per-job `if` guards below); the full build
+  # already gates the PR path.
+  push:
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:
@@ -21,17 +30,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # cargo check needs only the Rust toolchain plus the system C compiler
+      # (libgit2-sys / libsqlite3-sys build their vendored C with `cc`). It does
+      # not need the devenv profile (node/bun/sops/python) or JS deps, so skip
+      # both — that drops the ~8 min devenv provisioning to a ~1 min toolchain
+      # setup. This speeds up the PR check too; the full build (build.yaml) is
+      # unaffected and still provides heavyweight coverage.
       - uses: ./.github/actions/setup
         with:
           darkmatter-cachix-auth-token: ${{ secrets.DARKMATTER_CACHIX_AUTH_TOKEN }}
           setup-rust: true
           rust-cache-workspaces: apps/native/src-tauri
+          install-devenv: false
+          install-bun-deps: false
       - name: Check Rust app crate
         working-directory: apps/native/src-tauri
         run: cargo check --locked
 
   typescript:
     name: TypeScript
+    # PR/merge-queue only — the develop push tripwire is cargo check alone.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -53,6 +72,8 @@ jobs:
 
   treefmt:
     name: Treefmt
+    # PR/merge-queue only — the develop push tripwire is cargo check alone.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Closes ENG-550 (post-merge safety net portion).

**Finding first:** the pre-merge cargo-check gate ENG-550 asks for already exists — `evaluate.yml`'s `Rust Check` (`cargo check --locked`) has run on PRs since 2026-06-04, and ruleset `15037341` has *required* it (plus `TypeScript`, a PR, and the merge queue, with no bypass actors) on develop since 2026-06-08. The late-May compile breakages predate that gate. So the gate isn't the gap.

The gap is that **nothing re-checks develop after a commit lands** — notably the periodic `main → develop` merge, which can produce a broken tree from two individually green parents. This PR adds a lightweight post-merge tripwire:

- **`push: [develop]` trigger** runs `cargo check` against the actual post-merge tip. It's a *detector, not a gate* — it can't block, but it flips develop's commit status red within ~1 min so the team sees breakage immediately instead of via a confusing local build failure.
- **Tripwire = cargo check only.** TypeScript/Treefmt are guarded to the PR/merge-queue path; compile breakage is the failure mode we keep hitting.
- **Made the Rust Check genuinely light.** It was 9 min — but the `cargo check` itself was only **52s**; the other ~8 min was provisioning the full devenv profile (node/bun/sops/python) to run a Rust-only check. `cargo check` needs just the Rust toolchain + the system C compiler (`libgit2-sys`/`libsqlite3-sys` build their vendored C with `cc`), so this sets `install-devenv: false` + `install-bun-deps: false`. That drops it to a ~1 min toolchain setup **and speeds up the PR check too**. The full build (`build.yaml`) is untouched and still provides heavyweight coverage.

## Test Plan

- [ ] No test plan needed

This PR validates itself: `evaluate.yml` runs on `pull_request`, so the **Rust Check** job on this PR exercises the devenv-free `cargo check`. If it's green here, the slim setup works (and is now ~1 min instead of ~9). YAML validated locally; per-job `if` guards confirmed (only `rust-check` runs on push).

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed

CI-only change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
