### PR TITLE
feat: don't count nix-managed defaults as drift in the defaults scanner

### DIFF
--- a/apps/native/src-tauri/src/commands/helpers.rs
+++ b/apps/native/src-tauri/src/commands/helpers.rs
@@ -1,6 +1,6 @@
 use crate::state::{evolve_state, watcher};
 use crate::storage::store;
-use crate::system::nix;
+use crate::system::nix::{self, determine_host_attr};
 use crate::{git, shared_types};
 use tauri::AppHandle;
 
@@ -40,4 +40,21 @@ pub(super) fn handle_new_config_dir(
         .map_err(|e| e.to_string())?;
     let hosts = nix::list_darwin_hosts(dir).ok();
     Ok((evolve_state, hosts))
+}
+
+// Helper function to extract the hostname and config_dir from the app handle, returning an error if either is missing.
+pub(super) fn get_hostname_and_config_dir(
+    app: &AppHandle,
+    cmd: &str,
+) -> Result<(String, String), String> {
+    let hostname = determine_host_attr(app).unwrap_or_default();
+    let config_dir: String =
+        store::ensure_config_dir_exists(app).map_err(|e| capture_err(cmd, e))?;
+
+    if hostname.is_empty() {
+        log::warn!("No hostname configured, skipping launchd scan");
+        return Err("No hostname configured".to_string());
+    }
+
+    Ok((hostname, config_dir))
 }

--- a/apps/native/src-tauri/src/commands/helpers.rs
+++ b/apps/native/src-tauri/src/commands/helpers.rs
@@ -52,7 +52,7 @@ pub(super) fn get_hostname_and_config_dir(
         store::ensure_config_dir_exists(app).map_err(|e| capture_err(cmd, e))?;
 
     if hostname.is_empty() {
-        log::warn!("No hostname configured, skipping launchd scan");
+        log::warn!("No hostname configured.");
         return Err("No hostname configured".to_string());
     }
 

--- a/apps/native/src-tauri/src/commands/launchd.rs
+++ b/apps/native/src-tauri/src/commands/launchd.rs
@@ -1,24 +1,9 @@
-use super::helpers::capture_err;
+use super::helpers::{capture_err, get_hostname_and_config_dir};
 use crate::{
     shared_types::{self, LaunchdItem},
-    storage::store,
-    system::{launchd_scanner::scan_launchd_items_for_hostname, nix::determine_host_attr},
+    system::launchd_scanner::scan_launchd_items_for_hostname,
 };
 use tauri::AppHandle;
-
-// Helper function to extract the hostname and config_dir from the app handle, returning an error if either is missing.
-fn get_hostname_and_config_dir(app: &AppHandle, cmd: &str) -> Result<(String, String), String> {
-    let hostname = determine_host_attr(app).unwrap_or_default();
-    let config_dir: String =
-        store::ensure_config_dir_exists(app).map_err(|e| capture_err(cmd, e))?;
-
-    if hostname.is_empty() {
-        log::warn!("No hostname configured, skipping launchd scan");
-        return Err("No hostname configured".to_string());
-    }
-
-    Ok((hostname, config_dir))
-}
 
 /// Scans the system for launchd items that are configured but not managed by nix.
 #[tauri::command]

--- a/apps/native/src-tauri/src/commands/system_defaults.rs
+++ b/apps/native/src-tauri/src/commands/system_defaults.rs
@@ -1,4 +1,4 @@
-use super::helpers::capture_err;
+use super::helpers::{capture_err, get_hostname_and_config_dir};
 use crate::shared_types;
 use crate::storage::store;
 use crate::system::scanner;
@@ -29,7 +29,9 @@ pub async fn scan_system_defaults(
             });
         }
     }
-    Ok(scanner::scan_system_defaults())
+
+    let (hostname, config_dir) = get_hostname_and_config_dir(&app, "scan_system_defaults")?;
+    Ok(scanner::scan_system_defaults(&hostname, &config_dir))
 }
 
 /// Writes detected system defaults to a .nix module file, injects the import

--- a/apps/native/src-tauri/src/commands/system_defaults.rs
+++ b/apps/native/src-tauri/src/commands/system_defaults.rs
@@ -31,7 +31,14 @@ pub async fn scan_system_defaults(
     }
 
     let (hostname, config_dir) = get_hostname_and_config_dir(&app, "scan_system_defaults")?;
-    Ok(scanner::scan_system_defaults(&hostname, &config_dir))
+
+    let scan = tauri::async_runtime::spawn_blocking(move || {
+        scanner::scan_system_defaults(&hostname, &config_dir)
+    })
+    .await
+    .map_err(|e| capture_err("scan_system_defaults", e.to_string()))?;
+
+    Ok(scan)
 }
 
 /// Writes detected system defaults to a .nix module file, injects the import

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -35,6 +35,7 @@ use std::sync::OnceLock;
 use tauri::{AppHandle, Emitter};
 
 use crate::shared_types::LaunchdItemType;
+use crate::utils::normalize_path_input;
 
 const NIX_PATHS_FALLBACK: &[&str] = &[
     "/run/current-system/sw/bin",
@@ -61,6 +62,75 @@ struct NixLaunchdEvalItem {
 }
 
 static NIX_PATH_CACHE: OnceLock<String> = OnceLock::new();
+
+/// Gets a command with our typical setup to execute `nix`.
+fn nix_command(config_dir: &str) -> Command {
+    let mut cmd = Command::new("nix");
+    let normalized_config_dir =
+        normalize_path_input(config_dir).unwrap_or_else(|_| config_dir.into());
+    cmd.env("PATH", get_nix_path())
+        .env("NIX_CONFIG", "experimental-features = nix-command flakes")
+        .current_dir(normalized_config_dir);
+    cmd
+}
+
+fn nix_eval_value_to_string(value: serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(value) => value,
+        serde_json::Value::Bool(value) => value.to_string(),
+        serde_json::Value::Number(value) => value.to_string(),
+        value => value.to_string(),
+    }
+}
+
+/// Gets the current system.defaults values for a given host by running `nix eval`.
+/// NOTE that this only returns key entries for non-null values since `nix eval` always
+/// lists all available keys regardless of whether they are "set" in a flake or not.
+#[allow(dead_code)]
+pub fn get_nix_system_defaults_for_domain(
+    hostname: &str,
+    config_dir: &str,
+    domain: &str,
+) -> Result<BTreeMap<String, String>> {
+    // nix eval ~{config_dir}/#darwinConfigurations.<hostname>.config.system.defaults --json
+    let host_attr = serde_json::to_string(hostname)?;
+    let flake_attr = format!(
+        ".#darwinConfigurations.{}.config.system.defaults.{}",
+        host_attr, domain
+    );
+
+    let output = nix_command(config_dir)
+        .args(["eval", "--json", &flake_attr])
+        .output()
+        .with_context(|| {
+            format!(
+                "Failed to run nix eval for system.defaults using domain {} and attr {}",
+                domain, flake_attr
+            )
+        })?;
+
+    // Read the JSON into the result map, omitting keys with null values.
+    if !output.status.success() {
+        anyhow::bail!(
+            "Failed to evaluate system.defaults for host {}: {}",
+            hostname,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .with_context(|| format!("nix eval for system.defaults returned invalid UTF-8"))?;
+    let evaluated_items: BTreeMap<String, Option<serde_json::Value>> =
+        serde_json::from_str(&stdout)
+            .with_context(|| format!("Failed to parse nix eval JSON for system.defaults"))?;
+
+    let non_null_items = evaluated_items
+        .into_iter()
+        .filter_map(|(k, v)| v.map(|val| (k, nix_eval_value_to_string(val))))
+        .collect::<BTreeMap<String, String>>();
+
+    Ok(non_null_items)
+}
 
 /// Gets short info on all the nix-managed launchd items using `nix eval --json`.
 pub fn get_nix_launchd_items(hostname: &str, config_dir: &str) -> Result<Vec<NixLaunchdItem>> {
@@ -106,7 +176,7 @@ fn eval_nix_launchd_items(
         host_attr, option_path
     );
 
-    let output = Command::new("nix")
+    let output = nix_command(config_dir)
         .args([
             "eval",
             "--json",
@@ -122,8 +192,6 @@ fn eval_nix_launchd_items(
                   else [];
               })"#,
         ])
-        .current_dir(config_dir)
-        .env("PATH", get_nix_path())
         .output()
         .with_context(|| format!("Failed to run nix eval for {}", option_path))?;
 
@@ -203,7 +271,7 @@ pub fn determine_host_attr<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Opti
 }
 
 pub fn list_darwin_hosts(config_dir: &str) -> Result<Vec<String>> {
-    let output = Command::new("nix")
+    let output = nix_command(config_dir)
         .args([
             "eval",
             "--json",
@@ -211,9 +279,6 @@ pub fn list_darwin_hosts(config_dir: &str) -> Result<Vec<String>> {
             "--apply",
             "builtins.attrNames",
         ])
-        .current_dir(config_dir)
-        .env("PATH", get_nix_path())
-        .env("NIX_CONFIG", "experimental-features = nix-command flakes")
         .output()?;
 
     if !output.status.success() {
@@ -278,10 +343,8 @@ pub fn prefetch_darwin_rebuild_stream(app: &AppHandle) -> Result<()> {
     // All emit calls below are fire-and-forget: background thread; window may not be
     // listening. Tauri emit returns Err only when no listeners are registered.
     std::thread::spawn(move || {
-        let result = Command::new("nix")
+        let result = nix_command(".")
             .args(["build", "--no-link", "nix-darwin/master#darwin-rebuild"])
-            .env("PATH", get_nix_path_with_login_shell())
-            .env("NIX_CONFIG", "experimental-features = nix-command flakes")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output();
@@ -643,5 +706,21 @@ mod tests {
                 eprintln!("Error evaluating nix launchd items: {}", err);
             }
         }
+    }
+
+    #[test]
+    #[ignore = "Runs against the local system; enable explicitly when debugging the nix system defaults."]
+    #[cfg(target_os = "macos")]
+    fn test_get_nix_system_defaults_for_domain() -> Result<()> {
+        use crate::commands::config::get_this_hostname_cmd;
+
+        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        const CONFIG_DIR: &str = "~/.darwin";
+        let domain = "finder";
+
+        let defaults = get_nix_system_defaults_for_domain(&this_host_name, CONFIG_DIR, domain)?;
+        println!("System defaults for domain {}: {:#?}", domain, defaults);
+
+        Ok(())
     }
 }

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -342,9 +342,12 @@ pub fn prefetch_darwin_rebuild_stream(app: &AppHandle) -> Result<()> {
 
     // All emit calls below are fire-and-forget: background thread; window may not be
     // listening. Tauri emit returns Err only when no listeners are registered.
+    // Intentionall doesn't use `nix_command` in order to use get_nix_path_with_login_shell.
     std::thread::spawn(move || {
-        let result = nix_command(".")
+        let result = Command::new("nix")
             .args(["build", "--no-link", "nix-darwin/master#darwin-rebuild"])
+            .env("PATH", get_nix_path_with_login_shell())
+            .env("NIX_CONFIG", "experimental-features = nix-command flakes")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output();

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -1456,30 +1456,6 @@ fn e2e_system_defaults_scan() -> Option<SystemDefaultsScan> {
 // Domain reading
 // =============================================================================
 
-/// Gets the nix "system.defaults" group from one of our domain definitions.
-/// This is the first dotted-path-part of the nix_key following "system.defaults".
-/// For example, for the domain "com.apple.finder" the nix key is "system.defaults.finder.*",
-/// so the nix group is "finder".
-fn nix_group_name_for_domain(domain: &str) -> &str {
-    // 1. Get the keydef for this domain.
-    // 2. Get the nix_key for the first keydef in this domain.
-    // 3. Split the nix_key by '.' and return the 2th part (after "system.defaults").
-    for (d, defs) in KEY_DEFS {
-        match *d == domain {
-            true => {
-                if let Some(def) = defs.first() {
-                    let parts: Vec<&str> = def.nix_key.split('.').collect();
-                    if parts.len() > 2 {
-                        return parts[2];
-                    }
-                }
-            }
-            false => (),
-        }
-    }
-    domain
-}
-
 /// Read all keys from a macOS defaults domain using `defaults export`.
 /// Returns a map of key → string value.
 fn read_domain(domain: &str) -> BTreeMap<String, String> {
@@ -1586,8 +1562,16 @@ pub fn scan_system_defaults(hostname: &str, config_dir: &str) -> SystemDefaultsS
     for (domain, key_defs) in KEY_DEFS {
         let domain_values = read_domain(domain);
 
+        // Gets the nix "system.defaults" group from one of our domain definitions.
+        // This is the first dotted-path-part of the nix_key following "system.defaults".
+        // For example, for the domain "com.apple.finder" the nix key is "system.defaults.finder.*",
+        // so the nix group is "finder".
+        let nix_group_name = key_defs
+            .first()
+            .and_then(|def| def.nix_key.split('.').nth(2))
+            .unwrap_or(domain);
+
         // Get the current values managed by nix.
-        let nix_group_name = nix_group_name_for_domain(domain);
         let current_nix_managed_values =
             nix::get_nix_system_defaults_for_domain(hostname, config_dir, nix_group_name);
 
@@ -2352,19 +2336,5 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn test_get_nix_group_name_for_domain() {
-        assert_eq!(nix_group_name_for_domain("com.apple.dock"), "dock");
-        assert_eq!(nix_group_name_for_domain("com.apple.finder"), "finder");
-        assert_eq!(
-            nix_group_name_for_domain("NSGlobalDomain"),
-            "NSGlobalDomain"
-        );
-        assert_eq!(
-            nix_group_name_for_domain("unknown.domain"),
-            "unknown.domain"
-        );
     }
 }

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -6,6 +6,7 @@
 //! files from the detected customizations.
 
 pub(crate) use crate::shared_types::{RecommendedPrompt, SystemDefault, SystemDefaultsScan};
+use crate::system::nix;
 use std::collections::BTreeMap;
 use std::process::Command;
 
@@ -1455,6 +1456,30 @@ fn e2e_system_defaults_scan() -> Option<SystemDefaultsScan> {
 // Domain reading
 // =============================================================================
 
+/// Gets the nix "system.defaults" group from one of our domain definitions.
+/// This is the first dotted-path-part of the nix_key following "system.defaults".
+/// For example, for the domain "com.apple.finder" the nix key is "system.defaults.finder.*",
+/// so the nix group is "finder".
+fn nix_group_name_for_domain(domain: &str) -> &str {
+    // 1. Get the keydef for this domain.
+    // 2. Get the nix_key for the first keydef in this domain.
+    // 3. Split the nix_key by '.' and return the 2th part (after "system.defaults").
+    for (d, defs) in KEY_DEFS {
+        match *d == domain {
+            true => {
+                if let Some(def) = defs.first() {
+                    let parts: Vec<&str> = def.nix_key.split('.').collect();
+                    if parts.len() > 2 {
+                        return parts[2];
+                    }
+                }
+            }
+            false => (),
+        }
+    }
+    domain
+}
+
 /// Read all keys from a macOS defaults domain using `defaults export`.
 /// Returns a map of key → string value.
 fn read_domain(domain: &str) -> BTreeMap<String, String> {
@@ -1545,10 +1570,10 @@ fn normalize_bool(val: &str) -> &'static str {
 // =============================================================================
 
 /// Scan all supported macOS defaults domains and return settings that differ
-/// from the factory defaults.
+/// from the factory defaults AND are not managed by nix-darwin.
 /// If you want to make sure none of the KeyDefs are stale by running their
 /// results through a nix build you can play with the value of GENERATE_EVERYTHING.
-pub fn scan_system_defaults() -> SystemDefaultsScan {
+pub fn scan_system_defaults(hostname: &str, config_dir: &str) -> SystemDefaultsScan {
     if let Some(scan) = e2e_system_defaults_scan() {
         return scan;
     }
@@ -1561,7 +1586,21 @@ pub fn scan_system_defaults() -> SystemDefaultsScan {
     for (domain, key_defs) in KEY_DEFS {
         let domain_values = read_domain(domain);
 
+        // Get the current values managed by nix.
+        let nix_group_name = nix_group_name_for_domain(domain);
+        let current_nix_managed_values =
+            nix::get_nix_system_defaults_for_domain(hostname, config_dir, nix_group_name);
+
         for def in *key_defs {
+            // Check if this key is currently managed by nix. If it is, we skip it because we don't want to report it as a non-default.
+            // Currently we won't compare the value against the factory default because if it's managed by nix it might be intentionally set to a default
+            // or non-default value.
+            if let Ok(ref nix_values) = current_nix_managed_values {
+                if nix_values.contains_key(def.defaults_key) {
+                    continue;
+                }
+            }
+
             total_scanned += 1;
 
             let current = match domain_values.get(def.defaults_key) {
@@ -1907,9 +1946,14 @@ mod tests {
     #[ignore = "Runs against the local system; enable explicitly when debugging the defaults scanner."]
     #[cfg(target_os = "macos")]
     fn test_scan_system_defaults() {
-        let scan = scan_system_defaults();
+        use crate::commands::config::get_this_hostname_cmd;
+
+        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        const CONFIG_DIR: &str = "~/.darwin";
+
+        let scan = scan_system_defaults(&this_host_name, CONFIG_DIR);
         println!(
-            "Scanned {} settings, found {} non-defaults:",
+            "Scanned {} settings, found {} unmanaged non-defaults:",
             scan.total_scanned,
             scan.defaults.len()
         );
@@ -2308,5 +2352,19 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_get_nix_group_name_for_domain() {
+        assert_eq!(nix_group_name_for_domain("com.apple.dock"), "dock");
+        assert_eq!(nix_group_name_for_domain("com.apple.finder"), "finder");
+        assert_eq!(
+            nix_group_name_for_domain("NSGlobalDomain"),
+            "NSGlobalDomain"
+        );
+        assert_eq!(
+            nix_group_name_for_domain("unknown.domain"),
+            "unknown.domain"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Use `nix eval` to find non-null `system.defaults.*` values which indicate the default is currently nix-managed, and don't count that in the system defaults scanner when calculating "drift" and making tracking suggestions.

Note that we really need to fix the issue I already entered about merging values instead of relying on the existence of the "system-defaults.nix" file; else you can only click a "track" button precisely one time before the suggestions disappear seemingly forever. Keep that in mind when testing.

<!-- What does this PR do? Why? -->

## Test Plan

Some unit-testing against the local machine, and manual using the UI.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed