### PR TITLE
feat: refactor system-defaults apply to use semantic Nix edits instead of full file generation

### DIFF
--- a/apps/native/src-tauri/src/commands/system_defaults.rs
+++ b/apps/native/src-tauri/src/commands/system_defaults.rs
@@ -1,6 +1,5 @@
 use super::helpers::{capture_err, get_hostname_and_config_dir};
 use crate::shared_types;
-use crate::storage::store;
 use crate::system::scanner;
 use tauri::AppHandle;
 
@@ -15,21 +14,6 @@ pub async fn get_recommended_prompt() -> Result<Option<shared_types::Recommended
 pub async fn scan_system_defaults(
     app: AppHandle,
 ) -> Result<shared_types::SystemDefaultsScan, String> {
-    // Check if system-defaults.nix already exists in the config dir
-    if let Ok(dir) = store::get_config_dir(&app) {
-        let nix_path = std::path::Path::new(&dir)
-            .join("modules")
-            .join("darwin")
-            .join("system-defaults.nix");
-        if nix_path.exists() {
-            // Already applied — return empty scan so the CTA stays hidden
-            return Ok(shared_types::SystemDefaultsScan {
-                defaults: vec![],
-                total_scanned: 0,
-            });
-        }
-    }
-
     let (hostname, config_dir) = get_hostname_and_config_dir(&app, "scan_system_defaults")?;
 
     let scan = tauri::async_runtime::spawn_blocking(move || {
@@ -48,7 +32,9 @@ pub async fn apply_system_defaults(
     app: AppHandle,
     defaults: Vec<shared_types::SystemDefault>,
 ) -> Result<shared_types::ConfigEditApplyResult, String> {
-    crate::managed_edits::system_defaults::apply_system_defaults(&app, defaults)
+    let (hostname, _) = get_hostname_and_config_dir(&app, "apply_system_defaults")?;
+
+    crate::managed_edits::system_defaults::apply_system_defaults(&app, &hostname, defaults)
         .await
         .map_err(|e| capture_err("apply_system_defaults", e))
 }

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -1062,12 +1062,22 @@ fn infer_inner_indent(attrset_text: &str) -> String {
 
 /// Escape a string for safe insertion into a Nix string literal.
 pub(crate) fn escape_nix_string(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\t', "\\t")
-        .replace("${", "\\${")
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '$' if chars.peek() == Some(&'{') => {
+                out.push_str("\\${");
+                chars.next(); // consume '{'
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 /// Quote and escape a list of string values for safe insertion into Nix list literals.
@@ -1713,5 +1723,31 @@ environment.systemPackages = with pkgs; [
             escaped,
             "This is a \\\"test\\\" string with \\\\ backslashes and \\${dollar} signs."
         );
+    }
+
+    #[test]
+    fn escape_nix_string_only_escapes_interpolation_start() {
+        let cases = [
+            ("$HOME", "$HOME"),
+            ("${name}", "\\${name}"),
+            (
+                "prefix ${one}${two} suffix",
+                "prefix \\${one}\\${two} suffix",
+            ),
+            ("unterminated ${", "unterminated \\${"),
+            ("just $ and { braces }", "just $ and { braces }"),
+            ("$x{not-interpolation}", "$x{not-interpolation}"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(escape_nix_string(input), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn escape_nix_string_handles_backslash_before_interpolation() {
+        let escaped = escape_nix_string(r"\${already-looking-escaped}");
+
+        assert_eq!(escaped, r"\\\${already-looking-escaped}");
     }
 }

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -1060,6 +1060,16 @@ fn infer_inner_indent(attrset_text: &str) -> String {
     "    ".to_string() // default: 4 spaces
 }
 
+/// Escape a string for safe insertion into a Nix string literal.
+pub(crate) fn escape_nix_string(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\t', "\\t")
+        .replace("${", "\\${")
+}
+
 /// Quote and escape a list of string values for safe insertion into Nix list literals.
 ///
 /// This escapes backslashes, double quotes and dollar signs, and wraps each value
@@ -1693,5 +1703,15 @@ environment.systemPackages = with pkgs; [
         let input: Vec<String> = vec![];
         let quoted = nix_quote_values(&input);
         assert!(quoted.is_empty());
+    }
+
+    #[test]
+    fn test_escape_nix_string() {
+        let input = "This is a \"test\" string with \\ backslashes and ${dollar} signs.";
+        let escaped = escape_nix_string(input);
+        assert_eq!(
+            escaped,
+            "This is a \\\"test\\\" string with \\\\ backslashes and \\${dollar} signs."
+        );
     }
 }

--- a/apps/native/src-tauri/src/managed_edits/system_defaults.rs
+++ b/apps/native/src-tauri/src/managed_edits/system_defaults.rs
@@ -1,51 +1,179 @@
 //! Applies detected macOS system defaults to the nix-darwin configuration.
 
 use anyhow::{Context, Result};
-use tauri::AppHandle;
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
 
+use crate::evolve::nix_file_editor::{apply_semantic_edit, escape_nix_string};
+use crate::evolve::types::{FileEditAction, SemanticFileEdit};
+use crate::system::nix::get_system_primary_user;
 use crate::system::scanner;
 use crate::{managed_edits::managed_edit, shared_types};
+use tauri::AppHandle;
 
-/// Writes detected system defaults to a .nix module file, injects the import
-/// into flake.nix, creates an evolution + summarization pipeline so the
-/// frontend lands on the evolve step with a populated changeMap.
+/// Name of the file that we use for defaults tracking. Note that this allows the user
+/// to already have defaults defined in other flakes. But it's not trivial to try
+/// and find any such possibly-appropriate existing location to add to, so we
+/// hook up our own as needed the first time you use the tracking feature.
+const SYSTEM_DEFAULTS_MODULE_FILENAME: &str = "system-defaults.nix";
+
+/// Gets the relative path to the system defaults module, which is always `modules/darwin/system-defaults.nix`
+/// under the config dir (which the caller controls, it's not calculated here).
+fn system_defaults_module_path() -> String {
+    format!("modules/darwin/{SYSTEM_DEFAULTS_MODULE_FILENAME}")
+}
+
+/// Generates a bare-bones system defaults module while optionally setting the required `system.primaryUser` attribute,
+/// This is used as the starting point for managing system defaults, and is later injected into the user's
+/// config if not already present.
+fn system_defaults_module_template(add_primary_user: bool) -> String {
+    let mut module = String::from("{\n  # macOS system defaults managed by nixmac.\n");
+
+    if add_primary_user {
+        let username = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+
+        module.push_str(&format!(
+            r#"  # Required by nix-darwin for system.defaults.* options.
+  system.primaryUser = "{}";
+"#,
+            escape_nix_string(&username)
+        ));
+    }
+
+    module.push_str("}\n");
+    module
+}
+
+/// Helper method used when grouping nix values that contain dots in quoted keys.
+/// Returns the index of the last unquoted dot in the string, or None if there are no unquoted dots.
+fn rfind_unquoted_dot(value: &str) -> Option<usize> {
+    let mut in_quotes = false;
+    let mut escaped = false;
+    let mut last_dot = None;
+
+    for (idx, ch) in value.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_quotes => escaped = true,
+            '"' => in_quotes = !in_quotes,
+            '.' if !in_quotes => last_dot = Some(idx),
+            _ => {}
+        }
+    }
+
+    last_dot
+}
+
+/// Ensures the managed system-defaults module exists and is imported.
+///
+/// This only creates the module shell when it is missing. Applying individual
+/// `system.defaults.*` values is handled separately through semantic Nix edits.
+pub fn ensure_system_defaults_module(
+    config_dir: &str,
+    add_primary_user: bool,
+) -> Result<std::path::PathBuf> {
+    let modules_dir = std::path::Path::new(config_dir)
+        .join("modules")
+        .join("darwin");
+    std::fs::create_dir_all(&modules_dir)
+        .with_context(|| format!("failed to create directory '{}'", modules_dir.display()))?;
+
+    // Use an existing primaryUser if available.
+    let module_path = modules_dir.join(SYSTEM_DEFAULTS_MODULE_FILENAME);
+    if !module_path.exists() {
+        std::fs::write(
+            &module_path,
+            system_defaults_module_template(add_primary_user),
+        )
+        .with_context(|| format!("failed to write '{}'", module_path.display()))?;
+    }
+
+    managed_edit::inject_darwin_module_import(
+        config_dir,
+        SYSTEM_DEFAULTS_MODULE_FILENAME,
+        "ensure_system_defaults_module",
+    )?;
+
+    Ok(module_path)
+}
+
+/// Groups the given system defaults by their nix key prefix (everything before the last dot),
+/// returning a map of group -> (attr -> value) for each default.
+fn group_system_defaults(
+    defaults: &[scanner::SystemDefault],
+) -> BTreeMap<String, Map<String, Value>> {
+    let mut groups: BTreeMap<String, Map<String, Value>> = BTreeMap::new();
+
+    for default in defaults {
+        let Some(last_dot) = rfind_unquoted_dot(&default.nix_key) else {
+            log::warn!(
+                "[apply_system_defaults] skipping default with invalid nix key '{}'",
+                default.nix_key
+            );
+            continue;
+        };
+        let group = &default.nix_key[..last_dot];
+        let attr = &default.nix_key[last_dot + 1..];
+        let value =
+            scanner::system_default_current_value_to_json(&default.current_value, group, attr);
+        groups
+            .entry(group.to_string())
+            .or_default()
+            .insert(attr.to_string(), value);
+    }
+
+    groups
+}
+
+/// Applies the given system defaults to the managed system-defaults module using semantic Nix edits.
+fn apply_system_defaults_to_module(
+    config_dir: &std::path::Path,
+    defaults: &[scanner::SystemDefault],
+) -> Result<()> {
+    for (group, attrs) in group_system_defaults(defaults) {
+        apply_semantic_edit(
+            config_dir,
+            &SemanticFileEdit {
+                path: system_defaults_module_path(),
+                action: FileEditAction::SetAttrs { path: group, attrs },
+            },
+            None,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Ensures the managed system-defaults module is hooked up, applies the passed
+/// defaults through semantic Nix edits, and enters the managed review flow.
 pub async fn apply_system_defaults(
     app: &AppHandle,
+    hostname: &str,
     defaults: Vec<scanner::SystemDefault>,
 ) -> Result<shared_types::ConfigEditApplyResult> {
     let context = managed_edit::prepare_managed_edit(app)?;
     let dir = context.dir.clone();
+    let config_path = std::path::Path::new(&dir);
 
-    // 1. Generate nix file content
     log::info!(
-        "[apply_system_defaults] Generating nix content for {} defaults",
+        "[apply_system_defaults] Applying {} defaults",
         defaults.len()
     );
-    let nix_content = scanner::generate_system_defaults_nix(&defaults);
 
-    // 2. Ensure modules/darwin directory exists
-    let modules_dir = std::path::Path::new(&dir).join("modules").join("darwin");
-    std::fs::create_dir_all(&modules_dir).context("Failed to create modules dir")?;
+    let primary_user = get_system_primary_user(hostname, &dir);
 
-    // 3. Write system-defaults.nix
-    let nix_path = modules_dir.join("system-defaults.nix");
-    std::fs::write(&nix_path, &nix_content).context("Failed to write system-defaults.nix")?;
+    let module_path = ensure_system_defaults_module(&dir, primary_user.is_none())
+        .context("Failed to ensure system-defaults.nix exists and is imported")?;
     log::info!(
-        "[apply_system_defaults] Wrote {} defaults to {:?}",
-        defaults.len(),
-        nix_path
+        "[apply_system_defaults] Ensured module at {:?}",
+        module_path
     );
 
-    // 4. Inject import into the file that contains the nix-darwin modules list.
-    let target_path = managed_edit::inject_darwin_module_import(
-        &dir,
-        "system-defaults.nix",
-        "apply_system_defaults",
-    )?;
-    log::info!(
-        "[apply_system_defaults] Injected module import into {:?}",
-        target_path
-    );
+    apply_system_defaults_to_module(config_path, &defaults)
+        .context("Failed to apply system defaults to module")?;
 
     let working_tree_status =
         crate::git::status(&dir).context("Failed to get working tree status for evolve state")?;
@@ -63,4 +191,120 @@ pub async fn apply_system_defaults(
         "apply_system_defaults",
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(path: &std::path::Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("failed to create parent directories");
+        }
+        std::fs::write(path, content).expect("failed to write test file");
+    }
+
+    fn system_default(nix_key: &str, current_value: &str) -> scanner::SystemDefault {
+        scanner::SystemDefault {
+            nix_key: nix_key.to_string(),
+            label: nix_key.to_string(),
+            category: "Test".to_string(),
+            current_value: current_value.to_string(),
+            default_value: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_ensure_system_defaults_module_creates_shell_and_import() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        write_file(
+            &temp.path().join("flake.nix"),
+            "darwinConfigurations.test = nix-darwin.lib.darwinSystem { modules=[\n  ./configuration.nix\n]; };",
+        );
+
+        let config_dir = temp.path().to_string_lossy();
+        let module_path =
+            ensure_system_defaults_module(&config_dir, false).expect("module should be ensured");
+        let module = std::fs::read_to_string(&module_path).expect("module should be readable");
+        let flake = std::fs::read_to_string(temp.path().join("flake.nix"))
+            .expect("flake should be readable");
+
+        assert!(!module.contains("system.primaryUser"));
+        assert!(!module.contains("system.defaults.dock"));
+        assert!(flake.contains("./modules/darwin/system-defaults.nix"));
+    }
+
+    #[test]
+    fn test_system_defaults_module_template_adds_primary_user_when_provided() {
+        let module = system_defaults_module_template(true);
+
+        assert!(module.contains("system.primaryUser = \""));
+    }
+
+    #[test]
+    fn test_apply_system_defaults_to_module_uses_semantic_edits() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        write_file(
+            &temp.path().join(system_defaults_module_path()),
+            r#"{ config, ... }:
+{
+  system.primaryUser = "me";
+
+  system.defaults.dock = {
+    autohide = false;
+  };
+}
+"#,
+        );
+
+        apply_system_defaults_to_module(
+            temp.path(),
+            &[
+                system_default("system.defaults.dock.autohide", "true"),
+                system_default("system.defaults.dock.tilesize", "48"),
+                system_default(
+                    "system.defaults.NSGlobalDomain.\"com.apple.sound.beep.feedback\"",
+                    "0",
+                ),
+            ],
+        )
+        .expect("defaults should apply");
+
+        let module = std::fs::read_to_string(temp.path().join(system_defaults_module_path()))
+            .expect("module should be readable");
+        assert!(module.contains("system.primaryUser = \"me\";"));
+        assert!(module.contains("autohide = true;"));
+        assert!(module.contains("tilesize = 48;"));
+        assert!(module.contains("\"com.apple.sound.beep.feedback\" = 0;"));
+    }
+
+    #[test]
+    fn test_group_system_defaults() {
+        let defaults = vec![
+            system_default("system.defaults.dock.autohide", "true"),
+            system_default("system.defaults.dock.tilesize", "48"),
+            system_default(
+                "system.defaults.NSGlobalDomain.\"com.apple.sound.beep.feedback\"",
+                "0",
+            ),
+        ];
+
+        let grouped = group_system_defaults(&defaults);
+
+        assert_eq!(grouped.len(), 2);
+        assert!(grouped.contains_key("system.defaults.dock"));
+        assert!(grouped.contains_key("system.defaults.NSGlobalDomain"));
+
+        let dock_attrs = &grouped["system.defaults.dock"];
+        assert_eq!(dock_attrs.len(), 2);
+        assert_eq!(dock_attrs["autohide"], Value::Bool(true));
+        assert_eq!(dock_attrs["tilesize"], Value::Number(48.into()));
+
+        let global_attrs = &grouped["system.defaults.NSGlobalDomain"];
+        assert_eq!(global_attrs.len(), 1);
+        assert_eq!(
+            global_attrs["\"com.apple.sound.beep.feedback\""],
+            Value::Number(0.into())
+        );
+    }
 }

--- a/apps/native/src-tauri/src/managed_edits/system_defaults.rs
+++ b/apps/native/src-tauri/src/managed_edits/system_defaults.rs
@@ -89,6 +89,25 @@ pub fn ensure_system_defaults_module(
             system_defaults_module_template(add_primary_user),
         )
         .with_context(|| format!("failed to write '{}'", module_path.display()))?;
+    } else if add_primary_user {
+        // If the module already exists but the overall config has no system.primaryUser,
+        // ensure this module defines it (required for system.defaults.* options).
+        let module = std::fs::read_to_string(&module_path)
+            .with_context(|| format!("failed to read '{}'", module_path.display()))?;
+        if !module.contains("system.primaryUser") {
+            let username = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+            apply_semantic_edit(
+                std::path::Path::new(config_dir),
+                &SemanticFileEdit {
+                    path: system_defaults_module_path(),
+                    action: FileEditAction::Set {
+                        path: "system.primaryUser".to_string(),
+                        value: Value::String(username),
+                    },
+                },
+                None,
+            )?;
+        }
     }
 
     managed_edit::inject_darwin_module_import(
@@ -231,6 +250,38 @@ mod tests {
 
         assert!(!module.contains("system.primaryUser"));
         assert!(!module.contains("system.defaults.dock"));
+        assert!(flake.contains("./modules/darwin/system-defaults.nix"));
+    }
+
+    #[test]
+    fn test_ensure_system_defaults_module_adds_primary_user_when_not_creating_new_module() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        write_file(
+            &temp.path().join("flake.nix"),
+            "darwinConfigurations.test = nix-darwin.lib.darwinSystem { modules=[\n  ./configuration.nix\n]; };",
+        );
+        write_file(
+            &temp.path().join(system_defaults_module_path()),
+            r#"{ config, ... }:
+{
+  # Existing module content.
+  system.defaults.dock = {
+    autohide = true;
+  };
+}
+"#,
+        );
+
+        let config_dir = temp.path().to_string_lossy();
+        let module_path =
+            ensure_system_defaults_module(&config_dir, true).expect("module should be ensured");
+        let module = std::fs::read_to_string(&module_path).expect("module should be readable");
+        let flake = std::fs::read_to_string(temp.path().join("flake.nix"))
+            .expect("flake should be readable");
+
+        assert!(module.contains("system.primaryUser = \""));
+        assert!(module.contains("system.defaults.dock = {"));
+        assert!(module.contains("autohide = true;"));
         assert!(flake.contains("./modules/darwin/system-defaults.nix"));
     }
 

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -98,7 +98,7 @@ pub fn get_system_primary_user(hostname: &str, config_dir: &str) -> Option<Strin
         .ok()?;
 
     if !output.status.success() {
-        error!(
+        log::debug!(
             "Failed to evaluate system.primaryUser for host {}: {}",
             hostname,
             String::from_utf8_lossy(&output.stderr)

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -832,9 +832,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn test_get_system_primary_user() {
-        use crate::commands::config::get_this_hostname_cmd;
+        use crate::bootstrap::default_config::detect_hostname;
 
-        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        let this_host_name = detect_hostname().expect("failed to get hostname");
         const CONFIG_DIR: &str = "~/.darwin";
 
         match get_system_primary_user(&this_host_name, CONFIG_DIR) {

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -83,10 +83,37 @@ fn nix_eval_value_to_string(value: serde_json::Value) -> String {
     }
 }
 
+/// Gets the `system.primaryUser` for the given host by running `nix eval` if it's
+/// defined. This is required for (for example) setting system.defaults.
+pub fn get_system_primary_user(hostname: &str, config_dir: &str) -> Option<String> {
+    let host_attr = serde_json::to_string(hostname).ok()?;
+    let flake_attr = format!(
+        ".#darwinConfigurations.{}.config.system.primaryUser",
+        host_attr
+    );
+
+    let output = nix_command(config_dir)
+        .args(["eval", "--json", &flake_attr])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        error!(
+            "Failed to evaluate system.primaryUser for host {}: {}",
+            hostname,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let primary_user: Option<String> = serde_json::from_str(&stdout).ok()?;
+    primary_user
+}
+
 /// Gets the current system.defaults values for a given host by running `nix eval`.
 /// NOTE that this only returns key entries for non-null values since `nix eval` always
 /// lists all available keys regardless of whether they are "set" in a flake or not.
-#[allow(dead_code)]
 pub fn get_nix_system_defaults_for_domain(
     hostname: &str,
     config_dir: &str,
@@ -799,5 +826,20 @@ mod tests {
         println!("System defaults for domain {}: {:#?}", domain, defaults);
 
         Ok(())
+    }
+
+    #[ignore = "Runs against the local system; enable explicitly when debugging the nix system defaults."]
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_get_system_primary_user() {
+        use crate::commands::config::get_this_hostname_cmd;
+
+        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        const CONFIG_DIR: &str = "~/.darwin";
+
+        match get_system_primary_user(&this_host_name, CONFIG_DIR) {
+            Some(user) => println!("Primary user for host {}: {}", this_host_name, user),
+            None => println!("No primary user defined for host {}", this_host_name),
+        }
     }
 }

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -5,7 +5,6 @@
 //! nix-darwin `system.defaults.*` keys. Also generates valid `.nix` module
 //! files from the detected customizations.
 
-use crate::bootstrap::default_config::detect_username;
 pub(crate) use crate::shared_types::{RecommendedPrompt, SystemDefault, SystemDefaultsScan};
 use crate::system::nix;
 use std::collections::BTreeMap;

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -1643,107 +1643,43 @@ fn rfind_unquoted_dot(s: &str) -> Option<usize> {
     last_dot
 }
 
-pub fn generate_system_defaults_nix(defaults: &[SystemDefault]) -> String {
-    // Group by nix-darwin attribute path prefix
-    // e.g. "system.defaults.dock.autohide" → group key "system.defaults.dock"
-    // Quoted segments (e.g. "com.apple.sound.beep.feedback") are kept intact.
-    let mut groups: BTreeMap<String, Vec<(&str, &str)>> = BTreeMap::new();
-
-    for d in defaults {
-        if let Some(last_dot) = rfind_unquoted_dot(&d.nix_key) {
-            let group = &d.nix_key[..last_dot];
-            let attr = &d.nix_key[last_dot + 1..];
-            groups
-                .entry(group.to_string())
-                .or_default()
-                .push((attr, &d.current_value));
-        }
-    }
-
-    // Detect the current macOS username for system.primaryUser
-    let username = detect_username();
-
-    let mut out = String::new();
-    out.push_str("{ config, ... }:\n\n{\n");
-    out.push_str("  # macOS system defaults\n");
-    out.push_str(
-        "  # Detected by nixmac system scanner \u{2014} these settings differ from macOS factory defaults.\n",
-    );
-    out.push('\n');
-    out.push_str(&format!(
-        "  # Required by nix-darwin for system.defaults.* options.\n  system.primaryUser = \"{}\";\n",
-        username
-    ));
-
-    for (group, attrs) in &groups {
-        out.push('\n');
-        out.push_str(&format!("  {} = {{\n", group));
-        for (attr, value) in attrs {
-            let nix_val = to_nix_value(value, group, attr);
-            out.push_str(&format!("    {} = {};\n", attr, nix_val));
-        }
-        out.push_str("  };\n");
-    }
-
-    out.push_str("}\n");
-    out
-}
-
-/// Convert a string value to appropriate Nix syntax based on content analysis.
-fn to_nix_value(value: &str, group: &str, attr: &str) -> String {
-    // Find the KeyDef to get the expected type and conversion metadata.
+pub(crate) fn system_default_current_value_to_json(
+    value: &str,
+    group: &str,
+    attr: &str,
+) -> serde_json::Value {
     let key_def = find_key_def(group, attr);
     if key_def.is_some_and(|def| def.factory_default == NULL_FLAG)
         && is_nullish_factory_value(value)
     {
-        return "null".to_string();
+        return serde_json::Value::Null;
     }
 
-    let val_type = key_def.map(|def| def.val_type);
-
-    match val_type {
-        Some(ValType::Bool) => {
-            if normalize_bool(value) == "true" {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
-        }
-        Some(ValType::Int) => {
-            // Ensure it's a valid integer
-            if let Ok(n) = value.trim().parse::<i64>() {
-                n.to_string()
-            } else {
-                format!("\"{}\"", escape_nix_string(value))
-            }
-        }
-        Some(ValType::Float) => {
-            if let Ok(f) = value.trim().parse::<f64>() {
-                // Format with enough precision
-                let s = format!("{}", f);
-                // Ensure it has a decimal point for Nix
-                if s.contains('.') {
-                    s
-                } else {
-                    format!("{}.0", s)
-                }
-            } else {
-                format!("\"{}\"", escape_nix_string(value))
-            }
-        }
+    match key_def.map(|def| def.val_type) {
+        Some(ValType::Bool) => serde_json::Value::Bool(normalize_bool(value) == "true"),
+        Some(ValType::Int) => value
+            .trim()
+            .parse::<i64>()
+            .map(serde_json::Value::from)
+            .unwrap_or_else(|_| serde_json::Value::String(value.to_string())),
+        Some(ValType::Float) => value
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .map(serde_json::Value::Number)
+            .unwrap_or_else(|| serde_json::Value::String(value.to_string())),
         Some(ValType::StringFromIntMap) => {
             if let Ok(n) = value.trim().parse::<i32>() {
                 if let Some(map) = key_def.and_then(|def| def.int_to_string_map) {
                     if let Some((_, mapped)) = map.iter().find(|(k, _)| *k == n) {
-                        return format!("\"{}\"", escape_nix_string(mapped));
+                        return serde_json::Value::String((*mapped).to_string());
                     }
                 }
             }
-            format!("\"{}\"", escape_nix_string(value))
+            serde_json::Value::String(value.to_string())
         }
-        Some(ValType::String) | None => {
-            format!("\"{}\"", escape_nix_string(value))
-        }
+        Some(ValType::String) | None => serde_json::Value::String(value.to_string()),
     }
 }
 
@@ -1765,15 +1701,6 @@ fn find_key_def(group: &str, attr: &str) -> Option<&'static KeyDef> {
         }
     }
     None
-}
-
-/// Escape special characters in a Nix string literal.
-fn escape_nix_string(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\t', "\\t")
-        .replace("${", "\\${")
 }
 
 // =============================================================================
@@ -2023,153 +1950,6 @@ mod tests {
         assert!(!values_differ("", NULL_FLAG, ValType::String));
         assert!(!values_differ("   ", NULL_FLAG, ValType::String));
         assert!(values_differ("custom", NULL_FLAG, ValType::String));
-    }
-
-    #[test]
-    fn test_to_nix_value_bool() {
-        assert_eq!(
-            to_nix_value("true", "system.defaults.dock", "autohide"),
-            "true"
-        );
-        assert_eq!(
-            to_nix_value("false", "system.defaults.dock", "autohide"),
-            "false"
-        );
-        assert_eq!(
-            to_nix_value("1", "system.defaults.dock", "autohide"),
-            "true"
-        );
-    }
-
-    #[test]
-    fn test_to_nix_value_int() {
-        assert_eq!(to_nix_value("16", "system.defaults.dock", "tilesize"), "16");
-        assert_eq!(
-            to_nix_value("120", "system.defaults.NSGlobalDomain", "KeyRepeat"),
-            "120"
-        );
-    }
-
-    #[test]
-    fn test_to_nix_value_float() {
-        assert_eq!(
-            to_nix_value("0.0", "system.defaults.dock", "autohide-delay"),
-            "0.0"
-        );
-    }
-
-    #[test]
-    fn test_to_nix_value_string() {
-        assert_eq!(
-            to_nix_value("left", "system.defaults.dock", "orientation"),
-            "\"left\""
-        );
-        assert_eq!(
-            to_nix_value(
-                "Dark",
-                "system.defaults.NSGlobalDomain",
-                "AppleInterfaceStyle"
-            ),
-            "\"Dark\""
-        );
-    }
-
-    #[test]
-    fn test_to_nix_value_string_from_int_map() {
-        assert_eq!(
-            to_nix_value("2", "system.defaults.hitoolbox", "AppleFnUsageType"),
-            "\"Show Emoji & Symbols\""
-        );
-        assert_eq!(
-            to_nix_value("99", "system.defaults.hitoolbox", "AppleFnUsageType"),
-            "\"99\""
-        );
-    }
-
-    #[test]
-    fn test_to_nix_value_null_flag_key() {
-        assert_eq!(
-            to_nix_value("", "system.defaults.dock", "persistent-apps"),
-            "null"
-        );
-        assert_eq!(
-            to_nix_value("   ", "system.defaults.dock", "persistent-apps"),
-            "null"
-        );
-    }
-
-    #[test]
-    fn test_to_nix_value_null_flag_key_preserves_non_empty_values() {
-        assert_eq!(
-            to_nix_value("0", "system.defaults.dock", "persistent-apps"),
-            "\"0\""
-        );
-        assert_eq!(
-            to_nix_value("false", "system.defaults.dock", "persistent-apps"),
-            "\"false\""
-        );
-    }
-
-    #[test]
-    fn test_escape_nix_string() {
-        assert_eq!(escape_nix_string("hello"), "hello");
-        assert_eq!(escape_nix_string("say \"hi\""), "say \\\"hi\\\"");
-        assert_eq!(escape_nix_string("${foo}"), "\\${foo}");
-    }
-
-    #[test]
-    fn test_generate_system_defaults_nix_empty() {
-        let result = generate_system_defaults_nix(&[]);
-        assert!(result.contains("{ config, ... }:"));
-        assert!(result.contains("# macOS system defaults"));
-    }
-
-    #[test]
-    fn test_generate_system_defaults_nix_grouped() {
-        let defaults = vec![
-            SystemDefault {
-                nix_key: "system.defaults.dock.autohide".into(),
-                label: "Automatically hide the Dock".into(),
-                category: "Dock".into(),
-                current_value: "true".into(),
-                default_value: "false".into(),
-            },
-            SystemDefault {
-                nix_key: "system.defaults.dock.orientation".into(),
-                label: "Dock position on screen".into(),
-                category: "Dock".into(),
-                current_value: "left".into(),
-                default_value: "bottom".into(),
-            },
-            SystemDefault {
-                nix_key: "system.defaults.NSGlobalDomain.AppleInterfaceStyle".into(),
-                label: "Dark Mode".into(),
-                category: "Global".into(),
-                current_value: "Dark".into(),
-                default_value: "".into(),
-            },
-        ];
-
-        let result = generate_system_defaults_nix(&defaults);
-        assert!(result.contains("system.defaults.NSGlobalDomain = {"));
-        assert!(result.contains("system.defaults.dock = {"));
-        assert!(result.contains("autohide = true;"));
-        assert!(result.contains("orientation = \"left\";"));
-        assert!(result.contains("AppleInterfaceStyle = \"Dark\";"));
-    }
-
-    #[test]
-    fn test_generate_system_defaults_nix_null_flag_key() {
-        let defaults = vec![SystemDefault {
-            nix_key: "system.defaults.dock.persistent-apps".into(),
-            label: "Persistent Dock apps".into(),
-            category: "Dock".into(),
-            current_value: "".into(),
-            default_value: NULL_FLAG.into(),
-        }];
-
-        let result = generate_system_defaults_nix(&defaults);
-        assert!(result.contains("persistent-apps = null;"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Use the "managed edits" capability when applying track-changes for `system.defaults`. This fixes two broadly obvious problems, namely:

1. Track-changes for defaults was one-shot; once you had tracked a change or the whole group, the `system-defaults.nix` file would get written and you'd never be presented with more possible changes to track.
2. When you would choose to track a change, it would overwrite that entire file, so any that you had tracked before would get blown away. That's exactly one of the things the managed-editor prevents.

Plus I think the code is generally cleaner now.

As part of this change, I added a new utility to get the `system.primaryUser`which fixes a less-obvious problem in the old system which is if you had that defined somewhere else, we would have duplicated it in the new flake.

<!-- What does this PR do? Why? -->

## Test Plan

New unit tests + manual testing in the UI.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed