### PR TITLE
feat: apply template placeholder substitution when importing a zip repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "walkdir",
  "zip 2.4.2",
 ]
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ sudo cp /etc/{bashrc,zshrc,zshenv} /etc/{bashrc,zshrc,zshenv}.before-nix-darwin
 sudo -i nix run nix-darwin/master#darwin-rebuild -- switch --flake ~/.darwin#$HOSTNAME
 ```
 
+### Nixmac Template Placeholders
+
+When you import a nix repository from a zip file, nixmac will perform substitution on the following placholder strings:
+
+| Placeholder | Value |
+| ----------- | ----- |
+| `HOSTNAME_PLACEHOLDER` | Hostname of the Mac you're running on |
+| `PLATFORM_PLACEHOLDER` | Platform architecture of the Mac you're running on |
+| `USERNAME_PLACEHOLDER` | Current username e.g. `$USER` |
+
 > **Determinate Nix note:** `darwin-rebuild` isn't installed globally. Run it via `sudo -i nix run nix-darwin/master#darwin-rebuild`.
 
 ## AI Configuration

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ sudo -i nix run nix-darwin/master#darwin-rebuild -- switch --flake ~/.darwin#$HO
 
 ### Nixmac Template Placeholders
 
-When you import a nix repository from a zip file, nixmac will perform substitution on the following placholder strings:
+When you import a nix repository from a zip file, nixmac will perform substitution on the following placeholder strings:
 
 | Placeholder | Value |
 | ----------- | ----- |

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -79,12 +79,18 @@ tiktoken-rs = "0.6"
 url = "2"
 opentelemetry = "0.29"
 opentelemetry_sdk = "0.29"
-opentelemetry-otlp = { version = "0.29", features = ["trace", "logs", "http-proto", "reqwest-client"] }
+opentelemetry-otlp = { version = "0.29", features = [
+  "trace",
+  "logs",
+  "http-proto",
+  "reqwest-client",
+] }
 opentelemetry-appender-tracing = "0.29"
 tracing-opentelemetry = "0.30"
 configurable = { path = "configurable" }
 hmac = "0.12"
 zip = { version = "2", default-features = false, features = ["deflate"] }
+walkdir = "2.5.0"
 plist = "1.9.0"
 
 [dependencies.tauri-plugin-sql]

--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -50,7 +50,11 @@ pub fn detect_hostname() -> Result<String, String> {
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    Ok(sanitize_hostname(&String::from_utf8_lossy(&output.stdout)))
+    let hostname = sanitize_hostname(&String::from_utf8_lossy(&output.stdout));
+    if hostname.is_empty() {
+        return Err("Hostname is empty".to_string());
+    }
+    Ok(hostname)
 }
 
 /// Detects the current macOS username from the environment, defaulting to "unknown" if not found.

--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -9,9 +9,54 @@ use std::path::Path;
 use std::process::Command;
 use tauri::{AppHandle, Manager};
 
+use crate::bootstrap::is_nix_file;
 use crate::git;
 use crate::storage::store;
 use crate::system::nix;
+
+/// Strips whitespace and the mDNS `.local` suffix so the result is usable as a
+/// nix-darwin configuration attribute name.
+fn sanitize_hostname(raw: &str) -> String {
+    let trimmed = raw.trim();
+    trimmed
+        .strip_suffix(".local")
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+/// Gets the hostname that we're running on.
+pub fn detect_hostname() -> Result<String, String> {
+    // Prefer `scutil --get LocalHostName`: unlike `hostname`, it never carries
+    // the `.local` suffix, which would otherwise end up in the generated
+    // darwinConfigurations."<hostname>" flake attribute.
+    if let Ok(output) = std::process::Command::new("scutil")
+        .args(["--get", "LocalHostName"])
+        .output()
+    {
+        if output.status.success() {
+            let name = sanitize_hostname(&String::from_utf8_lossy(&output.stdout));
+            if !name.is_empty() {
+                return Ok(name);
+            }
+        }
+    }
+
+    let output = std::process::Command::new("hostname")
+        .output()
+        .map_err(|e| format!("Failed to execute hostname command: {}", e))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to get hostname: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(sanitize_hostname(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Detects the current macOS username from the environment, defaulting to "unknown" if not found.
+pub fn detect_username() -> String {
+    std::env::var("USER").unwrap_or_else(|_| "unknown".to_string())
+}
 
 /// Detects the Darwin platform architecture.
 pub fn detect_darwin_platform() -> &'static str {
@@ -54,20 +99,12 @@ fn copy_template_dir(
             copy_template_dir(&src_path, &dest_path, hostname, platform, username)?;
         } else if src_path.is_file() {
             // Check if it's a .nix file that needs template processing
-            let is_nix_file = src_path
-                .extension()
-                .map(|ext| ext == "nix")
-                .unwrap_or(false);
-
-            if is_nix_file {
-                // Read and process template placeholders
-                let content = fs::read_to_string(&src_path)
-                    .map_err(|e| format!("Failed to read {}: {}", src_path.display(), e))?;
-
-                let processed = content
-                    .replace("HOSTNAME_PLACEHOLDER", hostname)
-                    .replace("PLATFORM_PLACEHOLDER", platform)
-                    .replace("USERNAME_PLACEHOLDER", username);
+            if is_nix_file(&src_path) {
+                // Read and process template placeholders using apply_template_placeholders.
+                let processed = crate::bootstrap::template::apply_template_placeholders(
+                    &src_path, hostname, platform, username,
+                )
+                .map_err(|e| format!("Failed to process template {}: {}", src_path.display(), e))?;
 
                 fs::write(&dest_path, processed)
                     .map_err(|e| format!("Failed to write {}: {}", dest_path.display(), e))?;
@@ -216,7 +253,7 @@ pub fn bootstrap(app: &AppHandle, hostname: &str) -> Result<(), String> {
     }
 
     let platform = detect_darwin_platform();
-    let username = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+    let username = detect_username();
     let template_path = resolve_template_path(app)?;
 
     log::info!("Using template from: {}", template_path.display());
@@ -310,5 +347,18 @@ mod tests {
         fs::write(temp.path().join(".DS_Store"), "").expect("create finder metadata");
 
         assert!(is_dir_safe_for_bootstrap(temp.path()).expect("check directory"));
+    }
+
+    #[test]
+    fn sanitize_hostname_strips_local_suffix_and_whitespace() {
+        assert_eq!(
+            sanitize_hostname("Coopers-MacBook-Pro.local\n"),
+            "Coopers-MacBook-Pro"
+        );
+        assert_eq!(
+            sanitize_hostname("Coopers-MacBook-Pro"),
+            "Coopers-MacBook-Pro"
+        );
+        assert_eq!(sanitize_hostname("  \n"), "");
     }
 }

--- a/apps/native/src-tauri/src/bootstrap/import.rs
+++ b/apps/native/src-tauri/src/bootstrap/import.rs
@@ -12,6 +12,10 @@ use anyhow::{Context, Result, anyhow, bail};
 use std::fs::File;
 use std::path::{Component, Path, PathBuf};
 
+use crate::bootstrap::default_config::{detect_hostname, detect_username};
+use crate::bootstrap::detect_darwin_platform;
+use crate::bootstrap::template::apply_template_placeholders_in_dir;
+
 /// A parsed GitHub/git reference ready to clone.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepoRef {
@@ -239,13 +243,18 @@ pub fn extract_zip(zip_path: &Path, dest: &Path) -> Result<()> {
             .with_context(|| format!("failed to extract {}", out_path.display()))?;
     }
 
+    let platform: &str = detect_darwin_platform();
+    let username = detect_username();
+    let hostname = detect_hostname().unwrap_or_else(|_| "localhost".to_string());
+    apply_template_placeholders_in_dir(dest, &hostname, platform, &username)?;
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
+    use std::{fs, io::Write};
 
     #[test]
     fn parses_owner_repo_shorthand() {
@@ -432,5 +441,38 @@ mod tests {
 
         assert!(dest.join("flake.nix").exists());
         assert!(dest.join("modules/base.nix").exists());
+    }
+
+    #[test]
+    fn extract_zip_processes_nested_nix_templates() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let zip_path = tmp.path().join("repo.zip");
+        write_zip(
+            &zip_path,
+            &[
+                ("repo-main/", ""),
+                (
+                    "repo-main/modules/darwin/default.nix",
+                    "host = \"HOSTNAME_PLACEHOLDER\"; system = \"PLATFORM_PLACEHOLDER\"; user = \"USERNAME_PLACEHOLDER\";",
+                ),
+                (
+                    "repo-main/modules/darwin/readme.txt",
+                    "HOSTNAME_PLACEHOLDER PLATFORM_PLACEHOLDER USERNAME_PLACEHOLDER",
+                ),
+            ],
+        );
+
+        let dest = tmp.path().join("out");
+        extract_zip(&zip_path, &dest).unwrap();
+
+        let nix = fs::read_to_string(dest.join("modules/darwin/default.nix")).unwrap();
+        assert!(!nix.contains("HOSTNAME_PLACEHOLDER"));
+        assert!(!nix.contains("PLATFORM_PLACEHOLDER"));
+        assert!(!nix.contains("USERNAME_PLACEHOLDER"));
+
+        let txt = fs::read_to_string(dest.join("modules/darwin/readme.txt")).unwrap();
+        assert!(txt.contains("HOSTNAME_PLACEHOLDER"));
+        assert!(txt.contains("PLATFORM_PLACEHOLDER"));
+        assert!(txt.contains("USERNAME_PLACEHOLDER"));
     }
 }

--- a/apps/native/src-tauri/src/bootstrap/mod.rs
+++ b/apps/native/src-tauri/src/bootstrap/mod.rs
@@ -7,6 +7,13 @@ pub mod default_config;
 pub mod import;
 pub mod template;
 
+use std::path::Path;
+
 // Re-export the key public API so callers can use short paths.
 #[allow(unused_imports)]
 pub use default_config::{bootstrap, detect_darwin_platform, finalize_flake_lock};
+
+/// Returns true if the path has a `.nix` extension, indicating it is likely a Nix file.
+pub(crate) fn is_nix_file(path: &Path) -> bool {
+    path.extension().map(|ext| ext == "nix").unwrap_or(false)
+}

--- a/apps/native/src-tauri/src/bootstrap/template.rs
+++ b/apps/native/src-tauri/src/bootstrap/template.rs
@@ -208,10 +208,8 @@ pub fn apply_template_placeholders_in_dir(
                 continue;
             }
 
-            let processed = crate::bootstrap::template::apply_template_placeholders(
-                path, hostname, platform, username,
-            )
-            .with_context(|| format!("failed to process template {}", path.display()))?;
+            let processed = apply_template_placeholders(path, hostname, platform, username)
+                .with_context(|| format!("failed to process template {}", path.display()))?;
             fs::write(path, processed)
                 .with_context(|| format!("failed to write {}", path.display()))?;
         }
@@ -228,8 +226,8 @@ pub fn apply_template_placeholders(
     platform: &str,
     username: &str,
 ) -> Result<String, Error> {
-    let content = fs::read_to_string(&src_path)
-        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", src_path.display(), e))?;
+    let content = fs::read_to_string(src_path)
+        .with_context(|| format!("failed to read {}", src_path.display()))?;
 
     let processed = content
         .replace("HOSTNAME_PLACEHOLDER", hostname)

--- a/apps/native/src-tauri/src/bootstrap/template.rs
+++ b/apps/native/src-tauri/src/bootstrap/template.rs
@@ -4,10 +4,14 @@
 //! This module provides a flexible templating system that can process
 //! Nix configuration files with variable substitution and conditional logic.
 
+use anyhow::{Context, Error, Result};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use tera::{Context, Tera};
+use tera::{Context as TeraContext, Tera};
+use walkdir::WalkDir;
+
+use crate::bootstrap::is_nix_file;
 
 /// Template engine wrapper for Nix configuration files.
 pub struct TemplateEngine {
@@ -124,15 +128,15 @@ impl TemplateContext {
     }
 
     /// Converts this context to a Tera context.
-    fn to_tera_context(&self) -> Context {
-        let mut ctx = Context::new();
+    fn to_tera_context(&self) -> TeraContext {
+        let mut ctx = TeraContext::new();
         for (key, value) in &self.values {
             self.insert_value_into_context(&mut ctx, key, value);
         }
         ctx
     }
 
-    fn insert_value_into_context(&self, ctx: &mut Context, key: &str, value: &ContextValue) {
+    fn insert_value_into_context(&self, ctx: &mut TeraContext, key: &str, value: &ContextValue) {
         fn context_value_to_json(value: &ContextValue) -> serde_json::Value {
             match value {
                 ContextValue::String(s) => serde_json::Value::String(s.clone()),
@@ -186,6 +190,53 @@ pub enum TemplateError {
     /// Error reading a template file
     #[error("Template I/O error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+/// Recursively applies template placeholder substitutions to all .nix files in `dir`.
+pub fn apply_template_placeholders_in_dir(
+    dir: &Path,
+    hostname: &str,
+    platform: &str,
+    username: &str,
+) -> Result<()> {
+    for entry in WalkDir::new(dir).min_depth(1) {
+        let entry = entry.with_context(|| format!("failed to walk {}", dir.display()))?;
+
+        if entry.file_type().is_file() {
+            let path = entry.path();
+            if !is_nix_file(path) {
+                continue;
+            }
+
+            let processed = crate::bootstrap::template::apply_template_placeholders(
+                path, hostname, platform, username,
+            )
+            .with_context(|| format!("failed to process template {}", path.display()))?;
+            fs::write(path, processed)
+                .with_context(|| format!("failed to write {}", path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Applies simple string substitutions for our "standard" nix-darwin-related
+/// placeholders in a file.
+pub fn apply_template_placeholders(
+    src_path: &Path,
+    hostname: &str,
+    platform: &str,
+    username: &str,
+) -> Result<String, Error> {
+    let content = fs::read_to_string(&src_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", src_path.display(), e))?;
+
+    let processed = content
+        .replace("HOSTNAME_PLACEHOLDER", hostname)
+        .replace("PLATFORM_PLACEHOLDER", platform)
+        .replace("USERNAME_PLACEHOLDER", username);
+
+    Ok(processed)
 }
 
 /// Renders a template file and writes the result to the output path.
@@ -319,5 +370,30 @@ mod tests {
         assert!(result.contains("\"My nix-darwin configuration\""));
         assert!(result.contains("darwinConfigurations.\"macbook-pro\""));
         assert!(result.contains("system = \"aarch64-darwin\""));
+    }
+
+    #[test]
+    fn test_apply_template_placeholders() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let template_path = temp_dir.path().join("template.nix");
+
+        // Write a template with all supported placeholders.
+        let content = r#"hostname = "HOSTNAME_PLACEHOLDER";
+platform = "PLATFORM_PLACEHOLDER";
+username = "USERNAME_PLACEHOLDER";"#;
+        fs::write(&template_path, content).unwrap();
+
+        let result = apply_template_placeholders(
+            &template_path,
+            "my-macbook",
+            "aarch64-darwin",
+            "my-username",
+        )
+        .unwrap();
+
+        // Assert that the results contain the expected substitutions.
+        assert!(result.contains("hostname = \"my-macbook\";"));
+        assert!(result.contains("platform = \"aarch64-darwin\";"));
+        assert!(result.contains("username = \"my-username\";"));
     }
 }

--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -18,20 +18,6 @@ pub async fn config_get(app: AppHandle) -> Result<types::Config, String> {
     })
 }
 
-/// Helper to get the hostname via a blocking command.
-pub fn get_this_hostname_cmd() -> Result<String, String> {
-    let output = std::process::Command::new("hostname")
-        .output()
-        .map_err(|e| capture_err("get_this_hostname", e))?;
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to get hostname: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    Ok(sanitize_hostname(&String::from_utf8_lossy(&output.stdout)))
-}
-
 /// Gets the hostname that we're running on, does not touch config but is used
 /// for UI convenience and onboarding defaults.
 /// The name of this function is specifically chosen to NOT get confused

--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -38,32 +38,9 @@ pub fn get_this_hostname_cmd() -> Result<String, String> {
 /// with an actual config read.
 #[tauri::command]
 pub async fn get_this_hostname() -> Result<String, String> {
-    // Prefer `scutil --get LocalHostName`: unlike `hostname`, it never carries
-    // the `.local` suffix, which would otherwise end up in the generated
-    // darwinConfigurations."<hostname>" flake attribute.
-    if let Ok(output) = std::process::Command::new("scutil")
-        .args(["--get", "LocalHostName"])
-        .output()
-    {
-        if output.status.success() {
-            let name = sanitize_hostname(&String::from_utf8_lossy(&output.stdout));
-            if !name.is_empty() {
-                return Ok(name);
-            }
-        }
-    }
-
-    get_this_hostname_cmd()
-}
-
-/// Strips whitespace and the mDNS `.local` suffix so the result is usable as a
-/// nix-darwin configuration attribute name.
-fn sanitize_hostname(raw: &str) -> String {
-    let trimmed = raw.trim();
-    trimmed
-        .strip_suffix(".local")
-        .unwrap_or(trimmed)
-        .to_string()
+    let hostname =
+        default_config::detect_hostname().map_err(|e| capture_err("get_this_hostname", e))?;
+    Ok(hostname)
 }
 
 /// Sets the nix-darwin host attribute (e.g., "Coopers-MacBook-Pro").
@@ -466,18 +443,5 @@ mod tests {
         assert!(validate_new_dir_location(&home.join(".darwin-test")).is_ok());
         assert!(validate_new_dir_location(&home.join("configs").join("darwin")).is_err());
         assert!(validate_new_dir_location(Path::new("/tmp/darwin")).is_err());
-    }
-
-    #[test]
-    fn sanitize_hostname_strips_local_suffix_and_whitespace() {
-        assert_eq!(
-            sanitize_hostname("Coopers-MacBook-Pro.local\n"),
-            "Coopers-MacBook-Pro"
-        );
-        assert_eq!(
-            sanitize_hostname("Coopers-MacBook-Pro"),
-            "Coopers-MacBook-Pro"
-        );
-        assert_eq!(sanitize_hostname("  \n"), "");
     }
 }

--- a/apps/native/src-tauri/src/system/launchd_scanner.rs
+++ b/apps/native/src-tauri/src/system/launchd_scanner.rs
@@ -415,9 +415,9 @@ mod tests {
     #[ignore = "Runs against the local system; enable explicitly when debugging the launchd scanner."]
     #[cfg(target_os = "macos")]
     fn test_scan_launchd_items() {
-        use crate::commands::config::get_this_hostname_cmd;
+        use crate::bootstrap::default_config::detect_hostname;
 
-        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        let this_host_name = detect_hostname().expect("failed to get hostname");
         const CONFIG_DIR: &str = "~/.darwin";
         let items = scan_launchd_items_for_hostname(&this_host_name, CONFIG_DIR);
         match items {

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -768,9 +768,9 @@ mod tests {
     #[ignore = "Runs against the local system; enable explicitly when debugging the nix launchd eval."]
     #[cfg(target_os = "macos")]
     fn test_get_nix_launchd_items() {
-        use crate::commands::config::get_this_hostname_cmd;
+        use crate::bootstrap::default_config::detect_hostname;
 
-        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        let this_host_name = detect_hostname().expect("failed to get hostname");
         const CONFIG_DIR: &str = "~/.darwin";
         let items = get_nix_launchd_items(&this_host_name, CONFIG_DIR);
         match items {
@@ -789,9 +789,9 @@ mod tests {
     #[ignore = "Runs against the local system; enable explicitly when debugging the nix system defaults."]
     #[cfg(target_os = "macos")]
     fn test_get_nix_system_defaults_for_domain() -> Result<()> {
-        use crate::commands::config::get_this_hostname_cmd;
+        use crate::bootstrap::default_config::detect_hostname;
 
-        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        let this_host_name = detect_hostname().expect("failed to get hostname");
         const CONFIG_DIR: &str = "~/.darwin";
         let domain = "finder";
 

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -1930,9 +1930,9 @@ mod tests {
     #[ignore = "Runs against the local system; enable explicitly when debugging the defaults scanner."]
     #[cfg(target_os = "macos")]
     fn test_scan_system_defaults() {
-        use crate::commands::config::get_this_hostname_cmd;
+        use crate::bootstrap::default_config::detect_hostname;
 
-        let this_host_name = get_this_hostname_cmd().expect("Failed to get hostname for test");
+        let this_host_name = detect_hostname().expect("failed to get hostname");
         const CONFIG_DIR: &str = "~/.darwin";
 
         let scan = scan_system_defaults(&this_host_name, CONFIG_DIR);


### PR DESCRIPTION
## Summary

This is to make the use case where the user unzips one of our template repositories (or one of theirs that uses our now-documented in the README contentions) work the way you would expect, e.g. you can select a correct hostname, and the user and architecture will be set when you subsequently try to build.

I went ahead and added a `walkdir` dep since it's already in Cargo.lock in about 10 different places and it makes the code cleaner/more robust. I also did some refactoring to put things in better places and increase some test coverage.

<!-- What does this PR do? Why? -->

## Test Plan

Manual (scenario described above) plus a variety of new unit tests.

- [ ] No test plan needed

## Docs

- [x] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [ ] No docs update needed