### PR TITLE
feat: gate Next button on initial commit check in setup step, make sure initial commit check shows up more correctly

### DIFF
--- a/apps/native/src/components/widget/controls/bootstrap-config.tsx
+++ b/apps/native/src/components/widget/controls/bootstrap-config.tsx
@@ -12,11 +12,18 @@ import { useEffect, useState } from "react";
 interface BootstrapConfigProps {
   label: string;
   onSuccess?: () => void;
+  showLabel?: boolean;
+  forceNeedsInitialCommit?: boolean;
 }
 
 const DEFAULT_HOSTNAME = "macbook";
 
-export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
+export function BootstrapConfig({
+  label,
+  onSuccess,
+  showLabel = true,
+  forceNeedsInitialCommit = false,
+}: BootstrapConfigProps) {
   const [hostname, setHostname] = useState(DEFAULT_HOSTNAME);
   const [hostnamePlaceholder, setHostnamePlaceholder] = useState(DEFAULT_HOSTNAME);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -59,7 +66,9 @@ export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
     tauriAPI.flake.existsAt(configDir).then(setFlakeExists).catch(() => setFlakeExists(false));
   }, [configDir]);
 
-  const needsInitialCommit = flakeExists && (gitStatus === null || gitStatus.headCommitHash === "");
+  const needsInitialCommit =
+    forceNeedsInitialCommit ||
+    (flakeExists && (gitStatus === null || gitStatus.headCommitHash === ""));
 
   const message = needsInitialCommit
     ? "flake.nix found but not committed — Nix needs a git commit to evaluate your flake"
@@ -83,7 +92,7 @@ export function BootstrapConfig({ label, onSuccess }: BootstrapConfigProps) {
 
   return (
     <div className="space-y-2">
-      <label className="font-medium text-sm">{label}</label>
+      {showLabel && <label className="font-medium text-sm">{label}</label>}
       <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
         <div className="flex items-start gap-2">
           <AlertCircle className="mt-0.5 h-4 w-4 text-muted-foreground" />

--- a/apps/native/src/components/widget/steps/setup-step.test.tsx
+++ b/apps/native/src/components/widget/steps/setup-step.test.tsx
@@ -6,13 +6,61 @@ import { useViewModel } from "@/stores/view-model";
 import { makeGlobalPreferences } from "@/utils/test-fixtures";
 
 const { mockSaveHost } = vi.hoisted(() => ({
+const { mockFlakeExistsAt, mockSaveHost, viewModelState, widgetState } = vi.hoisted(() => ({
+  mockFlakeExistsAt: vi.fn<(dir: string) => Promise<boolean>>(),
   mockSaveHost: vi.fn<(host: string) => Promise<void>>(),
+  viewModelState: {
+    git: {
+      headCommitHash: "abc123",
+    } as { headCommitHash: string | null } | null,
+  },
+}));
+
+vi.mock("@/stores/view-model", () => ({
+  useViewModel: <T,>(selector: (state: typeof viewModelState) => T) =>
+    selector(viewModelState),
+}));
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    flake: {
+      existsAt: mockFlakeExistsAt,
+    },
+  },
 }));
 
 vi.mock("@/hooks/use-darwin-config", () => ({
   useDarwinConfig: () => ({
     saveHost: mockSaveHost,
   }),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    children,
+    onValueChange,
+    value,
+  }: {
+    children: React.ReactNode;
+    onValueChange?: (value: string) => void;
+    value?: string;
+  }) => (
+    <select
+      aria-label="host-select"
+      value={value ?? ""}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{value}</option>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: ({ placeholder }: { placeholder: string }) => (
+    <option value="">{placeholder}</option>
+  ),
 }));
 
 vi.mock("@/components/widget/controls/directory-picker", () => ({
@@ -24,7 +72,11 @@ vi.mock("@/components/widget/controls/directory-picker", () => ({
 }));
 
 vi.mock("@/components/widget/controls/bootstrap-config", () => ({
-  BootstrapConfig: () => <div data-testid="bootstrap-config" />,
+  BootstrapConfig: ({ showLabel = true }: { showLabel?: boolean }) => (
+    <div data-testid="bootstrap-config" data-show-label={String(showLabel)}>
+      Make initial commit
+    </div>
+  ),
 }));
 
 import { SetupStep } from "./setup-step";
@@ -39,11 +91,14 @@ function seedConfig(configDir: string | null, hosts: string[], host: string | nu
 describe("<SetupStep>", () => {
   beforeEach(() => {
     seedConfig(null, [], null);
+    viewModelState.git = { headCommitHash: "abc123" };
+    mockFlakeExistsAt.mockReset();
+    mockFlakeExistsAt.mockResolvedValue(true);
     mockSaveHost.mockReset();
     mockSaveHost.mockResolvedValue();
   });
 
-  it("persists the displayed host when Next is clicked without changing the dropdown", async () => {
+  it("uses a prefilled host when showing Next", async () => {
     seedConfig("/Users/me/.nixmac", ["mbp"], "mbp");
 
     render(<SetupStep />);
@@ -63,5 +118,31 @@ describe("<SetupStep>", () => {
 
     expect(await screen.findByTestId("bootstrap-config")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+  });
+
+  it("does not show Next or initial commit before a host is filled", () => {
+    widgetState.configDir = "/Users/me/.nixmac";
+    widgetState.hosts = ["mbp", "mini"];
+    widgetState.host = "";
+
+    render(<SetupStep />);
+
+    expect(screen.queryByText("Make initial commit")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+    expect(mockFlakeExistsAt).not.toHaveBeenCalled();
+  });
+
+  it("shows the initial commit UI instead of Next when a prefilled host has no initial commit", async () => {
+    widgetState.configDir = "/Users/me/.nixmac";
+    widgetState.hosts = ["mbp", "mini"];
+    widgetState.host = "mbp";
+    viewModelState.git = { headCommitHash: "" };
+    mockFlakeExistsAt.mockResolvedValue(true);
+
+    render(<SetupStep />);
+
+    expect(await screen.findByText("Make initial commit")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+    expect(mockFlakeExistsAt).toHaveBeenCalledWith("/Users/me/.nixmac");
   });
 });

--- a/apps/native/src/components/widget/steps/setup-step.test.tsx
+++ b/apps/native/src/components/widget/steps/setup-step.test.tsx
@@ -2,23 +2,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { GitStatus } from "@/ipc/types";
 import { useViewModel } from "@/stores/view-model";
 import { makeGlobalPreferences } from "@/utils/test-fixtures";
 
-const { mockSaveHost } = vi.hoisted(() => ({
-const { mockFlakeExistsAt, mockSaveHost, viewModelState, widgetState } = vi.hoisted(() => ({
+const { mockFlakeExistsAt, mockSaveHost } = vi.hoisted(() => ({
   mockFlakeExistsAt: vi.fn<(dir: string) => Promise<boolean>>(),
   mockSaveHost: vi.fn<(host: string) => Promise<void>>(),
-  viewModelState: {
-    git: {
-      headCommitHash: "abc123",
-    } as { headCommitHash: string | null } | null,
-  },
-}));
-
-vi.mock("@/stores/view-model", () => ({
-  useViewModel: <T,>(selector: (state: typeof viewModelState) => T) =>
-    selector(viewModelState),
 }));
 
 vi.mock("@/ipc/api", () => ({
@@ -33,34 +23,6 @@ vi.mock("@/hooks/use-darwin-config", () => ({
   useDarwinConfig: () => ({
     saveHost: mockSaveHost,
   }),
-}));
-
-vi.mock("@/components/ui/select", () => ({
-  Select: ({
-    children,
-    onValueChange,
-    value,
-  }: {
-    children: React.ReactNode;
-    onValueChange?: (value: string) => void;
-    value?: string;
-  }) => (
-    <select
-      aria-label="host-select"
-      value={value ?? ""}
-      onChange={(event) => onValueChange?.(event.target.value)}
-    >
-      {children}
-    </select>
-  ),
-  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SelectItem: ({ value }: { value: string; children: React.ReactNode }) => (
-    <option value={value}>{value}</option>
-  ),
-  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SelectValue: ({ placeholder }: { placeholder: string }) => (
-    <option value="">{placeholder}</option>
-  ),
 }));
 
 vi.mock("@/components/widget/controls/directory-picker", () => ({
@@ -91,14 +53,14 @@ function seedConfig(configDir: string | null, hosts: string[], host: string | nu
 describe("<SetupStep>", () => {
   beforeEach(() => {
     seedConfig(null, [], null);
-    viewModelState.git = { headCommitHash: "abc123" };
+    useViewModel.setState({ git: { headCommitHash: "abc123" } as GitStatus });
     mockFlakeExistsAt.mockReset();
     mockFlakeExistsAt.mockResolvedValue(true);
     mockSaveHost.mockReset();
     mockSaveHost.mockResolvedValue();
   });
 
-  it("uses a prefilled host when showing Next", async () => {
+  it("persists the displayed host when Next is clicked without changing the dropdown", async () => {
     seedConfig("/Users/me/.nixmac", ["mbp"], "mbp");
 
     render(<SetupStep />);
@@ -121,9 +83,7 @@ describe("<SetupStep>", () => {
   });
 
   it("does not show Next or initial commit before a host is filled", () => {
-    widgetState.configDir = "/Users/me/.nixmac";
-    widgetState.hosts = ["mbp", "mini"];
-    widgetState.host = "";
+    seedConfig("/Users/me/.nixmac", ["mbp", "mini"], "");
 
     render(<SetupStep />);
 
@@ -133,10 +93,8 @@ describe("<SetupStep>", () => {
   });
 
   it("shows the initial commit UI instead of Next when a prefilled host has no initial commit", async () => {
-    widgetState.configDir = "/Users/me/.nixmac";
-    widgetState.hosts = ["mbp", "mini"];
-    widgetState.host = "mbp";
-    viewModelState.git = { headCommitHash: "" };
+    seedConfig("/Users/me/.nixmac", ["mbp", "mini"], "mbp");
+    useViewModel.setState({ git: { headCommitHash: "" } as GitStatus });
     mockFlakeExistsAt.mockResolvedValue(true);
 
     render(<SetupStep />);

--- a/apps/native/src/components/widget/steps/setup-step.tsx
+++ b/apps/native/src/components/widget/steps/setup-step.tsx
@@ -13,7 +13,6 @@ import { DirectoryPicker } from "@/components/widget/controls/directory-picker";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
 import { tauriAPI } from "@/ipc/api";
 import { useViewModel } from "@/stores/view-model";
-import { useViewModel } from "@/stores/view-model";
 import { Monitor } from "lucide-react";
 import { useEffect, useState } from "react";
 

--- a/apps/native/src/components/widget/steps/setup-step.tsx
+++ b/apps/native/src/components/widget/steps/setup-step.tsx
@@ -11,6 +11,8 @@ import {
 import { BootstrapConfig } from "@/components/widget/controls/bootstrap-config";
 import { DirectoryPicker } from "@/components/widget/controls/directory-picker";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
+import { tauriAPI } from "@/ipc/api";
+import { useViewModel } from "@/stores/view-model";
 import { useViewModel } from "@/stores/view-model";
 import { Monitor } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -19,8 +21,10 @@ export function SetupStep() {
   const configDir = useViewModel((state) => state.preferences?.configDir ?? "");
   const hosts = useViewModel((state) => state.hosts);
   const host = useViewModel((state) => state.preferences?.hostAttr ?? "");
+  const gitStatus = useViewModel((state) => state.git);
   const [configDirConfirmed, setConfigDirConfirmed] = useState(() => Boolean(configDir));
   const [selectedHost, setSelectedHost] = useState<string>("");
+  const [flakeExists, setFlakeExists] = useState<boolean | null>(null);
 
   const { saveHost } = useDarwinConfig();
 
@@ -31,6 +35,35 @@ export function SetupStep() {
   const hasConfigDir = Boolean(configDir) && configDirConfirmed;
   const hasHosts = hasConfigDir && hosts.length > 0;
   const effectiveHost = selectedHost || host;
+  const hasEffectiveHost = effectiveHost.trim().length > 0;
+  const needsInitialCommit =
+    hasEffectiveHost &&
+    flakeExists === true &&
+    (gitStatus === null || gitStatus.headCommitHash === "");
+  const checkingInitialCommit = hasHosts && hasEffectiveHost && flakeExists === null;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!hasConfigDir || (hasHosts && !hasEffectiveHost)) {
+      setFlakeExists(false);
+      return;
+    }
+
+    setFlakeExists(null);
+    tauriAPI.flake
+      .existsAt(configDir)
+      .then((exists) => {
+        if (!cancelled) setFlakeExists(exists);
+      })
+      .catch(() => {
+        if (!cancelled) setFlakeExists(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [configDir, effectiveHost, hasConfigDir, hasEffectiveHost, hasHosts]);
 
   return (
     <div className="flex flex-col items-center justify-center space-y-6 py-8">
@@ -83,8 +116,15 @@ export function SetupStep() {
           ) : (
             <BootstrapConfig label="2. Configuration" />
           )}
-          {hasHosts && (
-            <Button disabled={!effectiveHost} onClick={() => saveHost(effectiveHost)}>
+          {hasHosts && needsInitialCommit && (
+            <BootstrapConfig
+              label="2. Configuration"
+              showLabel={false}
+              forceNeedsInitialCommit
+            />
+          )}
+          {hasHosts && hasEffectiveHost && !needsInitialCommit && !checkingInitialCommit && (
+            <Button onClick={() => saveHost(effectiveHost)}>
               Next
             </Button>
           )}


### PR DESCRIPTION
## Summary

This fixes an issue where if you did an Import to a new directory, the "needs initial commit" check and corresponding UI would not show up, and the "Next" button would incorrectly allow you to jump right to the Evolve step. A side effect of that fix is that this _starts_ to clean up some of the weird behavior I've previously noted around the meaning and behavior of the "Next" button.

<!-- What does this PR do? Why? -->

## Test Plan

Added and updated vite tests, re-test import from zip in the UI.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed