### PR TITLE
feat: gate filesystem sections individually via `VITE_NIXMAC_FILESYSTEM` bitmask flag

### DIFF
--- a/apps/native/src/components/widget/filesystem/data.ts
+++ b/apps/native/src/components/widget/filesystem/data.ts
@@ -6,6 +6,7 @@ import type {
   SystemDefault,
   SystemDefaultsScan,
 } from "@/ipc/types";
+import { filesystemSectionEnabled, FilesystemSectionFlag } from "@/lib/flags";
 
 export type FileTone = "teal" | "amber" | "rose" | "blue" | "muted";
 export type FileStatus = "managed" | "changed" | "candidate";
@@ -67,6 +68,7 @@ export type Section = {
   id: SectionId;
   label: string;
   hint: string;
+  flagValue: FilesystemSectionFlag;
 };
 
 export type FsIconName =
@@ -84,13 +86,16 @@ export type FsIconName =
   | "settings"
   | "warn";
 
-export const SECTIONS: Section[] = [
-  { id: "entry", label: "Setup", hint: "Flake & host wiring" },
-  { id: "darwin", label: "System", hint: "macOS, packages, services" },
-  { id: "home", label: "Personal", hint: "Dotfiles & app prefs" },
-  { id: "support", label: "Secrets", hint: "Sops, overlays, scripts" },
-  { id: "manage", label: "Untracked", hint: "Machine state not yet in your config" },
+
+const allSections: Section[] = [
+  { id: "entry", label: "Setup", hint: "Flake & host wiring", flagValue: FilesystemSectionFlag.Entry },
+  { id: "darwin", label: "System", hint: "macOS, packages, services", flagValue: FilesystemSectionFlag.Darwin },
+  { id: "home", label: "Personal", hint: "Dotfiles & app prefs", flagValue: FilesystemSectionFlag.Home },
+  { id: "support", label: "Secrets", hint: "Sops, overlays, scripts", flagValue: FilesystemSectionFlag.Support },
+  { id: "manage", label: "Untracked", hint: "Machine state not yet in your config", flagValue: FilesystemSectionFlag.Manage },
 ];
+
+export const SECTIONS = allSections.filter((section) =>  filesystemSectionEnabled(section.flagValue));
 
 export const FILES: Record<SectionId, FsFile[]> = {
   entry: [

--- a/apps/native/src/lib/flags.ts
+++ b/apps/native/src/lib/flags.ts
@@ -1,23 +1,56 @@
 /**
  * Feature flags — VITE_-prefixed env vars compiled in at build time.
  *
- * Convention: a feature flag is `true` when explicitly set to "true",
- * "1", or "on", or implicitly when running under `import.meta.env.DEV`.
- * Anything else is `false`. Each flag has a single named export so it
- * can be tree-shaken independently.
+ * Most flags are simple booleans. The filesystem flag additionally supports
+ * a bitmask value that enables individual sections of the UI.
+ *
+ * For filesystem flags:
+ *   - "true", "1", or "on" enable all sections
+ *   - a positive integer enables the corresponding section bitmask
+ *   - "false", "0", "off", unset, or invalid values disable all sections
+ *   - in DEV builds, all sections are enabled by default unless the env var
+ *     is explicitly set, in which case its value takes precedence
  */
 
-function envFlag(value: unknown): boolean {
-  if (typeof value !== "string") return false;
-  const v = value.toLowerCase();
-  return v === "true" || v === "1" || v === "on";
+export const enum FilesystemSectionFlag {
+  Entry   = 1 << 1,
+  Darwin  = 1 << 2,
+  Home    = 1 << 3,
+  Support = 1 << 4,
+  Manage  = 1 << 5,
+};
+
+function envBitmask(value: unknown): number {
+  if (typeof value !== "string") return 0;
+  const v = value.trim().toLowerCase();
+  if (v === "true" || v === "1" || v === "on") {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  if (!/^\d+$/.test(v)) {
+    return 0;
+  }
+  return Number.parseInt(v, 10);
 }
+
+const filesystemEnv = import.meta.env.VITE_NIXMAC_FILESYSTEM;
+
+// In DEV builds if the env var IS set, use it as a bitmask so we
+// can test this behavior without doing a production build.
+const filesystemSectionMask =
+  filesystemEnv !== undefined
+    ? envBitmask(filesystemEnv)
+    : import.meta.env.DEV
+      ? Number.MAX_SAFE_INTEGER
+      : 0;
 
 /**
  * Filesystem view (header FolderTree button + view itself).
  * Currently backed by mock data — keep gated until wired to real
  * filesystem state. Visible in dev builds; opt-in in production via
- * `VITE_NIXMAC_FILESYSTEM=true`.
+ * `VITE_NIXMAC_FILESYSTEM=true` or a numerical value which is a mask of the flags.
  */
-export const filesystemViewEnabled =
-  import.meta.env.DEV || envFlag(import.meta.env.VITE_NIXMAC_FILESYSTEM);
+export const filesystemViewEnabled = filesystemSectionMask !== 0;
+
+export function filesystemSectionEnabled(flagValue: FilesystemSectionFlag): boolean {
+  return (filesystemSectionMask & flagValue) !== 0;
+}

--- a/apps/native/src/lib/flags.ts
+++ b/apps/native/src/lib/flags.ts
@@ -6,13 +6,13 @@
  *
  * For filesystem flags:
  *   - "true", "1", or "on" enable all sections
- *   - a positive integer enables the corresponding section bitmask
+ *   - any other positive integer enables the corresponding section bitmask
  *   - "false", "0", "off", unset, or invalid values disable all sections
  *   - in DEV builds, all sections are enabled by default unless the env var
  *     is explicitly set, in which case its value takes precedence
  */
 
-export const enum FilesystemSectionFlag {
+export enum FilesystemSectionFlag {
   Entry   = 1 << 1,
   Darwin  = 1 << 2,
   Home    = 1 << 3,


### PR DESCRIPTION
## Summary

Change VITE_NIXMAC_FILESYSTEM into a bitmask that turns individual tabs on and off because they won't all be ready for prime time at the same time presumably. Also made the env var take precedence in DEV if set to allow testing without having to do a production build.

<!-- What does this PR do? Why? -->

## ![Screenshot 2026-06-19 at 4.42.13 PM.png](https://app.graphite.com/user-attachments/assets/e262bb45-8356-4c3a-b584-a6de5ac0a790.png)



## Test Plan

Tested unset, all-on, and a couple of individual cases.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed