### PR TITLE
feat: use `whoami` crate for username detection instead of `USER` env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -3066,14 +3066,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -3474,6 +3474,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "whoami 2.1.2",
  "zip 2.4.2",
 ]
 
@@ -3707,6 +3708,15 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4732,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5893,7 +5903,7 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -5933,7 +5943,7 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -7575,6 +7585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7597,6 +7616,15 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -7851,7 +7879,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
- "wasite",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite 1.0.2",
+ "web-sys",
 ]
 
 [[package]]

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -92,6 +92,7 @@ hmac = "0.12"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 walkdir = "2.5.0"
 plist = "1.9.0"
+whoami = "2.1.2"
 
 [dependencies.tauri-plugin-sql]
 features = ["sqlite"] # or "postgres", or "mysql"

--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -59,6 +59,13 @@ pub fn detect_hostname() -> Result<String, String> {
 
 /// Detects the current macOS username from the environment, defaulting to "unknown" if not found.
 pub fn detect_username() -> String {
+    let username = whoami::username().unwrap();
+
+    // If we didn't get a user name from this, try the USER environment variable as a fallback before giving up entirely.
+    if !username.is_empty() {
+        return username;
+    }
+
     std::env::var("USER").unwrap_or_else(|_| "unknown".to_string())
 }
 

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -466,7 +466,7 @@ fn run_activate_with_path(activate_path: &str) -> Result<ActivateResult, anyhow:
     let nix_path = crate::system::nix::get_nix_path();
     let home = std::env::var("HOME").unwrap_or_default();
     let ssh_sock = std::env::var("SSH_AUTH_SOCK").unwrap_or_default();
-    let user = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
+    let user = whoami::username().unwrap_or_else(|_| "root".to_string());
 
     // Resolve the symlink to the real nix store path.
     // sudo / visudo match against the canonical path, not the symlink.

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -5,6 +5,7 @@
 //! nix-darwin `system.defaults.*` keys. Also generates valid `.nix` module
 //! files from the detected customizations.
 
+use crate::bootstrap::default_config::detect_username;
 pub(crate) use crate::shared_types::{RecommendedPrompt, SystemDefault, SystemDefaultsScan};
 use crate::system::nix;
 use std::collections::BTreeMap;
@@ -1660,7 +1661,7 @@ pub fn generate_system_defaults_nix(defaults: &[SystemDefault]) -> String {
     }
 
     // Detect the current macOS username for system.primaryUser
-    let username = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+    let username = detect_username();
 
     let mut out = String::new();
     out.push_str("{ config, ... }:\n\n{\n");


### PR DESCRIPTION
## Summary

This is allegedly the best way to do this in a Rust/Mac app.

<!-- What does this PR do? Why? -->

## Test Plan

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed