### PR TITLE
feat: support subdirectory imports, SSH auth, and HTTPS for git cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,9 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -3044,7 +3047,9 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -3083,6 +3088,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3356,7 +3375,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework 3.7.0",
@@ -3806,9 +3825,24 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "openssl-sys"
@@ -3818,6 +3852,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5076,7 +5111,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -30,6 +30,13 @@ tauri-plugin-websocket = "2.0.0"
 tauri-plugin-window-state = "2.0.0"
 tauri-plugin-notification = "2"
 
+git2 = { version = "0.21.0", features = [
+  "https",
+  "ssh",
+  "vendored-libgit2",
+  "vendored-openssl",
+] }
+
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
@@ -45,7 +52,6 @@ tempfile = "3.23.0"
 async-openai = "0.30.1"
 async-trait = "0.1"
 glob = "0.3"
-git2 = "0.21.0"
 ignore = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }

--- a/apps/native/src-tauri/src/bootstrap/import.rs
+++ b/apps/native/src-tauri/src/bootstrap/import.rs
@@ -9,6 +9,7 @@
 //! had selected an existing flake.
 
 use anyhow::{Context, Result, anyhow, bail};
+use git2::{Cred, FetchOptions, RemoteCallbacks};
 use std::fs::File;
 use std::path::{Component, Path, PathBuf};
 
@@ -170,17 +171,173 @@ fn validate_subdir(path: &str) -> Result<()> {
     Ok(())
 }
 
+/// Clones the repository specified by `spec` into `dest`, then copies the specified
+/// subdirectory (if any) into `dest`, stripping the wrapper directory that git sparse
+/// sparse checkout would normally require. This allows us to support subdirectory imports
+/// without forcing users to understand git's sparse checkout semantics.
+pub fn materialize_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
+    // We're going to have issues later if `dest` already exists as a non-empty directory, so check that upfront before doing any cloning.
+    if dest.exists() {
+        if !dest.is_dir() {
+            bail!(
+                "destination exists and is not a directory: {}",
+                dest.display()
+            );
+        } else if dest.read_dir()?.next().is_some() {
+            bail!("destination directory is not empty: {}", dest.display());
+        }
+    }
+
+    // Easy case. No subdirectory means we can clone directly into the destination.
+    if spec.subdir.is_none() {
+        return clone_repo(spec, dest);
+    }
+
+    let temp = tempfile::tempdir().context("failed to create temporary clone directory")?;
+    let checkout_dir = temp.path().join("repo");
+
+    // Perform the actual clone into a temp directory, then copy the specified subdirectory into the final destination.
+    clone_repo(spec, &checkout_dir)?;
+
+    let subdir = spec.subdir.as_ref().unwrap();
+    let source = checkout_dir.join(subdir);
+
+    if !source.is_dir() {
+        bail!(
+            "subdirectory '{}' does not exist in {}",
+            subdir,
+            spec.clone_url
+        );
+    }
+
+    copy_dir_contents(&source, dest)
+        .with_context(|| format!("failed to copy subdirectory '{}' into destination", subdir))?;
+
+    Ok(())
+}
+
 /// Clones `spec` into `dest`. `dest` must not already exist as a non-empty
 /// directory (libgit2 requires an empty/absent target).
-pub fn clone_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
+fn clone_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
+    log::info!(
+        "Cloning {} into {} at {}",
+        spec.clone_url,
+        dest.display(),
+        spec.git_ref.as_deref().unwrap_or("default branch")
+    );
     let mut builder = git2::build::RepoBuilder::new();
     if let Some(branch) = &spec.git_ref {
         builder.branch(branch);
     }
-    builder
-        .clone(&spec.clone_url, dest)
-        .with_context(|| format!("failed to clone {}", spec.clone_url))?;
+
+    // Add ssh agent auth. This is required even if we are ostensibly cloning with an https url and even for a public repo
+    // because libgit2 will sometimes attempt to use the ssh transport for https urls when the remote supports it,
+    // and/or somebody is remapping to always use ssh in their local git config (if they have it).
+    // So without these callbacks the clone will fail with an auth error instead of falling back to https.
+    let mut callbacks = RemoteCallbacks::new();
+    callbacks.credentials(|_url, username_from_url, allowed| {
+        if allowed.contains(git2::CredentialType::SSH_KEY) {
+            return Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"));
+        }
+        if allowed.contains(git2::CredentialType::DEFAULT) {
+            return Cred::default();
+        }
+        Cred::default()
+    });
+
+    let mut fetch_options = FetchOptions::new();
+    fetch_options.remote_callbacks(callbacks);
+
+    let mut builder = git2::build::RepoBuilder::new();
+    builder.fetch_options(fetch_options);
+
+    if let Err(error) = builder.clone(&spec.clone_url, dest) {
+        log::error!(
+            "libgit2 clone failed: clone_url={}, destination={}, git_ref={:?}, libgit2_code={:?}, libgit2_class={:?}, libgit2_message={}, error={}",
+            spec.clone_url,
+            dest.display(),
+            spec.git_ref,
+            error.code(),
+            error.class(),
+            error.message(),
+            error
+        );
+
+        bail!("failed to clone {}", spec.clone_url);
+    }
     Ok(())
+}
+
+/// Copies the contents of `source` into `dest`, creating `dest`. Assumes `dest` does not exist or is empty as a precondition.
+fn copy_dir_contents(source: &Path, dest: &Path) -> Result<()> {
+    std::fs::create_dir_all(dest)
+        .with_context(|| format!("failed to create destination {}", dest.display()))?;
+
+    for entry in std::fs::read_dir(source)
+        .with_context(|| format!("failed to read source directory {}", source.display()))?
+    {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+
+        let file_type = entry.file_type()?;
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&from, &to).with_context(|| {
+                format!("failed to copy {} to {}", from.display(), to.display())
+            })?;
+        } else if file_type.is_symlink() {
+            copy_symlink(&from, &to)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<()> {
+    std::fs::create_dir_all(dest)
+        .with_context(|| format!("failed to create directory {}", dest.display()))?;
+
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        let file_type = entry.file_type()?;
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&from, &to).with_context(|| {
+                format!("failed to copy {} to {}", from.display(), to.display())
+            })?;
+        } else if file_type.is_symlink() {
+            // Yes, git repos can contain symlinks, and we need to preserve them when copying subdirectories out of the temp clone.
+            copy_symlink(&from, &to)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(source: &Path, dest: &Path) -> Result<()> {
+    let target = std::fs::read_link(source)
+        .with_context(|| format!("failed to read symlink {}", source.display()))?;
+
+    std::os::unix::fs::symlink(&target, dest)
+        .with_context(|| format!("failed to create symlink {}", dest.display()))?;
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn copy_symlink(source: &Path, _dest: &Path) -> Result<()> {
+    bail!(
+        "symlinks are not supported on this platform: {}",
+        source.display()
+    )
 }
 
 /// Returns the single shared top-level directory across all archive entries,

--- a/apps/native/src-tauri/src/bootstrap/import.rs
+++ b/apps/native/src-tauri/src/bootstrap/import.rs
@@ -28,6 +28,23 @@ pub struct RepoRef {
     pub subdir: Option<String>,
 }
 
+/// Sanitize a clone URL for logging, removing any embedded credentials.
+fn sanitize_clone_url_for_logs(clone_url: &str) -> String {
+    if let Ok(mut url) = url::Url::parse(clone_url) {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+        return url.to_string();
+    }
+
+    if let Some((_, rest)) = clone_url.split_once('@') {
+        if rest.contains(':') {
+            return format!("***@{}", rest);
+        }
+    }
+
+    clone_url.to_string()
+}
+
 fn is_valid_segment(segment: &str) -> bool {
     !segment.is_empty()
         && segment
@@ -206,7 +223,7 @@ pub fn materialize_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
         bail!(
             "subdirectory '{}' does not exist in {}",
             subdir,
-            spec.clone_url
+            sanitize_clone_url_for_logs(&spec.clone_url),
         );
     }
 
@@ -221,7 +238,7 @@ pub fn materialize_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
 fn clone_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
     log::info!(
         "Cloning {} into {} at {}",
-        spec.clone_url,
+        sanitize_clone_url_for_logs(&spec.clone_url),
         dest.display(),
         spec.git_ref.as_deref().unwrap_or("default branch")
     );
@@ -248,13 +265,12 @@ fn clone_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
     let mut fetch_options = FetchOptions::new();
     fetch_options.remote_callbacks(callbacks);
 
-    let mut builder = git2::build::RepoBuilder::new();
     builder.fetch_options(fetch_options);
 
     if let Err(error) = builder.clone(&spec.clone_url, dest) {
         log::error!(
             "libgit2 clone failed: clone_url={}, destination={}, git_ref={:?}, libgit2_code={:?}, libgit2_class={:?}, libgit2_message={}, error={}",
-            spec.clone_url,
+            sanitize_clone_url_for_logs(&spec.clone_url),
             dest.display(),
             spec.git_ref,
             error.code(),
@@ -263,7 +279,11 @@ fn clone_repo(spec: &RepoRef, dest: &Path) -> Result<()> {
             error
         );
 
-        bail!("failed to clone {}", spec.clone_url);
+        bail!(
+            "failed to clone {}, detail = {}",
+            sanitize_clone_url_for_logs(&spec.clone_url),
+            error
+        );
     }
     Ok(())
 }
@@ -484,6 +504,115 @@ pub fn extract_zip(zip_path: &Path, dest: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use std::{fs, io::Write};
+
+    fn create_local_repo(path: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(path).unwrap();
+
+        fs::create_dir_all(path.join("config/modules")).unwrap();
+        fs::write(path.join("README.md"), "repository root").unwrap();
+        fs::write(path.join("config/flake.nix"), "default branch").unwrap();
+        fs::write(path.join("config/modules/default.nix"), "{ }").unwrap();
+
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"], git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let signature = git2::Signature::now("Test User", "test@example.com").unwrap();
+        let initial_id = repo
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "initial commit",
+                &tree,
+                &[],
+            )
+            .unwrap();
+        drop(tree);
+
+        let initial = repo.find_commit(initial_id).unwrap();
+        repo.branch("import-me", &initial, false).unwrap();
+        drop(initial);
+
+        repo.set_head("refs/heads/import-me").unwrap();
+        repo.checkout_head(None).unwrap();
+        fs::write(path.join("config/flake.nix"), "import branch").unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("config/flake.nix")).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parent = repo.find_commit(initial_id).unwrap();
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "branch commit",
+            &tree,
+            &[&parent],
+        )
+        .unwrap();
+        drop(parent);
+        drop(tree);
+
+        repo.set_head("refs/heads/master").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+
+        repo
+    }
+
+    #[test]
+    fn materialize_repo_clones_requested_branch_from_local_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let _repo = create_local_repo(&source);
+        let dest = tmp.path().join("dest");
+        let spec = RepoRef {
+            clone_url: source.to_string_lossy().into_owned(),
+            git_ref: Some("import-me".to_string()),
+            subdir: None,
+        };
+
+        materialize_repo(&spec, &dest).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dest.join("config/flake.nix")).unwrap(),
+            "import branch"
+        );
+        assert!(dest.join(".git").is_dir());
+        let cloned_repo = git2::Repository::open(&dest).unwrap();
+        let head = cloned_repo.head().unwrap();
+        assert_eq!(head.shorthand().unwrap(), "import-me");
+    }
+
+    #[test]
+    fn materialize_repo_copies_only_requested_subdirectory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let _repo = create_local_repo(&source);
+        let dest = tmp.path().join("dest");
+        let spec = RepoRef {
+            clone_url: source.to_string_lossy().into_owned(),
+            git_ref: None,
+            subdir: Some("config".to_string()),
+        };
+
+        materialize_repo(&spec, &dest).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dest.join("flake.nix")).unwrap(),
+            "default branch"
+        );
+        assert!(dest.join("modules/default.nix").is_file());
+        assert!(!dest.join("config").exists());
+        assert!(!dest.join("README.md").exists());
+        assert!(!dest.join(".git").exists());
+    }
 
     #[test]
     fn parses_owner_repo_shorthand() {
@@ -768,5 +897,22 @@ mod tests {
         assert!(txt.contains("HOSTNAME_PLACEHOLDER"));
         assert!(txt.contains("PLATFORM_PLACEHOLDER"));
         assert!(txt.contains("USERNAME_PLACEHOLDER"));
+    }
+
+    #[test]
+    fn test_sanitize_clone_url_for_logs() {
+        let url = "https://user:password@github.com/repo.git";
+        let sanitized = sanitize_clone_url_for_logs(url);
+        assert_eq!(sanitized, "https://github.com/repo.git");
+
+        // SSH
+        let url = "ssh://user:password@github.com/repo.git";
+        let sanitized = sanitize_clone_url_for_logs(url);
+        assert_eq!(sanitized, "ssh://github.com/repo.git");
+
+        // SCP-style with git://.
+        let url = "git://user:password@github.com/repo.git";
+        let sanitized = sanitize_clone_url_for_logs(url);
+        assert_eq!(sanitized, "git://github.com/repo.git");
     }
 }

--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -334,10 +334,12 @@ pub async fn config_import_github(
 
     // Clone on a blocking thread; libgit2 network I/O is synchronous.
     let target_for_clone = target.clone();
-    tauri::async_runtime::spawn_blocking(move || import::clone_repo(&spec, &target_for_clone))
-        .await
-        .map_err(|e| capture_err("config_import_github", e))?
-        .map_err(|e| capture_err("config_import_github", e))?;
+    tauri::async_runtime::spawn_blocking(move || {
+        import::materialize_repo(&spec, &target_for_clone)
+    })
+    .await
+    .map_err(|e| capture_err("config_import_github", e))?
+    .map_err(|e| capture_err("config_import_github", e))?;
 
     finalize_imported_dir(&app, &target)
 }

--- a/apps/native/src/components/widget/controls/repo-import.tsx
+++ b/apps/native/src/components/widget/controls/repo-import.tsx
@@ -98,11 +98,14 @@ export function RepoImport({ onImported }: RepoImportProps) {
             placeholder="owner/repo"
             className="font-mono text-xs"
             aria-label="GitHub repository reference"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             disabled={isImporting}
           />
           <p className="text-muted-foreground text-xs">
-            A public GitHub repo, e.g. <span className="font-mono">czxtm/darwin</span>. Add{" "}
-            <span className="font-mono">#branch</span> to clone a specific branch.
+            A public GitHub repo, e.g. <span className="font-mono">github.com/darkmatter/nixmac</span>. Add{" "}
+            <span className="font-mono">?ref= and/or ?dir=</span> to clone a specific branch or use a subdirectory.
           </p>
         </div>
       ) : (


### PR DESCRIPTION
## Summary

As far as I can tell, cloning with libgit2 must never have worked.

With this PR you can finally correctly import a nix-darwin config from a git repo with an optional directory and ref. Try using a URL-like thing in the UI like:

`darkmatter/nixmac?ref=develop&dir=apps/native/templates/nix-darwin-determinate`

But maybe find one from a repo that is WAY smaller than `nixmac` unless you're very patient.

I updated the UI text to better reflect the new syntax and behavior for the URL, although we may want to add more UI help/docs around this including examples and maybe builders.

<!-- What does this PR do? Why? -->

## Test Plan

Manually tested a couple different repos/paths.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed