### PR TITLE
Fix git status diff dropping +/-/space line origin markers

### DIFF
--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -315,6 +315,13 @@ pub fn status(dir: &str) -> Result<GitStatus> {
     // ------------------------------------------------------------
     let mut diff_string = String::new();
     diff.print(git2::DiffFormat::Patch, |_d, _h, line| {
+        // Prepend the +/-/space origin marker for body lines. File ('F') and
+        // hunk ('H') headers already carry their prefix in `line.content()`,
+        // so they fall through without an added char — matching `git diff`.
+        match line.origin() {
+            '+' | '-' | ' ' => diff_string.push(line.origin()),
+            _ => {}
+        }
         diff_string.push_str(std::str::from_utf8(line.content()).unwrap_or_default());
         true
     })?;
@@ -816,6 +823,47 @@ mod tests {
         let status = status(&repo_dir_str).unwrap();
         assert!(!status.files.is_empty());
         assert!(status.branch.is_some());
+    }
+
+    #[test]
+    fn test_status_diff_preserves_line_origin_markers() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        // Commit a known three-line file.
+        fs::write(repo_dir.join("file.txt"), "line1\nline2\nline3\n").unwrap();
+        crate::git::commit_all(&repo_dir_str, "chore: initial").unwrap();
+
+        // Change the middle line and stage it.
+        fs::write(repo_dir.join("file.txt"), "line1\nLINE2\nline3\n").unwrap();
+        let repo = git2::Repository::open(&repo_dir).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("file.txt")).unwrap();
+        index.write().unwrap();
+
+        let status = status(&repo_dir_str).unwrap();
+
+        // Body lines must carry their +/- origin marker so consumers can tell
+        // additions from deletions (regression: markers were being dropped).
+        assert!(
+            status.diff.contains("-line2\n"),
+            "diff should mark the deleted line with '-':\n{}",
+            status.diff
+        );
+        assert!(
+            status.diff.contains("+LINE2\n"),
+            "diff should mark the added line with '+':\n{}",
+            status.diff
+        );
+        // Context lines keep their leading space; the bare, unmarked deleted
+        // line must not appear.
+        assert!(
+            !status.diff.contains("\nline2\n"),
+            "deleted line must not appear without an origin marker:\n{}",
+            status.diff
+        );
     }
 
     #[test]


### PR DESCRIPTION


## Summary

PR #274 missed a small thing that was causing the `grader.py` in the eval suite get confused. Diffs where missing `---` and `+++` markers of blocks added/removed.

This fixes it. See commit message for details.

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
