### PR TITLE
feat: pref-based auto-format Nix files with `nixfmt` after applying semantic edits

### DIFF
--- a/apps/native/src-tauri/resources/schemas/settings.schema.json
+++ b/apps/native/src-tauri/resources/schemas/settings.schema.json
@@ -36,6 +36,6 @@
       "type": "integer"
     }
   },
-  "title": "Evolution",
+  "title": "User Preferences",
   "type": "object"
 }

--- a/apps/native/src-tauri/src/commands/dev_configs.rs
+++ b/apps/native/src-tauri/src/commands/dev_configs.rs
@@ -98,12 +98,12 @@ mod tests {
     }
 
     #[test]
-    fn evolution_limits_is_registered_via_inventory() {
-        // Verifies the link-time submit! actually wires EvolutionLimits into
+    fn user_preferences_is_registered_via_inventory() {
+        // Verifies the link-time submit! actually wires UserPreferences into
         // the static collection. If inventory's linker tricks regress on a
         // future toolchain, this test catches it before the dev settings UI
         // silently goes empty.
-        assert!(find_meta("EvolutionLimits").is_some());
+        assert!(find_meta("UserPreferences").is_some());
     }
 
     #[test]

--- a/apps/native/src-tauri/src/commands/settings_io.rs
+++ b/apps/native/src-tauri/src/commands/settings_io.rs
@@ -11,7 +11,7 @@
 //! before invoking import.
 
 use super::helpers::capture_err;
-use crate::evolve::config::EvolutionLimits;
+use crate::evolve::config::UserPreferences;
 use crate::observable::Observable;
 use crate::shared_types::{ExportResult, ImportResult};
 use crate::state::preferences::GlobalPreferences;
@@ -79,7 +79,7 @@ fn collect_slice_export_entries(
         );
     }
 
-    if let Some(limits) = app.try_state::<Observable<EvolutionLimits>>() {
+    if let Some(limits) = app.try_state::<Observable<UserPreferences>>() {
         merge_export_object(
             &mut output,
             &mut skipped,
@@ -166,8 +166,8 @@ pub async fn settings_import(app: AppHandle) -> Result<Option<ImportResult>, Str
         *global = prefs;
     }
 
-    if let Some(limits) = app.try_state::<Observable<EvolutionLimits>>() {
-        let prefs = serde_json::from_value::<EvolutionLimits>(imported_value)
+    if let Some(limits) = app.try_state::<Observable<UserPreferences>>() {
+        let prefs = serde_json::from_value::<UserPreferences>(imported_value)
             .map_err(|e| capture_err("settings_import", e))?;
         let mut limits = limits.write_sync();
         *limits = prefs;
@@ -231,6 +231,7 @@ mod tests {
             serde_json::to_value(GlobalPreferences {
                 host_attr: Some("macbook".to_string()),
                 developer_mode: true,
+                auto_format_nix_files: Some(true),
                 ..GlobalPreferences::default()
             })
             .unwrap(),
@@ -239,7 +240,7 @@ mod tests {
         merge_export_object(
             &mut output,
             &mut skipped,
-            serde_json::to_value(EvolutionLimits {
+            serde_json::to_value(UserPreferences {
                 max_iterations: 12,
                 max_token_budget: 80_000,
                 max_build_attempts: 4,
@@ -253,6 +254,7 @@ mod tests {
         assert_eq!(output.get("developerMode"), Some(&json!(true)));
         assert_eq!(output.get("maxIterations"), Some(&json!(12)));
         assert_eq!(output.get("maxBuildAttempts"), Some(&json!(4)));
+        assert_eq!(output.get("autoFormatNixFiles"), Some(&json!(true)));
         assert!(!output.contains_key("openaiApiKey"));
         assert!(!output.contains_key("promptHistory"));
         assert!(skipped.is_empty());

--- a/apps/native/src-tauri/src/commands/settings_io.rs
+++ b/apps/native/src-tauri/src/commands/settings_io.rs
@@ -231,7 +231,7 @@ mod tests {
             serde_json::to_value(GlobalPreferences {
                 host_attr: Some("macbook".to_string()),
                 developer_mode: true,
-                auto_format_nix_files: Some(true),
+                auto_format_nix_files: true,
                 ..GlobalPreferences::default()
             })
             .unwrap(),

--- a/apps/native/src-tauri/src/evolve/config.rs
+++ b/apps/native/src-tauri/src/evolve/config.rs
@@ -3,7 +3,7 @@
 //! Storage is repo-scoped — values live under `<config_dir>/.nixmac/settings.json`
 //! so they ride along with the user's nix config repo across machines.
 //!
-//! The struct is managed as an `Observable<EvolutionLimits>` at startup. The
+//! The struct is managed as an `Observable<UserPreferences>` at startup. The
 //! derive macro pushes its metadata into the compile-time `inventory`
 //! collection so Developer settings can render and update it without opening
 //! store files directly.
@@ -20,17 +20,17 @@ use crate::observable::{ConfiguredRepoScopedJson, Observable, Persistence};
 use crate::state::preferences;
 use crate::storage::store::DEFAULT_MAX_TOKEN_BUDGET;
 
-pub const EVOLUTION_LIMITS_CHANGED_EVENT: &str = "evolution_limits_changed";
+pub const USER_PREFERENCES_CHANGED_EVENT: &str = "user_preferences_changed";
 pub(crate) const DEFAULT_NIXMAC_MAX_TOKEN_BUDGET: u32 = 750_000;
 
 #[derive(Configurable, Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", default)]
 #[config(
     scope = "repo",
-    display_name = "Evolution",
+    display_name = "User Preferences",
     description = "How long the agent will try before giving up."
 )]
-pub struct EvolutionLimits {
+pub struct UserPreferences {
     #[config(
         default = 25,
         key = "maxIterations",
@@ -73,7 +73,7 @@ pub struct EvolutionLimits {
 // `preferences::load_or_default`), and on the dev-settings whole-struct
 // `set` path when an incoming JSON payload is missing fields. Deriving
 // `Default` would produce zeros, which would be wrong here.
-impl Default for EvolutionLimits {
+impl Default for UserPreferences {
     fn default() -> Self {
         Self {
             max_iterations: 25,
@@ -84,7 +84,7 @@ impl Default for EvolutionLimits {
     }
 }
 
-impl EvolutionLimits {
+impl UserPreferences {
     pub fn apply_ui_update(&mut self, update: &crate::shared_types::UiPrefsUpdate) {
         if let Some(v) = update.max_iterations {
             self.max_iterations = v;
@@ -109,15 +109,15 @@ pub(crate) fn effective_max_token_budget(provider: &str, configured_max_token_bu
     }
 }
 
-pub fn try_read<R: Runtime>(app: &AppHandle<R>) -> Option<EvolutionLimits> {
-    app.try_state::<Observable<EvolutionLimits>>()
+pub fn try_read<R: Runtime>(app: &AppHandle<R>) -> Option<UserPreferences> {
+    app.try_state::<Observable<UserPreferences>>()
         .map(|limits| limits.read_sync().clone())
 }
 
-pub fn write<R: Runtime>(app: &AppHandle<R>, f: impl FnOnce(&mut EvolutionLimits)) -> Result<()> {
+pub fn write<R: Runtime>(app: &AppHandle<R>, f: impl FnOnce(&mut UserPreferences)) -> Result<()> {
     let limits = app
-        .try_state::<Observable<EvolutionLimits>>()
-        .ok_or_else(|| anyhow::anyhow!("EvolutionLimits observable is not managed"))?;
+        .try_state::<Observable<UserPreferences>>()
+        .ok_or_else(|| anyhow::anyhow!("UserPreferences observable is not managed"))?;
     let mut next = limits.read_sync().clone();
     f(&mut next);
     if *limits.read_sync() == next {
@@ -127,15 +127,15 @@ pub fn write<R: Runtime>(app: &AppHandle<R>, f: impl FnOnce(&mut EvolutionLimits
     Ok(())
 }
 
-pub fn read_or_default<R: Runtime>(app: &AppHandle<R>) -> EvolutionLimits {
+pub fn read_or_default<R: Runtime>(app: &AppHandle<R>) -> UserPreferences {
     try_read(app).unwrap_or_default()
 }
 
-pub fn load_observable<R: Runtime>(app: &AppHandle<R>) -> Result<Observable<EvolutionLimits>> {
+pub fn load_observable<R: Runtime>(app: &AppHandle<R>) -> Result<Observable<UserPreferences>> {
     let persistence: Arc<dyn Persistence> = Arc::new(ConfiguredRepoScopedJson::new(app.clone()));
-    let initial = preferences::load_or_default::<EvolutionLimits>(persistence.as_ref())?;
+    let initial = preferences::load_or_default::<UserPreferences>(persistence.as_ref())?;
     Ok(Observable::new(initial)
-        .emit_to(app, EVOLUTION_LIMITS_CHANGED_EVENT)
+        .emit_to(app, USER_PREFERENCES_CHANGED_EVENT)
         .persist_to(persistence))
 }
 
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn default_matches_configured_field_defaults() {
-        let limits = EvolutionLimits::default();
+        let limits = UserPreferences::default();
 
         assert_eq!(limits.max_iterations, 25);
         assert_eq!(limits.max_token_budget, 50_000);
@@ -154,8 +154,8 @@ mod tests {
     }
 
     #[test]
-    fn unknown_fields_do_not_change_limits() {
-        let limits: EvolutionLimits = serde_json::from_value(serde_json::json!({
+    fn unknown_fields_do_not_change_user_preferences() {
+        let limits: UserPreferences = serde_json::from_value(serde_json::json!({
             "maxIterations": 11,
             "maxTokenBudget": 80_000,
             "maxBuildAttempts": 3,
@@ -166,7 +166,7 @@ mod tests {
 
         assert_eq!(
             limits,
-            EvolutionLimits {
+            UserPreferences {
                 max_iterations: 11,
                 max_token_budget: 80_000,
                 max_build_attempts: 3,
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn missing_fields_use_defaults() {
-        let limits: EvolutionLimits = serde_json::from_value(serde_json::json!({
+        let limits: UserPreferences = serde_json::from_value(serde_json::json!({
             "maxIterations": 11,
         }))
         .expect("limits deserialize");

--- a/apps/native/src-tauri/src/evolve/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/ensure_secret.rs
@@ -79,6 +79,7 @@ pub struct EnsureSecretResult {
 pub fn execute_ensure_secret(
     base: &Path,
     args: &serde_json::Value,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> Result<EnsureSecretResult> {
     let parsed: EnsureSecretArgs = serde_json::from_value(args.clone()).map_err(|error| {
@@ -112,7 +113,14 @@ pub fn execute_ensure_secret(
     edit_secret_blocking(base, &secret_path, &age.key_path)?;
 
     if let Some(inject) = parsed.inject {
-        inject_secret(base, &parsed.name, &secret_path, &inject, gitignore_matcher)?;
+        inject_secret(
+            base,
+            &parsed.name,
+            &secret_path,
+            &inject,
+            auto_format,
+            gitignore_matcher,
+        )?;
     }
 
     let runtime_path = runtime_secret_path(&parsed.name);
@@ -151,6 +159,7 @@ fn inject_secret(
     name: &str,
     secret_path: &str,
     inject: &SecretInject,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> Result<()> {
     if inject.file.trim().is_empty() {
@@ -192,6 +201,7 @@ fn inject_secret(
                 attrs,
             },
         },
+        auto_format,
         gitignore_matcher,
     )?;
 
@@ -210,6 +220,7 @@ fn inject_secret(
                 value: nix_expr_meta_value(&format!("config.sops.secrets.\"{}\".path", name)),
             },
         },
+        auto_format,
         gitignore_matcher,
     )?;
 
@@ -455,7 +466,7 @@ mod tests {
             "name": secret_name,
         });
 
-        let result = execute_ensure_secret(&base, &args, None)
+        let result = execute_ensure_secret(&base, &args, false, None)
             .expect("execute_ensure_secret should succeed after interactive edit is completed");
 
         assert_eq!(result.name, secret_name);

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -944,15 +944,16 @@ pub async fn generate_evolution<R: Runtime>(
     // every run). `app.state` panics if the observable isn't managed; that is
     // intentional — it surfaces a startup misconfiguration immediately
     // instead of silently swapping in field defaults.
-    let config::EvolutionLimits {
+    let config::UserPreferences {
         mut max_build_attempts,
         max_token_budget: configured_max_token_budget,
         mut max_iterations,
         ..
     } = app
-        .state::<crate::observable::Observable<config::EvolutionLimits>>()
+        .state::<crate::observable::Observable<config::UserPreferences>>()
         .read_sync()
         .clone();
+    let auto_format_nix_files = crate::state::ui_prefs::auto_format_nix_files(app);
     let mut max_token_budget =
         config::effective_max_token_budget(&provider_type, configured_max_token_budget);
 
@@ -1316,6 +1317,7 @@ pub async fn generate_evolution<R: Runtime>(
                         host_attr.as_str(),
                         tool_name,
                         &args,
+                        auto_format_nix_files,
                         gitignore_matcher.as_ref(),
                     );
 

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -338,6 +338,7 @@ fn render_nix_expression_literal(
 pub fn apply_semantic_edit(
     base: &Path,
     edit: &SemanticFileEdit,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> anyhow::Result<()> {
     rewrite_existing_file_in_dir(
@@ -372,15 +373,21 @@ pub fn apply_semantic_edit(
         },
     )?;
 
-    // Format the file by default.
-    // If the formatting fails for some reason, allow the edit to be successful (but warn).
-    let config_dir = base.to_string_lossy();
-    let format_result = nix_format(&config_dir, &edit.path);
-    if let Err(e) = format_result {
-        log::warn!(
-            "apply_semantic_edit succeeded but nix-format failed: {}. The file may be left in an unformatted state; run nix-format manually to fix formatting issues.",
-            e
+    // Format the file conditionally.
+    if auto_format {
+        log::debug!(
+            "apply_semantic_edit: auto_format is enabled, running nix-format on {}",
+            edit.path
         );
+        // If the formatting fails for some reason, allow the edit to be successful (but warn).
+        let config_dir = base.to_string_lossy();
+        let format_result = nix_format(&config_dir, &edit.path);
+        if let Err(e) = format_result {
+            log::warn!(
+                "apply_semantic_edit succeeded but nix-format failed: {}. The file may be left in an unformatted state; run nix-format manually to fix formatting issues.",
+                e
+            );
+        }
     }
     Ok(())
 }

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -384,7 +384,7 @@ pub fn apply_semantic_edit(
         let format_result = nix_format(&config_dir, &edit.path);
         if let Err(e) = format_result {
             log::warn!(
-                "apply_semantic_edit succeeded but nix-format failed: {}. The file may be left in an unformatted state; run nix-format manually to fix formatting issues.",
+                "apply_semantic_edit succeeded but nixfmt failed: {}. The file may be left in an unformatted state; run nixfmt manually to fix formatting issues.",
                 e
             );
         }

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -1,6 +1,7 @@
 //! `nix_file_editor`: Apply "smart"" edits to Nix files, such as adding/removing packages from a list or setting scalar values.
 
 use crate::evolve::types::SemanticFileEdit;
+use crate::system::nix::nix_format;
 use anyhow::{Context, Result};
 use log::{debug, info};
 use rnix::SyntaxNode;
@@ -371,6 +372,16 @@ pub fn apply_semantic_edit(
         },
     )?;
 
+    // Format the file by default.
+    // If the formatting fails for some reason, allow the edit to be successful (but warn).
+    let config_dir = base.to_string_lossy();
+    let format_result = nix_format(&config_dir, &edit.path);
+    if let Err(e) = format_result {
+        log::warn!(
+            "apply_semantic_edit succeeded but nix-format failed: {}. The file may be left in an unformatted state; run nix-format manually to fix formatting issues.",
+            e
+        );
+    }
     Ok(())
 }
 

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -70,6 +70,7 @@ pub(crate) struct ToolCtx<'a> {
     pub(crate) host_attr: &'a str,
     pub(crate) args: &'a serde_json::Value,
     pub(crate) gitignore_matcher: Option<&'a Gitignore>,
+    pub(crate) auto_format: bool,
 }
 
 /// Result of executing a tool call
@@ -112,6 +113,7 @@ pub fn execute_tool(
     host_attr: &str,
     name: &str,
     args: &serde_json::Value,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> Result<ToolResult> {
     let ctx = ToolCtx {
@@ -119,6 +121,7 @@ pub fn execute_tool(
         config_dir,
         host_attr,
         args,
+        auto_format,
         gitignore_matcher,
     };
 
@@ -268,6 +271,7 @@ mod tests {
             "dummy-host",
             "read_file",
             &json!({ "path": "secret.txt" }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -294,6 +298,7 @@ mod tests {
             "dummy-host",
             "read_file",
             &json!({ "path": "nested/secret.txt" }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -321,6 +326,7 @@ mod tests {
             "dummy-host",
             "list_files",
             &json!({ "pattern": "**/*.txt" }),
+            false,
             gitignore_matcher.as_ref(),
         )
         .expect("list_files should succeed");
@@ -350,6 +356,7 @@ mod tests {
                 "search": "",
                 "replace": "hello"
             }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -382,6 +389,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -413,6 +421,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         );
 
@@ -446,6 +455,7 @@ mod tests {
                 "path": "homebrew.casks",
                 "value": ["docker", "iterm2", "audacity", "rectangle"]
             }),
+            false,
             None,
         );
 
@@ -475,6 +485,7 @@ mod tests {
                 "path": "programs.example.extraPackages",
                 "value": ["alpha", "beta"]
             }),
+            false,
             None,
         );
 
@@ -508,6 +519,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         );
 
@@ -535,6 +547,7 @@ mod tests {
                     "set_attrs": "launchd.user.agents"
                 }
             }),
+            false,
             None,
         );
 
@@ -575,6 +588,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should quote Homebrew values");
@@ -611,6 +625,7 @@ mod tests {
                 "path": "modules/darwin/packages.nix",
                 "values": ["wget"]
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should accept add shorthand");
@@ -663,6 +678,7 @@ mod tests {
                 "attr_path": "home.packages",
                 "values": ["fd"]
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should accept explicit attr_path shorthand");
@@ -701,6 +717,7 @@ mod tests {
                 "path": "packages.nix",
                 "values": ["fd"]
             }),
+            false,
             None,
         );
 
@@ -744,6 +761,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should match quoted Homebrew values");
@@ -770,6 +788,7 @@ mod tests {
                 "search": "[]",
                 "replace": "[\"git\"]"
             }),
+            false,
             None,
         )
         .expect("data.json edits should be allowed");
@@ -792,6 +811,7 @@ mod tests {
                 "search": "{}",
                 "replace": "{\"name\":\"Changed\"}"
             }),
+            false,
             None,
         );
 
@@ -815,6 +835,7 @@ mod tests {
                 "search": "{}",
                 "replace": "{\"enabled\":true}"
             }),
+            false,
             None,
         );
 
@@ -843,6 +864,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         );
 
@@ -867,6 +889,7 @@ mod tests {
                     "target": "environment.variables.API_TOKEN"
                 }
             }),
+            false,
             None,
         );
 
@@ -892,6 +915,7 @@ mod tests {
                 "search": "",
                 "replace": "hello"
             }),
+            false,
             gitignore_matcher.as_ref(),
         );
 

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -502,6 +502,7 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             path: path.to_string(),
             action: action.clone(),
         },
+        ctx.auto_format,
         ctx.gitignore_matcher,
     )?;
 

--- a/apps/native/src-tauri/src/evolve/tools/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/tools/ensure_secret.rs
@@ -79,6 +79,11 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
         ensure_nixmac_edit_allowed("ensure_secret", inject_file)?;
     }
 
-    let result = execute_ensure_secret(ctx.repo_root, ctx.args, ctx.gitignore_matcher)?;
+    let result = execute_ensure_secret(
+        ctx.repo_root,
+        ctx.args,
+        ctx.auto_format,
+        ctx.gitignore_matcher,
+    )?;
     Ok(ToolResult::EnsureSecret(result))
 }

--- a/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
+++ b/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
@@ -185,8 +185,12 @@ pub async fn apply_homebrew_diff(
     }
     let item_count = homebrew_item_count(&diff);
 
-    apply_homebrew_import(diff, std::path::Path::new(&dir))
-        .context("Failed to apply Homebrew diff")?;
+    apply_homebrew_import(
+        diff,
+        std::path::Path::new(&dir),
+        crate::state::ui_prefs::auto_format_nix_files(app),
+    )
+    .context("Failed to apply Homebrew diff")?;
 
     let working_tree_status =
         crate::git::status(&dir).context("Failed to get working tree status for evolve state")?;
@@ -592,7 +596,11 @@ fn apply_homebrew_data_import(
 /// Writes missing items in the diff to the config, using the source field to determine where to write.
 /// If the source is empty, we'll set up the official .nixmac/homebrew module and write data.json.
 /// We also hook up .nixmac to flake.nix in that case.
-pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) -> Result<()> {
+pub fn apply_homebrew_import(
+    diff: HomebrewState,
+    config_dir: &std::path::Path,
+    auto_format: bool,
+) -> Result<()> {
     if diff.casks.is_empty() && diff.brews.is_empty() && diff.taps.is_empty() {
         return Ok(());
     }
@@ -669,6 +677,7 @@ pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) 
                     values: nix_quote_values(&diff.taps),
                 },
             },
+            auto_format,
             None,
         )?;
     }
@@ -683,6 +692,7 @@ pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) 
                     values: nix_quote_values(&diff.brews),
                 },
             },
+            auto_format,
             None,
         )?;
     }
@@ -697,6 +707,7 @@ pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) 
                     values: nix_quote_values(&diff.casks),
                 },
             },
+            auto_format,
             None,
         )?;
     }
@@ -1144,7 +1155,7 @@ mod tests {
         let sanitized = sanitize_homebrew_diff(submitted, fresh_installed, fresh_config);
 
         assert_eq!(sanitized.source, None);
-        apply_homebrew_import(sanitized, temp.path())
+        apply_homebrew_import(sanitized, temp.path(), false)
             .expect("sanitized apply should create default module");
 
         let data_file = temp.path().join(NIXMAC_HOMEBREW_DATA_PATH);
@@ -1192,7 +1203,8 @@ mod tests {
             last_checked: 0,
         };
 
-        apply_homebrew_import(diff, temp.path()).expect("apply_homebrew_import should succeed");
+        apply_homebrew_import(diff, temp.path(), false)
+            .expect("apply_homebrew_import should succeed");
 
         let data_file = temp.path().join(NIXMAC_HOMEBREW_DATA_PATH);
         let data: Value = serde_json::from_str(
@@ -1225,7 +1237,7 @@ mod tests {
             last_checked: 0,
         };
 
-        let err = apply_homebrew_import(diff, temp.path())
+        let err = apply_homebrew_import(diff, temp.path(), false)
             .expect_err("default .nixmac source should require flake.nix");
 
         assert!(err.to_string().contains("flake.nix"));
@@ -1274,7 +1286,8 @@ mod tests {
             last_checked: 0,
         };
 
-        apply_homebrew_import(diff, temp.path()).expect("apply_homebrew_import should succeed");
+        apply_homebrew_import(diff, temp.path(), false)
+            .expect("apply_homebrew_import should succeed");
 
         let flake_content = std::fs::read_to_string(flake).expect("flake should remain readable");
         assert_eq!(

--- a/apps/native/src-tauri/src/managed_edits/system_defaults.rs
+++ b/apps/native/src-tauri/src/managed_edits/system_defaults.rs
@@ -74,6 +74,7 @@ fn rfind_unquoted_dot(value: &str) -> Option<usize> {
 pub fn ensure_system_defaults_module(
     config_dir: &str,
     add_primary_user: bool,
+    auto_format: bool,
 ) -> Result<std::path::PathBuf> {
     let modules_dir = std::path::Path::new(config_dir)
         .join("modules")
@@ -105,6 +106,7 @@ pub fn ensure_system_defaults_module(
                         value: Value::String(username),
                     },
                 },
+                auto_format,
                 None,
             )?;
         }
@@ -151,6 +153,7 @@ fn group_system_defaults(
 fn apply_system_defaults_to_module(
     config_dir: &std::path::Path,
     defaults: &[scanner::SystemDefault],
+    auto_format: bool,
 ) -> Result<()> {
     for (group, attrs) in group_system_defaults(defaults) {
         apply_semantic_edit(
@@ -159,6 +162,7 @@ fn apply_system_defaults_to_module(
                 path: system_defaults_module_path(),
                 action: FileEditAction::SetAttrs { path: group, attrs },
             },
+            auto_format,
             None,
         )?;
     }
@@ -184,14 +188,17 @@ pub async fn apply_system_defaults(
 
     let primary_user = get_system_primary_user(hostname, &dir);
 
-    let module_path = ensure_system_defaults_module(&dir, primary_user.is_none())
-        .context("Failed to ensure system-defaults.nix exists and is imported")?;
+    let auto_format_nix_files = crate::state::ui_prefs::auto_format_nix_files(app);
+
+    let module_path =
+        ensure_system_defaults_module(&dir, primary_user.is_none(), auto_format_nix_files)
+            .context("Failed to ensure system-defaults.nix exists and is imported")?;
     log::info!(
         "[apply_system_defaults] Ensured module at {:?}",
         module_path
     );
 
-    apply_system_defaults_to_module(config_path, &defaults)
+    apply_system_defaults_to_module(config_path, &defaults, auto_format_nix_files)
         .context("Failed to apply system defaults to module")?;
 
     let working_tree_status =
@@ -242,8 +249,8 @@ mod tests {
         );
 
         let config_dir = temp.path().to_string_lossy();
-        let module_path =
-            ensure_system_defaults_module(&config_dir, false).expect("module should be ensured");
+        let module_path = ensure_system_defaults_module(&config_dir, false, false)
+            .expect("module should be ensured");
         let module = std::fs::read_to_string(&module_path).expect("module should be readable");
         let flake = std::fs::read_to_string(temp.path().join("flake.nix"))
             .expect("flake should be readable");
@@ -273,8 +280,8 @@ mod tests {
         );
 
         let config_dir = temp.path().to_string_lossy();
-        let module_path =
-            ensure_system_defaults_module(&config_dir, true).expect("module should be ensured");
+        let module_path = ensure_system_defaults_module(&config_dir, true, false)
+            .expect("module should be ensured");
         let module = std::fs::read_to_string(&module_path).expect("module should be readable");
         let flake = std::fs::read_to_string(temp.path().join("flake.nix"))
             .expect("flake should be readable");
@@ -318,6 +325,7 @@ mod tests {
                     "0",
                 ),
             ],
+            false,
         )
         .expect("defaults should apply");
 

--- a/apps/native/src-tauri/src/schema_gen.rs
+++ b/apps/native/src-tauri/src/schema_gen.rs
@@ -7,14 +7,14 @@ use configurable::{ConfigurableMeta, inventory};
 use std::path::Path;
 
 use crate::env::config::NixmacEnvSettings;
-use crate::evolve::config::EvolutionLimits;
+use crate::evolve::config::UserPreferences;
 
 const DEFAULT_OUT_DIR: &str = "resources/schemas";
 
 /// Ensures inventory entries are linked into the binary.
 fn link_configurables() {
     let _ = (
-        EvolutionLimits::json_schema(),
+        UserPreferences::json_schema(),
         NixmacEnvSettings::json_schema(),
     );
 }
@@ -48,9 +48,9 @@ mod tests {
     use serde_json::Value;
 
     #[test]
-    fn evolution_limits_json_schema_has_expected_shape() {
+    fn user_preferences_json_schema_has_expected_shape() {
         link_configurables();
-        let schema = EvolutionLimits::json_schema();
+        let schema = UserPreferences::json_schema();
         assert_eq!(
             schema.get("$schema").and_then(Value::as_str),
             Some("https://json-schema.org/draft/2020-12/schema")

--- a/apps/native/src-tauri/src/shared_types/prefs.rs
+++ b/apps/native/src-tauri/src/shared_types/prefs.rs
@@ -68,7 +68,7 @@ pub struct UiPrefs {
     /// `None` or missing key = use PostHog default.
     pub feature_flag_overrides: Option<BTreeMap<String, String>>,
     /// Whether or not to auto-format Nix files when making changes to the flakes.
-    pub auto_format_nix_files: Option<bool>,
+    pub auto_format_nix_files: bool,
 }
 
 /// Partial update to UI preferences — every field is optional so the caller
@@ -180,7 +180,7 @@ pub struct GlobalPreferences {
     /// Timestamp (unix secs) of the last successful build/evolution apply. Set by `finalize_apply`.
     pub onboarding_last_build_at: Option<i64>,
     /// Whether or not to auto-format Nix files when making changes to the flakes.
-    pub auto_format_nix_files: Option<bool>,
+    pub auto_format_nix_files: bool,
 }
 
 impl Default for GlobalPreferences {
@@ -210,7 +210,7 @@ impl Default for GlobalPreferences {
             onboarding_mac_scanned_at: None,
             onboarding_login_decided: false,
             onboarding_last_build_at: None,
-            auto_format_nix_files: None,
+            auto_format_nix_files: false,
         }
     }
 }
@@ -279,7 +279,7 @@ impl GlobalPreferences {
             self.onboarding_login_decided = v;
         }
         if let Some(v) = update.auto_format_nix_files {
-            self.auto_format_nix_files = Some(v);
+            self.auto_format_nix_files = v;
         }
     }
 

--- a/apps/native/src-tauri/src/shared_types/prefs.rs
+++ b/apps/native/src-tauri/src/shared_types/prefs.rs
@@ -67,6 +67,8 @@ pub struct UiPrefs {
     /// Developer-only feature flag overrides (flag key → variant string).
     /// `None` or missing key = use PostHog default.
     pub feature_flag_overrides: Option<BTreeMap<String, String>>,
+    /// Whether or not to auto-format Nix files when making changes to the flakes.
+    pub auto_format_nix_files: Option<bool>,
 }
 
 /// Partial update to UI preferences — every field is optional so the caller
@@ -139,6 +141,8 @@ pub struct UiPrefsUpdate {
     pub onboarding_mac_scanned_at: Option<i64>,
     /// Set true once the user logged in or explicitly chose bring-your-own-key.
     pub onboarding_login_decided: Option<bool>,
+    /// Auto-format Nix files after smart edits.
+    pub auto_format_nix_files: Option<bool>,
 }
 
 /// Preferences local to this app installation.
@@ -175,6 +179,8 @@ pub struct GlobalPreferences {
     pub onboarding_login_decided: bool,
     /// Timestamp (unix secs) of the last successful build/evolution apply. Set by `finalize_apply`.
     pub onboarding_last_build_at: Option<i64>,
+    /// Whether or not to auto-format Nix files when making changes to the flakes.
+    pub auto_format_nix_files: Option<bool>,
 }
 
 impl Default for GlobalPreferences {
@@ -204,6 +210,7 @@ impl Default for GlobalPreferences {
             onboarding_mac_scanned_at: None,
             onboarding_login_decided: false,
             onboarding_last_build_at: None,
+            auto_format_nix_files: None,
         }
     }
 }
@@ -271,6 +278,9 @@ impl GlobalPreferences {
         if let Some(v) = update.onboarding_login_decided {
             self.onboarding_login_decided = v;
         }
+        if let Some(v) = update.auto_format_nix_files {
+            self.auto_format_nix_files = Some(v);
+        }
     }
 
     /// Builds the non-secret subset of [`UiPrefs`] from global preferences.
@@ -301,6 +311,7 @@ impl GlobalPreferences {
             pinned_version: self.pinned_version.clone(),
             update_channel: self.update_channel,
             feature_flag_overrides: self.feature_flag_overrides.clone(),
+            auto_format_nix_files: self.auto_format_nix_files,
         }
     }
 }

--- a/apps/native/src-tauri/src/state/preferences.rs
+++ b/apps/native/src-tauri/src/state/preferences.rs
@@ -171,7 +171,7 @@ mod tests {
             "updateChannel": "develop"
         }));
 
-        let prefs = load_or_default::<GlobalPreferences>(&persistence).unwrap();
+        let prefs: GlobalPreferences = load_or_default::<GlobalPreferences>(&persistence).unwrap();
 
         assert_eq!(prefs.host_attr.as_deref(), Some("macbook"));
         assert_eq!(prefs.config_dir.as_deref(), Some("/Users/cm/.darwin"));

--- a/apps/native/src-tauri/src/state/ui_prefs.rs
+++ b/apps/native/src-tauri/src/state/ui_prefs.rs
@@ -46,6 +46,12 @@ fn needs_limits_update(update: &UiPrefsUpdate) -> bool {
         || update.max_output_tokens.is_some()
 }
 
+pub fn auto_format_nix_files<R: Runtime>(app: &AppHandle<R>) -> bool {
+    preferences::try_read(app)
+        .and_then(|prefs| prefs.auto_format_nix_files)
+        .unwrap_or(false)
+}
+
 fn apply_secret_updates<R: Runtime>(app: &AppHandle<R>, update: &UiPrefsUpdate) -> Result<()> {
     if let Some(key) = &update.openrouter_api_key {
         secrets::set_openrouter_api_key(app, key)?;
@@ -165,6 +171,10 @@ mod tests {
         }));
         assert!(needs_limits_update(&UiPrefsUpdate {
             max_iterations: Some(10),
+            ..Default::default()
+        }));
+        assert!(!needs_limits_update(&UiPrefsUpdate {
+            auto_format_nix_files: Some(true),
             ..Default::default()
         }));
     }

--- a/apps/native/src-tauri/src/state/ui_prefs.rs
+++ b/apps/native/src-tauri/src/state/ui_prefs.rs
@@ -47,9 +47,7 @@ fn needs_limits_update(update: &UiPrefsUpdate) -> bool {
 }
 
 pub fn auto_format_nix_files<R: Runtime>(app: &AppHandle<R>) -> bool {
-    preferences::try_read(app)
-        .and_then(|prefs| prefs.auto_format_nix_files)
-        .unwrap_or(false)
+    preferences::try_read(app).is_some_and(|prefs| prefs.auto_format_nix_files)
 }
 
 fn apply_secret_updates<R: Runtime>(app: &AppHandle<R>, update: &UiPrefsUpdate) -> Result<()> {

--- a/apps/native/src-tauri/src/system/launchd_scanner.rs
+++ b/apps/native/src-tauri/src/system/launchd_scanner.rs
@@ -371,6 +371,7 @@ pub async fn apply_launchd_items_to_flake(
         target_path
     );
 
+    let auto_format_nix_files = crate::state::ui_prefs::auto_format_nix_files(app);
     for (path, attrs) in launchd_items_by_scope(&items) {
         if attrs.is_empty() {
             continue;
@@ -385,6 +386,7 @@ pub async fn apply_launchd_items_to_flake(
                     attrs,
                 },
             },
+            auto_format_nix_files,
             None,
         )
         .with_context(|| format!("Failed to apply launchd items at {}", path))?;
@@ -568,6 +570,7 @@ mod tests {
                         attrs,
                     },
                 },
+                false,
                 None,
             )
             .expect("semantic edit");
@@ -635,6 +638,7 @@ mod tests {
                         attrs,
                     },
                 },
+                false,
                 None,
             )
             .expect("semantic edit");

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -359,6 +359,26 @@ pub fn get_nix_version() -> Option<String> {
     }
 }
 
+/// Runs `nixfmt` directly from the flake on the provided file.
+/// Executes the command:
+/// `nix run nixpkgs#nixfmt -- <file>`
+pub fn nix_format(config_dir: &str, file: &str) -> Result<String> {
+    log::debug!("Running nix format on file: {}", file);
+
+    let output = nix_command(config_dir)
+        .args(["run", "nixpkgs#nixfmt", "--", file])
+        .output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        anyhow::bail!(
+            "Failed to format with nixfmt: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
 /// Prefetches darwin-rebuild by running `nix build --no-link nix-darwin/master#darwin-rebuild`.
 /// This caches the derivation in the nix store so the `nix run` fallback in darwin.rs is fast.
 /// Emits `nix:darwin-rebuild:end` with `{ ok: bool, error?: string }` on completion.

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -359,7 +359,7 @@ pub fn get_nix_version() -> Option<String> {
     }
 }
 
-/// Runs `nixfmt` directly from the flake on the provided file.
+/// Runs `nixfmt` (from nixpkgs via `nix run`) against the provided file in `config_dir`.
 /// Executes the command:
 /// `nix run nixpkgs#nixfmt -- <file>`
 pub fn nix_format(config_dir: &str, file: &str) -> Result<String> {

--- a/apps/native/src/components/widget/settings/preferences-tab.tsx
+++ b/apps/native/src/components/widget/settings/preferences-tab.tsx
@@ -10,6 +10,7 @@ export function PreferencesTab() {
   const autoSummarizeOnFocus = useViewModel((s) => s.preferences?.autoSummarizeOnFocus ?? false);
   const scanHomebrewOnStartup = useViewModel((s) => s.preferences?.scanHomebrewOnStartup ?? true);
   const defaultToDiffTab = useViewModel((s) => s.preferences?.defaultToDiffTab ?? false);
+  const autoFormatNixFiles = useViewModel((s) => s.preferences?.autoFormatNixFiles ?? false);
 
   return (
     <div className="space-y-6">
@@ -81,6 +82,18 @@ export function PreferencesTab() {
               <Switch
                 checked={defaultToDiffTab}
                 onCheckedChange={(checked) => setPref("defaultToDiffTab", checked)}
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-lg border border-border p-3">
+              <div className="space-y-0.5">
+                <div className="text-sm">Auto-Format Nix Files</div>
+                <div className="text-muted-foreground text-xs">
+                  Automatically format Nix files after smart edits
+                </div>
+              </div>
+              <Switch
+                checked={autoFormatNixFiles}
+                onCheckedChange={(checked) => setPref("autoFormatNixFiles", checked)}
               />
             </div>
           </div>

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1113,7 +1113,11 @@ onboardingLoginDecided: boolean;
 /**
  * Timestamp (unix secs) of the last successful build/evolution apply. Set by `finalize_apply`.
  */
-onboardingLastBuildAt: number | null }
+onboardingLastBuildAt: number | null; 
+/**
+ * Whether or not to auto-format Nix files when making changes to the flakes.
+ */
+autoFormatNixFiles: boolean | null }
 
 /**
  * A commit entry combining git log data, tag-derived flags, optional DB metadata, and raw diff changes.
@@ -1922,7 +1926,11 @@ updateChannel: UpdateChannel;
  * Developer-only feature flag overrides (flag key → variant string).
  * `None` or missing key = use PostHog default.
  */
-featureFlagOverrides: Partial<{ [key in string]: string }> | null }
+featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
+/**
+ * Whether or not to auto-format Nix files when making changes to the flakes.
+ */
+autoFormatNixFiles: boolean | null }
 
 /**
  * Partial update to UI preferences — every field is optional so the caller
@@ -2037,7 +2045,11 @@ onboardingMacScannedAt: number | null;
 /**
  * Set true once the user logged in or explicitly chose bring-your-own-key.
  */
-onboardingLoginDecided: boolean | null }
+onboardingLoginDecided: boolean | null; 
+/**
+ * Auto-format Nix files after smart edits.
+ */
+autoFormatNixFiles: boolean | null }
 
 /**
  * Auto-update channel selected for release-mode builds.

--- a/apps/native/src/types/preferences.ts
+++ b/apps/native/src/types/preferences.ts
@@ -5,4 +5,5 @@ export type BoolPrefKey =
   | "autoSummarizeOnFocus"
   | "scanHomebrewOnStartup"
   | "defaultToDiffTab"
-  | "experimentalSpinningMascot";
+  | "experimentalSpinningMascot"
+  | "autoFormatNixFiles";


### PR DESCRIPTION
## Summary

Add a fail-free nixfmt step to the end of semantic edits (which seems more appropriate than formatting an entire repo or even an entire diff at the end). This way, the limitations of our semantic editor won't cause unusual-looking flake files. By putting it there instead of just in the tool, it will also be applied in other places we us the semantic editor, like tracking untracked changes.

Here is an example from one where I intentionally put some bad indents in my commited flake:

```
diff --git a/modules/darwin/packages.nix b/modules/darwin/packages.nix
index bdbbe63..7c19bc6 100644
--- a/modules/darwin/packages.nix
+++ b/modules/darwin/packages.nix
@@ -23,8 +23,10 @@
     # git   # version control
     # vim   # editor
     # htop  # process viewer
-];
+    ripgrep
+    wget
+  ];
 
   # If you prefer per-user profiles, consider using `home-manager` instead
   # of placing everything in the global system profile.
-   }
+}
```

<!-- What does this PR do? Why? -->

Hook it up to a new UI preference:

![Screenshot 2026-06-29 at 4.13.51 PM.png](https://app.graphite.com/user-attachments/assets/f4904956-9500-434c-b79f-d88d2d0859e8.png)

Note that this preference _only uses the new settings framework_ and therefore is not tracked in settings.json. I also renamed the evolve package preferences struct to `UserPreferences` at @czxtm 's suggestion; however, in order to make the new auto-format setting wired into the existing UI, that preference itself needed to go into `UiPrefs.` I feel like we need some more extensive rework/refactoring of how all this works to get to where I understand we want to go, but I think that is way out of scope for this PR.

## Test Plan

Ran a few manual cases that cause non-trivial nix file edits. Also test the UI preference on and off.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed