### PR TITLE
chore: upgrade Rust edition from 2021 to 2024 to match treefmt

### DIFF
--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.22.0"
 description = "Nixmac - macOS nix-darwin configuration manager"
 authors = ["Darkmatter Labs"]
 license = "MIT"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/apps/native/src-tauri/configurable-derive/Cargo.toml
+++ b/apps/native/src-tauri/configurable-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "configurable-derive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Procedural derive macro for the configurable crate"
 license = "MIT"
 

--- a/apps/native/src-tauri/configurable/Cargo.toml
+++ b/apps/native/src-tauri/configurable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "configurable"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Derive macro + runtime for typed, store-backed dev settings"
 license = "MIT"
 


### PR DESCRIPTION
## Summary

This will stop formatting fights between treefmt and other tooling. Note that you _cannot_ simply remove edition because that defaults to a different one that does not match treefmt, which I finally figured out after spelunking around generated toml files is set to "2024".

<!-- What does this PR do? Why? -->

## Test Plan

I ran `treefmt` and `cargo fmt` and prayed for no diffs.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed