### PR TITLE
feat: track customization sources through onboarding and apply them jit before first build

### DIFF
--- a/apps/native/src-tauri/resources/schemas/settings.schema.json
+++ b/apps/native/src-tauri/resources/schemas/settings.schema.json
@@ -36,6 +36,6 @@
       "type": "integer"
     }
   },
-  "title": "Evolution",
+  "title": "User Preferences",
   "type": "object"
 }

--- a/apps/native/src-tauri/src/commands/dev_configs.rs
+++ b/apps/native/src-tauri/src/commands/dev_configs.rs
@@ -98,12 +98,12 @@ mod tests {
     }
 
     #[test]
-    fn evolution_limits_is_registered_via_inventory() {
-        // Verifies the link-time submit! actually wires EvolutionLimits into
+    fn user_preferences_is_registered_via_inventory() {
+        // Verifies the link-time submit! actually wires UserPreferences into
         // the static collection. If inventory's linker tricks regress on a
         // future toolchain, this test catches it before the dev settings UI
         // silently goes empty.
-        assert!(find_meta("EvolutionLimits").is_some());
+        assert!(find_meta("UserPreferences").is_some());
     }
 
     #[test]

--- a/apps/native/src-tauri/src/commands/settings_io.rs
+++ b/apps/native/src-tauri/src/commands/settings_io.rs
@@ -11,7 +11,7 @@
 //! before invoking import.
 
 use super::helpers::capture_err;
-use crate::evolve::config::EvolutionLimits;
+use crate::evolve::config::UserPreferences;
 use crate::observable::Observable;
 use crate::shared_types::{ExportResult, ImportResult};
 use crate::state::preferences::GlobalPreferences;
@@ -79,7 +79,7 @@ fn collect_slice_export_entries(
         );
     }
 
-    if let Some(limits) = app.try_state::<Observable<EvolutionLimits>>() {
+    if let Some(limits) = app.try_state::<Observable<UserPreferences>>() {
         merge_export_object(
             &mut output,
             &mut skipped,
@@ -166,8 +166,8 @@ pub async fn settings_import(app: AppHandle) -> Result<Option<ImportResult>, Str
         *global = prefs;
     }
 
-    if let Some(limits) = app.try_state::<Observable<EvolutionLimits>>() {
-        let prefs = serde_json::from_value::<EvolutionLimits>(imported_value)
+    if let Some(limits) = app.try_state::<Observable<UserPreferences>>() {
+        let prefs = serde_json::from_value::<UserPreferences>(imported_value)
             .map_err(|e| capture_err("settings_import", e))?;
         let mut limits = limits.write_sync();
         *limits = prefs;
@@ -231,6 +231,7 @@ mod tests {
             serde_json::to_value(GlobalPreferences {
                 host_attr: Some("macbook".to_string()),
                 developer_mode: true,
+                auto_format_nix_files: true,
                 ..GlobalPreferences::default()
             })
             .unwrap(),
@@ -239,7 +240,7 @@ mod tests {
         merge_export_object(
             &mut output,
             &mut skipped,
-            serde_json::to_value(EvolutionLimits {
+            serde_json::to_value(UserPreferences {
                 max_iterations: 12,
                 max_token_budget: 80_000,
                 max_build_attempts: 4,
@@ -253,6 +254,7 @@ mod tests {
         assert_eq!(output.get("developerMode"), Some(&json!(true)));
         assert_eq!(output.get("maxIterations"), Some(&json!(12)));
         assert_eq!(output.get("maxBuildAttempts"), Some(&json!(4)));
+        assert_eq!(output.get("autoFormatNixFiles"), Some(&json!(true)));
         assert!(!output.contains_key("openaiApiKey"));
         assert!(!output.contains_key("promptHistory"));
         assert!(skipped.is_empty());

--- a/apps/native/src-tauri/src/evolve/config.rs
+++ b/apps/native/src-tauri/src/evolve/config.rs
@@ -3,7 +3,7 @@
 //! Storage is repo-scoped — values live under `<config_dir>/.nixmac/settings.json`
 //! so they ride along with the user's nix config repo across machines.
 //!
-//! The struct is managed as an `Observable<EvolutionLimits>` at startup. The
+//! The struct is managed as an `Observable<UserPreferences>` at startup. The
 //! derive macro pushes its metadata into the compile-time `inventory`
 //! collection so Developer settings can render and update it without opening
 //! store files directly.
@@ -20,17 +20,17 @@ use crate::observable::{ConfiguredRepoScopedJson, Observable, Persistence};
 use crate::state::preferences;
 use crate::storage::store::DEFAULT_MAX_TOKEN_BUDGET;
 
-pub const EVOLUTION_LIMITS_CHANGED_EVENT: &str = "evolution_limits_changed";
+pub const USER_PREFERENCES_CHANGED_EVENT: &str = "user_preferences_changed";
 pub(crate) const DEFAULT_NIXMAC_MAX_TOKEN_BUDGET: u32 = 750_000;
 
 #[derive(Configurable, Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", default)]
 #[config(
     scope = "repo",
-    display_name = "Evolution",
+    display_name = "User Preferences",
     description = "How long the agent will try before giving up."
 )]
-pub struct EvolutionLimits {
+pub struct UserPreferences {
     #[config(
         default = 25,
         key = "maxIterations",
@@ -73,7 +73,7 @@ pub struct EvolutionLimits {
 // `preferences::load_or_default`), and on the dev-settings whole-struct
 // `set` path when an incoming JSON payload is missing fields. Deriving
 // `Default` would produce zeros, which would be wrong here.
-impl Default for EvolutionLimits {
+impl Default for UserPreferences {
     fn default() -> Self {
         Self {
             max_iterations: 25,
@@ -84,7 +84,7 @@ impl Default for EvolutionLimits {
     }
 }
 
-impl EvolutionLimits {
+impl UserPreferences {
     pub fn apply_ui_update(&mut self, update: &crate::shared_types::UiPrefsUpdate) {
         if let Some(v) = update.max_iterations {
             self.max_iterations = v;
@@ -109,15 +109,15 @@ pub(crate) fn effective_max_token_budget(provider: &str, configured_max_token_bu
     }
 }
 
-pub fn try_read<R: Runtime>(app: &AppHandle<R>) -> Option<EvolutionLimits> {
-    app.try_state::<Observable<EvolutionLimits>>()
+pub fn try_read<R: Runtime>(app: &AppHandle<R>) -> Option<UserPreferences> {
+    app.try_state::<Observable<UserPreferences>>()
         .map(|limits| limits.read_sync().clone())
 }
 
-pub fn write<R: Runtime>(app: &AppHandle<R>, f: impl FnOnce(&mut EvolutionLimits)) -> Result<()> {
+pub fn write<R: Runtime>(app: &AppHandle<R>, f: impl FnOnce(&mut UserPreferences)) -> Result<()> {
     let limits = app
-        .try_state::<Observable<EvolutionLimits>>()
-        .ok_or_else(|| anyhow::anyhow!("EvolutionLimits observable is not managed"))?;
+        .try_state::<Observable<UserPreferences>>()
+        .ok_or_else(|| anyhow::anyhow!("UserPreferences observable is not managed"))?;
     let mut next = limits.read_sync().clone();
     f(&mut next);
     if *limits.read_sync() == next {
@@ -127,15 +127,15 @@ pub fn write<R: Runtime>(app: &AppHandle<R>, f: impl FnOnce(&mut EvolutionLimits
     Ok(())
 }
 
-pub fn read_or_default<R: Runtime>(app: &AppHandle<R>) -> EvolutionLimits {
+pub fn read_or_default<R: Runtime>(app: &AppHandle<R>) -> UserPreferences {
     try_read(app).unwrap_or_default()
 }
 
-pub fn load_observable<R: Runtime>(app: &AppHandle<R>) -> Result<Observable<EvolutionLimits>> {
+pub fn load_observable<R: Runtime>(app: &AppHandle<R>) -> Result<Observable<UserPreferences>> {
     let persistence: Arc<dyn Persistence> = Arc::new(ConfiguredRepoScopedJson::new(app.clone()));
-    let initial = preferences::load_or_default::<EvolutionLimits>(persistence.as_ref())?;
+    let initial = preferences::load_or_default::<UserPreferences>(persistence.as_ref())?;
     Ok(Observable::new(initial)
-        .emit_to(app, EVOLUTION_LIMITS_CHANGED_EVENT)
+        .emit_to(app, USER_PREFERENCES_CHANGED_EVENT)
         .persist_to(persistence))
 }
 
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn default_matches_configured_field_defaults() {
-        let limits = EvolutionLimits::default();
+        let limits = UserPreferences::default();
 
         assert_eq!(limits.max_iterations, 25);
         assert_eq!(limits.max_token_budget, 50_000);
@@ -154,8 +154,8 @@ mod tests {
     }
 
     #[test]
-    fn unknown_fields_do_not_change_limits() {
-        let limits: EvolutionLimits = serde_json::from_value(serde_json::json!({
+    fn unknown_fields_do_not_change_user_preferences() {
+        let limits: UserPreferences = serde_json::from_value(serde_json::json!({
             "maxIterations": 11,
             "maxTokenBudget": 80_000,
             "maxBuildAttempts": 3,
@@ -166,7 +166,7 @@ mod tests {
 
         assert_eq!(
             limits,
-            EvolutionLimits {
+            UserPreferences {
                 max_iterations: 11,
                 max_token_budget: 80_000,
                 max_build_attempts: 3,
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn missing_fields_use_defaults() {
-        let limits: EvolutionLimits = serde_json::from_value(serde_json::json!({
+        let limits: UserPreferences = serde_json::from_value(serde_json::json!({
             "maxIterations": 11,
         }))
         .expect("limits deserialize");

--- a/apps/native/src-tauri/src/evolve/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/ensure_secret.rs
@@ -79,6 +79,7 @@ pub struct EnsureSecretResult {
 pub fn execute_ensure_secret(
     base: &Path,
     args: &serde_json::Value,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> Result<EnsureSecretResult> {
     let parsed: EnsureSecretArgs = serde_json::from_value(args.clone()).map_err(|error| {
@@ -112,7 +113,14 @@ pub fn execute_ensure_secret(
     edit_secret_blocking(base, &secret_path, &age.key_path)?;
 
     if let Some(inject) = parsed.inject {
-        inject_secret(base, &parsed.name, &secret_path, &inject, gitignore_matcher)?;
+        inject_secret(
+            base,
+            &parsed.name,
+            &secret_path,
+            &inject,
+            auto_format,
+            gitignore_matcher,
+        )?;
     }
 
     let runtime_path = runtime_secret_path(&parsed.name);
@@ -151,6 +159,7 @@ fn inject_secret(
     name: &str,
     secret_path: &str,
     inject: &SecretInject,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> Result<()> {
     if inject.file.trim().is_empty() {
@@ -192,6 +201,7 @@ fn inject_secret(
                 attrs,
             },
         },
+        auto_format,
         gitignore_matcher,
     )?;
 
@@ -210,6 +220,7 @@ fn inject_secret(
                 value: nix_expr_meta_value(&format!("config.sops.secrets.\"{}\".path", name)),
             },
         },
+        auto_format,
         gitignore_matcher,
     )?;
 
@@ -455,7 +466,7 @@ mod tests {
             "name": secret_name,
         });
 
-        let result = execute_ensure_secret(&base, &args, None)
+        let result = execute_ensure_secret(&base, &args, false, None)
             .expect("execute_ensure_secret should succeed after interactive edit is completed");
 
         assert_eq!(result.name, secret_name);

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -944,15 +944,16 @@ pub async fn generate_evolution<R: Runtime>(
     // every run). `app.state` panics if the observable isn't managed; that is
     // intentional — it surfaces a startup misconfiguration immediately
     // instead of silently swapping in field defaults.
-    let config::EvolutionLimits {
+    let config::UserPreferences {
         mut max_build_attempts,
         max_token_budget: configured_max_token_budget,
         mut max_iterations,
         ..
     } = app
-        .state::<crate::observable::Observable<config::EvolutionLimits>>()
+        .state::<crate::observable::Observable<config::UserPreferences>>()
         .read_sync()
         .clone();
+    let auto_format_nix_files = crate::state::ui_prefs::auto_format_nix_files(app);
     let mut max_token_budget =
         config::effective_max_token_budget(&provider_type, configured_max_token_budget);
 
@@ -1316,6 +1317,7 @@ pub async fn generate_evolution<R: Runtime>(
                         host_attr.as_str(),
                         tool_name,
                         &args,
+                        auto_format_nix_files,
                         gitignore_matcher.as_ref(),
                     );
 

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -1,6 +1,7 @@
 //! `nix_file_editor`: Apply "smart"" edits to Nix files, such as adding/removing packages from a list or setting scalar values.
 
 use crate::evolve::types::SemanticFileEdit;
+use crate::system::nix::nix_format;
 use anyhow::{Context, Result};
 use log::{debug, info};
 use rnix::SyntaxNode;
@@ -337,6 +338,7 @@ fn render_nix_expression_literal(
 pub fn apply_semantic_edit(
     base: &Path,
     edit: &SemanticFileEdit,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> anyhow::Result<()> {
     rewrite_existing_file_in_dir(
@@ -371,6 +373,22 @@ pub fn apply_semantic_edit(
         },
     )?;
 
+    // Format the file conditionally.
+    if auto_format {
+        log::debug!(
+            "apply_semantic_edit: auto_format is enabled, running nix-format on {}",
+            edit.path
+        );
+        // If the formatting fails for some reason, allow the edit to be successful (but warn).
+        let config_dir = base.to_string_lossy();
+        let format_result = nix_format(&config_dir, &edit.path);
+        if let Err(e) = format_result {
+            log::warn!(
+                "apply_semantic_edit succeeded but nixfmt failed: {}. The file may be left in an unformatted state; run nixfmt manually to fix formatting issues.",
+                e
+            );
+        }
+    }
     Ok(())
 }
 

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -70,6 +70,7 @@ pub(crate) struct ToolCtx<'a> {
     pub(crate) host_attr: &'a str,
     pub(crate) args: &'a serde_json::Value,
     pub(crate) gitignore_matcher: Option<&'a Gitignore>,
+    pub(crate) auto_format: bool,
 }
 
 /// Result of executing a tool call
@@ -112,6 +113,7 @@ pub fn execute_tool(
     host_attr: &str,
     name: &str,
     args: &serde_json::Value,
+    auto_format: bool,
     gitignore_matcher: Option<&Gitignore>,
 ) -> Result<ToolResult> {
     let ctx = ToolCtx {
@@ -119,6 +121,7 @@ pub fn execute_tool(
         config_dir,
         host_attr,
         args,
+        auto_format,
         gitignore_matcher,
     };
 
@@ -268,6 +271,7 @@ mod tests {
             "dummy-host",
             "read_file",
             &json!({ "path": "secret.txt" }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -294,6 +298,7 @@ mod tests {
             "dummy-host",
             "read_file",
             &json!({ "path": "nested/secret.txt" }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -321,6 +326,7 @@ mod tests {
             "dummy-host",
             "list_files",
             &json!({ "pattern": "**/*.txt" }),
+            false,
             gitignore_matcher.as_ref(),
         )
         .expect("list_files should succeed");
@@ -350,6 +356,7 @@ mod tests {
                 "search": "",
                 "replace": "hello"
             }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -382,6 +389,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             gitignore_matcher.as_ref(),
         );
 
@@ -413,6 +421,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         );
 
@@ -446,6 +455,7 @@ mod tests {
                 "path": "homebrew.casks",
                 "value": ["docker", "iterm2", "audacity", "rectangle"]
             }),
+            false,
             None,
         );
 
@@ -475,6 +485,7 @@ mod tests {
                 "path": "programs.example.extraPackages",
                 "value": ["alpha", "beta"]
             }),
+            false,
             None,
         );
 
@@ -508,6 +519,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         );
 
@@ -535,6 +547,7 @@ mod tests {
                     "set_attrs": "launchd.user.agents"
                 }
             }),
+            false,
             None,
         );
 
@@ -575,6 +588,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should quote Homebrew values");
@@ -611,6 +625,7 @@ mod tests {
                 "path": "modules/darwin/packages.nix",
                 "values": ["wget"]
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should accept add shorthand");
@@ -663,6 +678,7 @@ mod tests {
                 "attr_path": "home.packages",
                 "values": ["fd"]
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should accept explicit attr_path shorthand");
@@ -701,6 +717,7 @@ mod tests {
                 "path": "packages.nix",
                 "values": ["fd"]
             }),
+            false,
             None,
         );
 
@@ -744,6 +761,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         )
         .expect("edit_nix_file should match quoted Homebrew values");
@@ -770,6 +788,7 @@ mod tests {
                 "search": "[]",
                 "replace": "[\"git\"]"
             }),
+            false,
             None,
         )
         .expect("data.json edits should be allowed");
@@ -792,6 +811,7 @@ mod tests {
                 "search": "{}",
                 "replace": "{\"name\":\"Changed\"}"
             }),
+            false,
             None,
         );
 
@@ -815,6 +835,7 @@ mod tests {
                 "search": "{}",
                 "replace": "{\"enabled\":true}"
             }),
+            false,
             None,
         );
 
@@ -843,6 +864,7 @@ mod tests {
                     }
                 }
             }),
+            false,
             None,
         );
 
@@ -867,6 +889,7 @@ mod tests {
                     "target": "environment.variables.API_TOKEN"
                 }
             }),
+            false,
             None,
         );
 
@@ -892,6 +915,7 @@ mod tests {
                 "search": "",
                 "replace": "hello"
             }),
+            false,
             gitignore_matcher.as_ref(),
         );
 

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -502,6 +502,7 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             path: path.to_string(),
             action: action.clone(),
         },
+        ctx.auto_format,
         ctx.gitignore_matcher,
     )?;
 

--- a/apps/native/src-tauri/src/evolve/tools/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/tools/ensure_secret.rs
@@ -79,6 +79,11 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
         ensure_nixmac_edit_allowed("ensure_secret", inject_file)?;
     }
 
-    let result = execute_ensure_secret(ctx.repo_root, ctx.args, ctx.gitignore_matcher)?;
+    let result = execute_ensure_secret(
+        ctx.repo_root,
+        ctx.args,
+        ctx.auto_format,
+        ctx.gitignore_matcher,
+    )?;
     Ok(ToolResult::EnsureSecret(result))
 }

--- a/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
+++ b/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
@@ -185,8 +185,12 @@ pub async fn apply_homebrew_diff(
     }
     let item_count = homebrew_item_count(&diff);
 
-    apply_homebrew_import(diff, std::path::Path::new(&dir))
-        .context("Failed to apply Homebrew diff")?;
+    apply_homebrew_import(
+        diff,
+        std::path::Path::new(&dir),
+        crate::state::ui_prefs::auto_format_nix_files(app),
+    )
+    .context("Failed to apply Homebrew diff")?;
 
     let working_tree_status =
         crate::git::status(&dir).context("Failed to get working tree status for evolve state")?;
@@ -592,7 +596,11 @@ fn apply_homebrew_data_import(
 /// Writes missing items in the diff to the config, using the source field to determine where to write.
 /// If the source is empty, we'll set up the official .nixmac/homebrew module and write data.json.
 /// We also hook up .nixmac to flake.nix in that case.
-pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) -> Result<()> {
+pub fn apply_homebrew_import(
+    diff: HomebrewState,
+    config_dir: &std::path::Path,
+    auto_format: bool,
+) -> Result<()> {
     if diff.casks.is_empty() && diff.brews.is_empty() && diff.taps.is_empty() {
         return Ok(());
     }
@@ -669,6 +677,7 @@ pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) 
                     values: nix_quote_values(&diff.taps),
                 },
             },
+            auto_format,
             None,
         )?;
     }
@@ -683,6 +692,7 @@ pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) 
                     values: nix_quote_values(&diff.brews),
                 },
             },
+            auto_format,
             None,
         )?;
     }
@@ -697,6 +707,7 @@ pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) 
                     values: nix_quote_values(&diff.casks),
                 },
             },
+            auto_format,
             None,
         )?;
     }
@@ -1144,7 +1155,7 @@ mod tests {
         let sanitized = sanitize_homebrew_diff(submitted, fresh_installed, fresh_config);
 
         assert_eq!(sanitized.source, None);
-        apply_homebrew_import(sanitized, temp.path())
+        apply_homebrew_import(sanitized, temp.path(), false)
             .expect("sanitized apply should create default module");
 
         let data_file = temp.path().join(NIXMAC_HOMEBREW_DATA_PATH);
@@ -1192,7 +1203,8 @@ mod tests {
             last_checked: 0,
         };
 
-        apply_homebrew_import(diff, temp.path()).expect("apply_homebrew_import should succeed");
+        apply_homebrew_import(diff, temp.path(), false)
+            .expect("apply_homebrew_import should succeed");
 
         let data_file = temp.path().join(NIXMAC_HOMEBREW_DATA_PATH);
         let data: Value = serde_json::from_str(
@@ -1225,7 +1237,7 @@ mod tests {
             last_checked: 0,
         };
 
-        let err = apply_homebrew_import(diff, temp.path())
+        let err = apply_homebrew_import(diff, temp.path(), false)
             .expect_err("default .nixmac source should require flake.nix");
 
         assert!(err.to_string().contains("flake.nix"));
@@ -1274,7 +1286,8 @@ mod tests {
             last_checked: 0,
         };
 
-        apply_homebrew_import(diff, temp.path()).expect("apply_homebrew_import should succeed");
+        apply_homebrew_import(diff, temp.path(), false)
+            .expect("apply_homebrew_import should succeed");
 
         let flake_content = std::fs::read_to_string(flake).expect("flake should remain readable");
         assert_eq!(

--- a/apps/native/src-tauri/src/managed_edits/system_defaults.rs
+++ b/apps/native/src-tauri/src/managed_edits/system_defaults.rs
@@ -74,6 +74,7 @@ fn rfind_unquoted_dot(value: &str) -> Option<usize> {
 pub fn ensure_system_defaults_module(
     config_dir: &str,
     add_primary_user: bool,
+    auto_format: bool,
 ) -> Result<std::path::PathBuf> {
     let modules_dir = std::path::Path::new(config_dir)
         .join("modules")
@@ -105,6 +106,7 @@ pub fn ensure_system_defaults_module(
                         value: Value::String(username),
                     },
                 },
+                auto_format,
                 None,
             )?;
         }
@@ -151,6 +153,7 @@ fn group_system_defaults(
 fn apply_system_defaults_to_module(
     config_dir: &std::path::Path,
     defaults: &[scanner::SystemDefault],
+    auto_format: bool,
 ) -> Result<()> {
     for (group, attrs) in group_system_defaults(defaults) {
         apply_semantic_edit(
@@ -159,6 +162,7 @@ fn apply_system_defaults_to_module(
                 path: system_defaults_module_path(),
                 action: FileEditAction::SetAttrs { path: group, attrs },
             },
+            auto_format,
             None,
         )?;
     }
@@ -184,14 +188,17 @@ pub async fn apply_system_defaults(
 
     let primary_user = get_system_primary_user(hostname, &dir);
 
-    let module_path = ensure_system_defaults_module(&dir, primary_user.is_none())
-        .context("Failed to ensure system-defaults.nix exists and is imported")?;
+    let auto_format_nix_files = crate::state::ui_prefs::auto_format_nix_files(app);
+
+    let module_path =
+        ensure_system_defaults_module(&dir, primary_user.is_none(), auto_format_nix_files)
+            .context("Failed to ensure system-defaults.nix exists and is imported")?;
     log::info!(
         "[apply_system_defaults] Ensured module at {:?}",
         module_path
     );
 
-    apply_system_defaults_to_module(config_path, &defaults)
+    apply_system_defaults_to_module(config_path, &defaults, auto_format_nix_files)
         .context("Failed to apply system defaults to module")?;
 
     let working_tree_status =
@@ -242,8 +249,8 @@ mod tests {
         );
 
         let config_dir = temp.path().to_string_lossy();
-        let module_path =
-            ensure_system_defaults_module(&config_dir, false).expect("module should be ensured");
+        let module_path = ensure_system_defaults_module(&config_dir, false, false)
+            .expect("module should be ensured");
         let module = std::fs::read_to_string(&module_path).expect("module should be readable");
         let flake = std::fs::read_to_string(temp.path().join("flake.nix"))
             .expect("flake should be readable");
@@ -273,8 +280,8 @@ mod tests {
         );
 
         let config_dir = temp.path().to_string_lossy();
-        let module_path =
-            ensure_system_defaults_module(&config_dir, true).expect("module should be ensured");
+        let module_path = ensure_system_defaults_module(&config_dir, true, false)
+            .expect("module should be ensured");
         let module = std::fs::read_to_string(&module_path).expect("module should be readable");
         let flake = std::fs::read_to_string(temp.path().join("flake.nix"))
             .expect("flake should be readable");
@@ -318,6 +325,7 @@ mod tests {
                     "0",
                 ),
             ],
+            false,
         )
         .expect("defaults should apply");
 

--- a/apps/native/src-tauri/src/schema_gen.rs
+++ b/apps/native/src-tauri/src/schema_gen.rs
@@ -7,14 +7,14 @@ use configurable::{ConfigurableMeta, inventory};
 use std::path::Path;
 
 use crate::env::config::NixmacEnvSettings;
-use crate::evolve::config::EvolutionLimits;
+use crate::evolve::config::UserPreferences;
 
 const DEFAULT_OUT_DIR: &str = "resources/schemas";
 
 /// Ensures inventory entries are linked into the binary.
 fn link_configurables() {
     let _ = (
-        EvolutionLimits::json_schema(),
+        UserPreferences::json_schema(),
         NixmacEnvSettings::json_schema(),
     );
 }
@@ -48,9 +48,9 @@ mod tests {
     use serde_json::Value;
 
     #[test]
-    fn evolution_limits_json_schema_has_expected_shape() {
+    fn user_preferences_json_schema_has_expected_shape() {
         link_configurables();
-        let schema = EvolutionLimits::json_schema();
+        let schema = UserPreferences::json_schema();
         assert_eq!(
             schema.get("$schema").and_then(Value::as_str),
             Some("https://json-schema.org/draft/2020-12/schema")

--- a/apps/native/src-tauri/src/shared_types/prefs.rs
+++ b/apps/native/src-tauri/src/shared_types/prefs.rs
@@ -67,6 +67,8 @@ pub struct UiPrefs {
     /// Developer-only feature flag overrides (flag key → variant string).
     /// `None` or missing key = use PostHog default.
     pub feature_flag_overrides: Option<BTreeMap<String, String>>,
+    /// Whether or not to auto-format Nix files when making changes to the flakes.
+    pub auto_format_nix_files: bool,
 }
 
 /// Partial update to UI preferences — every field is optional so the caller
@@ -139,6 +141,8 @@ pub struct UiPrefsUpdate {
     pub onboarding_mac_scanned_at: Option<i64>,
     /// Set true once the user logged in or explicitly chose bring-your-own-key.
     pub onboarding_login_decided: Option<bool>,
+    /// Auto-format Nix files after smart edits.
+    pub auto_format_nix_files: Option<bool>,
 }
 
 /// Preferences local to this app installation.
@@ -175,6 +179,8 @@ pub struct GlobalPreferences {
     pub onboarding_login_decided: bool,
     /// Timestamp (unix secs) of the last successful build/evolution apply. Set by `finalize_apply`.
     pub onboarding_last_build_at: Option<i64>,
+    /// Whether or not to auto-format Nix files when making changes to the flakes.
+    pub auto_format_nix_files: bool,
 }
 
 impl Default for GlobalPreferences {
@@ -204,6 +210,7 @@ impl Default for GlobalPreferences {
             onboarding_mac_scanned_at: None,
             onboarding_login_decided: false,
             onboarding_last_build_at: None,
+            auto_format_nix_files: false,
         }
     }
 }
@@ -271,6 +278,9 @@ impl GlobalPreferences {
         if let Some(v) = update.onboarding_login_decided {
             self.onboarding_login_decided = v;
         }
+        if let Some(v) = update.auto_format_nix_files {
+            self.auto_format_nix_files = v;
+        }
     }
 
     /// Builds the non-secret subset of [`UiPrefs`] from global preferences.
@@ -301,6 +311,7 @@ impl GlobalPreferences {
             pinned_version: self.pinned_version.clone(),
             update_channel: self.update_channel,
             feature_flag_overrides: self.feature_flag_overrides.clone(),
+            auto_format_nix_files: self.auto_format_nix_files,
         }
     }
 }

--- a/apps/native/src-tauri/src/state/preferences.rs
+++ b/apps/native/src-tauri/src/state/preferences.rs
@@ -171,7 +171,7 @@ mod tests {
             "updateChannel": "develop"
         }));
 
-        let prefs = load_or_default::<GlobalPreferences>(&persistence).unwrap();
+        let prefs: GlobalPreferences = load_or_default::<GlobalPreferences>(&persistence).unwrap();
 
         assert_eq!(prefs.host_attr.as_deref(), Some("macbook"));
         assert_eq!(prefs.config_dir.as_deref(), Some("/Users/cm/.darwin"));

--- a/apps/native/src-tauri/src/state/ui_prefs.rs
+++ b/apps/native/src-tauri/src/state/ui_prefs.rs
@@ -46,6 +46,10 @@ fn needs_limits_update(update: &UiPrefsUpdate) -> bool {
         || update.max_output_tokens.is_some()
 }
 
+pub fn auto_format_nix_files<R: Runtime>(app: &AppHandle<R>) -> bool {
+    preferences::try_read(app).is_some_and(|prefs| prefs.auto_format_nix_files)
+}
+
 fn apply_secret_updates<R: Runtime>(app: &AppHandle<R>, update: &UiPrefsUpdate) -> Result<()> {
     if let Some(key) = &update.openrouter_api_key {
         secrets::set_openrouter_api_key(app, key)?;
@@ -165,6 +169,10 @@ mod tests {
         }));
         assert!(needs_limits_update(&UiPrefsUpdate {
             max_iterations: Some(10),
+            ..Default::default()
+        }));
+        assert!(!needs_limits_update(&UiPrefsUpdate {
+            auto_format_nix_files: Some(true),
             ..Default::default()
         }));
     }

--- a/apps/native/src-tauri/src/system/launchd_scanner.rs
+++ b/apps/native/src-tauri/src/system/launchd_scanner.rs
@@ -371,6 +371,7 @@ pub async fn apply_launchd_items_to_flake(
         target_path
     );
 
+    let auto_format_nix_files = crate::state::ui_prefs::auto_format_nix_files(app);
     for (path, attrs) in launchd_items_by_scope(&items) {
         if attrs.is_empty() {
             continue;
@@ -385,6 +386,7 @@ pub async fn apply_launchd_items_to_flake(
                     attrs,
                 },
             },
+            auto_format_nix_files,
             None,
         )
         .with_context(|| format!("Failed to apply launchd items at {}", path))?;
@@ -568,6 +570,7 @@ mod tests {
                         attrs,
                     },
                 },
+                false,
                 None,
             )
             .expect("semantic edit");
@@ -635,6 +638,7 @@ mod tests {
                         attrs,
                     },
                 },
+                false,
                 None,
             )
             .expect("semantic edit");

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -359,6 +359,26 @@ pub fn get_nix_version() -> Option<String> {
     }
 }
 
+/// Runs `nixfmt` (from nixpkgs via `nix run`) against the provided file in `config_dir`.
+/// Executes the command:
+/// `nix run nixpkgs#nixfmt -- <file>`
+pub fn nix_format(config_dir: &str, file: &str) -> Result<String> {
+    log::debug!("Running nix format on file: {}", file);
+
+    let output = nix_command(config_dir)
+        .args(["run", "nixpkgs#nixfmt", "--", file])
+        .output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        anyhow::bail!(
+            "Failed to format with nixfmt: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
 /// Prefetches darwin-rebuild by running `nix build --no-link nix-darwin/master#darwin-rebuild`.
 /// This caches the derivation in the nix store so the `nix run` fallback in darwin.rs is fast.
 /// Emits `nix:darwin-rebuild:end` with `{ ok: bool, error?: string }` on completion.

--- a/apps/native/src-tauri/src/system/permissions.rs
+++ b/apps/native/src-tauri/src/system/permissions.rs
@@ -522,7 +522,7 @@ mod tests {
         let _env_restore =
             crate::test_support::EnvVarRestore::capture(&["VITE_NIXMAC_SKIP_PERMISSIONS"]);
 
-        std::env::set_var("VITE_NIXMAC_SKIP_PERMISSIONS", "true");
+        unsafe { std::env::set_var("VITE_NIXMAC_SKIP_PERMISSIONS", "true") };
 
         assert!(!vite_skip_permissions_enabled());
     }

--- a/apps/native/src-tauri/src/system/permissions.rs
+++ b/apps/native/src-tauri/src/system/permissions.rs
@@ -97,6 +97,22 @@ fn vite_skip_permissions_enabled() -> bool {
     false
 }
 
+fn skip_permissions_enabled() -> bool {
+    vite_skip_permissions_enabled() || e2e_skip_permissions_enabled()
+}
+
+fn granted_permissions_state() -> PermissionsState {
+    let mut permissions = get_default_permissions();
+    for perm in &mut permissions {
+        perm.status = PermissionStatus::Granted;
+    }
+    PermissionsState {
+        permissions,
+        all_required_granted: true,
+        checked_at: Some(chrono::Utc::now().timestamp()),
+    }
+}
+
 fn granted_folder_permission(id: &str, name: &str, description: &str) -> Permission {
     Permission {
         id: id.to_string(),
@@ -262,19 +278,11 @@ fn check_admin_privileges() -> PermissionStatus {
 
 /// Check all permissions and return the current state
 pub fn check_all_permissions() -> PermissionsState {
-    // In CI/E2E mode, skip all permission checks and report everything as granted.
-    // The E2E test environment may not have FDA granted and can't obtain it programmatically.
-    if e2e_skip_permissions_enabled() {
-        info!("NIXMAC_SKIP_PERMISSIONS=1: reporting all permissions as granted");
-        let mut permissions = get_default_permissions();
-        for perm in &mut permissions {
-            perm.status = PermissionStatus::Granted;
-        }
-        return PermissionsState {
-            permissions,
-            all_required_granted: true,
-            checked_at: Some(chrono::Utc::now().timestamp()),
-        };
+    // Debug/test environments may not have TCC permissions granted and cannot
+    // obtain them programmatically, so the skip flags satisfy the whole gate.
+    if skip_permissions_enabled() {
+        info!("permission skip enabled: reporting all permissions as granted");
+        return granted_permissions_state();
     }
 
     let mut permissions = get_default_permissions();
@@ -558,5 +566,51 @@ mod tests {
 
         unsafe { std::env::set_var("VITE_NIXMAC_SKIP_PERMISSIONS", "true") };
         assert_eq!(vite_skip_permissions_enabled(), cfg!(debug_assertions));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn vite_permission_skip_reports_all_permissions_granted() {
+        let _env_lock = crate::test_support::e2e_env_lock();
+        let _env_restore = crate::test_support::EnvVarRestore::capture(&[
+            "NIXMAC_SKIP_PERMISSIONS",
+            "VITE_NIXMAC_SKIP_PERMISSIONS",
+        ]);
+
+        unsafe { std::env::remove_var("NIXMAC_SKIP_PERMISSIONS") };
+        unsafe { std::env::set_var("VITE_NIXMAC_SKIP_PERMISSIONS", "true") };
+
+        let state = check_all_permissions();
+
+        assert!(state.all_required_granted);
+        assert!(
+            state
+                .permissions
+                .iter()
+                .all(|permission| permission.status == PermissionStatus::Granted)
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn nixmac_permission_skip_reports_all_permissions_granted() {
+        let _env_lock = crate::test_support::e2e_env_lock();
+        let _env_restore = crate::test_support::EnvVarRestore::capture(&[
+            "NIXMAC_SKIP_PERMISSIONS",
+            "VITE_NIXMAC_SKIP_PERMISSIONS",
+        ]);
+
+        unsafe { std::env::set_var("NIXMAC_SKIP_PERMISSIONS", "true") };
+        unsafe { std::env::remove_var("VITE_NIXMAC_SKIP_PERMISSIONS") };
+
+        let state = check_all_permissions();
+
+        assert!(state.all_required_granted);
+        assert!(
+            state
+                .permissions
+                .iter()
+                .all(|permission| permission.status == PermissionStatus::Granted)
+        );
     }
 }

--- a/apps/native/src/components/nixmac-mascot/README.md
+++ b/apps/native/src/components/nixmac-mascot/README.md
@@ -123,4 +123,3 @@ All paths read the same `nixmac-mascot.svg`, so re-rig geometry there.
 For real lighting / materials / perspective beyond flat faces, rebuild in
 [React Three Fiber](https://r3f.docs.pmnd.rs) (`three` + `@react-three/fiber`) and
 load a GLB. Bigger dependency; only worth it if you want shading, not flat faces.
-

--- a/apps/native/src/components/widget/onboarding/lib/customizations.ts
+++ b/apps/native/src/components/widget/onboarding/lib/customizations.ts
@@ -1,4 +1,11 @@
-import type { HomebrewState, LaunchdItem, SystemDefaultsScan } from "@/ipc/types";
+import type {
+  HomebrewItem,
+  HomebrewState,
+  LaunchdItem,
+  SystemDefault,
+  SystemDefaultsScan,
+} from "@/ipc/types";
+import type { TrackedCustomizationSource } from "@nixmac/state";
 
 export type CustomizationGroupId =
   | "macos-settings"
@@ -7,6 +14,14 @@ export type CustomizationGroupId =
   | "launch-agents";
 
 export type GroupSeverity = "info" | "warning";
+
+export type CustomizationSource = TrackedCustomizationSource;
+
+export interface TrackedCustomizationBuckets {
+  homebrew: HomebrewItem[];
+  launchd: LaunchdItem[];
+  systemDefaults: SystemDefault[];
+}
 
 export interface CustomizationItem {
   id: string;
@@ -18,6 +33,8 @@ export interface CustomizationItem {
   meta: string;
   /** The nix line this item would add to the config */
   nixLine: string;
+  /** The original scanner payload, tagged by scanner type for apply-time routing. */
+  source: CustomizationSource;
 }
 
 export interface CustomizationGroup {
@@ -51,6 +68,7 @@ function defaultsGroup(scan: SystemDefaultsScan): CustomizationGroup | null {
       detail: `${d.nixKey} = ${d.currentValue}`,
       meta: `default: ${d.defaultValue}`,
       nixLine: `${d.nixKey} = ${d.currentValue};`,
+      source: { type: "system-default", item: d },
     })),
   };
 }
@@ -70,6 +88,7 @@ function casksGroup(state: HomebrewState): CustomizationGroup | null {
       detail: "Homebrew cask",
       meta: "cask",
       nixLine: `homebrew.casks = [ "${name}" ];`,
+      source: { type: "homebrew", item: { name, version: null, itemType: "cask" } },
     })),
   };
 }
@@ -89,6 +108,7 @@ function tapsGroup(state: HomebrewState): CustomizationGroup | null {
       detail: "Homebrew tap",
       meta: "tap",
       nixLine: `homebrew.taps = [ "${name}" ];`,
+      source: { type: "homebrew", item: { name, version: null, itemType: "tap" } },
     })),
   };
 }
@@ -110,6 +130,7 @@ function launchdGroup(items: LaunchdItem[]): CustomizationGroup | null {
       nixLine: `launchd.user.agents.${item.name || "service"}.serviceConfig.ProgramArguments = [ ${item.programArguments
         .map((a) => `"${a}"`)
         .join(" ")} ];`,
+      source: { type: "launchd", item },
     })),
   };
 }
@@ -132,6 +153,48 @@ export function totalCustomizations(groups: CustomizationGroup[]): number {
   return groups.reduce((sum, g) => sum + g.items.length, 0);
 }
 
+export function collectTrackedCustomizationSources(
+  trackedCustomizations: string[],
+  trackedCustomizationSources: Record<string, CustomizationSource>,
+): TrackedCustomizationBuckets {
+  const homebrew: HomebrewItem[] = [];
+  const launchd: LaunchdItem[] = [];
+  const systemDefaults: SystemDefault[] = [];
+
+  for (const id of trackedCustomizations) {
+    const source = trackedCustomizationSources[id];
+    if (!source) continue;
+
+    switch (source.type) {
+      case "homebrew":
+        homebrew.push(source.item);
+        break;
+      case "launchd":
+        launchd.push(source.item);
+        break;
+      case "system-default":
+        systemDefaults.push(source.item);
+        break;
+    }
+  }
+
+  return {
+    homebrew: uniqueHomebrewItems(homebrew),
+    launchd,
+    systemDefaults,
+  };
+}
+
+function uniqueHomebrewItems(items: HomebrewItem[]): HomebrewItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.itemType}:${item.name}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 /** A small static sample used by Storybook and as a graceful fallback. */
 export const MOCK_CUSTOMIZATION_GROUPS: CustomizationGroup[] = [
   {
@@ -150,6 +213,16 @@ export const MOCK_CUSTOMIZATION_GROUPS: CustomizationGroup[] = [
         detail: "system.defaults.dock.expose-group-apps = true",
         meta: "default: false",
         nixLine: "system.defaults.dock.expose-group-apps = true;",
+        source: {
+          type: "system-default",
+          item: {
+            nixKey: "system.defaults.dock.expose-group-apps",
+            label: "Group windows by application in Mission Control",
+            category: "Dock",
+            currentValue: "true",
+            defaultValue: "false",
+          },
+        },
       },
       {
         id: "default-wm",
@@ -157,6 +230,16 @@ export const MOCK_CUSTOMIZATION_GROUPS: CustomizationGroup[] = [
         detail: "system.defaults.WindowManager.HideDesktop = true",
         meta: "default: false",
         nixLine: "system.defaults.WindowManager.HideDesktop = true;",
+        source: {
+          type: "system-default",
+          item: {
+            nixKey: "system.defaults.WindowManager.HideDesktop",
+            label: "Hide desktop items in Stage Manager",
+            category: "Window Manager",
+            currentValue: "true",
+            defaultValue: "false",
+          },
+        },
       },
     ],
   },
@@ -174,6 +257,7 @@ export const MOCK_CUSTOMIZATION_GROUPS: CustomizationGroup[] = [
         detail: "Homebrew cask",
         meta: "cask",
         nixLine: 'homebrew.casks = [ "raycast" ];',
+        source: { type: "homebrew", item: { name: "raycast", version: null, itemType: "cask" } },
       },
       {
         id: "cask-ghostty",
@@ -181,6 +265,7 @@ export const MOCK_CUSTOMIZATION_GROUPS: CustomizationGroup[] = [
         detail: "Homebrew cask",
         meta: "cask",
         nixLine: 'homebrew.casks = [ "ghostty" ];',
+        source: { type: "homebrew", item: { name: "ghostty", version: null, itemType: "cask" } },
       },
     ],
   },

--- a/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
@@ -29,7 +29,7 @@ const meta = preview.meta({
   parameters: { layout: "centered" },
   decorators: [
     (Story: React.ComponentType) => (
-      <div className="dark relative min-h-[600px] min-w-[800px] overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
+      <div className="dark relative min-h-150 min-w-200 overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
         <Story />
       </div>
     ),
@@ -244,6 +244,7 @@ function installBackend(startAt: string) {
   syncVM();
   onboardingActions.setState({
     trackedCustomizations: [],
+    trackedCustomizationSources: {},
     inferenceDeferred: false,
     celebrating: false,
     viewingStep: null,

--- a/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
@@ -29,7 +29,7 @@ const meta = preview.meta({
   parameters: { layout: "centered" },
   decorators: [
     (Story: React.ComponentType) => (
-      <div className="dark relative min-h-150 min-w-200 overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
+      <div className="dark relative min-h-[600px] min-w-[800px] overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
         <Story />
       </div>
     ),

--- a/apps/native/src/components/widget/onboarding/onboarding-step-content.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-step-content.tsx
@@ -15,6 +15,7 @@ interface OnboardingStepContentProps {
 
 export function OnboardingStepContent({ currentStep, title }: OnboardingStepContentProps) {
   const trackedCustomizations = useOnboarding((s) => s.trackedCustomizations);
+  const trackedCustomizationSources = useOnboarding((s) => s.trackedCustomizationSources);
   // Inference readiness is a durable fact: provider + model are persisted to
   // GlobalPreferences by InferenceSetup, and the login decision is recorded
   // separately. The build step only needs to know inference is configured.
@@ -33,6 +34,7 @@ export function OnboardingStepContent({ currentStep, title }: OnboardingStepCont
         {currentStep === "customizations" && (
           <CustomizationsStep
             tracked={trackedCustomizations}
+            trackedSources={trackedCustomizationSources}
             onSetTracked={onboardingActions.setTrackedCustomizations}
             onContinue={markMacScanned}
           />

--- a/apps/native/src/components/widget/onboarding/steps/build-step.tsx
+++ b/apps/native/src/components/widget/onboarding/steps/build-step.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { StepShell } from "@/components/widget/onboarding/step-shell";
 import { InferenceSetup } from "@/components/widget/onboarding/inference/inference-setup";
+import { collectTrackedCustomizationSources } from "@/components/widget/onboarding/lib/customizations";
 import { stepEyebrow } from "@/components/widget/onboarding/lib/onboarding";
 
 // Lazy so lottie-web (and its canvas usage) stays out of the main bundle and
@@ -26,6 +27,7 @@ const CelebrationOverlay = lazy(() =>
 );
 import { onboardingActions, useOnboarding, useViewModel } from "@nixmac/state";
 import { useApply } from "@/hooks/use-apply";
+import { tauriAPI } from "@/ipc/api";
 import { cn } from "@/lib/utils";
 import { getTelemetry } from "@/lib/telemetry/instance";
 import type { InferenceConfig } from "@/components/widget/onboarding/lib/inference";
@@ -107,8 +109,45 @@ export function BuildStep({ hasInference, onConfigureInference }: BuildStepProps
     }
   }, [status, hasInference, dismissedCelebration, celebrating]);
 
-  function runBuild() {
+  async function applyTrackedCustomizations() {
+    // Keep this outside handleApply, which is also used for ordinary rebuilds
+    // after onboarding and has no customization scan context.
+    const { trackedCustomizations, trackedCustomizationSources } = useOnboarding.getState();
+    const trackedSources = collectTrackedCustomizationSources(
+      trackedCustomizations,
+      trackedCustomizationSources,
+    );
+
+    if (trackedSources.homebrew.length > 0) {
+      // deprecated(orpc): replace with client/orpc from @/lib/orpc
+      await tauriAPI.homebrew.addItems(trackedSources.homebrew);
+    }
+    if (trackedSources.launchd.length > 0) {
+      // deprecated(orpc): replace with client/orpc from @/lib/orpc
+      await tauriAPI.launchd.applyLaunchdItems(trackedSources.launchd);
+    }
+    if (trackedSources.systemDefaults.length > 0) {
+      // deprecated(orpc): replace with client/orpc from @/lib/orpc
+      await tauriAPI.scanner.applyDefaults(trackedSources.systemDefaults);
+    }
+  }
+
+  // Runs the "first" build as part of onboarding. Before it can do that, it needs
+  // to apply any selected "tracking" customizations.
+  async function runFirstBuild() {
     setStarted(true);
+
+    // Keep this outside handleApply, which is also used for ordinary rebuilds
+    // after onboarding and has no customization scan context.
+    try {
+      await applyTrackedCustomizations();
+    } catch (error) {
+      console.error("Failed to apply tracked customizations before first build:", error);
+      setStarted(false);
+      setTrackedOutcome("error");
+      return;
+    }
+
     setTrackedOutcome(null);
     getTelemetry().captureEvent({ name: "first_build_started" });
     void handleApply();
@@ -129,7 +168,7 @@ export function BuildStep({ hasInference, onConfigureInference }: BuildStepProps
           <code className="block truncate font-mono text-foreground text-sm">{command}</code>
         </div>
         {status === "idle" ? (
-          <Button onClick={runBuild} className="shrink-0">
+          <Button onClick={runFirstBuild} className="shrink-0">
             <Play className="size-4" aria-hidden="true" />
             Run build
           </Button>
@@ -139,7 +178,7 @@ export function BuildStep({ hasInference, onConfigureInference }: BuildStepProps
             Building…
           </Button>
         ) : status === "error" ? (
-          <Button onClick={runBuild} className="shrink-0">
+          <Button onClick={runFirstBuild} className="shrink-0">
             <RotateCcw className="size-4" aria-hidden="true" />
             Retry build
           </Button>

--- a/apps/native/src/components/widget/onboarding/steps/build-step.tsx
+++ b/apps/native/src/components/widget/onboarding/steps/build-step.tsx
@@ -130,6 +130,9 @@ export function BuildStep({ hasInference, onConfigureInference }: BuildStepProps
       // deprecated(orpc): replace with client/orpc from @/lib/orpc
       await tauriAPI.scanner.applyDefaults(trackedSources.systemDefaults);
     }
+
+    // Avoid re-applying on build retries; changes are now represented in the config.
+    onboardingActions.setTrackedCustomizations([], {});
   }
 
   // Runs the "first" build as part of onboarding. Before it can do that, it needs

--- a/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
+++ b/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
@@ -379,38 +379,46 @@ function GroupCard({
         isWarning ? "border-warning/30" : "border-border",
       )}
     >
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        className="flex w-full items-start gap-3 p-4 text-left"
-      >
+      <div className="flex w-full items-start gap-3 p-4 text-left">
         <Checkbox
           checked={allTracked}
-          onCheckedChange={() => onTrack(group.items)}
+          onCheckedChange={(checked) => {
+            if (checked === true) {
+              onTrack(group.items);
+            } else {
+              onUntrack(ids);
+            }
+          }}
           className={cn("size-4 border-none", allTracked ? "bg-white" : "bg-zinc-700")}
         />
-        <span className="min-w-0 flex-1">
-          <span className="flex items-center gap-2 font-semibold text-sm">
-            {group.items.length} {group.title}
-            {allTracked ? <Check className="size-4 text-success" aria-hidden="true" /> : null}
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex min-w-0 flex-1 items-start gap-3 text-left"
+        >
+          <span className="min-w-0 flex-1">
+            <span className="flex items-center gap-2 font-semibold text-sm">
+              {group.items.length} {group.title}
+              {allTracked ? <Check className="size-4 text-success" aria-hidden="true" /> : null}
+            </span>
+            <span className="mt-1 block text-pretty text-muted-foreground text-xs leading-relaxed">
+              {group.description}
+            </span>
+            <span className="mt-2 block font-mono text-muted-foreground/80 text-xs">
+              <span className="text-muted-foreground">$ {group.command}</span>
+              {group.commandNote ? ` (${group.commandNote})` : ""} · scanned just now · would land
+              in <span className="text-foreground">{group.landingPath}</span>
+            </span>
           </span>
-          <span className="mt-1 block text-pretty text-muted-foreground text-xs leading-relaxed">
-            {group.description}
-          </span>
-          <span className="mt-2 block font-mono text-muted-foreground/80 text-xs">
-            <span className="text-muted-foreground">$ {group.command}</span>
-            {group.commandNote ? ` (${group.commandNote})` : ""} · scanned just now · would land in{" "}
-            <span className="text-foreground">{group.landingPath}</span>
-          </span>
-        </span>
-        <ChevronDown
-          className={cn(
-            "mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform",
-            expanded && "rotate-180",
-          )}
-          aria-hidden="true"
-        />
-      </button>
+          <ChevronDown
+            className={cn(
+              "mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform",
+              expanded && "rotate-180",
+            )}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
 
       {expanded ? (
         <>

--- a/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
+++ b/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
@@ -8,6 +8,8 @@ import {
   MOCK_CUSTOMIZATION_GROUPS,
   totalCustomizations,
   type CustomizationGroup,
+  type CustomizationItem,
+  type CustomizationSource,
 } from "@/components/widget/onboarding/lib/customizations";
 import { stepEyebrow } from "@/components/widget/onboarding/lib/onboarding";
 import { StepShell } from "@/components/widget/onboarding/step-shell";
@@ -39,7 +41,8 @@ const SCAN_TARGETS = [
 
 interface CustomizationsStepProps {
   tracked: string[];
-  onSetTracked: (ids: string[]) => void;
+  trackedSources: Record<string, CustomizationSource>;
+  onSetTracked: (ids: string[], sources: Record<string, CustomizationSource>) => void;
   onContinue: () => void;
 }
 
@@ -63,19 +66,35 @@ async function runScan(): Promise<CustomizationGroup[]> {
   return buildCustomizationGroups({ defaults, homebrew, launchd });
 }
 
-export function CustomizationsStep({ tracked, onSetTracked, onContinue }: CustomizationsStepProps) {
+export function CustomizationsStep({
+  tracked,
+  trackedSources,
+  onSetTracked,
+  onContinue,
+}: CustomizationsStepProps) {
   const [scanState, setScanState] = useState<ScanState>("idle");
   const [groups, setGroups] = useState<CustomizationGroup[] | null>(null);
   const [animationDone, setAnimationDone] = useState(false);
   const trackedSet = new Set(tracked);
 
-  function track(ids: string[]) {
-    onSetTracked([...new Set([...tracked, ...ids])]);
+  function sourceMapForItems(items: CustomizationItem[]): Record<string, CustomizationSource> {
+    return Object.fromEntries(items.map((item) => [item.id, item.source]));
+  }
+
+  function track(items: CustomizationItem[]) {
+    const ids = items.map((item) => item.id);
+    const nextSources = { ...trackedSources, ...sourceMapForItems(items) };
+    const nextTracked = [...new Set([...tracked, ...ids])];
+    onSetTracked(nextTracked, nextSources);
   }
 
   function untrack(ids: string[]) {
     const remove = new Set(ids);
-    onSetTracked(tracked.filter((id) => !remove.has(id)));
+    const nextTracked = tracked.filter((id) => !remove.has(id));
+    const nextSources = Object.fromEntries(
+      Object.entries(trackedSources).filter(([id]) => !remove.has(id)),
+    );
+    onSetTracked(nextTracked, nextSources);
   }
 
   const trackedCount = tracked.length;
@@ -106,6 +125,7 @@ export function CustomizationsStep({ tracked, onSetTracked, onContinue }: Custom
   function startScan() {
     setGroups(null);
     setAnimationDone(false);
+    onSetTracked([], {});
     getTelemetry().captureEvent({ name: "customizations_scanned" });
     setScanState("scanning");
   }
@@ -340,7 +360,7 @@ function GroupCard({
 }: {
   group: CustomizationGroup;
   trackedSet: Set<string>;
-  onTrack: (ids: string[]) => void;
+  onTrack: (items: CustomizationItem[]) => void;
   onUntrack: (ids: string[]) => void;
 }) {
   const [expanded, setExpanded] = useState(group.severity === "info");
@@ -366,7 +386,7 @@ function GroupCard({
       >
         <Checkbox
           checked={allTracked}
-          onCheckedChange={() => onTrack(ids)}
+          onCheckedChange={() => onTrack(group.items)}
           className={cn("size-4 border-none", allTracked ? "bg-white" : "bg-zinc-700")}
         />
         <span className="min-w-0 flex-1">
@@ -401,7 +421,7 @@ function GroupCard({
                 Tracking all {ids.length}
               </Button>
             ) : (
-              <Button size="sm" onClick={() => onTrack(ids)}>
+              <Button size="sm" onClick={() => onTrack(group.items)}>
                 <Plus className="size-4" aria-hidden="true" />
                 Track{" "}
                 {someTracked
@@ -445,7 +465,7 @@ function GroupCard({
                     ) : (
                       <button
                         type="button"
-                        onClick={() => onTrack([item.id])}
+                        onClick={() => onTrack([item])}
                         className="font-medium text-primary text-xs hover:underline"
                       >
                         Track

--- a/apps/native/src/components/widget/onboarding/use-onboarding-flow.ts
+++ b/apps/native/src/components/widget/onboarding/use-onboarding-flow.ts
@@ -36,7 +36,9 @@ export function useOnboardingFlow(): {
   const celebrating = useOnboarding((s) => s.celebrating);
   const viewingStep = useOnboarding((s) => s.viewingStep);
 
-  const permissionsReady = !(permissionsHydrated && permissions && !permissions.allRequiredGranted);
+  const permissionsReady =
+    settings.skipPermissions ||
+    !(permissionsHydrated && permissions && !permissions.allRequiredGranted);
   const nixReady =
     (nixInstalled === true && darwinRebuildAvailable === true) ||
     settings.nixInstalledOverride === true;

--- a/apps/native/src/components/widget/settings/preferences-tab.tsx
+++ b/apps/native/src/components/widget/settings/preferences-tab.tsx
@@ -10,6 +10,7 @@ export function PreferencesTab() {
   const autoSummarizeOnFocus = useViewModel((s) => s.preferences?.autoSummarizeOnFocus ?? false);
   const scanHomebrewOnStartup = useViewModel((s) => s.preferences?.scanHomebrewOnStartup ?? true);
   const defaultToDiffTab = useViewModel((s) => s.preferences?.defaultToDiffTab ?? false);
+  const autoFormatNixFiles = useViewModel((s) => s.preferences?.autoFormatNixFiles ?? false);
 
   return (
     <div className="space-y-6">
@@ -81,6 +82,18 @@ export function PreferencesTab() {
               <Switch
                 checked={defaultToDiffTab}
                 onCheckedChange={(checked) => setPref("defaultToDiffTab", checked)}
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-lg border border-border p-3">
+              <div className="space-y-0.5">
+                <div className="text-sm">Auto-Format Nix Files</div>
+                <div className="text-muted-foreground text-xs">
+                  Automatically format Nix files after smart edits
+                </div>
+              </div>
+              <Switch
+                checked={autoFormatNixFiles}
+                onCheckedChange={(checked) => setPref("autoFormatNixFiles", checked)}
               />
             </div>
           </div>

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1113,7 +1113,11 @@ onboardingLoginDecided: boolean;
 /**
  * Timestamp (unix secs) of the last successful build/evolution apply. Set by `finalize_apply`.
  */
-onboardingLastBuildAt: number | null }
+onboardingLastBuildAt: number | null; 
+/**
+ * Whether or not to auto-format Nix files when making changes to the flakes.
+ */
+autoFormatNixFiles: boolean | null }
 
 /**
  * A commit entry combining git log data, tag-derived flags, optional DB metadata, and raw diff changes.
@@ -1922,7 +1926,11 @@ updateChannel: UpdateChannel;
  * Developer-only feature flag overrides (flag key → variant string).
  * `None` or missing key = use PostHog default.
  */
-featureFlagOverrides: Partial<{ [key in string]: string }> | null }
+featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
+/**
+ * Whether or not to auto-format Nix files when making changes to the flakes.
+ */
+autoFormatNixFiles: boolean | null }
 
 /**
  * Partial update to UI preferences — every field is optional so the caller
@@ -2037,7 +2045,11 @@ onboardingMacScannedAt: number | null;
 /**
  * Set true once the user logged in or explicitly chose bring-your-own-key.
  */
-onboardingLoginDecided: boolean | null }
+onboardingLoginDecided: boolean | null; 
+/**
+ * Auto-format Nix files after smart edits.
+ */
+autoFormatNixFiles: boolean | null }
 
 /**
  * Auto-update channel selected for release-mode builds.

--- a/apps/native/src/lib/env.ts
+++ b/apps/native/src/lib/env.ts
@@ -52,6 +52,7 @@ export type SettingsType = {
   readonly posthogHost: string;
   readonly filesystemEnabled: boolean;
   readonly nixInstalledOverride?: boolean;
+  readonly skipPermissions: boolean;
 };
 
 function loadMergedProfile(): EnvProfile {
@@ -71,6 +72,7 @@ function toSettings(profile: EnvProfile): SettingsType {
     posthogHost: profile.VITE_POSTHOG_HOST,
     filesystemEnabled: profile.VITE_NIXMAC_FILESYSTEM,
     nixInstalledOverride: profile.NIX_INSTALLED_OVERRIDE ? true : undefined,
+    skipPermissions: profile.VITE_NIXMAC_SKIP_PERMISSIONS,
   };
 }
 

--- a/apps/native/src/lib/env.ts
+++ b/apps/native/src/lib/env.ts
@@ -105,4 +105,3 @@ export function getWebSiteUrl(): string {
 
 
 console.log("Running with env", import.meta.env);
-console.log("Running with settings", settings);

--- a/apps/native/src/types/preferences.ts
+++ b/apps/native/src/types/preferences.ts
@@ -5,4 +5,5 @@ export type BoolPrefKey =
   | "autoSummarizeOnFocus"
   | "scanHomebrewOnStartup"
   | "defaultToDiffTab"
-  | "experimentalSpinningMascot";
+  | "experimentalSpinningMascot"
+  | "autoFormatNixFiles";

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -74,10 +74,7 @@ export {
   selectViewingStep,
   useOnboarding,
   type OnboardingSelector,
-  type OnboardingStateValues,
-  type OnboardingStepId,
-  type TrackedCustomizationSource,
 } from "./onboarding";
-export type { OnboardingStateValues, OnboardingStepId } from "./onboarding";
+export type { TrackedCustomizationSource } from "./onboarding";
 
 export type { InferenceConfig, InferenceMode } from "./onboarding-types";

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -69,10 +69,14 @@ export {
 export {
   selectCelebrating,
   selectInferenceDeferred,
+  selectTrackedCustomizationSources,
   selectTrackedCustomizations,
   selectViewingStep,
   useOnboarding,
   type OnboardingSelector,
+  type OnboardingStateValues,
+  type OnboardingStepId,
+  type TrackedCustomizationSource,
 } from "./onboarding";
 export type { OnboardingStateValues, OnboardingStepId } from "./onboarding";
 

--- a/packages/state/src/onboarding/index.ts
+++ b/packages/state/src/onboarding/index.ts
@@ -8,9 +8,10 @@ export {
 export {
   selectCelebrating,
   selectInferenceDeferred,
+  selectTrackedCustomizationSources,
   selectTrackedCustomizations,
   selectViewingStep,
   useOnboarding,
   type OnboardingSelector,
 } from "./selectors";
-export type { OnboardingStateValues, OnboardingStepId } from "./types";
+export type { OnboardingStateValues, OnboardingStepId, TrackedCustomizationSource } from "./types";

--- a/packages/state/src/onboarding/index.ts
+++ b/packages/state/src/onboarding/index.ts
@@ -14,4 +14,4 @@ export {
   useOnboarding,
   type OnboardingSelector,
 } from "./selectors";
-export type { OnboardingStateValues, OnboardingStepId, TrackedCustomizationSource } from "./types";
+export type { TrackedCustomizationSource } from "./types";

--- a/packages/state/src/onboarding/selectors.ts
+++ b/packages/state/src/onboarding/selectors.ts
@@ -8,6 +8,8 @@ export type OnboardingSelector<T> = (state: OnboardingStore) => T;
 
 export const selectTrackedCustomizations = (state: OnboardingStore) =>
   state.trackedCustomizations;
+export const selectTrackedCustomizationSources = (state: OnboardingStateValues) =>
+  state.trackedCustomizationSources;
 export const selectInferenceDeferred = (state: OnboardingStore) => state.inferenceDeferred;
 export const selectCelebrating = (state: OnboardingStore) => state.celebrating;
 export const selectViewingStep = (state: OnboardingStore) => state.viewingStep;

--- a/packages/state/src/onboarding/selectors.ts
+++ b/packages/state/src/onboarding/selectors.ts
@@ -1,5 +1,6 @@
 import { onboardingStore } from "./store";
 import type { OnboardingStore } from "./store";
+import { OnboardingStateValues } from "./types";
 
 /** Subscribe to transient onboarding UI state. */
 export const useOnboarding = onboardingStore;

--- a/packages/state/src/onboarding/store.ts
+++ b/packages/state/src/onboarding/store.ts
@@ -11,6 +11,7 @@ import type { OnboardingStateValues, OnboardingStepId } from "./types";
 
 export const initialOnboardingState: OnboardingStateValues = {
   trackedCustomizations: [],
+  trackedCustomizationSources: {},
   inferenceDeferred: false,
   celebrating: false,
   viewingStep: null,

--- a/packages/state/src/onboarding/store.ts
+++ b/packages/state/src/onboarding/store.ts
@@ -20,7 +20,10 @@ export const initialOnboardingState: OnboardingStateValues = {
 /** Imperative writers for the transient onboarding UI store. */
 export type OnboardingActions = {
   reset: () => void;
-  setTrackedCustomizations: (trackedCustomizations: string[]) => void;
+  setTrackedCustomizations: (
+    trackedCustomizations: string[],
+    trackedCustomizationSources: OnboardingStateValues["trackedCustomizationSources"],
+  ) => void;
   /** Defer inference to the build step (inline setup runs alongside the build). */
   deferInference: () => void;
   /** Keep the success celebration mounted after the build gate is satisfied. */
@@ -34,7 +37,8 @@ export type OnboardingStore = OnboardingStateValues & OnboardingActions;
 export const onboardingStore = create<OnboardingStore>()((set) => ({
   ...initialOnboardingState,
   reset: () => set(initialOnboardingState),
-  setTrackedCustomizations: (trackedCustomizations) => set({ trackedCustomizations }),
+  setTrackedCustomizations: (trackedCustomizations, trackedCustomizationSources) =>
+    set({ trackedCustomizations, trackedCustomizationSources }),
   deferInference: () => set({ inferenceDeferred: true }),
   setCelebrating: (celebrating) => set({ celebrating }),
   setViewingStep: (viewingStep) => set({ viewingStep }),

--- a/packages/state/src/onboarding/types.ts
+++ b/packages/state/src/onboarding/types.ts
@@ -1,3 +1,5 @@
+import type { HomebrewItem, LaunchdItem, SystemDefault } from "@nixmac/native/ipc/types";
+
 export type OnboardingStepId =
   | "permissions"
   | "nix-setup"
@@ -5,6 +7,11 @@ export type OnboardingStepId =
   | "customizations"
   | "inference"
   | "build";
+
+export type TrackedCustomizationSource =
+  | { type: "homebrew"; item: HomebrewItem }
+  | { type: "launchd"; item: LaunchdItem }
+  | { type: "system-default"; item: SystemDefault };
 
 /**
  * Transient, session-only onboarding UI state. Completion and per-step progress
@@ -15,6 +22,8 @@ export type OnboardingStepId =
 export type OnboardingStateValues = {
   /** IDs of detected customizations the user toggled while reviewing the scan. */
   trackedCustomizations: string[];
+  /** Original scanner payload for each tracked customization, keyed by customization ID. */
+  trackedCustomizationSources: Record<string, TrackedCustomizationSource>;
   /** User chose to defer inference setup until the first build runs. */
   inferenceDeferred: boolean;
   /** Keep the success celebration mounted after the build gate is satisfied. */


### PR DESCRIPTION
## Summary

The new onboarding flow had a TODO to actually apply any customizations selected for tracking before doing the build. This PR fixes that.

It also restores the intended functionality of the `SKIP_PERMISSIONS` env var to enable better testability.

Overall, it ends up being a pretty clean change -- the biggest effort is around preserving the original applyable data structures instead of just the frontend's synthetic id's.

<img width="774" height="727" alt="image" src="https://github.com/user-attachments/assets/b6767553-9c2f-476d-8042-024cd3e4d43c" />

## Test Plan

Manual. I tried a change of each time and verified that the expected diffs were created. That said, I'm also relying on the fact that the apply code paths are exactly the same ones we use in the "normal" scanner.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed