### PR TITLE
ci: sign and notarize on PR builds, decouple from release tagging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -194,7 +194,9 @@ jobs:
           path: ${{ runner.temp }}/sccache
           key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
-      # Import Apple Developer certificate (only for releases with secrets).
+      # Import Apple Developer certificate (whenever secrets are available —
+      # signing/notarization is independent of release mode, so PR builds get
+      # notarized artifacts too; only tagging/publishing below is mode-gated).
       # Placed AFTER the Tauri build to avoid replacing the keychain search list
       # before `bun run desktop:build`, which caused DMG bundling failures on tags.
       # The normalizer needs this keychain to re-sign updater archives after
@@ -221,6 +223,7 @@ jobs:
 
       # Sign the app bundle (required for notarization)
       - name: Sign app bundle
+        if: steps.check-secrets.outputs.has_certificate == 'true'
         run: bash ops/scripts/release/sign-app.sh
       # Replace unsigned app inside the Tauri-built DMG with the signed one.
       # We mount the DMG read-write, swap the .app in place, and re-compress so
@@ -233,6 +236,8 @@ jobs:
         run: bash ops/scripts/release/swap-signed-dmg.sh
       # Notarize the app (requires Apple Developer account)
       - name: Notarize app
+        if: steps.check-secrets.outputs.has_certificate == 'true' &&
+          steps.check-secrets.outputs.has_notarization == 'true'
         shell: 'sops exec-env ops/secrets/secrets.sops.json "bash -e {0}"'
         run: bash ops/scripts/release/notarize.sh
       - name: Check macOS app portability


### PR DESCRIPTION
Signing/notarization steps were gated on release mode (tag/release/develop), so PR builds shipped unsigned, un-notarized artifacts. Gate them only on secret availability; tagging and publishing remain mode-gated.

## Summary

<!-- What does this PR do? Why? -->

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
