### PR TITLE
feat: use `nix eval` to read Homebrew state from the actual nix shell when diffing

### DIFF
--- a/apps/native/src-tauri/src/commands/homebrew.rs
+++ b/apps/native/src-tauri/src/commands/homebrew.rs
@@ -1,5 +1,4 @@
-use super::helpers::capture_err;
-use crate::storage::store;
+use super::helpers::{capture_err, get_hostname_and_config_dir};
 use crate::{managed_edits, shared_types};
 use std::path::Path;
 use tauri::AppHandle;
@@ -9,7 +8,9 @@ pub async fn homebrew_apply_diff(
     app: AppHandle,
     diff: shared_types::HomebrewState,
 ) -> Result<shared_types::ConfigEditApplyResult, String> {
-    crate::managed_edits::homebrew_adopt::apply_homebrew_diff(&app, diff)
+    let (hostname, _) = get_hostname_and_config_dir(&app, "homebrew_apply_diff")?;
+
+    crate::managed_edits::homebrew_adopt::apply_homebrew_diff(&app, &hostname, diff)
         .await
         .map_err(|e| capture_err("homebrew_apply_diff", e))
 }
@@ -18,10 +19,9 @@ pub async fn homebrew_apply_diff(
 pub async fn homebrew_get_state_diff(
     app: AppHandle,
 ) -> Result<shared_types::HomebrewState, String> {
-    let dir = store::ensure_config_dir_exists(&app)
-        .map_err(|e| capture_err("homebrew_get_state_diff", e))?;
+    let (hostname, dir) = get_hostname_and_config_dir(&app, "homebrew_get_state_diff")?;
 
-    managed_edits::homebrew_adopt::get_homebrew_state_diff(Path::new(&dir))
+    managed_edits::homebrew_adopt::get_homebrew_state_diff(Path::new(&dir), &hostname)
         .map_err(|e| capture_err("homebrew_get_state_diff", e))
 }
 

--- a/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
+++ b/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
@@ -11,7 +11,6 @@ use shared_types::HomebrewItem;
 use tauri::AppHandle;
 
 const NIXMAC_HOMEBREW_DATA_PATH: &str = ".nixmac/homebrew/data.json";
-const NIXMAC_HOMEBREW_NIX_EVAL: &str = "nix eval";
 const LEGACY_HOMEBREW_NIX_TEMPLATE: &str = r#"{ config, pkgs, ... }:
 
 {
@@ -285,7 +284,8 @@ fn load_nix_eval_homebrew(config_dir: &std::path::Path, hostname: &str) -> Resul
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("invalid config dir path"))?;
 
-    let attr = NIX_EVAL_HOMEBREW_ATTR_TEMPLATE.replace("{hostname}", &hostname);
+    let safe_host_attr = serde_json::to_string(hostname)?;
+    let attr = NIX_EVAL_HOMEBREW_ATTR_TEMPLATE.replace("{hostname}", &safe_host_attr);
     let output = nix_command(path)
         .args(["eval", "--json", "--apply", NIX_EVAL_HOMEBREW_APPLY, &attr])
         .output()?;
@@ -308,10 +308,7 @@ fn load_nix_eval_homebrew(config_dir: &std::path::Path, hostname: &str) -> Resul
          "taps": []
          }
     */
-    let mut state = make_homebrew_state(
-        is_homebrew_installed(),
-        Some(NIXMAC_HOMEBREW_NIX_EVAL.to_string()),
-    );
+    let mut state = make_homebrew_state(is_homebrew_installed(), None);
     state.brews = json
         .get("brews")
         .and_then(|v| v.as_array())
@@ -421,7 +418,12 @@ fn load_nix_config_homebrew(config_dir: &std::path::Path) -> Result<HomebrewStat
 /// Reads the homebrew state first by using nix-eval and if that fails by falling
 /// back to some heuristic evaluation of likely flake files.
 fn load_nix_homebrew(config_dir: &std::path::Path, hostname: &str) -> Result<HomebrewState> {
-    load_nix_eval_homebrew(config_dir, hostname).or_else(|_| load_nix_config_homebrew(config_dir))
+    load_nix_eval_homebrew(config_dir, hostname).or_else(|e| {
+        log::warn!(
+            "load_nix_homebrew: nix eval failed, falling back to heuristic config parse: {e}"
+        );
+        load_nix_config_homebrew(config_dir)
+    })
 }
 
 /// Finds what's missing from the config compared to the installed state,

--- a/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
+++ b/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
@@ -2,6 +2,7 @@ use crate::evolve::file_ops::resolve_path_in_dir_allow_create;
 use crate::evolve::nix_file_editor::{apply_semantic_edit, nix_quote_values};
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 use crate::shared_types::{HomebrewItemType, HomebrewState};
+use crate::system::nix::nix_command;
 use crate::system::nix_ast_lists::parse_string_lists_by_attrpath;
 use crate::{managed_edits::managed_edit, shared_types};
 use anyhow::{Context, Result};
@@ -10,6 +11,7 @@ use shared_types::HomebrewItem;
 use tauri::AppHandle;
 
 const NIXMAC_HOMEBREW_DATA_PATH: &str = ".nixmac/homebrew/data.json";
+const NIXMAC_HOMEBREW_NIX_EVAL: &str = "nix eval";
 const LEGACY_HOMEBREW_NIX_TEMPLATE: &str = r#"{ config, pkgs, ... }:
 
 {
@@ -20,6 +22,17 @@ const LEGACY_HOMEBREW_NIX_TEMPLATE: &str = r#"{ config, pkgs, ... }:
   };
 }
 "#;
+
+/// Nix apply expression to read the names of Homebrew taps, brews, and casks
+/// with nix-eval.
+const NIX_EVAL_HOMEBREW_APPLY: &str = r#"cfg: {
+  brews = builtins.map (x: x.name) cfg.brews;
+  casks = builtins.map (x: x.name) cfg.casks;
+  taps = builtins.map (x: x.name) cfg.taps;
+}"#;
+
+const NIX_EVAL_HOMEBREW_ATTR_TEMPLATE: &str =
+    r#".#darwinConfigurations."{hostname}".config.homebrew"#;
 
 /// Checks if Homebrew is installed by trying to run `brew --version`.
 fn is_homebrew_installed() -> bool {
@@ -157,9 +170,12 @@ fn load_homebrew_data_state(path: &std::path::Path) -> Result<HomebrewState> {
 }
 
 /// Gets the current homebrew state from the system and nix config, computes the diff, and returns it.
-pub fn get_homebrew_state_diff(config_dir: &std::path::Path) -> Result<HomebrewState> {
+pub fn get_homebrew_state_diff(
+    config_dir: &std::path::Path,
+    hostname: &str,
+) -> Result<HomebrewState> {
     let installed = scan_homebrew();
-    let config = load_nix_config_homebrew(config_dir);
+    let config = load_nix_homebrew(config_dir, hostname)?;
     Ok(compute_homebrew_diff(installed, config))
 }
 
@@ -167,6 +183,7 @@ pub fn get_homebrew_state_diff(config_dir: &std::path::Path) -> Result<HomebrewS
 /// branch, and enters the managed review flow so the frontend lands on the evolve step.
 pub async fn apply_homebrew_diff(
     app: &AppHandle,
+    hostname: &str,
     diff: shared_types::HomebrewState,
 ) -> Result<shared_types::ConfigEditApplyResult> {
     let context = managed_edit::prepare_managed_edit(app)?;
@@ -174,7 +191,7 @@ pub async fn apply_homebrew_diff(
 
     let submitted_source = diff.source.clone();
     let fresh_installed = scan_homebrew();
-    let fresh_config = load_nix_config_homebrew(std::path::Path::new(&dir));
+    let fresh_config = load_nix_homebrew(std::path::Path::new(&dir), hostname)?;
     let diff = sanitize_homebrew_diff(diff, fresh_installed, fresh_config);
     if submitted_source != diff.source {
         log::warn!(
@@ -262,6 +279,76 @@ pub fn scan_homebrew() -> HomebrewState {
     state
 }
 
+/// Reads the homebrew state by using nix-eval in the provided config directory.
+fn load_nix_eval_homebrew(config_dir: &std::path::Path, hostname: &str) -> Result<HomebrewState> {
+    let path = config_dir
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("invalid config dir path"))?;
+
+    let attr = NIX_EVAL_HOMEBREW_ATTR_TEMPLATE.replace("{hostname}", &hostname);
+    let output = nix_command(path)
+        .args(["eval", "--json", "--apply", NIX_EVAL_HOMEBREW_APPLY, &attr])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "nix eval failed with exit code {}: {}",
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .with_context(|| "failed to parse nix eval output as JSON")?;
+
+    // The JSON looks like this, let's process it into the HomebrewState struct:
+    /*
+         {
+         "brews": [],
+         "casks": [],
+         "taps": []
+         }
+    */
+    let mut state = make_homebrew_state(
+        is_homebrew_installed(),
+        Some(NIXMAC_HOMEBREW_NIX_EVAL.to_string()),
+    );
+    state.brews = json
+        .get("brews")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    state.casks = json
+        .get("casks")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    state.taps = json
+        .get("taps")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    log::debug!(
+        "load_nix_eval_homebrew: loaded state from nix-eval: brew count={}, cask count={}, tap count={}",
+        state.brews.len(),
+        state.casks.len(),
+        state.taps.len()
+    );
+    Ok(state)
+}
+
 /// Reads the homebrew state currently in nix config in the provided config dir, if it exists.
 /// Otherwise returns an empty state.
 /// The only supported nix config layouts for homebrew are:
@@ -271,13 +358,13 @@ pub fn scan_homebrew() -> HomebrewState {
 ///
 /// Depending on which one exists, we'll set the source field to the full
 /// path of the file or "flake-modules/darwin.nix" respectively, which can be used to determine where to write changes.
-pub fn load_nix_config_homebrew(config_dir: &std::path::Path) -> HomebrewState {
+fn load_nix_config_homebrew(config_dir: &std::path::Path) -> Result<HomebrewState> {
     let mut state = make_homebrew_state(is_homebrew_installed(), None);
 
     let nixmac_homebrew_data = config_dir.join(NIXMAC_HOMEBREW_DATA_PATH);
     if nixmac_homebrew_data.exists() {
         match load_homebrew_data_state(&nixmac_homebrew_data) {
-            Ok(data_state) => return data_state,
+            Ok(data_state) => return Ok(data_state),
             Err(e) => {
                 log::warn!(
                     "failed to read Nixmac Homebrew data from '{}': {}",
@@ -322,7 +409,19 @@ pub fn load_nix_config_homebrew(config_dir: &std::path::Path) -> HomebrewState {
         }
     }
 
-    state
+    log::debug!(
+        "load_nix_config_homebrew: loaded state from nix config: brew count={}, cask count={}, tap count={}",
+        state.brews.len(),
+        state.casks.len(),
+        state.taps.len()
+    );
+    Ok(state)
+}
+
+/// Reads the homebrew state first by using nix-eval and if that fails by falling
+/// back to some heuristic evaluation of likely flake files.
+fn load_nix_homebrew(config_dir: &std::path::Path, hostname: &str) -> Result<HomebrewState> {
+    load_nix_eval_homebrew(config_dir, hostname).or_else(|_| load_nix_config_homebrew(config_dir))
 }
 
 /// Finds what's missing from the config compared to the installed state,
@@ -592,6 +691,8 @@ fn apply_homebrew_data_import(
 /// Writes missing items in the diff to the config, using the source field to determine where to write.
 /// If the source is empty, we'll set up the official .nixmac/homebrew module and write data.json.
 /// We also hook up .nixmac to flake.nix in that case.
+/// TODO: We can try to use nix-eval to get any current homebrew state, look at the source(s),
+/// and try to apply the changes to the "correct" source instead of the well-known .nixmac/homebrew/data.json.
 pub fn apply_homebrew_import(diff: HomebrewState, config_dir: &std::path::Path) -> Result<()> {
     if diff.casks.is_empty() && diff.brews.is_empty() && diff.taps.is_empty() {
         return Ok(());
@@ -734,6 +835,22 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Runs against the local system; enable explicitly when debugging the nix eval homebrew."]
+    #[cfg(target_os = "macos")]
+    fn test_load_nix_eval_homebrew_against_this_host() {
+        use crate::bootstrap::default_config::detect_hostname;
+        use std::path::Path;
+
+        let this_host_name = detect_hostname().expect("failed to get hostname");
+        const CONFIG_DIR: &str = "~/.darwin";
+        let state = load_nix_eval_homebrew(Path::new(CONFIG_DIR), &this_host_name)
+            .expect("failed to load nix eval homebrew");
+
+        // Print the state for debugging purposes, but don't assert on it since it may vary by host.
+        println!("Loaded nix eval homebrew state: {:?}", state);
+    }
+
+    #[test]
     fn load_nix_config_homebrew_reads_nixmac_data_file() {
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let data_file = temp.path().join(NIXMAC_HOMEBREW_DATA_PATH);
@@ -747,7 +864,8 @@ mod tests {
 "#,
         );
 
-        let state = load_nix_config_homebrew(temp.path());
+        let state =
+            load_nix_config_homebrew(temp.path()).expect("failed to load nix config homebrew");
 
         assert_eq!(state.source.as_deref(), Some(NIXMAC_HOMEBREW_DATA_PATH));
         assert_eq!(state.casks, vec!["iterm2", "raycast"]);
@@ -773,7 +891,8 @@ mod tests {
 "#,
         );
 
-        let state = load_nix_config_homebrew(temp.path());
+        let state =
+            load_nix_config_homebrew(temp.path()).expect("failed to load nix config homebrew");
 
         assert_eq!(state.source.as_deref(), Some(NIXMAC_HOMEBREW_DATA_PATH));
         assert_eq!(state.brews, vec!["git"]);
@@ -796,7 +915,8 @@ mod tests {
 "#,
         );
 
-        let state = load_nix_config_homebrew(temp.path());
+        let state =
+            load_nix_config_homebrew(temp.path()).expect("failed to load nix config homebrew");
 
         assert_eq!(
             state.source.as_deref(),
@@ -823,7 +943,8 @@ mod tests {
 "#,
         );
 
-        let state = load_nix_config_homebrew(temp.path());
+        let state =
+            load_nix_config_homebrew(temp.path()).expect("failed to load nix config homebrew");
 
         assert_eq!(
             state.source.as_deref(),
@@ -860,7 +981,8 @@ mod tests {
 "#,
         );
 
-        let state = load_nix_config_homebrew(temp.path());
+        let state =
+            load_nix_config_homebrew(temp.path()).expect("failed to load nix config homebrew");
 
         assert_eq!(state.casks, vec!["iterm2", "raycast"]);
         assert_eq!(state.brews, vec!["git", "jq"]);

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -67,9 +67,10 @@ pub fn dry_run_build_check(
     crate::git::intent_add_untracked(config_dir)?;
 
     let mut command = Command::new("nix");
+    let safe_host_attr = serde_json::to_string(host_attr)?;
     command
         .arg("build")
-        .arg(format!(".#darwinConfigurations.{}.system", host_attr))
+        .arg(format!(".#darwinConfigurations.{}.system", safe_host_attr))
         .arg("--dry-run");
 
     if show_trace {

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -64,7 +64,7 @@ struct NixLaunchdEvalItem {
 static NIX_PATH_CACHE: OnceLock<String> = OnceLock::new();
 
 /// Gets a command with our typical setup to execute `nix`.
-fn nix_command(config_dir: &str) -> Command {
+pub fn nix_command(config_dir: &str) -> Command {
     let mut cmd = Command::new("nix");
     let normalized_config_dir =
         normalize_path_input(config_dir).unwrap_or_else(|_| config_dir.into());

--- a/apps/native/src/components/widget/onboarding/onboarding-flow.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-flow.tsx
@@ -17,20 +17,21 @@ export function OnboardingFlow() {
 
   return (
     <div
-      className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-y-auto px-4 py-8 sm:px-6"
+      className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-hidden px-4 py-8 sm:px-6"
       data-testid="onboarding-flow"
     >
       <OnboardingHeader title={`Step ${stepIndex(activeStep) + 1} of ${STEPS.length}`} />
 
-      <div className="grid flex-1 gap-8 md:grid-cols-[220px_1fr]">
+      <div className="grid min-h-0 flex-1 gap-8 md:grid-cols-[220px_1fr]">
         <OnboardingSidebar
-
           activeStep={activeStep}
           furthestStep={furthestStep}
           progress={progress}
           onStepSelect={goToStep}
         />
-        <OnboardingStepContent currentStep={activeStep} title={stepLabel(activeStep)} />
+        <div className="min-h-0 overflow-y-auto pb-4 pr-1">
+          <OnboardingStepContent currentStep={activeStep} title={stepLabel(activeStep)} />
+        </div>
       </div>
     </div>
   );

--- a/apps/native/src/components/widget/onboarding/onboarding-sidebar.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-sidebar.tsx
@@ -15,7 +15,7 @@ export function OnboardingSidebar({
   onStepSelect,
 }: OnboardingSidebarProps) {
   return (
-    <aside className="md:border-border md:border-r md:pr-6">
+    <aside className="md:sticky md:top-0 md:self-start md:border-border md:border-r md:pr-6">
       <div className="mb-4 md:hidden">
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
           <div


### PR DESCRIPTION
## Summary

Use `nix eval` to get the Homebrew state when creating diffs to use with the track-customizations feature, falling back to the "old" way of heuristically looking at flake files if that fails for some reason.

<!-- What does this PR do? Why? -->

## Test Plan

Manual testing, and added an on-demand unit test so you can try the core new function on your local system.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed