### PR TITLE
fix: constrain onboarding step content scroll to content area, make sidebar sticky

### DIFF
--- a/apps/native/src/components/widget/onboarding/onboarding-flow.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-flow.tsx
@@ -17,20 +17,21 @@ export function OnboardingFlow() {
 
   return (
     <div
-      className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-y-auto px-4 py-8 sm:px-6"
+      className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-hidden px-4 py-8 sm:px-6"
       data-testid="onboarding-flow"
     >
       <OnboardingHeader title={`Step ${stepIndex(activeStep) + 1} of ${STEPS.length}`} />
 
-      <div className="grid flex-1 gap-8 md:grid-cols-[220px_1fr]">
+      <div className="grid min-h-0 flex-1 gap-8 md:grid-cols-[220px_1fr]">
         <OnboardingSidebar
-
           activeStep={activeStep}
           furthestStep={furthestStep}
           progress={progress}
           onStepSelect={goToStep}
         />
-        <OnboardingStepContent currentStep={activeStep} title={stepLabel(activeStep)} />
+        <div className="min-h-0 overflow-y-auto pb-4 pr-1">
+          <OnboardingStepContent currentStep={activeStep} title={stepLabel(activeStep)} />
+        </div>
       </div>
     </div>
   );

--- a/apps/native/src/components/widget/onboarding/onboarding-sidebar.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-sidebar.tsx
@@ -15,7 +15,7 @@ export function OnboardingSidebar({
   onStepSelect,
 }: OnboardingSidebarProps) {
   return (
-    <aside className="md:border-border md:border-r md:pr-6">
+    <aside className="md:sticky md:top-0 md:self-start md:border-border md:border-r md:pr-6">
       <div className="mb-4 md:hidden">
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
           <div


### PR DESCRIPTION
## Summary

Fixes Linear issue ENG-585 where the left sidebar scrolled with the main content; now it's fixed.

<!-- What does this PR do? Why? -->

## ![Screenshot 2026-07-03 at 2.12.58 PM.png](https://app.graphite.com/user-attachments/assets/c4b24f36-46e0-46df-93e4-f11dff969056.png)



## Test Plan

See the screenshot.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed