### PR TITLE
feat: buffered summaries

### DIFF
--- a/apps/native/.storybook/mocks/tauri-runtime.ts
+++ b/apps/native/.storybook/mocks/tauri-runtime.ts
@@ -301,8 +301,8 @@ export const orpcHandlers: Record<string, OrpcHandler> = {
   "evolveMascot.show": async () => okResult(),
   "evolveMascot.hide": async () => okResult(),
   "history.get": async () => {
-    const { viewModelActions } = await import("@nixmac/state");
-    return viewModelActions.getState().history ?? [];
+    // History lives in TanStack Query now (not ViewModelStore).
+    return { items: [], total: 0, hasMore: false };
   },
   "homebrew.getStateDiff": async () => ({
     isInstalled: true,

--- a/apps/native/.storybook/mocks/tauri-runtime.ts
+++ b/apps/native/.storybook/mocks/tauri-runtime.ts
@@ -497,7 +497,7 @@ export async function invoke(command: string, args?: Record<string, unknown>) {
       // instead of injecting a list that flips the prompt-history UI post-render.
       return [...vm.promptHistory];
     case "get_history":
-      return vm.history ?? [];
+      return { items: [], total: 0, hasMore: false };
     case "ui_get_prefs":
       return { ...prefs };
     case "permissions_check_all":
@@ -729,7 +729,7 @@ export const storybookTauriAPI = {
     },
   },
   history: {
-    get: async () => [],
+    get: async () => ({ items: [], total: 0, hasMore: false }),
     generateFrom: async () => undefined,
   },
   homebrew: {

--- a/apps/native/src-tauri/examples/specta_gen_ts.rs
+++ b/apps/native/src-tauri/examples/specta_gen_ts.rs
@@ -77,6 +77,7 @@ fn main() {
         .register::<shared_types::EvolveStep>()
         .register::<shared_types::EvolveState>()
         .register::<shared_types::HistoryItem>()
+        .register::<shared_types::HistoryPage>()
         .register::<shared_types::ChangeType>()
         .register::<shared_types::GitFileStatus>()
         .register::<shared_types::GitStatus>()

--- a/apps/native/src-tauri/src/commands/summarize.rs
+++ b/apps/native/src-tauri/src/commands/summarize.rs
@@ -50,8 +50,10 @@ pub async fn run_summarize_current(
 
 pub async fn fetch_history(
     app: AppHandle,
-) -> Result<Vec<crate::shared_types::HistoryItem>, String> {
-    crate::history::get_history(&app)
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Result<crate::shared_types::HistoryPage, String> {
+    crate::history::get_history(&app, limit, offset)
         .await
         .map_err(|e| capture_err("get_history", e))
 }
@@ -115,8 +117,8 @@ pub async fn summarize_current(
 }
 
 #[tauri::command]
-pub async fn get_history(app: AppHandle) -> Result<Vec<crate::shared_types::HistoryItem>, String> {
-    fetch_history(app).await
+pub async fn get_history(app: AppHandle) -> Result<crate::shared_types::HistoryPage, String> {
+    fetch_history(app, None, None).await
 }
 
 #[tauri::command]

--- a/apps/native/src-tauri/src/db/store_whole_diff_changeset.rs
+++ b/apps/native/src-tauri/src/db/store_whole_diff_changeset.rs
@@ -1,4 +1,5 @@
-//! Persists a whole-diff summarization result — one group, one commit message.
+//! Persists a whole-diff summarization result — one or more groups, each with
+//! its own commit message, where every change is linked to its group's summary.
 
 use anyhow::Result;
 use diesel::connection::Connection;
@@ -9,32 +10,53 @@ use crate::db::changesets::{
     link_change_to_set, upsert_change,
 };
 use crate::sqlite_types::Change;
+use crate::summarize::pipelines::whole_diff::GroupedChange;
 
 #[allow(clippy::too_many_arguments)]
 pub fn store(
     pool: &DbPool,
-    changes: &[Change],
-    message: &str,
+    groups: &[GroupedChange],
+    generated_commit_message: &str,
     commit_id: Option<i64>,
     base_commit_id: i64,
     commit_message: Option<&str>,
     evolution_id: Option<i64>,
 ) -> Result<i64> {
-    let title = message.lines().next().unwrap_or(message).trim();
-    let description = message.trim();
-
     let mut conn = pool.get()?;
     let now = crate::utils::unix_now();
 
     conn.transaction::<i64, anyhow::Error, _>(|conn| {
-        let group_summary_id = insert_change_summary(conn, title, description, "DONE", now)?;
+        let mut change_ids: Vec<i64> = Vec::with_capacity(groups.len());
 
-        let mut change_ids = Vec::with_capacity(changes.len());
-        for change in changes {
+        // One group_summary row per distinct summary string; multiple changes
+        // sharing a summary are linked to the same row. Summary equality is
+        // intentionally string-based — two groups with identical text are
+        // collapsed, mirroring how `group_existing` reconstructs groups by
+        // `group_summary.id`.
+        let mut summary_id_by_text: std::collections::HashMap<String, i64> =
+            std::collections::HashMap::new();
+
+        for grouped in groups {
+            let change = &grouped.change;
+            let description = grouped.summary.trim();
+            let title = description.lines().next().unwrap_or(description).trim();
+
+            let group_summary_id = if let Some(id) = summary_id_by_text.get(description) {
+                *id
+            } else {
+                let id = insert_change_summary(conn, title, description, "DONE", now)?;
+                summary_id_by_text.insert(description.to_string(), id);
+                id
+            };
+
             let own_title = std::path::Path::new(&change.filename)
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or(&change.filename);
+            // Per-change own_summary mirrors the group summary; the read path
+            // treats a change without an own_summary as "unsummarized" and
+            // surfaces it in `unsummarized_hashes`, so we set it to keep the
+            // change off the re-summarize list.
             let own_summary_id = insert_change_summary(conn, own_title, description, "DONE", now)?;
             upsert_change(conn, change, Some(own_summary_id))?;
             let change_id = get_change_id_by_hash(conn, &change.hash)?;
@@ -47,7 +69,7 @@ pub fn store(
             commit_id,
             base_commit_id,
             commit_message,
-            Some(message),
+            Some(generated_commit_message),
             now,
             evolution_id,
         )?;
@@ -58,4 +80,34 @@ pub fn store(
 
         Ok(change_set_id)
     })
+}
+
+/// Convenience wrapper for callers that still produce a single message for
+/// the entire changeset (legacy single-group path).
+#[allow(dead_code)]
+pub fn store_single(
+    pool: &DbPool,
+    changes: &[Change],
+    message: &str,
+    commit_id: Option<i64>,
+    base_commit_id: i64,
+    commit_message: Option<&str>,
+    evolution_id: Option<i64>,
+) -> Result<i64> {
+    let groups: Vec<GroupedChange> = changes
+        .iter()
+        .map(|c| GroupedChange {
+            change: c.clone(),
+            summary: message.to_string(),
+        })
+        .collect();
+    store(
+        pool,
+        &groups,
+        message,
+        commit_id,
+        base_commit_id,
+        commit_message,
+        evolution_id,
+    )
 }

--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -277,6 +277,53 @@ pub fn log(
     Ok(commits)
 }
 
+/// Total number of commits reachable from `start_hash` (HEAD by default).
+///
+/// Cheaper than `log` because it only walks OIDs without hydrating commit
+/// metadata. Used to give the frontend a total count for pagination without
+/// materializing every commit.
+pub fn commit_count(dir: &str, start_hash: &str) -> Result<usize> {
+    let repo = Repository::discover(dir)?;
+    let commit = repo.revparse_single(start_hash)?.peel_to_commit()?;
+    let mut revwalk = repo.revwalk()?;
+    revwalk.set_sorting(git2::Sort::TIME)?;
+    revwalk.push(commit.id())?;
+    Ok(revwalk.count())
+}
+
+/// Commits reachable from `commit_hash`, newest-first, capped at `limit + 1`.
+///
+/// Returns `limit + 1` commits when available so the caller can diff each
+/// commit against its parent (the last item has no parent in the window and
+/// is skipped by the summarize pipeline). This avoids walking the entire log
+/// when summarizing a single commit by hash — the previous implementation
+/// loaded every commit from HEAD and then searched for `commit_hash`.
+pub fn log_from_commit(
+    dir: &str,
+    commit_hash: &str,
+    limit: usize,
+) -> Result<Vec<crate::sqlite_types::Commit>> {
+    let repo = Repository::discover(dir)?;
+    let commit = repo.revparse_single(commit_hash)?.peel_to_commit()?;
+    let mut revwalk = repo.revwalk()?;
+    revwalk.set_sorting(git2::Sort::TIME)?;
+    revwalk.push(commit.id())?;
+
+    let mut commits = Vec::with_capacity(limit.saturating_add(1).min(512));
+    for oid in revwalk.take(limit.saturating_add(1)) {
+        let c = repo.find_commit(oid?)?;
+        let subject = c.summary().unwrap_or_default().unwrap_or_default();
+        commits.push(crate::sqlite_types::Commit {
+            id: 0,
+            hash: c.id().to_string(),
+            tree_hash: c.tree_id().to_string(),
+            message: (!subject.is_empty()).then(|| subject.to_string()),
+            created_at: c.time().seconds(),
+        });
+    }
+    Ok(commits)
+}
+
 /// Returns structured FileDiffs representing the changes between `base_ref` and the working tree.
 /// We use this to feed change details to summarization for uncommitted changes since
 /// an arbitrary reference point (e.g. last commit, last push, evolution start, etc).

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -5,13 +5,34 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use tauri::{AppHandle, Manager, Runtime};
 
+/// Default page size when the caller doesn't specify a `limit`.
+///
+/// Kept modest because each item fans out into a diff + DB lookup; the
+/// frontend grows the list incrementally via infinite scroll.
+const DEFAULT_HISTORY_PAGE_SIZE: usize = 50;
+
 pub async fn get_history<R: Runtime>(
     app: &AppHandle<R>,
-) -> Result<Vec<crate::shared_types::HistoryItem>> {
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Result<crate::shared_types::HistoryPage> {
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let pool = app.state::<crate::db::DbPool>();
 
-    let git_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
+    // `limit` here is the *page size*; we fetch `limit + offset` from git and
+    // then skip `offset` so the per-commit fan-out below only touches the
+    // requested window — not the entire log.
+    let page_size = limit.unwrap_or(DEFAULT_HISTORY_PAGE_SIZE).clamp(1, 500);
+    let offset = offset.unwrap_or(0);
+    let fetch_limit = page_size.saturating_add(offset);
+
+    let git_commits = crate::git::query::log(&config_dir, "HEAD", Some(fetch_limit))?;
+    let total = crate::git::query::commit_count(&config_dir, "HEAD").unwrap_or(git_commits.len());
+    let git_commits = if offset >= git_commits.len() {
+        &git_commits[..0]
+    } else {
+        &git_commits[offset..]
+    };
 
     let build_state = crate::state::build_state::get(app).unwrap_or_default();
     let last_built_sha = if build_state.unknown_build() {
@@ -118,7 +139,12 @@ pub async fn get_history<R: Runtime>(
 
     populate_restore_history_items(&mut entries, origin_hashes);
 
-    Ok(entries)
+    let has_more = offset + entries.len() < total;
+    Ok(crate::shared_types::HistoryPage {
+        items: entries,
+        total,
+        has_more,
+    })
 }
 
 fn populate_restore_history_items(

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, Manager, Runtime};
 ///
 /// Kept modest because each item fans out into a diff + DB lookup; the
 /// frontend grows the list incrementally via infinite scroll.
-const DEFAULT_HISTORY_PAGE_SIZE: usize = 50;
+const DEFAULT_HISTORY_PAGE_SIZE: usize = 12;
 
 pub async fn get_history<R: Runtime>(
     app: &AppHandle<R>,

--- a/apps/native/src-tauri/src/orpc/history.rs
+++ b/apps/native/src-tauri/src/orpc/history.rs
@@ -2,10 +2,21 @@
 
 use super::{OrpcCtx, helpers::internal_err};
 use crate::commands::summarize;
-use crate::shared_types::HistoryItem;
+use crate::shared_types::HistoryPage;
 use orpc::*;
 use serde::{Deserialize, Serialize};
 use specta::Type;
+
+#[derive(Debug, Deserialize, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+struct GetHistoryInput {
+    /// Max items to return (page size). `None` uses the backend default.
+    #[specta(type = Option<f64>)]
+    limit: Option<usize>,
+    /// Number of items to skip from HEAD (newest-first offset). `None` = 0.
+    #[specta(type = Option<f64>)]
+    offset: Option<usize>,
+}
 
 #[derive(Debug, Deserialize, Serialize, Type)]
 #[serde(rename_all = "camelCase")]
@@ -15,8 +26,8 @@ struct GenerateHistoryFromInput {
     number: usize,
 }
 
-async fn get(ctx: OrpcCtx, _input: ()) -> Result<Vec<HistoryItem>, ORPCError> {
-    summarize::fetch_history(ctx.app)
+async fn get(ctx: OrpcCtx, input: GetHistoryInput) -> Result<HistoryPage, ORPCError> {
+    summarize::fetch_history(ctx.app, input.limit, input.offset)
         .await
         .map_err(|error| internal_err("history.get", error))
 }
@@ -30,7 +41,8 @@ async fn generate_from(ctx: OrpcCtx, input: GenerateHistoryFromInput) -> Result<
 pub fn routes() -> Router<OrpcCtx> {
     router! {
         "get" => os::<OrpcCtx>()
-            .output(orpc_specta::specta::<Vec<HistoryItem>>())
+            .input(orpc_specta::specta::<GetHistoryInput>())
+            .output(orpc_specta::specta::<HistoryPage>())
             .handler(get),
         "generateFrom" => os::<OrpcCtx>()
             .input(orpc_specta::specta::<GenerateHistoryFromInput>())

--- a/apps/native/src-tauri/src/shared_types/git.rs
+++ b/apps/native/src-tauri/src/shared_types/git.rs
@@ -184,3 +184,20 @@ pub struct HistoryItem {
     /// Whether this history item has been undone by a later restore operation.
     pub is_undone: bool,
 }
+
+/// A page of history items with a total count, returned by `history.get`.
+///
+/// `total` is the full commit count reachable from HEAD (not just this page),
+/// so the frontend can decide whether more pages exist without an extra round
+/// trip. `has_more` is the same thing expressed as a boolean for convenience.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryPage {
+    /// Items in this page, newest-first.
+    pub items: Vec<HistoryItem>,
+    /// Total number of commits reachable from HEAD.
+    #[specta(type = f64)]
+    pub total: usize,
+    /// True when more pages remain beyond this page (offset + items.len() < total).
+    pub has_more: bool,
+}

--- a/apps/native/src-tauri/src/summarize/build_prompt.rs
+++ b/apps/native/src-tauri/src/summarize/build_prompt.rs
@@ -21,17 +21,32 @@ pub fn list_changes(changes: &[&crate::sqlite_types::Change]) -> String {
         .collect()
 }
 
-/// Builds a prompt that summarizes all hunks in one conventional commit message.
+/// Builds a prompt that summarizes all changes as one or more conventional
+/// commit messages, each covering a subset of the changed files.
 pub fn whole_diff(changes: &[&crate::sqlite_types::Change]) -> String {
     join_sections(&[
-        "Generate a single conventional commit message for the following changes.\n\n".to_string(),
+        "Group the following changes into one or more conventional commit messages. \
+         Each group must share a coherent purpose (a single logical change). \
+         Return one object per group.\n\n"
+            .to_string(),
         list_changes(changes),
-        "\nFormat: <type>(<scope>): <description>\n".to_string(),
+        "\nFor each group, return a JSON object with:\n".to_string(),
+        "  - \"summary\": a conventional commit message in the form \
+           <type>(<scope>): <description>\n".to_string(),
+        "  - \"files\": an array of the file paths included in that group\n".to_string(),
         "Allowed types: feat, fix, chore, refactor, docs, style, test, perf\n".to_string(),
-        "Base the message only on the visible changes.\n".to_string(),
-        "Return ONLY valid JSON.\n".to_string(),
+        "Rules:\n".to_string(),
+        "- Base every summary only on the visible changes.\n".to_string(),
+        "- Do not invent intent that is not visible in the diff.\n".to_string(),
+        "- If the type is unclear, prefer \"chore\".\n".to_string(),
+        "- Every changed file must appear in exactly one group.\n".to_string(),
+        "- Prefer fewer groups; only split when changes are clearly unrelated.\n".to_string(),
+        "Return ONLY a valid JSON array.\n".to_string(),
         "Example:\n".to_string(),
-        "{\"message\":\"feat(darwin): enable dock auto-hide\"}\n\n".to_string(),
+        "[\n".to_string(),
+        "  {\"summary\":\"feat(darwin): enable dock auto-hide\",\"files\":[\"darwin/dock.nix\"]},\n".to_string(),
+        "  {\"summary\":\"chore: bump flake inputs\",\"files\":[\"flake.lock\"]}\n".to_string(),
+        "]\n\n".to_string(),
     ])
 }
 
@@ -41,7 +56,7 @@ mod tests {
     use crate::sqlite_types::Change;
 
     #[test]
-    fn whole_diff_does_not_request_per_hunk_json() {
+    fn whole_diff_requests_multi_item_array() {
         let change = Change {
             id: 1,
             hash: "deadbeef".into(),
@@ -53,11 +68,12 @@ mod tests {
         };
         let out = whole_diff(&[&change]);
         assert!(out.contains(&crate::utils::short_hash(&change.hash)));
-        assert!(out.contains("single conventional commit message "));
-        assert!(out.contains("\"message\""));
-        assert!(!out.contains("JSON:"));
-        assert!(!out.contains("\"changes\""));
-        assert!(!out.contains("\"group\""));
-        assert!(!out.contains("Title – Description"));
+        assert!(out.contains("one or more conventional commit messages"));
+        assert!(out.contains("\"summary\""));
+        assert!(out.contains("\"files\""));
+        assert!(out.contains("Return ONLY a valid JSON array"));
+        // Legacy single-message contract must be gone.
+        assert!(!out.contains("\"message\""));
+        assert!(!out.contains("single conventional commit message"));
     }
 }

--- a/apps/native/src-tauri/src/summarize/model_calls.rs
+++ b/apps/native/src-tauri/src/summarize/model_calls.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Runtime};
 
 use crate::ai::providers::{TokenUsage, create_provider};
-use crate::summarize::token_budgets::{changeset_summaries_budget, commit_message_budget};
+use crate::summarize::token_budgets::changeset_summaries_budget;
 
 /// One item in the model's multi-summary response: a conventional commit
 /// message plus the file paths it covers.
@@ -17,10 +17,6 @@ pub struct ChangesetSummaryItem {
     pub files: Vec<String>,
 }
 
-#[derive(Deserialize)]
-struct CommitMessageJson {
-    message: String,
-}
 
 async fn request_json<R: Runtime, T: serde::de::DeserializeOwned>(
     system_prompt: &str,
@@ -199,27 +195,6 @@ fn extract_json_object(raw: &str) -> &str {
 }
 
 
-pub async fn generate_commit_message<R: Runtime>(
-    system_prompt: &str,
-    user_prompt: &str,
-    app_handle: Option<&AppHandle<R>>,
-) -> Result<(String, TokenUsage)> {
-    let (parsed, usage) = request_json::<_, CommitMessageJson>(
-        system_prompt,
-        user_prompt,
-        commit_message_budget,
-        0.2,
-        "generate_commit_message",
-        app_handle,
-    )
-    .await?;
-    if parsed.message.trim().is_empty() {
-        return Err(anyhow::anyhow!(
-            "generate_commit_message: parsed empty message"
-        ));
-    }
-    Ok((parsed.message.trim().to_string(), usage))
-}
 
 /// Calls the model and parses a `[{ summary, files }]` array response.
 ///

--- a/apps/native/src-tauri/src/summarize/model_calls.rs
+++ b/apps/native/src-tauri/src/summarize/model_calls.rs
@@ -7,7 +7,15 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Runtime};
 
 use crate::ai::providers::{TokenUsage, create_provider};
-use crate::summarize::token_budgets::commit_message_budget;
+use crate::summarize::token_budgets::{changeset_summaries_budget, commit_message_budget};
+
+/// One item in the model's multi-summary response: a conventional commit
+/// message plus the file paths it covers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChangesetSummaryItem {
+    pub summary: String,
+    pub files: Vec<String>,
+}
 
 #[derive(Deserialize)]
 struct CommitMessageJson {
@@ -73,35 +81,123 @@ async fn request_json<R: Runtime, T: serde::de::DeserializeOwned>(
         ));
     }
 
-    let cleaned = strip_json_fences(&raw_response);
+    let cleaned = extract_json_object(&raw_response);
     match serde_json::from_str::<T>(cleaned) {
         Ok(parsed) => Ok((parsed, tokens_used)),
-        Err(e) => {
+        Err(first_err) => {
+            // Models occasionally wrap JSON in markdown fences or prepend
+            // prose even when a JSON response format is requested. The first
+            // parse already applied `extract_json_object` to tolerate that, so
+            // a remaining failure is most likely a non-deterministic malformed
+            // completion. Retry once with the same inputs before giving up.
             warn!(
-                "[{}] failed to parse JSON [id: {}]: {}. Raw: {}",
-                fn_name, request_id, e, raw_response
+                "[{}] JSON parse failed, retrying [id: {}]: {}. Raw: {}",
+                fn_name, request_id, first_err, raw_response
             );
-            Err(anyhow::anyhow!("{}: failed to parse JSON: {}", fn_name, e))
+
+            let retry_id = uuid::Uuid::new_v4().to_string();
+            let (retry_raw, retry_tokens) = match provider
+                .json_completion(
+                    system_prompt,
+                    user_prompt,
+                    allocation.output_tokens,
+                    Some(allocation.required_context_tokens),
+                    temperature,
+                    &retry_id,
+                )
+                .await
+            {
+                Ok(t) => t,
+                Err(e) => {
+                    let err_str = format!("{:#}", e);
+                    warn!(
+                        "[{}] retry provider completion failed: {}",
+                        fn_name, err_str
+                    );
+                    report_provider_error(fn_name, provider.model(), &retry_id, &err_str, fn_name);
+                    return Err(e);
+                }
+            };
+
+            if retry_raw.trim().is_empty() {
+                warn!(
+                    "[{}] retry returned empty response [id: {}]",
+                    fn_name, retry_id
+                );
+                return Err(anyhow::anyhow!(
+                    "{}: failed to parse JSON and retry returned empty response",
+                    fn_name
+                ));
+            }
+
+            let retry_cleaned = extract_json_object(&retry_raw);
+            match serde_json::from_str::<T>(retry_cleaned) {
+                Ok(parsed) => Ok((parsed, retry_tokens)),
+                Err(e) => {
+                    warn!(
+                        "[{}] retry also failed to parse JSON [id: {}]: {}. Raw: {}",
+                        fn_name, retry_id, e, retry_raw
+                    );
+                    Err(anyhow::anyhow!(
+                        "{}: failed to parse JSON after retry: {}",
+                        fn_name,
+                        e
+                    ))
+                }
+            }
         }
     }
 }
 
-/// Some models wrap their JSON output in a Markdown code fence
-/// (```json ... ``` or ``` ... ```). Strip that wrapper so the payload
-/// parses cleanly. Returns the input unchanged if no fence is present.
-fn strip_json_fences(raw: &str) -> &str {
+/// Extract the first JSON object or array from a model response.
+///
+/// Providers ask for `response_format: json_object` (or the local equivalent),
+/// but CLI-backed providers and some reasoning-style models still occasionally
+/// wrap output in markdown fences (```` ```json … ``` ````) or emit leading
+/// prose. This narrows the response to the first balanced `{ … }` or
+/// `[ … ]` span so the downstream `serde_json::from_str` is robust against
+/// that wrapping.
+fn extract_json_object(raw: &str) -> &str {
     let trimmed = raw.trim();
-    let Some(inner) = trimmed.strip_prefix("```") else {
-        return trimmed;
+
+    // Strip a single surrounding ```json … ``` or ``` … ``` fence.
+    let after_fence = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .map(str::trim_start)
+        .unwrap_or(trimmed);
+    let body = after_fence
+        .strip_suffix("```")
+        .map(str::trim_end)
+        .unwrap_or(after_fence);
+
+    // Narrow to the first balanced {...} or [...] span, tolerating
+    // leading/trailing prose. Arrays are produced when the model returns
+    // multiple summary items.
+    let obj_span = match (body.find('{'), body.rfind('}')) {
+        (Some(start), Some(end)) if end > start => Some(start..=end),
+        _ => None,
     };
-    // Drop the opening fence's language tag / rest of that line.
-    let inner = match inner.split_once('\n') {
-        Some((_lang, rest)) => rest,
-        None => inner,
+    let arr_span = match (body.find('['), body.rfind(']')) {
+        (Some(start), Some(end)) if end > start => Some(start..=end),
+        _ => None,
     };
-    // Drop the closing fence.
-    inner.trim_end().strip_suffix("```").unwrap_or(inner).trim()
+    match (obj_span, arr_span) {
+        (Some(obj), Some(arr)) => {
+            // Pick whichever starts first; if both start at the same position
+            // (impossible for { vs [), prefer the object.
+            if *obj.start() <= *arr.start() {
+                &body[obj]
+            } else {
+                &body[arr]
+            }
+        }
+        (Some(span), None) => &body[span],
+        (None, Some(span)) => &body[span],
+        (None, None) => body,
+    }
 }
+
 
 pub async fn generate_commit_message<R: Runtime>(
     system_prompt: &str,
@@ -123,6 +219,44 @@ pub async fn generate_commit_message<R: Runtime>(
         ));
     }
     Ok((parsed.message.trim().to_string(), usage))
+}
+
+/// Calls the model and parses a `[{ summary, files }]` array response.
+///
+/// Returns one or more summary items. The caller is responsible for matching
+/// `files` back to change rows; any change the model did not assign to a group
+/// is left for the caller to handle (e.g. as singles).
+pub async fn generate_changeset_summaries<R: Runtime>(
+    system_prompt: &str,
+    user_prompt: &str,
+    app_handle: Option<&AppHandle<R>>,
+) -> Result<(Vec<ChangesetSummaryItem>, TokenUsage)> {
+    let (items, usage) = request_json::<_, Vec<ChangesetSummaryItem>>(
+        system_prompt,
+        user_prompt,
+        changeset_summaries_budget,
+        0.2,
+        "generate_changeset_summaries",
+        app_handle,
+    )
+    .await?;
+
+    let cleaned: Vec<ChangesetSummaryItem> = items
+        .into_iter()
+        .map(|mut item| {
+            item.summary = item.summary.trim().to_string();
+            item
+        })
+        .filter(|item| !item.summary.is_empty())
+        .collect();
+
+    if cleaned.is_empty() {
+        return Err(anyhow::anyhow!(
+            "generate_changeset_summaries: parsed empty result list"
+        ));
+    }
+
+    Ok((cleaned, usage))
 }
 
 fn report_provider_error(
@@ -149,29 +283,65 @@ fn report_provider_error(
 
 #[cfg(test)]
 mod tests {
-    use super::strip_json_fences;
+    use super::*;
 
     #[test]
-    fn strips_json_language_fence() {
+    fn extract_plain_json() {
+        assert_eq!(
+            extract_json_object(r#"{"message":"hi"}"#),
+            r#"{"message":"hi"}"#
+        );
+    }
+
+    #[test]
+    fn extract_plain_array() {
+        assert_eq!(
+            extract_json_object(r#"[{"summary":"a","files":["f.nix"]}]"#),
+            r#"[{"summary":"a","files":["f.nix"]}]"#
+        );
+    }
+
+    #[test]
+    fn extract_strips_json_fence() {
         let raw = "```json\n{\"message\":\"hi\"}\n```";
-        assert_eq!(strip_json_fences(raw), "{\"message\":\"hi\"}");
+        assert_eq!(extract_json_object(raw), r#"{"message":"hi"}"#);
     }
 
     #[test]
-    fn strips_bare_fence() {
+    fn extract_strips_array_fence() {
+        let raw = "```json\n[{\"summary\":\"a\",\"files\":[]}]\n```";
+        assert_eq!(extract_json_object(raw), r#"[{"summary":"a","files":[]}]"#);
+    }
+
+    #[test]
+    fn extract_strips_bare_fence() {
         let raw = "```\n{\"message\":\"hi\"}\n```";
-        assert_eq!(strip_json_fences(raw), "{\"message\":\"hi\"}");
+        assert_eq!(extract_json_object(raw), r#"{"message":"hi"}"#);
     }
 
     #[test]
-    fn leaves_plain_json_untouched() {
-        let raw = "{\"message\":\"hi\"}";
-        assert_eq!(strip_json_fences(raw), "{\"message\":\"hi\"}");
+    fn extract_narrows_to_balanced_object() {
+        let raw = "Sure, here you go:\n{\"message\":\"hi\"}\nLet me know.";
+        assert_eq!(extract_json_object(raw), r#"{"message":"hi"}"#);
     }
 
     #[test]
-    fn handles_surrounding_whitespace() {
-        let raw = "  ```json\n{\"message\":\"hi\"}\n```  \n";
-        assert_eq!(strip_json_fences(raw), "{\"message\":\"hi\"}");
+    fn extract_narrows_to_balanced_array() {
+        let raw = "Sure, here you go:\n[{\"summary\":\"a\",\"files\":[]}]\nLet me know.";
+        assert_eq!(extract_json_object(raw), r#"[{"summary":"a","files":[]}]"#);
+    }
+
+    #[test]
+    fn extract_prefers_first_span_when_object_and_array_both_present() {
+        // An object embedded in prose, followed by an array — the object
+        // starts first, so it should win.
+        let raw = "ok: {\"a\":1} then [\"x\"]";
+        assert_eq!(extract_json_object(raw), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn extract_returns_body_when_no_braces() {
+        // No braces — return as-is so the caller's serde error stays informative.
+        assert_eq!(extract_json_object("not json"), "not json");
     }
 }

--- a/apps/native/src-tauri/src/summarize/pipelines/history.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/history.rs
@@ -5,6 +5,12 @@ use tauri::{AppHandle, Manager, Runtime};
 
 use crate::sqlite_types::Change;
 
+/// Summarize `number` commits starting at `commit_hash` (newest-first),
+/// diffing each commit against its parent.
+///
+/// This walks only the commits in the requested window via
+/// [`crate::git::query::log_from_commit`], avoiding the full-log scan the
+/// previous implementation performed.
 pub async fn from_commit_times_number<R: Runtime>(
     app: &AppHandle<R>,
     commit_hash: &str,
@@ -13,18 +19,10 @@ pub async fn from_commit_times_number<R: Runtime>(
     let config_dir = crate::storage::store::get_config_dir(app)?;
     let pool = app.state::<crate::db::DbPool>();
 
-    let all_commits = crate::git::query::log(&config_dir, "HEAD", None)?;
-    let start = match all_commits.iter().position(|c| c.hash == commit_hash) {
-        Some(i) => i,
-        None => return Ok(()),
-    };
-    let commits: Vec<_> = all_commits
-        .into_iter()
-        .skip(start)
-        .take(number + 1)
-        .collect();
-
-    if commits.is_empty() {
+    // `log_from_commit` returns up to `number + 1` commits (the extra one is
+    // the parent used as the diff base for the oldest commit in the window).
+    let commits = crate::git::query::log_from_commit(&config_dir, commit_hash, number)?;
+    if commits.len() < 2 {
         return Ok(());
     }
 

--- a/apps/native/src-tauri/src/summarize/pipelines/whole_diff.rs
+++ b/apps/native/src-tauri/src/summarize/pipelines/whole_diff.rs
@@ -1,23 +1,30 @@
-//! Whole-diff pipeline — one model call on the full diff, one summary message.
+//! Whole-diff pipeline — one model call on the full diff, producing one or
+//! more group summaries (each covering a subset of the changed files).
+
+use std::collections::HashMap;
 
 use anyhow::Result;
 use tauri::{AppHandle, Manager, Runtime};
 
 use crate::db::DbPool;
 use crate::sqlite_types::Change;
+use crate::summarize::model_calls::ChangesetSummaryItem;
 use crate::summarize::{build_prompt, sumlog as dbg};
 
 const WHOLE_DIFF_SYSTEM_PROMPT: &str = r#"
 You are a git commit message generator.
 
 Rules:
-- Produce exactly one conventional commit message.
-- Base the message only on the provided changes.
+- Group the provided changes into one or more conventional commit messages.
+- Each group must share a coherent purpose (a single logical change).
+- Base every summary only on the provided changes.
 - Do not invent intent that is not visible in the diff.
 - If the type is unclear, prefer "chore".
+- Every changed file must appear in exactly one group.
+- Prefer fewer groups; only split when changes are clearly unrelated.
 - Always return valid JSON in this format:
 
-{"message":"<commit message>"}
+[{"summary":"<commit message>","files":["<path>", ...]}, ...]
 "#;
 
 #[allow(clippy::too_many_arguments)]
@@ -48,17 +55,29 @@ pub async fn analyze<R: Runtime>(
     let user_prompt = build_prompt::whole_diff(&refs);
     dbg::new_log_prompt(&user_prompt);
 
-    let (message, _usage) = crate::summarize::model_calls::generate_commit_message(
+    let (items, _usage) = crate::summarize::model_calls::generate_changeset_summaries(
         WHOLE_DIFF_SYSTEM_PROMPT,
         &user_prompt,
         Some(app),
     )
     .await?;
 
+    let groups = partition_changes(changes, &items);
+
+    // The model may not reference every file. Build a single display string
+    // from all returned summaries so `generated_commit_message` (consumed by
+    // the commit-message pipeline) reflects the full changeset even when the
+    // model split it into several groups.
+    let generated_message = items
+        .iter()
+        .map(|item| item.summary.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
     let change_set_id = crate::db::store_whole_diff_changeset::store(
         &pool,
-        &changes,
-        &message,
+        &groups,
+        &generated_message,
         commit_id,
         base_commit_id,
         commit_message,
@@ -68,6 +87,71 @@ pub async fn analyze<R: Runtime>(
     emit_update(app, &pool, base_ref)?;
 
     Ok(Some(change_set_id))
+}
+
+/// A change assigned to a group summary.
+pub struct GroupedChange {
+    pub change: Change,
+    pub summary: String,
+}
+
+/// Matches model-returned file paths to change rows and groups them.
+///
+/// Files are matched by repository-relative basename (the model frequently
+/// returns short paths or basenames). Any change the model did not assign to
+/// a group is collected into a fallback group using the first summary, so no
+/// file is left unsummarized (which would otherwise trigger re-summarization
+/// loops in `group_existing`).
+fn partition_changes(changes: Vec<Change>, items: &[ChangesetSummaryItem]) -> Vec<GroupedChange> {
+    // Index model file paths by basename for tolerant matching. The model
+    // often emits `"foo.nix"` even when the stored path is `"dir/foo.nix"`.
+    let mut path_to_item: HashMap<String, usize> = HashMap::new();
+    for (i, item) in items.iter().enumerate() {
+        for file in &item.files {
+            path_to_item.insert(file.clone(), i);
+            if let Some(base) = std::path::Path::new(file)
+                .file_name()
+                .and_then(|n| n.to_str())
+            {
+                path_to_item.insert(base.to_string(), i);
+            }
+        }
+    }
+
+    let fallback_summary = items
+        .first()
+        .map(|i| i.summary.clone())
+        .unwrap_or_else(|| "chore: summarize changes".to_string());
+
+    let mut assigned = vec![false; changes.len()];
+    let mut groups: Vec<GroupedChange> = Vec::new();
+
+    for (idx, change) in changes.iter().enumerate() {
+        let matched = path_to_item.get(&change.filename).copied().or_else(|| {
+            std::path::Path::new(&change.filename)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .and_then(|base| path_to_item.get(base).copied())
+        });
+        if let Some(i) = matched {
+            assigned[idx] = true;
+            groups.push(GroupedChange {
+                change: change.clone(),
+                summary: items[i].summary.clone(),
+            });
+        }
+    }
+
+    for (idx, change) in changes.into_iter().enumerate() {
+        if !assigned[idx] {
+            groups.push(GroupedChange {
+                change,
+                summary: fallback_summary.clone(),
+            });
+        }
+    }
+
+    groups
 }
 
 fn emit_update<R: Runtime>(
@@ -85,4 +169,68 @@ fn emit_update<R: Runtime>(
     // The cell write emits `change_map_changed`.
     crate::state::change_map::update(app, semantic_map);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change(filename: &str) -> Change {
+        Change {
+            id: 0,
+            hash: format!("h-{filename}"),
+            filename: filename.to_string(),
+            diff: "+x".into(),
+            line_count: 1,
+            created_at: 0,
+            own_summary_id: None,
+        }
+    }
+
+    #[test]
+    fn matched_files_are_grouped_by_summary() {
+        let changes = vec![change("a.nix"), change("b.nix"), change("c.nix")];
+        let items = vec![
+            ChangesetSummaryItem {
+                summary: "feat: a and b".into(),
+                files: vec!["a.nix".into(), "b.nix".into()],
+            },
+            ChangesetSummaryItem {
+                summary: "fix: c".into(),
+                files: vec!["c.nix".into()],
+            },
+        ];
+        let groups = partition_changes(changes, &items);
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].summary, "feat: a and b");
+        assert_eq!(groups[1].summary, "feat: a and b");
+        assert_eq!(groups[2].summary, "fix: c");
+    }
+
+    #[test]
+    fn unmatched_files_fall_back_to_first_summary() {
+        let changes = vec![change("a.nix"), change("orphan.nix")];
+        let items = vec![ChangesetSummaryItem {
+            summary: "feat: a".into(),
+            files: vec!["a.nix".into()],
+        }];
+        let groups = partition_changes(changes, &items);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].summary, "feat: a");
+        // Orphan keeps the fallback so it isn't flagged unsummarized.
+        assert_eq!(groups[1].summary, "feat: a");
+        assert_eq!(groups[1].change.filename, "orphan.nix");
+    }
+
+    #[test]
+    fn basename_matching_resolves_nested_paths() {
+        let changes = vec![change("modules/darwin/dock.nix")];
+        let items = vec![ChangesetSummaryItem {
+            summary: "feat: dock".into(),
+            files: vec!["dock.nix".into()],
+        }];
+        let groups = partition_changes(changes, &items);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].summary, "feat: dock");
+    }
 }

--- a/apps/native/src-tauri/src/summarize/token_budgets.rs
+++ b/apps/native/src-tauri/src/summarize/token_budgets.rs
@@ -87,14 +87,6 @@ pub fn model_context_window(model: &str) -> u32 {
 
 const CHANGESET_SUMMARIES_MAX_OUTPUT_TOKENS: u32 = 2000;
 
-pub fn commit_message_budget(prompt: &str, model: &str) -> TokenAllocation {
-    let requested_output = crate::ai::model_capabilities::scale_output_tokens_for_model(
-        model,
-        COMMIT_MESSAGE_MAX_OUTPUT_TOKENS,
-    );
-    compute_token_allocation(prompt, requested_output, model_context_window(model))
-}
-
 pub fn changeset_summaries_budget(prompt: &str, model: &str) -> TokenAllocation {
     let requested_output = crate::ai::model_capabilities::scale_output_tokens_for_model(
         model,

--- a/apps/native/src-tauri/src/summarize/token_budgets.rs
+++ b/apps/native/src-tauri/src/summarize/token_budgets.rs
@@ -85,12 +85,20 @@ pub fn model_context_window(model: &str) -> u32 {
     crate::ai::model_capabilities::capabilities_for_model(model).context_window_tokens
 }
 
-const COMMIT_MESSAGE_MAX_OUTPUT_TOKENS: u32 = 600;
+const CHANGESET_SUMMARIES_MAX_OUTPUT_TOKENS: u32 = 2000;
 
 pub fn commit_message_budget(prompt: &str, model: &str) -> TokenAllocation {
     let requested_output = crate::ai::model_capabilities::scale_output_tokens_for_model(
         model,
         COMMIT_MESSAGE_MAX_OUTPUT_TOKENS,
+    );
+    compute_token_allocation(prompt, requested_output, model_context_window(model))
+}
+
+pub fn changeset_summaries_budget(prompt: &str, model: &str) -> TokenAllocation {
+    let requested_output = crate::ai::model_capabilities::scale_output_tokens_for_model(
+        model,
+        CHANGESET_SUMMARIES_MAX_OUTPUT_TOKENS,
     );
     compute_token_allocation(prompt, requested_output, model_context_window(model))
 }

--- a/apps/native/src/components/widget/history/analyze-history-button.tsx
+++ b/apps/native/src/components/widget/history/analyze-history-button.tsx
@@ -1,21 +1,21 @@
 import { Button } from "@/components/ui/button";
 import { AnalyzeButton } from "@/components/widget/summaries/analyze-button";
-import { useHistory } from "@/hooks/use-history";
-import { useViewModel } from "@nixmac/state";
+import { useHistory, useHistoryQuery } from "@/hooks/use-history";
 import { useUiState } from "@nixmac/state";
 import { Dna, Square } from "lucide-react";
 
 // Generates commit (if need be) and summary metadata for history items that are missing it.
 export function AnalyzeHistoryButton() {
-  const history = useViewModel((state) => state.history);
+  const { history } = useHistoryQuery();
   const analyzingSize = useUiState((state) => state.analyzingHistoryForHashes.size);
   const { analyzeMany, stopAnalyzing } = useHistory();
 
-  const recentUnsummarizedHashes = history
-    .filter((item) => !item.isBase)
+  const recentUnsummarized = history
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => !item.isBase)
     .slice(0, 5)
-    .filter((item) => !item.changeMap || item.unsummarizedHashes.length > 0)
-    .map((item) => item.hash);
+    .filter(({ item }) => !item.changeMap || item.unsummarizedHashes.length > 0)
+    .map(({ item, index }) => ({ hash: item.hash, priority: index }));
 
   //stop only works for queued items
   if (analyzingSize > 1) {
@@ -32,14 +32,14 @@ export function AnalyzeHistoryButton() {
       </Button>
     );
   }
-  if (recentUnsummarizedHashes.length > 0) {
+  if (recentUnsummarized.length > 0) {
     return (
       <AnalyzeButton
         disabled={analyzingSize === 1}
-        onClick={() => analyzeMany(recentUnsummarizedHashes)}
+        onClick={() => analyzeMany(recentUnsummarized)}
       >
         <Dna className="h-[10px] w-[10px]" />
-        Analyze recent ({recentUnsummarizedHashes.length})
+        Analyze recent ({recentUnsummarized.length})
       </AnalyzeButton>
     );
   }

--- a/apps/native/src/components/widget/history/analyze-history-item-button.tsx
+++ b/apps/native/src/components/widget/history/analyze-history-item-button.tsx
@@ -2,7 +2,7 @@ import { AnalyzeButton } from "@/components/widget/summaries/analyze-button";
 import { useHistory } from "@/hooks/use-history";
 import { useUiState } from "@nixmac/state";
 import { Dna, Loader2 } from "lucide-react";
-import { useState } from "react";
+
 interface AnalyzeHistoryItemButtonProps {
   hash: string;
   isPartial?: boolean;
@@ -14,23 +14,18 @@ export function AnalyzeHistoryItemButton({
   isPartial,
   className,
 }: AnalyzeHistoryItemButtonProps) {
-  const [localAnalyzing, setLocalAnalyzing] = useState(false);
-  const queuedByMany = useUiState((state) => state.analyzingHistoryForHashes.has(hash));
-  const isAnalyzing = localAnalyzing || queuedByMany;
+  // The summarize queue mirrors queued/in-flight hashes into this set, so
+  // membership covers both the "analyze all" flow and this button's own click.
+  const isAnalyzing = useUiState((state) => state.analyzingHistoryForHashes.has(hash));
   const { analyzeOne } = useHistory();
 
   return (
     <AnalyzeButton
       disabled={isAnalyzing}
       className={className}
-      onClick={async (e) => {
+      onClick={(e) => {
         e.stopPropagation();
-        setLocalAnalyzing(true);
-        try {
-          await analyzeOne(hash);
-        } finally {
-          setLocalAnalyzing(false);
-        }
+        analyzeOne(hash);
       }}
     >
       {isAnalyzing ? (

--- a/apps/native/src/components/widget/steps/history-step.tsx
+++ b/apps/native/src/components/widget/steps/history-step.tsx
@@ -57,7 +57,7 @@ export function HistoryStep() {
     <>
       <HistoryHeader count={total} />
       <div ref={scrollAreaRef} className="flex-1 min-h-0">
-        <ScrollArea className="h-full pb-3 pr-4">
+        <ScrollArea className="h-full pb-0 pr-4">
           <UncommittedChangesDetected
             isFlashing={isFlashing}
             onOpenDialog={() => setIsDiscardDialogOpen(true)}

--- a/apps/native/src/components/widget/steps/history-step.tsx
+++ b/apps/native/src/components/widget/steps/history-step.tsx
@@ -4,22 +4,25 @@ import { HistoryDayLabel } from "@/components/widget/history/history-day-label";
 import { HistoryHeader } from "@/components/widget/history/history-header";
 import { HistoryItemCard } from "@/components/widget/history/history-item-card";
 import { UncommittedChangesDetected } from "@/components/widget/notifications/uncommitted-changes-detected";
-import { useHistory } from "@/hooks/use-history";
+import { useHistoryQuery } from "@/hooks/use-history";
 import { PREVIEW_ITEM_HASH, useHistoryRestore } from "@/hooks/use-history-restore";
-import { useViewModel } from "@nixmac/state";
+import { useLazyHistorySummarize } from "@/hooks/use-lazy-history-summarize";
+import { Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
-export function HistoryScreen() {
-  const { loadHistory } = useHistory();
-  const history = useViewModel((state) => state.history);
+export function HistoryStep() {
+  const { history, total, hasNextPage, fetchNextPage, isFetchingNextPage } = useHistoryQuery();
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const [isFlashing, setIsFlashing] = useState(false);
   const [isDiscardDialogOpen, setIsDiscardDialogOpen] = useState(false);
 
-  useEffect(() => {
-    loadHistory();
-  }, [loadHistory]);
+  const { observeItem } = useLazyHistorySummarize({
+    history,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
 
   const handleUncommittedChanges = () => {
     const viewport = scrollAreaRef.current?.querySelector("[data-radix-scroll-area-viewport]");
@@ -52,7 +55,7 @@ export function HistoryScreen() {
 
   return (
     <>
-      <HistoryHeader count={history.length} />
+      <HistoryHeader count={total} />
       <div ref={scrollAreaRef} className="flex-1 min-h-0">
         <ScrollArea className="h-full pb-3 pr-4">
           <UncommittedChangesDetected
@@ -73,30 +76,37 @@ export function HistoryScreen() {
                   );
                 }
                 return (
-                  <HistoryItemCard
-                    key={fi.item.hash}
-                    item={fi.item}
-                    isRestoring={fi.item.hash === restoringHash}
-                    isPreview={fi.item.hash === PREVIEW_ITEM_HASH}
-                    isPreviewActive={!!previewTargetHash}
-                    deactivateCount={
-                      fi.item.hash === PREVIEW_ITEM_HASH ? previewDeactivateCount : undefined
-                    }
-                    timeline={{
-                      isFirst: fi.item.hash === firstCommitHash,
-                      isLast: fi.item.hash === lastCommitHash,
-                      isUndone: undoneSet.has(fi.item.hash),
-                      bottomFadeToUndone: bottomFadeToUndoneHashes.has(fi.item.hash),
-                      topFadeFromUndone: topFadeFromUndoneHashes.has(fi.item.hash),
-                    }}
-                    onRequestRestore={handleRequestRestore}
-                    onConfirmRestore={handleConfirmRestore}
-                    onCancelRestore={handleCancelPreview}
-                  />
+                  <div key={fi.item.hash} ref={observeItem} data-history-hash={fi.item.hash}>
+                    <HistoryItemCard
+                      item={fi.item}
+                      isRestoring={fi.item.hash === restoringHash}
+                      isPreview={fi.item.hash === PREVIEW_ITEM_HASH}
+                      isPreviewActive={!!previewTargetHash}
+                      deactivateCount={
+                        fi.item.hash === PREVIEW_ITEM_HASH ? previewDeactivateCount : undefined
+                      }
+                      timeline={{
+                        isFirst: fi.item.hash === firstCommitHash,
+                        isLast: fi.item.hash === lastCommitHash,
+                        isUndone: undoneSet.has(fi.item.hash),
+                        bottomFadeToUndone: bottomFadeToUndoneHashes.has(fi.item.hash),
+                        topFadeFromUndone: topFadeFromUndoneHashes.has(fi.item.hash),
+                      }}
+                      onRequestRestore={handleRequestRestore}
+                      onConfirmRestore={handleConfirmRestore}
+                      onCancelRestore={handleCancelPreview}
+                    />
+                  </div>
                 );
               })}
             </div>
           ))}
+          {isFetchingNextPage && (
+            <div className="flex items-center justify-center gap-2 py-3 text-xs text-neutral-500">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Loading older commits…
+            </div>
+          )}
         </ScrollArea>
       </div>
       <DiscardUncommittedDialog open={isDiscardDialogOpen} onOpenChange={setIsDiscardDialogOpen} />

--- a/apps/native/src/components/widget/steps/index.ts
+++ b/apps/native/src/components/widget/steps/index.ts
@@ -1,7 +1,7 @@
 export { FilesystemStep } from "../filesystem/filesystem-step";
 export { BeginStep } from "./begin-step";
 export { CommitStep } from "./commit-step";
-export { HistoryScreen as HistoryStep } from "./history-step";
+export { HistoryStep } from "./history-step";
 export { ReviewStep } from "./review-step";
 // Onboarding steps (permissions, nix-setup, setup) now live under
 // components/widget/onboarding and render via OnboardingFlow.

--- a/apps/native/src/hooks/use-history-restore.ts
+++ b/apps/native/src/hooks/use-history-restore.ts
@@ -1,10 +1,10 @@
-import { useState } from "react";
 import { useRebuildStream } from "@/hooks/use-rebuild-stream";
-import { useHistory } from "@/hooks/use-history";
 import type { HistoryItem } from "@/ipc/types";
-import { uiActions, useViewModel } from "@nixmac/state";
-import { getTelemetry } from "@/lib/telemetry/instance";
 import { client } from "@/lib/orpc";
+import { getTelemetry } from "@/lib/telemetry/instance";
+import { invalidateHistory } from "@/viewmodel/history";
+import { uiActions, useViewModel } from "@nixmac/state";
+import { useState } from "react";
 
 // Sentinel hash used to identify the frontend-only preview item.
 export const PREVIEW_ITEM_HASH = "n1xm4c0";
@@ -186,7 +186,6 @@ export function useHistoryRestore(
   history: HistoryItem[],
   onUncommittedChanges: () => void,
 ): HistoryRestoreResult {
-  const { loadHistory } = useHistory();
   const gitStatus = useViewModel((state) => state.git);
   const { triggerRebuild } = useRebuildStream();
 
@@ -242,7 +241,7 @@ export function useHistoryRestore(
           // The backend writes the git-state cell; `git_state_changed` mirrors it.
           await client.darwin.finalizeRestore({ targetHash: hash });
           getTelemetry().captureEvent({ name: "history_restored" });
-          await loadHistory();
+          invalidateHistory();
         },
         onFailure: async () => {
           await client.darwin.abortRestore();

--- a/apps/native/src/hooks/use-history.ts
+++ b/apps/native/src/hooks/use-history.ts
@@ -1,49 +1,93 @@
-import { client } from "@/lib/orpc";
-import { uiActions, useUiState, viewModelActions } from "@nixmac/state";
-import { refreshHistorySnapshot } from "@/viewmodel/history";
+import type { HistoryItem } from "@/ipc/types";
+import { orpc } from "@/lib/orpc";
+import {
+  clearSummarizeQueue,
+  enqueueSummarize,
+  type SummarizeQueueEntry,
+} from "@/lib/summarize-queue";
+import { uiActions, useUiState } from "@nixmac/state";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 
-const loadHistory = () => refreshHistorySnapshot();
+/** Page size for the infinite history query. */
+export const HISTORY_PAGE_SIZE = 50;
 
-const analyzeOne = async (hash: string) => {
-  try {
-    await client.history.generateFrom({ commitHash: hash, number: 1 });
-    await loadHistory();
-  } catch (e) {
-    uiActions.setError(`Failed to analyze changes: ${e}`);
-  }
+/**
+ * Paginated history backed by TanStack Query (`orpc.history.get`).
+ *
+ * Pages are keyed by offset; `change_map_changed` / `git_state_changed`
+ * invalidate the query (see `viewmodel/history.ts`), so loaded pages refetch
+ * automatically after summarize/commit/restore operations.
+ */
+export function useHistoryQuery() {
+  const query = useInfiniteQuery(
+    orpc.history.get.infiniteOptions({
+      input: (pageParam: number) => ({ limit: HISTORY_PAGE_SIZE, offset: pageParam }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) =>
+        lastPage.hasMore ? allPages.length * HISTORY_PAGE_SIZE : undefined,
+    }),
+  );
+
+  const history: HistoryItem[] = useMemo(() => {
+    const pages = query.data?.pages ?? [];
+    // Dedup across page boundaries: a commit landing at HEAD between fetches
+    // shifts offsets, so the same hash can appear in two adjacent pages.
+    const seen = new Set<string>();
+    const items: HistoryItem[] = [];
+    for (const page of pages) {
+      for (const item of page.items) {
+        if (!seen.has(item.hash)) {
+          seen.add(item.hash);
+          items.push(item);
+        }
+      }
+    }
+    return items;
+  }, [query.data]);
+
+  const pages = query.data?.pages;
+  const total = pages?.[pages.length - 1]?.total ?? 0;
+
+  return {
+    history,
+    total,
+    hasNextPage: query.hasNextPage,
+    fetchNextPage: query.fetchNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
+}
+
+/**
+ * Queue a single item for summarization at front-of-queue priority.
+ * Forces past the failed-this-session guard — this is the manual retry path.
+ * Progress is observable via `analyzingHistoryForHashes` in the UI store.
+ */
+const analyzeOne = (hash: string) => {
+  enqueueSummarize([{ hash, priority: -1 }], true);
 };
 
-const analyzeMany = async (hashes: string[]) => {
-  for (const hash of hashes) {
-    uiActions.addAnalyzingHistoryHash(hash);
-  }
-  for (const hash of hashes) {
-    const store = useUiState.getState();
-    if (!store.analyzingHistoryForHashes.has(hash)) break;
-    const item = viewModelActions.getState().history.find((h) => h.hash === hash);
-    if (item?.changeMap && item.unsummarizedHashes.length === 0) {
-      uiActions.removeAnalyzingHistoryHash(hash);
-      continue;
-    }
-    try {
-      await client.history.generateFrom({ commitHash: hash, number: 1 });
-      await loadHistory();
-    } catch (e) {
-      uiActions.setState({ analyzingHistoryForHashes: new Set() });
-      uiActions.setError(`Failed to analyze changes: ${e}`);
-      return;
-    } finally {
-      uiActions.removeAnalyzingHistoryHash(hash);
-    }
-  }
+/**
+ * Queue many items for summarization. `entries` carry each item's index in
+ * the newest-first history list so the queue drains most-recent-first.
+ */
+const analyzeMany = (entries: SummarizeQueueEntry[]) => {
+  enqueueSummarize(entries);
 };
 
+/** Stop all queued summarization (the in-flight request finishes). */
 const stopAnalyzing = () => {
-  const current = useUiState.getState().analyzingHistoryForHashes;
-  const [first] = current;
-  uiActions.setState({ analyzingHistoryForHashes: new Set(first ? [first] : []) });
+  clearSummarizeQueue();
+  uiActions.setState({ analyzingHistoryForHashes: new Set<string>() });
 };
 
 export function useHistory() {
-  return { loadHistory, analyzeOne, analyzeMany, stopAnalyzing };
+  return { analyzeOne, analyzeMany, stopAnalyzing };
+}
+
+/** Whether any summarize work is queued or in flight. */
+export function useIsAnalyzingHistory(): boolean {
+  return useUiState((state) => state.analyzingHistoryForHashes.size > 0);
 }

--- a/apps/native/src/hooks/use-lazy-history-summarize.ts
+++ b/apps/native/src/hooks/use-lazy-history-summarize.ts
@@ -1,0 +1,116 @@
+// Visibility-driven lazy summarization for the history timeline.
+//
+// Watches which history cards are in the viewport (IntersectionObserver) and
+// enqueues unsummarized items within the visible range plus LOOKAHEAD_ITEMS
+// beyond it. The serial queue drains newest-first, so on-screen commits are
+// summarized before lookahead ones. Also drives infinite-scroll pagination:
+// when the viewport nears the end of loaded pages, the next page is fetched.
+
+import type { HistoryItem } from "@/ipc/types";
+import { enqueueSummarize } from "@/lib/summarize-queue";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/** Items to summarize beyond the visible range ("a page or two beyond"). */
+const LOOKAHEAD_ITEMS = 10;
+
+/** Fetch the next history page when fewer than this many items remain below. */
+const PAGE_FETCH_THRESHOLD = 10;
+
+function needsSummarize(item: HistoryItem): boolean {
+  if (item.isBase || item.isUndone || item.isOrphanedRestore) return false;
+  // Restore commits inherit their origin's summary; nothing to generate.
+  if (item.originHash) return false;
+  return !item.changeMap || item.unsummarizedHashes.length > 0;
+}
+
+export function useLazyHistorySummarize({
+  history,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: {
+  history: HistoryItem[];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+}) {
+  // hash → visible, maintained by one shared IntersectionObserver.
+  const visibleHashesRef = useRef(new Set<string>());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const [visibleVersion, setVisibleVersion] = useState(0);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (observed) => {
+        let changed = false;
+        for (const entry of observed) {
+          const hash = (entry.target as HTMLElement).dataset.historyHash;
+          if (!hash) continue;
+          const has = visibleHashesRef.current.has(hash);
+          if (entry.isIntersecting && !has) {
+            visibleHashesRef.current.add(hash);
+            changed = true;
+          } else if (!entry.isIntersecting && has) {
+            visibleHashesRef.current.delete(hash);
+            changed = true;
+          }
+        }
+        if (changed) setVisibleVersion((v) => v + 1);
+      },
+      // Root null = window viewport; the widget is a single-window app so the
+      // ScrollArea viewport and window viewport coincide vertically.
+      { rootMargin: "100px 0px" },
+    );
+    observerRef.current = observer;
+    const visibleHashes = visibleHashesRef.current;
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+      visibleHashes.clear();
+    };
+  }, []);
+
+  /** Ref callback for each history card wrapper; requires data-history-hash. */
+  const observeItem = useCallback((node: HTMLElement | null) => {
+    if (node) observerRef.current?.observe(node);
+    // Unobserve happens implicitly on disconnect; per-node cleanup uses the
+    // callback-ref contract (React calls with null on unmount).
+  }, []);
+
+  const indexByHash = useMemo(() => {
+    const map = new Map<string, number>();
+    history.forEach((item, i) => map.set(item.hash, i));
+    return map;
+  }, [history]);
+
+  // React to visibility / data changes: enqueue summarize work + paginate.
+  useEffect(() => {
+    if (history.length === 0) return;
+
+    const visibleIndices = [...visibleHashesRef.current]
+      .map((hash) => indexByHash.get(hash))
+      .filter((i): i is number => i !== undefined);
+    if (visibleIndices.length === 0) return;
+
+    const firstVisible = Math.min(...visibleIndices);
+    const lastVisible = Math.max(...visibleIndices);
+    const rangeEnd = Math.min(history.length - 1, lastVisible + LOOKAHEAD_ITEMS);
+
+    const entries = [];
+    for (let i = firstVisible; i <= rangeEnd; i++) {
+      const item = history[i];
+      if (needsSummarize(item)) {
+        entries.push({ hash: item.hash, priority: i });
+      }
+    }
+    if (entries.length > 0) enqueueSummarize(entries);
+
+    // Infinite scroll: pull the next page when the lookahead window runs
+    // past the loaded items.
+    if (hasNextPage && !isFetchingNextPage && lastVisible + PAGE_FETCH_THRESHOLD >= history.length) {
+      fetchNextPage();
+    }
+  }, [visibleVersion, history, indexByHash, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return { observeItem };
+}

--- a/apps/native/src/ipc/api.ts
+++ b/apps/native/src/ipc/api.ts
@@ -313,7 +313,7 @@ export const tauriAPI = {
 
   history: {
     /** @deprecated Use `client.history.get()` or `orpc.history.get` from `@/lib/orpc`. */
-    get: () => client.history.get(),
+    get: () => client.history.get({ limit: null, offset: null }),
     /** @deprecated Use `client.history.generateFrom()` or `orpc.history.generateFrom` from `@/lib/orpc`. */
     generateFrom: (commitHash: string, number: number) =>
       client.history.generateFrom({ commitHash, number }),

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -879,6 +879,16 @@ export type GatherMetadataInput = { request: FeedbackMetadataRequest }
 
 export type GenerateHistoryFromInput = { commitHash: string; number: number }
 
+export type GetHistoryInput = { 
+/**
+ * Max items to return (page size). `None` uses the backend default.
+ */
+limit: number | null; 
+/**
+ * Number of items to skip from HEAD (newest-first offset). `None` = 0.
+ */
+offset: number | null }
+
 export type GitCommitFileInput = { filename: string; message: string }
 
 export type GitCommitInput = { message: string }
@@ -1200,6 +1210,27 @@ isOrphanedRestore: boolean;
  * Whether this history item has been undone by a later restore operation.
  */
 isUndone: boolean }
+
+/**
+ * A page of history items with a total count, returned by `history.get`.
+ * 
+ * `total` is the full commit count reachable from HEAD (not just this page),
+ * so the frontend can decide whether more pages exist without an extra round
+ * trip. `has_more` is the same thing expressed as a boolean for convenience.
+ */
+export type HistoryPage = { 
+/**
+ * Items in this page, newest-first.
+ */
+items: HistoryItem[]; 
+/**
+ * Total number of commits reachable from HEAD.
+ */
+total: number; 
+/**
+ * True when more pages remain beyond this page (offset + items.len() < total).
+ */
+hasMore: boolean }
 
 export type HomebrewItem = { name: string; version: string | null; itemType: HomebrewItemType }
 
@@ -1958,7 +1989,7 @@ export type Procedures = {
   }
   history: {
     generateFrom: Client<Record<never, never>, GenerateHistoryFromInput, void, Error>
-    get: Client<Record<never, never>, void, HistoryItem[], Error>
+    get: Client<Record<never, never>, GetHistoryInput, HistoryPage, Error>
   }
   homebrew: {
     addItems: Client<Record<never, never>, AddItemsInput, ConfigEditApplyResult, Error>

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1436,6 +1436,27 @@ isOrphanedRestore: boolean;
  */
 isUndone: boolean }
 
+/**
+ * A page of history items with a total count, returned by `history.get`.
+ * 
+ * `total` is the full commit count reachable from HEAD (not just this page),
+ * so the frontend can decide whether more pages exist without an extra round
+ * trip. `has_more` is the same thing expressed as a boolean for convenience.
+ */
+export type HistoryPage = { 
+/**
+ * Items in this page, newest-first.
+ */
+items: HistoryItem[]; 
+/**
+ * Total number of commits reachable from HEAD.
+ */
+total: number; 
+/**
+ * True when more pages remain beyond this page (offset + items.len() < total).
+ */
+hasMore: boolean }
+
 export type HomebrewItem = { name: string; version: string | null; itemType: HomebrewItemType }
 
 export type HomebrewItemType = "tap" | "cask" | "brew"

--- a/apps/native/src/lib/summarize-queue.ts
+++ b/apps/native/src/lib/summarize-queue.ts
@@ -1,0 +1,109 @@
+// Serial queue for history summarization (`history.generateFrom`).
+//
+// The backend summarizes one commit per call and each call costs a model
+// request, so requests are buffered and drained strictly one at a time.
+// Priority is recency: entries carry the item's index in the newest-first
+// history list, and the drain loop always picks the lowest index — so the
+// visible (newest) commits summarize before lookahead ones, even when new
+// entries arrive mid-drain.
+//
+// Per-item failures are skipped, not fatal: one flaky model response must not
+// abort a long backfill. The user can retry any item via its Analyze button.
+
+import { client } from "@/lib/orpc";
+import { invalidateHistory } from "@/viewmodel/history";
+import { uiActions, useUiState } from "@nixmac/state";
+
+/** hash → priority (history index; lower = newer = drained first). */
+const pending = new Map<string, number>();
+/**
+ * Hashes that failed once this session. The lazy enqueuer re-runs on every
+ * history refetch, so without this guard a persistently-failing item would
+ * retry in a loop. Manual retries (`force`) clear the mark.
+ */
+const failed = new Set<string>();
+let draining = false;
+
+export type SummarizeQueueEntry = {
+  hash: string;
+  /** Index of the item in the newest-first history list. */
+  priority: number;
+};
+
+/**
+ * Add entries to the queue (deduplicated by hash, keeping the best priority)
+ * and start draining if idle. Safe to call repeatedly with overlapping sets —
+ * e.g. on every visible-range change.
+ *
+ * Entries that already failed this session are skipped unless `force` is set
+ * (used by the per-item Analyze button for explicit retries).
+ */
+export function enqueueSummarize(entries: SummarizeQueueEntry[], force = false): void {
+  for (const { hash, priority } of entries) {
+    if (failed.has(hash)) {
+      if (!force) continue;
+      failed.delete(hash);
+    }
+    const existing = pending.get(hash);
+    if (existing === undefined || priority < existing) {
+      pending.set(hash, priority);
+    }
+    uiActions.addAnalyzingHistoryHash(hash);
+  }
+  void drain();
+}
+
+/** Clear all queued (not-yet-started) work and its pending-state badges. */
+export function clearSummarizeQueue(): void {
+  for (const hash of pending.keys()) {
+    uiActions.removeAnalyzingHistoryHash(hash);
+  }
+  pending.clear();
+}
+
+/** Number of entries waiting in the queue (excluding the in-flight one). */
+export function summarizeQueueSize(): number {
+  return pending.size;
+}
+
+async function drain(): Promise<void> {
+  if (draining) return;
+  draining = true;
+  try {
+    while (pending.size > 0) {
+      const hash = takeNewest();
+      if (!hash) break;
+      // The user may have hit "Stop analyzing", which clears the UI set —
+      // treat missing membership as a cancellation for this hash.
+      if (!useUiState.getState().analyzingHistoryForHashes.has(hash)) continue;
+      try {
+        await client.history.generateFrom({ commitHash: hash, number: 1 });
+      } catch (error) {
+        // Skip and continue: log for diagnosis but keep the backfill going.
+        console.warn(`[summarize-queue] failed for ${hash}, skipping:`, error);
+        failed.add(hash);
+      } finally {
+        uiActions.removeAnalyzingHistoryHash(hash);
+      }
+      // Backfills of old commits don't reliably emit `change_map_changed`
+      // (the working-tree map is unchanged), so refresh explicitly.
+      invalidateHistory();
+    }
+  } finally {
+    draining = false;
+  }
+}
+
+/** Remove and return the pending hash with the lowest priority (newest). */
+function takeNewest(): string | undefined {
+  let bestHash: string | undefined;
+  let bestPriority = Number.POSITIVE_INFINITY;
+  for (const [hash, priority] of pending) {
+    if (priority < bestPriority) {
+      bestPriority = priority;
+      bestHash = hash;
+    }
+  }
+  if (bestHash !== undefined) pending.delete(bestHash);
+  return bestHash;
+}

--- a/apps/native/src/stories/landing-page.stories.tsx
+++ b/apps/native/src/stories/landing-page.stories.tsx
@@ -1,14 +1,14 @@
 // @ts-nocheck - Marketing stories compose typed app fixtures and partial store state.
 import preview from "#storybook/preview";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { DriftDiffPreview } from "@/components/widget/drift/drift-diff-preview";
 import { EvolveProgress } from "@/components/widget/overlays/evolve-progress";
 import { SummaryItems } from "@/components/widget/summaries/summary-items";
 import { DarwinWidget } from "@/components/widget/widget";
 import type { EvolveEvent, EvolveState, GitStatus, SemanticChangeMap } from "@/ipc/types";
 import { cn } from "@/lib/utils";
-import { nav, RouterProvider, router } from "@/router";
+import { nav, router, RouterProvider } from "@/router";
 import {
   makeGlobalPreferences,
   makeGrantedPermissions,
@@ -218,7 +218,6 @@ function seedWidgetState(preset: WidgetPreset) {
     promptHistory: [],
     rebuildStatus: makeRebuildStatus(),
     rebuildLog: { lines: [], rawLines: [], notices: [] },
-    history: [],
   });
 
   uiActions.setShowHistory(false);

--- a/apps/native/src/viewmodel/change-map.ts
+++ b/apps/native/src/viewmodel/change-map.ts
@@ -2,7 +2,7 @@ import type { SemanticChangeMap } from "@/ipc/types";
 import { client } from "@/lib/orpc";
 import { viewModelActions } from "@nixmac/state";
 import { bindBackendSlice } from "./_helpers";
-import { refreshHistorySnapshot } from "./history";
+import { invalidateHistory } from "./history";
 
 function mirrorChangeMapState(changeMap: SemanticChangeMap | null): void {
   viewModelActions.setState({ changeMap });
@@ -18,6 +18,6 @@ export function startChangeMapSync(): Promise<() => void> {
     hydrate: () => client.summarizedChanges.getChangeMap(),
     event: "change_map_changed",
     mirror: mirrorChangeMapState,
-    onEvent: () => void refreshHistorySnapshot(),
+    onEvent: () => invalidateHistory(),
   });
 }

--- a/apps/native/src/viewmodel/git.ts
+++ b/apps/native/src/viewmodel/git.ts
@@ -1,8 +1,8 @@
-import { tauriAPI, ipcRenderer } from "@/ipc/api";
+import { ipcRenderer, tauriAPI } from "@/ipc/api";
 import type { GitState, GitStatus } from "@/ipc/types";
 import { uiActions, viewModelActions } from "@nixmac/state";
 import { bindBackendSlice } from "./_helpers";
-import { refreshHistorySnapshot } from "./history";
+import { invalidateHistory } from "./history";
 
 function mirrorGitState(git: GitStatus | null, externalBuildDetected = false): void {
   viewModelActions.setState((state) => ({
@@ -34,7 +34,7 @@ export async function startGitSync(): Promise<() => void> {
       event: "git_state_changed",
       mirror: ({ gitStatus, externalBuildDetected }) =>
         mirrorGitState(gitStatus, externalBuildDetected),
-      onEvent: () => void refreshHistorySnapshot(),
+      onEvent: () => invalidateHistory(),
     }),
     ipcRenderer.on<string>("git_state_error", (event) => {
       uiActions.setError(event.payload);

--- a/apps/native/src/viewmodel/history.ts
+++ b/apps/native/src/viewmodel/history.ts
@@ -1,11 +1,13 @@
-import { client } from "@/lib/orpc";
-import { viewModelActions } from "@nixmac/state";
+import { orpc, queryClient } from "@/lib/orpc";
 
-export async function refreshHistorySnapshot(): Promise<void> {
-  try {
-    const items = await client.history.get();
-    viewModelActions.setState({ history: items });
-  } catch (error) {
-    console.error("[viewmodel] history refresh failed:", error);
-  }
+/**
+ * Invalidate the cached history query so any mounted `useHistoryQuery()` hook
+ * refetches its loaded pages.
+ *
+ * History is server state owned by TanStack Query (`orpc.history.get`), not
+ * the ViewModel — backend events (`change_map_changed`, `git_state_changed`)
+ * call this instead of mirroring a snapshot into Zustand.
+ */
+export function invalidateHistory(): void {
+  void queryClient.invalidateQueries({ queryKey: orpc.history.key() });
 }

--- a/apps/native/src/viewmodel/viewmodel.test.ts
+++ b/apps/native/src/viewmodel/viewmodel.test.ts
@@ -67,9 +67,6 @@ vi.mock("@/ipc/api", () => ({
     summarizedChanges: {
       getChangeMap: vi.fn(() => Promise.resolve(apiMocks.changeMap)),
     },
-    history: {
-      get: vi.fn(() => Promise.resolve([])),
-    },
     preferences: {
       get: vi.fn(() => Promise.resolve(apiMocks.preferences)),
     },
@@ -107,9 +104,14 @@ vi.mock("@/lib/orpc", () => ({
         Promise.resolve(apiMocks.changeMap),
       ),
     },
+  },
+  orpc: {
     history: {
-      get: vi.fn<() => Promise<never[]>>(() => Promise.resolve([])),
+      key: vi.fn(() => ["history"]),
     },
+  },
+  queryClient: {
+    invalidateQueries: vi.fn<() => Promise<void>>(() => Promise.resolve()),
   },
 }));
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1,17 +1,10 @@
 export {
 	initialViewModelState,
-	viewModelActions,
-	viewModelStore,
-	type ViewModelActions,
-	type ViewModelStore,
-} from "./viewmodel";
-export {
 	selectChangeMap,
 	selectEvolve,
 	selectEvolveEvents,
 	selectExternalBuildDetected,
 	selectGit,
-	selectHistory,
 	selectHosts,
 	selectNixInstall,
 	selectPermissions,
@@ -21,18 +14,16 @@ export {
 	selectRebuildLog,
 	selectRebuildStatus,
 	useViewModel,
+	viewModelActions,
+	viewModelStore,
+	type ViewModelActions,
 	type ViewModelSelector,
+	type ViewModelStore
 } from "./viewmodel";
 export type { RebuildLog, ViewModel, ViewModelState } from "./viewmodel";
 
 export {
 	initialUiState,
-	uiActions,
-	uiStore,
-	type UiStateActions,
-	type UiStateStore,
-} from "./ui";
-export {
 	selectCommitMessageSuggestion,
 	selectConsoleLogs,
 	selectConversationalResponse,
@@ -47,15 +38,19 @@ export {
 	selectIsProcessing,
 	selectIsSummarizing,
 	selectProcessingAction,
-	selectRecommendedPrompt,
 	selectRebuildContext,
 	selectRebuildPanelDismissed,
+	selectRecommendedPrompt,
 	selectSettingsActiveTab,
 	selectSettingsOpen,
 	selectShowFilesystem,
 	selectShowHistory,
+	uiActions,
+	uiStore,
 	useUiState,
+	type UiStateActions,
 	type UiStateSelector,
+	type UiStateStore
 } from "./ui";
 export type { ProcessingAction, SettingsTab, UiStateValues } from "./ui";
 
@@ -63,16 +58,14 @@ export {
 	initialOnboardingState,
 	onboardingActions,
 	onboardingStore,
-	type OnboardingActions,
-	type OnboardingStore,
-} from "./onboarding";
-export {
 	selectCelebrating,
 	selectInferenceDeferred,
 	selectTrackedCustomizations,
 	selectViewingStep,
 	useOnboarding,
+	type OnboardingActions,
 	type OnboardingSelector,
+	type OnboardingStore
 } from "./onboarding";
 export type { InferenceSetupDraft, TrackedCustomizationSource } from "./onboarding";
 

--- a/packages/state/src/viewmodel/index.ts
+++ b/packages/state/src/viewmodel/index.ts
@@ -1,11 +1,9 @@
-export { initialViewModelState, viewModelActions, viewModelStore, type ViewModelActions, type ViewModelStore } from "./store";
 export {
   selectChangeMap,
   selectEvolve,
   selectEvolveEvents,
   selectExternalBuildDetected,
   selectGit,
-  selectHistory,
   selectHosts,
   selectNixInstall,
   selectPermissions,
@@ -15,6 +13,7 @@ export {
   selectRebuildLog,
   selectRebuildStatus,
   useViewModel,
-  type ViewModelSelector,
+  type ViewModelSelector
 } from "./selectors";
+export { initialViewModelState, viewModelActions, viewModelStore, type ViewModelActions, type ViewModelStore } from "./store";
 export type { RebuildLog, ViewModel, ViewModelState } from "./types";

--- a/packages/state/src/viewmodel/selectors.ts
+++ b/packages/state/src/viewmodel/selectors.ts
@@ -1,5 +1,5 @@
-import { viewModelStore } from "./store";
 import type { ViewModelStore } from "./store";
+import { viewModelStore } from "./store";
 
 /** Subscribe to slices of the Rust-backed ViewModel. */
 export const useViewModel = viewModelStore;
@@ -18,6 +18,5 @@ export const selectRebuildStatus = (state: ViewModelStore) => state.rebuildStatu
 export const selectRebuildLog = (state: ViewModelStore) => state.rebuildLog;
 export const selectEvolveEvents = (state: ViewModelStore) => state.evolveEvents;
 export const selectPromptHistory = (state: ViewModelStore) => state.promptHistory;
-export const selectHistory = (state: ViewModelStore) => state.history;
 export const selectExternalBuildDetected = (state: ViewModelStore) =>
   state.build.externalBuildDetected;

--- a/packages/state/src/viewmodel/store.ts
+++ b/packages/state/src/viewmodel/store.ts
@@ -22,7 +22,6 @@ export const initialViewModelState: ViewModelState = {
     externalBuildDetected: false,
   },
   changeMap: null,
-  history: [],
   preferences: null,
   onboardingState: null,
   hosts: [],

--- a/packages/state/src/viewmodel/types.ts
+++ b/packages/state/src/viewmodel/types.ts
@@ -3,7 +3,6 @@ import type {
   EvolveState,
   GitStatus,
   GlobalPreferences,
-  HistoryItem,
   NixInstallState,
   OnboardingState,
   PermissionsState,
@@ -31,7 +30,6 @@ export type ViewModelState = {
   git: GitStatus | null;
   build: BuildView;
   changeMap: SemanticChangeMap | null;
-  history: HistoryItem[];
   /** Mirrored `GlobalPreferences`; null until the slice hydrates. */
   preferences: GlobalPreferences | null;
   /** Mirrored onboarding lifecycle (completion latch); null until hydrated. */


### PR DESCRIPTION
## Summary

Rebased onto `main` (cherry-picked the feature commits; dropped the old `chore: lint` noise).

Implements a queue, pagination, and lazy summarization so history backfills don’t explode token spend by summarizing the entire git log file-by-file.

## Test plan

- [x] `cargo check` on rebased branch
- [ ] CI green
- [ ] Manual: open History, confirm first page loads and further summaries queue lazily