### PR TITLE
refactor: authenticate feedback submissions with device API key, refactor/simplify feedback URL construction

### DIFF
--- a/apps/native/env.development.json
+++ b/apps/native/env.development.json
@@ -7,5 +7,6 @@
   "VITE_POSTHOG_HOST": "https://us.i.posthog.com",
   "VITE_NIXMAC_FILESYSTEM": true,
   "NIXMAC_RECORD_COMPLETIONS": true,
-  "SENTRY_DSN": "https://6c8d46aee3769e5936d0a5098939be5e@sentry.drkmttr.dev/5"
+  "SENTRY_DSN": "https://6c8d46aee3769e5936d0a5098939be5e@sentry.drkmttr.dev/5",
+  "SUBMITTED_FEEDBACK_DSN": "TODO Define me"
 }

--- a/apps/native/env.development.json
+++ b/apps/native/env.development.json
@@ -8,5 +8,5 @@
   "VITE_NIXMAC_FILESYSTEM": true,
   "NIXMAC_RECORD_COMPLETIONS": true,
   "SENTRY_DSN": "https://6c8d46aee3769e5936d0a5098939be5e@sentry.drkmttr.dev/5",
-  "SUBMITTED_FEEDBACK_DSN": "TODO Define me"
+  "SUBMITTED_FEEDBACK_DSN": "dsn_6f4b9a5e8c2d4f1a9b3c7e2d5a1f0b4c"
 }

--- a/apps/native/env.e2e.json
+++ b/apps/native/env.e2e.json
@@ -3,5 +3,6 @@
   "NIXMAC_ENV": "e2e",
   "NIXMAC_DISABLE_UPDATER": true,
   "VITE_NIXMAC_SKIP_PERMISSIONS": true,
-  "VITE_SERVER_URL": "http://nixmac.com"
+  "VITE_SERVER_URL": "http://nixmac.com",
+  "SUBMITTED_FEEDBACK_DSN": "TODO Define me"
 }

--- a/apps/native/env.e2e.json
+++ b/apps/native/env.e2e.json
@@ -4,5 +4,5 @@
   "NIXMAC_DISABLE_UPDATER": true,
   "VITE_NIXMAC_SKIP_PERMISSIONS": true,
   "VITE_SERVER_URL": "http://nixmac.com",
-  "SUBMITTED_FEEDBACK_DSN": "TODO Define me"
+  "SUBMITTED_FEEDBACK_DSN": "dsn_6f4b9a5e8c2d4f1a9b3c7e2d5a1f0b4c"
 }

--- a/apps/native/env.release.json
+++ b/apps/native/env.release.json
@@ -3,5 +3,6 @@
   "NIXMAC_ENV": "production",
   "VITE_SERVER_URL": "https://nixmac.com",
   "VITE_POSTHOG_HOST": "https://us.i.posthog.com",
-  "SENTRY_DSN": "https://6c8d46aee3769e5936d0a5098939be5e@sentry.drkmttr.dev/5"
+  "SENTRY_DSN": "https://6c8d46aee3769e5936d0a5098939be5e@sentry.drkmttr.dev/5",
+  "SUBMITTED_FEEDBACK_DSN": "TODO Define me"
 }

--- a/apps/native/env.release.json
+++ b/apps/native/env.release.json
@@ -4,5 +4,5 @@
   "VITE_SERVER_URL": "https://nixmac.com",
   "VITE_POSTHOG_HOST": "https://us.i.posthog.com",
   "SENTRY_DSN": "https://6c8d46aee3769e5936d0a5098939be5e@sentry.drkmttr.dev/5",
-  "SUBMITTED_FEEDBACK_DSN": "TODO Define me"
+  "SUBMITTED_FEEDBACK_DSN": "dsn_6f4b9a5e8c2d4f1a9b3c7e2d5a1f0b4c"
 }

--- a/apps/native/src-tauri/src/env/mod.rs
+++ b/apps/native/src-tauri/src/env/mod.rs
@@ -206,10 +206,7 @@ mod tests {
 
         unsafe { std::env::set_var(keys::VITE_SERVER_URL, "https://example.com") };
         unsafe { std::env::set_var(keys::SUBMITTED_FEEDBACK_DSN, "test-dsn") };
-        assert_eq!(
-            feedback_url().unwrap(),
-            "https://example.com/api/feedback/test-dsn"
-        );
+        assert_eq!(feedback_url().unwrap(), "https://example.com/api/feedback");
 
         unsafe { std::env::remove_var(keys::VITE_SERVER_URL) };
         unsafe { std::env::remove_var(keys::SUBMITTED_FEEDBACK_DSN) };

--- a/apps/native/src-tauri/src/env/mod.rs
+++ b/apps/native/src-tauri/src/env/mod.rs
@@ -97,16 +97,10 @@ fn web_server_url_for_config(config_dir: Option<&str>) -> Result<String> {
 
 /// Constructs the full feedback submission URL from environment configuration.
 pub fn feedback_url() -> Result<String> {
-    feedback_url_for_config(None)
-}
-
-fn feedback_url_for_config(config_dir: Option<&str>) -> Result<String> {
-    let resolved = settings(config_dir);
+    let resolved = settings(None);
     let base =
         non_empty(resolved.vite_server_url).context("sending feedback not configured (url)")?;
-    let dsn = non_empty(resolved.submitted_feedback_dsn)
-        .context("sending feedback not configured (dsn)")?;
-    Ok(format!("{base}/api/feedback/{dsn}"))
+    Ok(format!("{base}/api/feedback"))
 }
 
 #[allow(dead_code)]

--- a/apps/native/src-tauri/src/env/mod.rs
+++ b/apps/native/src-tauri/src/env/mod.rs
@@ -208,9 +208,8 @@ mod tests {
         unsafe { std::env::set_var(keys::SUBMITTED_FEEDBACK_DSN, "test-dsn") };
         assert_eq!(feedback_url().unwrap(), "https://example.com/api/feedback");
 
-        unsafe { std::env::remove_var(keys::VITE_SERVER_URL) };
-        unsafe { std::env::remove_var(keys::SUBMITTED_FEEDBACK_DSN) };
-        assert!(feedback_url().is_err());
+        // No real way to test an unset VITE_SERVER_URL because the build.rs embed will always provide a default
+        // from the JSON files.
     }
 
     #[test]

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -9,7 +9,7 @@ use crate::shared_types::Evolution;
 use crate::storage::store;
 use crate::system::{nix, secret_scanner};
 use crate::types;
-use anyhow::{Context, Result};
+use anyhow::{self, Context, Result};
 use chrono::Utc;
 use log::{debug, warn};
 use serde_json::Value;
@@ -518,16 +518,61 @@ fn get_report_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_data.join("report.json"))
 }
 
+/// Constructs the full feedback submission URL and API key from environment configuration.
+struct FeedbackDestination {
+    url: String,
+    api_key: String,
+}
+
+/// Error type for feedback submission failures
+enum FeedbackSendError {
+    Server(reqwest::StatusCode),
+    Network(reqwest_middleware::Error),
+}
+
+/// Determine the feedback submission destination (URL and API key) from environment and store.
+fn feedback_destination(app: &AppHandle) -> Result<Option<FeedbackDestination>> {
+    let url = match crate::env::feedback_url() {
+        Ok(url) => url,
+        Err(_) => return Ok(None),
+    };
+    let api_key = store::get_device_api_key(app)?
+        .ok_or_else(|| anyhow::anyhow!("Sign in before sending feedback"))?;
+
+    Ok(Some(FeedbackDestination { url, api_key }))
+}
+
+/// Helper function to send a feedback payload to the server, returning success or error.
+async fn send_feedback_payload(
+    client: &reqwest_middleware::ClientWithMiddleware,
+    destination: &FeedbackDestination,
+    payload: &Value,
+) -> std::result::Result<(), FeedbackSendError> {
+    match client
+        .post(&destination.url)
+        .header("Content-Type", "application/json")
+        .header("x-api-key", &destination.api_key)
+        .json(payload)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => Ok(()),
+        Ok(resp) => Err(FeedbackSendError::Server(resp.status())),
+        Err(error) => Err(FeedbackSendError::Network(error)),
+    }
+}
+
 /// Submit feedback: try to POST, save to disk on failure, also flush any pending reports.
 /// Returns true if the new submission was sent successfully.
 pub async fn submit(app: &AppHandle, payload: String) -> Result<bool> {
-    let feedback_url = match crate::env::feedback_url() {
-        Ok(url) => url,
-        Err(_) => {
+    let destination = match feedback_destination(app)? {
+        Some(destination) => destination,
+        None => {
             log::error!("[feedback] Feedback system is not configured");
             return Ok(false);
         }
     };
+
     let settings = crate::env::settings(None);
     let dsn = settings.submitted_feedback_dsn;
 
@@ -550,21 +595,15 @@ pub async fn submit(app: &AppHandle, payload: String) -> Result<bool> {
     };
     let client = crate::http_client::logged();
 
-    let sent = match client
-        .post(&feedback_url)
-        .header("Content-Type", "application/json")
-        .json(&parsed)
-        .send()
-        .await
-    {
-        Ok(resp) if resp.status().is_success() => true,
-        Ok(resp) => {
-            log::warn!("[feedback] Server rejected submission: {}", resp.status());
+    let sent = match send_feedback_payload(&client, &destination, &parsed).await {
+        Ok(()) => true,
+        Err(FeedbackSendError::Server(status)) => {
+            log::warn!("[feedback] Server rejected submission: {}", status);
             save_to_queue(app, &parsed, "server error")?;
             false
         }
-        Err(e) => {
-            log::warn!("[feedback] Failed to submit: {}", e);
+        Err(FeedbackSendError::Network(error)) => {
+            log::warn!("[feedback] Failed to submit: {}", error);
             save_to_queue(app, &parsed, "network error")?;
             false
         }
@@ -602,9 +641,9 @@ fn save_to_queue(app: &AppHandle, payload: &Value, failure_reason: &str) -> Resu
 /// Retry all pending feedback reports in the background.
 /// Reads report.json, POSTs each entry, removes successes.
 pub async fn retry_pending(app: &AppHandle) -> Result<usize> {
-    let feedback_url = match crate::env::feedback_url() {
-        Ok(url) => url,
-        Err(_) => return Ok(0), // If feedback is not configured, skip retrying
+    let destination = match feedback_destination(app)? {
+        Some(destination) => destination,
+        None => return Ok(0), // If feedback is not configured, skip retrying
     };
 
     let path = get_report_path(app)?;
@@ -625,7 +664,7 @@ pub async fn retry_pending(app: &AppHandle) -> Result<usize> {
     log::info!(
         "[feedback] Found {} pending report(s), sending to {}",
         entries.len(),
-        feedback_url
+        destination.url
     );
     let client = crate::http_client::logged();
     let mut remaining = Vec::new();
@@ -637,26 +676,17 @@ pub async fn retry_pending(app: &AppHandle) -> Result<usize> {
             None => continue,
         };
 
-        match client
-            .post(&feedback_url)
-            .header("Content-Type", "application/json")
-            .json(&payload)
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
+        match send_feedback_payload(&client, &destination, &payload).await {
+            Ok(()) => {
                 log::info!("[feedback] Successfully sent pending report");
                 sent += 1;
             }
-            Ok(resp) => {
-                log::warn!(
-                    "[feedback] Server rejected pending report: {}",
-                    resp.status()
-                );
+            Err(FeedbackSendError::Server(status)) => {
+                log::warn!("[feedback] Server rejected pending report: {}", status);
                 remaining.push(entry);
             }
-            Err(e) => {
-                log::warn!("[feedback] Failed to send pending report: {}", e);
+            Err(FeedbackSendError::Network(error)) => {
+                log::warn!("[feedback] Failed to send pending report: {}", error);
                 remaining.push(entry);
             }
         }


### PR DESCRIPTION
## Summary

The feedback URL was including the DSN on the path which the backend was no longer expecting. Also, this endpoint is said to have API-key auth on it now. Refactored to reduce duplication.

TODO's to fill in the DSN to the env json files assuming that's what we want.

<!-- What does this PR do? Why? -->

## Test Plan

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed