### PR TITLE
Custom remote templates in "Start from scratch" + allow subfolders in home

### DIFF
--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -123,6 +123,12 @@ pub fn detect_darwin_platform() -> &'static str {
 /// - `HOSTNAME_PLACEHOLDER` -> the provided hostname
 /// - `PLATFORM_PLACEHOLDER` -> the detected platform (aarch64-darwin or x86_64-darwin)
 /// - `USERNAME_PLACEHOLDER` -> the current macOS username
+///
+/// Template sources are not always trusted (remote template repos arrive as
+/// git clones), so VCS state and Finder metadata are never copied, and
+/// symlinks are skipped rather than followed — following them would let a
+/// hostile template recurse forever (`ln -s . self`) or pull out-of-tree file
+/// contents into a config the user may later publish.
 fn copy_template_dir(
     src: &Path,
     dest: &Path,
@@ -138,13 +144,23 @@ fn copy_template_dir(
     {
         let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
         let src_path = entry.path();
+        if entry.file_name() == ".git" || entry.file_name() == ".DS_Store" {
+            continue;
+        }
+        let file_type = entry
+            .file_type()
+            .map_err(|e| format!("Failed to inspect {}: {}", src_path.display(), e))?;
+        if file_type.is_symlink() {
+            log::warn!("Skipping symlink in template: {}", src_path.display());
+            continue;
+        }
         let file_name = render_template_file_name(&entry.file_name(), hostname, platform, username);
         let dest_path = dest.join(&file_name);
 
-        if src_path.is_dir() {
+        if file_type.is_dir() {
             // Recursively copy subdirectories
             copy_template_dir(&src_path, &dest_path, hostname, platform, username)?;
-        } else if src_path.is_file() {
+        } else if file_type.is_file() {
             // Check if it's a .nix file that needs template processing
             if is_nix_file(&src_path) {
                 // Read and process template placeholders using apply_template_placeholders.
@@ -163,6 +179,23 @@ fn copy_template_dir(
         }
     }
 
+    Ok(())
+}
+
+/// Validates a hostname destined for template placeholder substitution.
+/// The value is spliced into file *names* that pass through `Path::join`, so
+/// anything beyond a conservative charset (or a lone `.`/`..`) is rejected to
+/// keep every rendered path inside the destination.
+fn validate_template_hostname(hostname: &str) -> Result<(), String> {
+    let valid_chars = hostname
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    if hostname.is_empty() || !valid_chars || hostname == "." || hostname == ".." {
+        return Err(format!(
+            "Invalid hostname '{}': use letters, digits, '.', '_' and '-'",
+            hostname
+        ));
+    }
     Ok(())
 }
 
@@ -296,8 +329,44 @@ pub fn bootstrap_with_template(
         return Ok(());
     }
 
-    // Safety check: only proceed if directory is empty or git-only.
-    // This prevents accidentally overwriting an existing non-empty directory.
+    let template_dir = template_dir_for_id(template_id)?;
+    let template_path = resolve_template_path(app, template_dir)?;
+
+    log::info!("Using template from: {}", template_path.display());
+
+    scaffold_template(
+        &template_path,
+        &dir,
+        hostname,
+        detect_darwin_platform(),
+        &detect_username(),
+    )?;
+
+    if nix::is_nix_installed() {
+        if let Err(e) = finalize_flake_lock(app) {
+            log::info!("Could not finalize flake.lock during bootstrap: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Scaffolds a configuration into `dest_dir` from a template directory: the
+/// destination-safety check, template copy with placeholder substitution,
+/// git init, and the tagged initial commit. Template-agnostic — the source
+/// can be a bundled template or a checked-out remote one.
+pub fn scaffold_template(
+    template_path: &Path,
+    dest_dir: &str,
+    hostname: &str,
+    platform: &str,
+    username: &str,
+) -> Result<(), String> {
+    validate_template_hostname(hostname)?;
+
+    // Safety check: only proceed if directory is empty or git-only. It lives
+    // here, next to the code that writes, so every scaffold path gets it.
+    let dest_path = Path::new(dest_dir);
     if !is_dir_safe_for_bootstrap(dest_path)
         .map_err(|e| format!("Failed to check bootstrap safety: {}", e))?
     {
@@ -307,33 +376,20 @@ pub fn bootstrap_with_template(
         ));
     }
 
-    let platform = detect_darwin_platform();
-    let username = detect_username();
-    let template_dir = template_dir_for_id(template_id)?;
-    let template_path = resolve_template_path(app, template_dir)?;
-
-    log::info!("Using template from: {}", template_path.display());
-
     // Copy and process all template files recursively
-    copy_template_dir(&template_path, dest_path, hostname, platform, &username)?;
+    copy_template_dir(template_path, dest_path, hostname, platform, username)?;
 
-    // Initialize git repository and commit templates (without flake.lock)
-    git::init::init_repo(&dir).map_err(|e| format!("Failed to init git: {}", e))?;
-    let info = git::commit_all(&dir, "chore: initial nix-darwin configuration")
+    // Initialize git repository and commit templates
+    git::init::init_repo(dest_dir).map_err(|e| format!("Failed to init git: {}", e))?;
+    let info = git::commit_all(dest_dir, "chore: initial nix-darwin configuration")
         .map_err(|e| format!("Failed to commit: {}", e))?;
     if let Err(e) = git::tag_commit(
-        &dir,
+        dest_dir,
         &format!("nixmac-base-{}", &info.hash[..8]),
         &info.hash,
         false,
     ) {
         log::warn!("Failed to tag initial commit as base: {}", e);
-    }
-
-    if nix::is_nix_installed() {
-        if let Err(e) = finalize_flake_lock(app) {
-            log::info!("Could not finalize flake.lock during bootstrap: {}", e);
-        }
     }
 
     Ok(())
@@ -363,9 +419,14 @@ pub fn finalize_flake_lock(app: &AppHandle) -> Result<(), String> {
         ));
     }
 
-    // Stage lock file and commit
-    let info = git::commit_all(&dir, "chore: add flake.lock")
-        .map_err(|e| format!("Failed to commit flake.lock: {}", e))?;
+    // Stage lock file and commit. A template may ship a complete flake.lock
+    // that `nix flake lock` leaves untouched — already committed, nothing to
+    // do.
+    let info = match git::commit_all(&dir, "chore: add flake.lock") {
+        Ok(info) => info,
+        Err(e) if e.to_string().contains("nothing to commit") => return Ok(()),
+        Err(e) => return Err(format!("Failed to commit flake.lock: {}", e)),
+    };
     if let Err(e) = git::tag_commit(
         &dir,
         &format!("nixmac-base-{}", &info.hash[..8]),
@@ -403,6 +464,81 @@ mod tests {
         fs::write(temp.path().join(".DS_Store"), "").expect("create finder metadata");
 
         assert!(is_dir_safe_for_bootstrap(temp.path()).expect("check directory"));
+    }
+
+    #[test]
+    fn copy_template_dir_skips_vcs_metadata_and_symlinks() {
+        let src = tempfile::tempdir().expect("create source dir");
+        fs::create_dir_all(src.path().join(".git/objects")).expect("create git dir");
+        fs::write(src.path().join(".git/HEAD"), "ref").expect("create git file");
+        fs::write(src.path().join(".DS_Store"), "").expect("create finder metadata");
+        fs::write(src.path().join("flake.nix"), "{ }").expect("create flake");
+
+        let outside = tempfile::tempdir().expect("create outside dir");
+        fs::write(outside.path().join("secret"), "leak").expect("create outside file");
+        std::os::unix::fs::symlink(outside.path().join("secret"), src.path().join("linked.nix"))
+            .expect("create symlink");
+        // A self-referential symlink must not cause unbounded recursion.
+        std::os::unix::fs::symlink(src.path(), src.path().join("loop")).expect("create loop");
+
+        let dest = tempfile::tempdir().expect("create dest dir");
+        copy_template_dir(src.path(), dest.path(), "host", "aarch64-darwin", "user")
+            .expect("copy template");
+
+        assert!(dest.path().join("flake.nix").is_file());
+        assert!(!dest.path().join(".git").exists());
+        assert!(!dest.path().join(".DS_Store").exists());
+        assert!(!dest.path().join("linked.nix").exists());
+        assert!(!dest.path().join("loop").exists());
+    }
+
+    #[test]
+    fn validate_template_hostname_rejects_path_escapes() {
+        assert!(validate_template_hostname("Coopers-MacBook-Pro").is_ok());
+        assert!(validate_template_hostname("host.1_x").is_ok());
+
+        for bad in ["", ".", "..", "a/b", "../evil", "host name", "host\n"] {
+            assert!(validate_template_hostname(bad).is_err(), "accepted {bad:?}");
+        }
+    }
+
+    #[test]
+    fn scaffold_template_creates_tagged_initial_commit() {
+        let src = tempfile::tempdir().expect("create source dir");
+        fs::write(
+            src.path().join("flake.nix"),
+            "darwinConfigurations.HOSTNAME_PLACEHOLDER = { };",
+        )
+        .expect("create flake");
+
+        let dest = tempfile::tempdir().expect("create dest dir");
+        let dest_dir = dest.path().to_string_lossy().to_string();
+        scaffold_template(src.path(), &dest_dir, "my-mac", "aarch64-darwin", "user")
+            .expect("scaffold");
+
+        let flake = fs::read_to_string(dest.path().join("flake.nix")).expect("read flake");
+        assert!(flake.contains("darwinConfigurations.my-mac"));
+
+        let repo = git2::Repository::open(dest.path()).expect("open repo");
+        let head = repo.head().expect("head").peel_to_commit().expect("commit");
+        assert_eq!(head.parent_count(), 0);
+        assert!(repo.remotes().expect("remotes").is_empty());
+        let tags = repo.tag_names(Some("nixmac-base-*")).expect("tags");
+        assert_eq!(tags.len(), 1);
+    }
+
+    #[test]
+    fn scaffold_template_rejects_non_empty_destination() {
+        let src = tempfile::tempdir().expect("create source dir");
+        fs::write(src.path().join("flake.nix"), "{ }").expect("create flake");
+
+        let dest = tempfile::tempdir().expect("create dest dir");
+        fs::write(dest.path().join("existing"), "keep").expect("create existing file");
+        let dest_dir = dest.path().to_string_lossy().to_string();
+
+        let err = scaffold_template(src.path(), &dest_dir, "my-mac", "aarch64-darwin", "user")
+            .expect_err("must reject");
+        assert!(err.contains("not empty"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -186,7 +186,7 @@ fn copy_template_dir(
 /// The value is spliced into file *names* that pass through `Path::join`, so
 /// anything beyond a conservative charset (or a lone `.`/`..`) is rejected to
 /// keep every rendered path inside the destination.
-fn validate_template_hostname(hostname: &str) -> Result<(), String> {
+pub(crate) fn validate_template_hostname(hostname: &str) -> Result<(), String> {
     let valid_chars = hostname
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));

--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -129,13 +129,19 @@ pub fn detect_darwin_platform() -> &'static str {
 /// symlinks are skipped rather than followed — following them would let a
 /// hostile template recurse forever (`ln -s . self`) or pull out-of-tree file
 /// contents into a config the user may later publish.
+///
+/// Returns whether the template consumed the hostname placeholder in any
+/// `.nix` content or file name — i.e. it is host-parameterized per the
+/// template conventions, so `darwinConfigurations.<hostname>` can be assumed
+/// to exist after rendering.
 fn copy_template_dir(
     src: &Path,
     dest: &Path,
     hostname: &str,
     platform: &str,
     username: &str,
-) -> Result<(), String> {
+) -> Result<bool, String> {
+    let mut hostname_used = false;
     fs::create_dir_all(dest)
         .map_err(|e| format!("Failed to create directory {}: {}", dest.display(), e))?;
 
@@ -154,18 +160,25 @@ fn copy_template_dir(
             log::warn!("Skipping symlink in template: {}", src_path.display());
             continue;
         }
+        if let Some(raw_name) = entry.file_name().to_str() {
+            hostname_used |=
+                raw_name.contains("HOSTNAME_PLACEHOLDER") || raw_name.contains("{{hostname}}");
+        }
         let file_name = render_template_file_name(&entry.file_name(), hostname, platform, username);
         let dest_path = dest.join(&file_name);
 
         if file_type.is_dir() {
             // Recursively copy subdirectories
-            copy_template_dir(&src_path, &dest_path, hostname, platform, username)?;
+            hostname_used |=
+                copy_template_dir(&src_path, &dest_path, hostname, platform, username)?;
         } else if file_type.is_file() {
             // Check if it's a .nix file that needs template processing
             if is_nix_file(&src_path) {
-                // Read and process template placeholders using apply_template_placeholders.
-                let processed = crate::bootstrap::template::apply_template_placeholders(
-                    &src_path, hostname, platform, username,
+                let content = fs::read_to_string(&src_path)
+                    .map_err(|e| format!("Failed to read {}: {}", src_path.display(), e))?;
+                hostname_used |= content.contains("HOSTNAME_PLACEHOLDER");
+                let processed = crate::bootstrap::template::apply_template_placeholders_to_string(
+                    &content, hostname, platform, username,
                 )
                 .map_err(|e| format!("Failed to process template {}: {}", src_path.display(), e))?;
 
@@ -179,7 +192,7 @@ fn copy_template_dir(
         }
     }
 
-    Ok(())
+    Ok(hostname_used)
 }
 
 /// Validates a hostname destined for template placeholder substitution.
@@ -351,6 +364,16 @@ pub fn bootstrap_with_template(
     Ok(())
 }
 
+/// Facts observed while scaffolding, used to decide follow-up behavior.
+#[derive(Debug)]
+pub struct ScaffoldOutcome {
+    /// The template consumed the hostname placeholder (in `.nix` contents or
+    /// file names). Per the template conventions this means
+    /// `darwinConfigurations.<hostname>` exists after rendering, so the
+    /// hostname can be adopted as the host attribute without probing.
+    pub hostname_used: bool,
+}
+
 /// Scaffolds a configuration into `dest_dir` from a template directory: the
 /// destination-safety check, template copy with placeholder substitution,
 /// git init, and the tagged initial commit. Template-agnostic — the source
@@ -361,7 +384,7 @@ pub fn scaffold_template(
     hostname: &str,
     platform: &str,
     username: &str,
-) -> Result<(), String> {
+) -> Result<ScaffoldOutcome, String> {
     validate_template_hostname(hostname)?;
 
     // Safety check: only proceed if directory is empty or git-only. It lives
@@ -377,7 +400,7 @@ pub fn scaffold_template(
     }
 
     // Copy and process all template files recursively
-    copy_template_dir(template_path, dest_path, hostname, platform, username)?;
+    let hostname_used = copy_template_dir(template_path, dest_path, hostname, platform, username)?;
 
     // Initialize git repository and commit templates
     git::init::init_repo(dest_dir).map_err(|e| format!("Failed to init git: {}", e))?;
@@ -392,7 +415,7 @@ pub fn scaffold_template(
         log::warn!("Failed to tag initial commit as base: {}", e);
     }
 
-    Ok(())
+    Ok(ScaffoldOutcome { hostname_used })
 }
 
 /// Generates flake.lock and commits it as a follow-up to bootstrap.
@@ -482,14 +505,49 @@ mod tests {
         std::os::unix::fs::symlink(src.path(), src.path().join("loop")).expect("create loop");
 
         let dest = tempfile::tempdir().expect("create dest dir");
-        copy_template_dir(src.path(), dest.path(), "host", "aarch64-darwin", "user")
-            .expect("copy template");
+        let hostname_used =
+            copy_template_dir(src.path(), dest.path(), "host", "aarch64-darwin", "user")
+                .expect("copy template");
 
+        // `{ }` uses no placeholder, so the template is not host-parameterized.
+        assert!(!hostname_used);
         assert!(dest.path().join("flake.nix").is_file());
         assert!(!dest.path().join(".git").exists());
         assert!(!dest.path().join(".DS_Store").exists());
         assert!(!dest.path().join("linked.nix").exists());
         assert!(!dest.path().join("loop").exists());
+    }
+
+    #[test]
+    fn copy_template_dir_detects_hostname_placeholder_usage() {
+        // In .nix contents.
+        let src = tempfile::tempdir().expect("create source dir");
+        fs::write(
+            src.path().join("flake.nix"),
+            "darwinConfigurations.HOSTNAME_PLACEHOLDER = { };",
+        )
+        .expect("create flake");
+        let dest = tempfile::tempdir().expect("create dest dir");
+        assert!(
+            copy_template_dir(src.path(), dest.path(), "host", "aarch64-darwin", "user")
+                .expect("copy template")
+        );
+
+        // In file names only.
+        let src = tempfile::tempdir().expect("create source dir");
+        fs::create_dir_all(src.path().join("hosts/HOSTNAME_PLACEHOLDER")).expect("create dir");
+        fs::write(
+            src.path().join("hosts/HOSTNAME_PLACEHOLDER/default.nix"),
+            "{ }",
+        )
+        .expect("create module");
+        fs::write(src.path().join("flake.nix"), "{ }").expect("create flake");
+        let dest = tempfile::tempdir().expect("create dest dir");
+        assert!(
+            copy_template_dir(src.path(), dest.path(), "host", "aarch64-darwin", "user")
+                .expect("copy template")
+        );
+        assert!(dest.path().join("hosts/host/default.nix").is_file());
     }
 
     #[test]
@@ -513,8 +571,9 @@ mod tests {
 
         let dest = tempfile::tempdir().expect("create dest dir");
         let dest_dir = dest.path().to_string_lossy().to_string();
-        scaffold_template(src.path(), &dest_dir, "my-mac", "aarch64-darwin", "user")
+        let outcome = scaffold_template(src.path(), &dest_dir, "my-mac", "aarch64-darwin", "user")
             .expect("scaffold");
+        assert!(outcome.hostname_used);
 
         let flake = fs::read_to_string(dest.path().join("flake.nix")).expect("read flake");
         assert!(flake.contains("darwinConfigurations.my-mac"));

--- a/apps/native/src-tauri/src/bootstrap/import.rs
+++ b/apps/native/src-tauri/src/bootstrap/import.rs
@@ -115,6 +115,7 @@ fn owner_and_repo(locator: &str) -> Result<(String, String)> {
 ///   * `owner/repo?ref=<ref>`
 ///   * `owner/repo?dir=<subdir>`
 ///   * `owner/repo?ref=<ref>&dir=<subdir>`
+///   * `github:owner/repo[?query]` (Nix-style sugar for the shorthand)
 ///   * `github.com/owner/repo[.git]`
 ///   * `https://github.com/owner/repo[.git]`
 ///   * `git@github.com:owner/repo[.git]`
@@ -127,15 +128,30 @@ fn owner_and_repo(locator: &str) -> Result<(String, String)> {
 /// Query parameters are consumed by the parser and are not included in the
 /// resulting clone URL.
 ///
-/// This intentionally does NOT support Nix flake references such as:
-///   * `github:owner/repo`
-///   * `github:owner/repo?dir=subdir`
-///   * `nixpkgs#hello`
+/// Beyond the `github:` prefix, Nix flake reference syntax is intentionally
+/// NOT supported: `github:owner/repo/<ref>` (use `?ref=` instead) and
+/// attribute suffixes like `nixpkgs#hello` are rejected.
 pub fn parse_repo_ref(input: &str) -> Result<RepoRef> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         bail!("Repository reference is required");
     }
+
+    // Nix-style `github:owner/repo` sugar for the shorthand form. The
+    // path-segment ref form is rejected with a pointer to `?ref=`, which the
+    // shorthand supports.
+    let trimmed = match trimmed.strip_prefix("github:") {
+        Some(rest) => {
+            let locator_part = rest.split('?').next().unwrap_or(rest);
+            if locator_part.trim_matches('/').split('/').count() > 2 {
+                bail!(
+                    "'github:owner/repo/<ref>' is not supported; use 'github:owner/repo?ref=<ref>' instead"
+                );
+            }
+            rest
+        }
+        None => trimmed,
+    };
 
     let (locator, git_ref, subdir) = parse_query_params(trimmed)?;
     let (owner, repo) = owner_and_repo(locator)?;
@@ -662,6 +678,23 @@ mod tests {
     }
 
     #[test]
+    fn parses_github_prefix_sugar() {
+        let r = parse_repo_ref("github:czxtm/darwin").unwrap();
+        assert_eq!(r.clone_url, "https://github.com/czxtm/darwin.git");
+        assert_eq!(r.owner, "czxtm");
+        assert_eq!(r.repo, "darwin");
+
+        let r = parse_repo_ref("github:czxtm/darwin?ref=main&dir=hosts/work").unwrap();
+        assert_eq!(r.clone_url, "https://github.com/czxtm/darwin.git");
+        assert_eq!(r.git_ref.as_deref(), Some("main"));
+        assert_eq!(r.subdir.as_deref(), Some("hosts/work"));
+
+        // The Nix path-segment ref form points the user at ?ref= instead.
+        let err = parse_repo_ref("github:czxtm/darwin/main").unwrap_err();
+        assert!(err.to_string().contains("?ref="));
+    }
+
+    #[test]
     fn parses_owner_repo_with_ref_and_subdir() {
         let r = parse_repo_ref("czxtm/darwin?ref=main&dir=hosts/work").unwrap();
         assert_eq!(
@@ -732,7 +765,6 @@ mod tests {
         assert!(parse_repo_ref("a/b/c").is_err());
         assert!(parse_repo_ref("bad owner/repo").is_err());
         assert!(parse_repo_ref("owner/bad!repo").is_err());
-        assert!(parse_repo_ref("github:owner/repo").is_err());
         assert!(parse_repo_ref("czxtm/darwin#main").is_err());
     }
 

--- a/apps/native/src-tauri/src/bootstrap/template.rs
+++ b/apps/native/src-tauri/src/bootstrap/template.rs
@@ -228,7 +228,17 @@ pub fn apply_template_placeholders(
 ) -> Result<String, Error> {
     let content = fs::read_to_string(src_path)
         .with_context(|| format!("failed to read {}", src_path.display()))?;
+    apply_template_placeholders_to_string(&content, hostname, platform, username)
+}
 
+/// String-level variant of [`apply_template_placeholders`] for callers that
+/// already hold the content (and e.g. inspected it for placeholder usage).
+pub fn apply_template_placeholders_to_string(
+    content: &str,
+    hostname: &str,
+    platform: &str,
+    username: &str,
+) -> Result<String, Error> {
     let processed = content
         .replace("HOSTNAME_PLACEHOLDER", hostname)
         .replace("PLATFORM_PLACEHOLDER", platform)

--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -93,6 +93,11 @@ fn is_dir_empty_or_only_git(path: &Path) -> Result<bool, String> {
     Ok(false)
 }
 
+/// Validates the location for a new or imported configuration directory: the
+/// canonical /etc/nix-darwin location, or any directory inside the user's
+/// home — nested paths like `~/tmp/nix-darwin` are fine, missing parents are
+/// created by the callers. Paths are compared lexically (normalization does
+/// not resolve `..`), so parent-dir segments are rejected outright.
 fn validate_new_dir_location(path: &Path) -> Result<(), String> {
     if canonical_config::is_canonical_config_path(path) {
         return Ok(());
@@ -100,16 +105,19 @@ fn validate_new_dir_location(path: &Path) -> Result<(), String> {
 
     let home = dirs::home_dir().ok_or_else(|| "Failed to resolve home directory".to_string())?;
     let relative = path.strip_prefix(&home).map_err(|_| {
-        "New configuration directories must be created directly in your home directory".to_string()
+        "New configuration directories must live inside your home directory (or at /etc/nix-darwin)"
+            .to_string()
     })?;
 
-    let mut components = relative.components();
-    let Some(Component::Normal(_)) = components.next() else {
-        return Err("Use a directory name, not a path".to_string());
-    };
-
-    if components.next().is_some() {
-        return Err("Use a directory name, not a path".to_string());
+    let mut components = relative.components().peekable();
+    if components.peek().is_none() {
+        return Err(
+            "Choose a directory inside your home directory, not the home directory itself"
+                .to_string(),
+        );
+    }
+    if !components.all(|c| matches!(c, Component::Normal(_))) {
+        return Err("Directory paths must not contain '.' or '..' segments".to_string());
     }
 
     Ok(())
@@ -819,12 +827,39 @@ mod tests {
     }
 
     #[test]
-    fn new_config_dir_must_be_a_direct_home_child() {
+    fn new_config_dir_must_live_under_home() {
         let home = dirs::home_dir().expect("home directory");
 
         assert!(validate_new_dir_location(&home.join(".darwin-test")).is_ok());
-        assert!(validate_new_dir_location(&home.join("configs").join("darwin")).is_err());
+        // Nested destinations are fine; missing parents get created.
+        assert!(validate_new_dir_location(&home.join("configs").join("darwin")).is_ok());
+        assert!(validate_new_dir_location(&home.join("tmp/deeply/nested")).is_ok());
+
+        assert!(validate_new_dir_location(&home).is_err());
         assert!(validate_new_dir_location(Path::new("/tmp/darwin")).is_err());
+        // Lexical comparison: `..` segments could escape home. (Lone `.`
+        // segments are normalized away by Path::components and stay allowed.)
+        assert!(validate_new_dir_location(&home.join("a/../../etc")).is_err());
+        assert!(validate_new_dir_location(&home.join("a/./b")).is_ok());
+    }
+
+    #[test]
+    fn prepare_import_target_creates_missing_parents() {
+        let home = dirs::home_dir().expect("home directory");
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let parent = home.join(format!(".nixmac-test-nested-{nonce}"));
+        let dir = parent.join("inner/nix-darwin");
+
+        let target = prepare_import_target(Some(dir.to_string_lossy().to_string()))
+            .expect("prepare nested import target");
+        assert_eq!(target.path, dir);
+        assert!(target.created);
+        assert!(target.path.is_dir());
+
+        let _ = fs::remove_dir_all(parent);
     }
 
     #[test]

--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -1,6 +1,7 @@
 use super::helpers::{capture_err, handle_new_config_dir};
 use crate::bootstrap::{default_config, discover, import};
 use crate::storage::{canonical_config, store};
+use crate::system::nix;
 use crate::{shared_types, types, utils};
 use std::path::{Component, Path, PathBuf};
 use tauri::AppHandle;
@@ -254,6 +255,130 @@ pub async fn bootstrap_default_config(
     template_id: Option<String>,
 ) -> Result<(), String> {
     default_config::bootstrap_with_template(&app, &hostname, template_id.as_deref())
+}
+
+/// Resolves the template root inside a checked-out template repository: the
+/// clone itself, or the `?dir=` subdirectory. The root must contain a
+/// `flake.nix`; the error lists the flake locations found elsewhere in the
+/// repository so the user can fix the reference's `?dir=`.
+fn resolve_template_root(clone_dir: &Path, subdir: Option<&str>) -> Result<PathBuf, String> {
+    let root = match subdir {
+        Some(subdir) => {
+            let dir = clone_dir.join(subdir);
+            if !dir.is_dir() {
+                return Err(format!(
+                    "Subdirectory '{}' does not exist in the template repository",
+                    subdir
+                ));
+            }
+            dir
+        }
+        None => clone_dir.to_path_buf(),
+    };
+    if root.join("flake.nix").is_file() {
+        return Ok(root);
+    }
+
+    let location = match subdir {
+        Some(subdir) => format!("subdirectory '{}' of the template repository", subdir),
+        None => "the template repository".to_string(),
+    };
+    let candidates: Vec<String> =
+        discover::find_flake_dirs(clone_dir, discover::FLAKE_SEARCH_DEPTH)
+            .into_iter()
+            .map(|dir| {
+                if dir.is_empty() {
+                    "<repository root>".to_string()
+                } else {
+                    dir
+                }
+            })
+            .collect();
+    if candidates.is_empty() {
+        Err(format!("No flake.nix found in {}.", location))
+    } else {
+        Err(format!(
+            "No flake.nix found in {}. Found flakes at: {}. Set ?dir=<subdirectory> accordingly (omit ?dir= for the repository root).",
+            location,
+            candidates.join(", ")
+        ))
+    }
+}
+
+/// Scaffolds a fresh configuration into `target` from a template checked out
+/// at `clone_dir`: placeholder rendering, fresh git history. Split from the
+/// async command so the clone-independent part is unit-testable.
+fn scaffold_template_from_clone(
+    clone_dir: &Path,
+    subdir: Option<&str>,
+    hostname: &str,
+    target: &Path,
+) -> Result<(), String> {
+    let template_root = resolve_template_root(clone_dir, subdir)?;
+    default_config::scaffold_template(
+        &template_root,
+        &target.to_string_lossy(),
+        hostname,
+        default_config::detect_darwin_platform(),
+        &default_config::detect_username(),
+    )
+}
+
+/// Creates a new configuration from a remote template repository (e.g.
+/// `github:owner/repo?dir=templates/mac`). The repo is cloned into a
+/// temporary directory and the referenced template directory is scaffolded
+/// into a fresh config dir — unlike imports, the template's git history is
+/// deliberately NOT inherited. The config dir is only selected on success,
+/// so a failed clone or validation never advances onboarding.
+pub async fn config_create_from_template(
+    app: AppHandle,
+    template_ref: String,
+    hostname: String,
+    dir_name: Option<String>,
+) -> Result<shared_types::SetDirResult, String> {
+    // Cheap validations before any network or filesystem work.
+    default_config::validate_template_hostname(&hostname)?;
+    let spec = import::parse_repo_ref(&template_ref).map_err(|e| e.to_string())?;
+    let subdir = spec.subdir.clone();
+
+    let target = prepare_import_target(dir_name)?;
+
+    // Clone the whole template repo into a tempdir on a blocking thread;
+    // libgit2 network I/O is synchronous. The tempdir cleans itself up.
+    let scaffolded = async {
+        let temp = tempfile::tempdir()
+            .map_err(|e| format!("Failed to create temporary directory: {}", e))?;
+        let clone_dir = temp.path().join("repo");
+
+        let app_for_clone = app.clone();
+        let clone_dir_for_clone = clone_dir.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            import::materialize_repo(Some(app_for_clone), &spec, &clone_dir_for_clone)
+        })
+        .await
+        .map_err(|e| capture_err("config_create_from_template", e))?
+        .map_err(|e| capture_err("config_create_from_template", e))?;
+
+        scaffold_template_from_clone(&clone_dir, subdir.as_deref(), &hostname, &target.path)
+    }
+    .await;
+
+    if let Err(e) = scaffolded {
+        cleanup_import_target(&target);
+        return Err(e);
+    }
+
+    let result = finalize_imported_dir(&app, &target.path)?;
+
+    // Mirror the bundled bootstrap: generate and commit flake.lock once the
+    // config dir is selected. Non-fatal — a template may ship its own lock.
+    if nix::is_nix_installed() {
+        if let Err(e) = default_config::finalize_flake_lock(&app) {
+            log::info!("Could not finalize flake.lock for the template: {}", e);
+        }
+    }
+
+    Ok(result)
 }
 
 /// Resolves an optional destination into an absolute target for an imported
@@ -725,6 +850,71 @@ mod tests {
             choose_flake_dir(dirs(&["a", "b"])),
             FlakeChoice::Ambiguous(dirs(&["a", "b"]))
         );
+    }
+
+    /// Lays out a fake checked-out template repository: `.git` metadata at
+    /// the root plus a nested template using placeholders.
+    fn fake_template_clone(root: &Path) {
+        fs::create_dir_all(root.join(".git/objects")).expect("create git dir");
+        fs::write(root.join(".git/HEAD"), "ref").expect("create git file");
+        fs::write(root.join("README.md"), "about these templates").expect("create readme");
+        fs::create_dir_all(root.join("templates/mac")).expect("create template dir");
+        fs::write(
+            root.join("templates/mac/flake.nix"),
+            "darwinConfigurations.HOSTNAME_PLACEHOLDER = { };",
+        )
+        .expect("create flake");
+    }
+
+    #[test]
+    fn resolve_template_root_requires_flake_and_lists_candidates() {
+        let clone = temp_dir("template-root");
+        fake_template_clone(&clone);
+
+        assert_eq!(
+            resolve_template_root(&clone, Some("templates/mac")).expect("resolve subdir"),
+            clone.join("templates/mac")
+        );
+
+        let err = resolve_template_root(&clone, None).expect_err("root has no flake");
+        assert!(err.contains("templates/mac"), "unhelpful error: {err}");
+
+        let err = resolve_template_root(&clone, Some("templates")).expect_err("no flake in subdir");
+        assert!(err.contains("templates/mac"), "unhelpful error: {err}");
+
+        assert!(
+            resolve_template_root(&clone, Some("missing"))
+                .expect_err("missing subdir")
+                .contains("does not exist")
+        );
+
+        let _ = fs::remove_dir_all(clone);
+    }
+
+    #[test]
+    fn scaffold_template_from_clone_renders_fresh_history_without_repo_git() {
+        let clone = temp_dir("template-scaffold-clone");
+        fake_template_clone(&clone);
+        let target = temp_dir("template-scaffold-target");
+        fs::create_dir_all(&target).expect("create target");
+
+        scaffold_template_from_clone(&clone, Some("templates/mac"), "my-mac", &target)
+            .expect("scaffold");
+
+        let flake = fs::read_to_string(target.join("flake.nix")).expect("read flake");
+        assert!(flake.contains("darwinConfigurations.my-mac"));
+        // Only the template subdir's contents land in the target.
+        assert!(!target.join("README.md").exists());
+        assert!(!target.join("templates").exists());
+
+        // Fresh history: a single parentless commit, no remotes.
+        let repo = git2::Repository::open(&target).expect("open repo");
+        let head = repo.head().expect("head").peel_to_commit().expect("commit");
+        assert_eq!(head.parent_count(), 0);
+        assert!(repo.remotes().expect("remotes").is_empty());
+
+        let _ = fs::remove_dir_all(clone);
+        let _ = fs::remove_dir_all(target);
     }
 
     #[test]

--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -313,7 +313,7 @@ fn scaffold_template_from_clone(
     subdir: Option<&str>,
     hostname: &str,
     target: &Path,
-) -> Result<(), String> {
+) -> Result<default_config::ScaffoldOutcome, String> {
     let template_root = resolve_template_root(clone_dir, subdir)?;
     default_config::scaffold_template(
         &template_root,
@@ -363,12 +363,28 @@ pub async fn config_create_from_template(
     }
     .await;
 
-    if let Err(e) = scaffolded {
-        cleanup_import_target(&target);
-        return Err(e);
-    }
+    let outcome = match scaffolded {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            cleanup_import_target(&target);
+            return Err(e);
+        }
+    };
 
     let result = finalize_imported_dir(&app, &target.path)?;
+
+    // The config dir changed, so any previous host attribute is stale. When
+    // the template consumed the hostname placeholder it is host-parameterized
+    // per the template conventions — adopt the chosen name directly, exactly
+    // like a bundled template. Otherwise leave it empty so the Choose Machine
+    // step resolves the template's actual hosts.
+    let host_attr = if outcome.hostname_used {
+        hostname.as_str()
+    } else {
+        ""
+    };
+    store::set_host_attr(&app, host_attr)
+        .map_err(|e| capture_err("config_create_from_template", e))?;
 
     // Mirror the bundled bootstrap: generate and commit flake.lock once the
     // config dir is selected. Non-fatal — a template may ship its own lock.
@@ -898,8 +914,11 @@ mod tests {
         let target = temp_dir("template-scaffold-target");
         fs::create_dir_all(&target).expect("create target");
 
-        scaffold_template_from_clone(&clone, Some("templates/mac"), "my-mac", &target)
-            .expect("scaffold");
+        let outcome =
+            scaffold_template_from_clone(&clone, Some("templates/mac"), "my-mac", &target)
+                .expect("scaffold");
+        // The fixture uses HOSTNAME_PLACEHOLDER, so the hostname is adoptable.
+        assert!(outcome.hostname_used);
 
         let flake = fs::read_to_string(target.join("flake.nix")).expect("read flake");
         assert!(flake.contains("darwinConfigurations.my-mac"));

--- a/apps/native/src-tauri/src/orpc/config.rs
+++ b/apps/native/src-tauri/src/orpc/config.rs
@@ -35,6 +35,15 @@ struct ConfigImportZipInput {
 
 #[derive(Debug, Deserialize, Serialize, Type)]
 #[serde(rename_all = "camelCase")]
+struct ConfigCreateFromTemplateInput {
+    /// Repository reference for the template, e.g. `github:owner/repo?dir=templates/mac`.
+    template_ref: String,
+    hostname: String,
+    dir_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
 struct ConfigFinalizeImportInput {
     clone_dir: String,
     /// Relative flake directory inside `clone_dir`; empty for the root.
@@ -116,6 +125,15 @@ async fn import_zip(
         .map_err(|error| internal_err("config.importZip", error))
 }
 
+async fn create_from_template(
+    ctx: OrpcCtx,
+    input: ConfigCreateFromTemplateInput,
+) -> Result<SetDirResult, ORPCError> {
+    config::config_create_from_template(ctx.app, input.template_ref, input.hostname, input.dir_name)
+        .await
+        .map_err(|error| internal_err("config.createFromTemplate", error))
+}
+
 async fn finalize_import(
     ctx: OrpcCtx,
     input: ConfigFinalizeImportInput,
@@ -171,6 +189,10 @@ pub fn routes() -> Router<OrpcCtx> {
             .input(orpc_specta::specta::<ConfigImportZipInput>())
             .output(orpc_specta::specta::<ImportConfigResult>())
             .handler(import_zip),
+        "createFromTemplate" => os::<OrpcCtx>()
+            .input(orpc_specta::specta::<ConfigCreateFromTemplateInput>())
+            .output(orpc_specta::specta::<SetDirResult>())
+            .handler(create_from_template),
         "finalizeImport" => os::<OrpcCtx>()
             .input(orpc_specta::specta::<ConfigFinalizeImportInput>())
             .output(orpc_specta::specta::<ImportConfigResult>())

--- a/apps/native/src/components/widget/controls/repo-import.tsx
+++ b/apps/native/src/components/widget/controls/repo-import.tsx
@@ -147,7 +147,8 @@ export function RepoImport({ onImported }: RepoImportProps) {
 
       <div className="space-y-1">
         <label htmlFor="import-dir-name" className="text-xs text-muted-foreground">
-          Destination folder (in your home directory)
+          Destination — a folder name or a path like{" "}
+          <span className="font-mono">~/dev/nix-darwin</span>
         </label>
         <Input
           id="import-dir-name"

--- a/apps/native/src/components/widget/controls/repo-ref-input.tsx
+++ b/apps/native/src/components/widget/controls/repo-ref-input.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Check, Link2, TriangleAlert } from "lucide-react";
+import type { ParsedFlakeRef } from "@/components/widget/onboarding/lib/flake-ref";
+import { cn } from "@/lib/utils";
+
+interface RepoRefInputProps {
+  id: string;
+  value: string;
+  /** Parse result for `value` (callers usually memoize `parseFlakeRef`). */
+  parsed: ParsedFlakeRef;
+  onChange: (value: string) => void;
+  /** Invoked on Enter. */
+  onSubmit?: () => void;
+  placeholder?: string;
+  /** Hint shown before the user has typed anything. */
+  idleHint?: ReactNode;
+}
+
+/**
+ * Repository-reference input with live validation feedback, shared by the
+ * flake-ref import source and the custom-template create flow.
+ */
+export function RepoRefInput({
+  id,
+  value,
+  parsed,
+  onChange,
+  onSubmit,
+  placeholder = "owner/repo?ref=main&dir=hosts/work",
+  idleHint,
+}: RepoRefInputProps) {
+  const touched = value.trim().length > 0;
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-lg border bg-background px-3 py-2 transition-colors focus-within:ring-2 focus-within:ring-ring",
+          touched && !parsed.valid ? "border-destructive" : "border-input",
+        )}
+      >
+        <Link2 className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <input
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onSubmit?.();
+          }}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoComplete="off"
+          placeholder={placeholder}
+          className="w-full bg-transparent font-mono text-sm outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+
+      <div className="mt-2 min-h-5 text-xs" aria-live="polite">
+        {touched && parsed.valid ? (
+          <span
+            className={cn(
+              "flex items-center gap-1.5",
+              parsed.importable ? "text-success" : "text-warning",
+            )}
+          >
+            {parsed.importable ? (
+              <Check className="size-3.5" aria-hidden="true" />
+            ) : (
+              <TriangleAlert className="size-3.5" aria-hidden="true" />
+            )}
+            <span className="font-medium">{parsed.label}</span>
+            <span className="text-muted-foreground">— {parsed.hint}</span>
+          </span>
+        ) : touched && !parsed.valid ? (
+          <span className="flex items-center gap-1.5 text-destructive">
+            <TriangleAlert className="size-3.5" aria-hidden="true" />
+            {parsed.hint}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">
+            {idleHint ?? (
+              <>
+                Supports <code className="font-mono">owner/repo</code>, GitHub URLs, SSH URLs, and
+                optional <code className="font-mono">?ref=</code>/
+                <code className="font-mono">?dir=</code>.
+              </>
+            )}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/native/src/components/widget/onboarding/lib/flake-ref.test.ts
+++ b/apps/native/src/components/widget/onboarding/lib/flake-ref.test.ts
@@ -85,12 +85,26 @@ describe("parseFlakeRef", () => {
 		});
 	});
 
-	it("rejects unsupported or malformed forms", () => {
+	it("accepts nix-style github: sugar for the shorthand", () => {
 		expect(parseFlakeRef("github:owner/repo")).toMatchObject({
-			valid: false,
-			importable: false,
+			valid: true,
+			importable: true,
+			type: "repo",
 		});
 
+		expect(parseFlakeRef("github:owner/repo?ref=main&dir=hosts/work")).toMatchObject({
+			valid: true,
+			importable: true,
+			type: "repo",
+		});
+
+		// The Nix path-segment ref form points the user at ?ref= instead.
+		const pathRef = parseFlakeRef("github:owner/repo/main");
+		expect(pathRef).toMatchObject({ valid: false, importable: false });
+		expect(pathRef.hint).toContain("?ref=");
+	});
+
+	it("rejects unsupported or malformed forms", () => {
 		expect(parseFlakeRef("/www.github.com/czxtm/darwin/")).toMatchObject({
 			valid: false,
 			importable: false,

--- a/apps/native/src/components/widget/onboarding/lib/flake-ref.ts
+++ b/apps/native/src/components/widget/onboarding/lib/flake-ref.ts
@@ -107,7 +107,7 @@ function ownerAndRepoFromLocator(
  * `bootstrap::import::parse_repo_ref`.
  */
 export function parseFlakeRef(raw: string): ParsedFlakeRef {
-	const input = raw.trim();
+	let input = raw.trim();
 
 	if (!input) {
 		return {
@@ -117,6 +117,23 @@ export function parseFlakeRef(raw: string): ParsedFlakeRef {
 			hint: "Paste a repository reference to continue.",
 			importable: false,
 		};
+	}
+
+	// Nix-style `github:owner/repo` sugar for the shorthand form (mirrors
+	// `bootstrap::import::parse_repo_ref`). The path-segment ref form is
+	// pointed at `?ref=`, which the shorthand supports.
+	if (input.startsWith("github:")) {
+		input = input.slice("github:".length);
+		const locatorPart = (input.split("?", 2)[0] ?? "").replace(/^\/+|\/+$/g, "");
+		if (locatorPart.split("/").filter(Boolean).length > 2) {
+			return {
+				valid: false,
+				type: "unknown",
+				label: "",
+				hint: "'github:owner/repo/<ref>' is not supported — use github:owner/repo?ref=<ref> instead.",
+				importable: false,
+			};
+		}
 	}
 
 	const { locator, error } = parseQuery(input);
@@ -166,6 +183,7 @@ export function parseFlakeRef(raw: string): ParsedFlakeRef {
 /** Example refs surfaced as quick-fill chips in the UI. */
 export const EXAMPLE_REFS: { ref: string; note: string }[] = [
 	{ ref: "owner/repo", note: "GitHub shorthand" },
+	{ ref: "github:owner/repo?dir=hosts/work", note: "Nix-style GitHub ref" },
 	{ ref: "owner/repo?ref=main", note: "Shorthand + branch/tag" },
 	{ ref: "owner/repo?dir=hosts/work", note: "Shorthand + subdirectory" },
 	{ ref: "owner/repo?ref=main&dir=hosts/work", note: "Shorthand + ref + dir" },

--- a/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
@@ -344,6 +344,8 @@ function installBackend(startAt: string) {
   // The local-folder source picks a folder, locates the flake, then sets the dir.
   patchOrpc("config.pickFolder", async () => "/Users/demo/Documents/nix-darwin");
   patchOrpc("flake.locate", async () => [""]);
+  // Custom-template creates scaffold atomically and return a SetDirResult.
+  patchOrpc("config.createFromTemplate", async () => setConfigWithHosts("/Users/demo/.darwin"));
   patch(tauriAPI.config, "setDir", async (dir: string) => setConfigWithHosts(dir));
   patchOrpc("config.setDir", async (input) =>
     setConfigWithHosts((input as { dir: string }).dir),

--- a/apps/native/src/components/widget/onboarding/source/create-source.test.tsx
+++ b/apps/native/src/components/widget/onboarding/source/create-source.test.tsx
@@ -141,9 +141,11 @@ describe("CreateSource", () => {
         "/etc/nix-darwin",
       ),
     );
-    // The atomic command owns target preparation; prepareNewDir must not run.
+    // The atomic command owns target preparation and the host attribute;
+    // neither prepareNewDir nor a client-side hostAttr reset may run.
     expect(mockPrepareNewDir).not.toHaveBeenCalled();
     expect(mockBootstrapDefault).not.toHaveBeenCalled();
+    expect(mockSetHostAttr).not.toHaveBeenCalled();
     expect(onCreated).toHaveBeenCalled();
   });
 

--- a/apps/native/src/components/widget/onboarding/source/create-source.test.tsx
+++ b/apps/native/src/components/widget/onboarding/source/create-source.test.tsx
@@ -1,0 +1,170 @@
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateSource } from "@/components/widget/onboarding/source/create-source";
+import { uiActions } from "@nixmac/state";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type SetDirResult = { dir: string; changed: boolean };
+
+const mockNormalize = vi.fn<(input: string) => Promise<string>>();
+const mockPrepareNewDir = vi.fn<(dir: string) => Promise<SetDirResult>>();
+const mockBootstrapDefault =
+  vi.fn<(hostname: string, templateId: string | null) => Promise<void>>();
+const mockCreateFromTemplate =
+  vi.fn<(templateRef: string, hostname: string, dirName: string | null) => Promise<SetDirResult>>();
+const mockSetHostAttr = vi.fn<(host: string) => Promise<void>>();
+const mockGetThisHostname = vi.fn<() => Promise<string>>();
+
+vi.mock("@/lib/orpc", async () => {
+  const { createTanstackQueryUtils } = await import("@orpc/tanstack-query");
+  const client = {
+    path: {
+      normalize: ({ input }: { input: string }) => mockNormalize(input),
+    },
+    config: {
+      prepareNewDir: ({ dir }: { dir: string }) => mockPrepareNewDir(dir),
+      createFromTemplate: ({
+        templateRef,
+        hostname,
+        dirName,
+      }: {
+        templateRef: string;
+        hostname: string;
+        dirName: string | null;
+      }) => mockCreateFromTemplate(templateRef, hostname, dirName),
+      setHostAttr: ({ host }: { host: string }) => mockSetHostAttr(host),
+      getThisHostname: () => mockGetThisHostname(),
+    },
+    flake: {
+      bootstrapDefault: ({
+        hostname,
+        templateId,
+      }: {
+        hostname: string;
+        templateId: string | null;
+      }) => mockBootstrapDefault(hostname, templateId),
+    },
+  };
+  return { client, orpc: createTanstackQueryUtils(client) };
+});
+
+function renderCreateSource(onCreated?: () => void) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CreateSource onCreated={onCreated} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uiActions.setError(null);
+  mockNormalize.mockImplementation(async (input) => input);
+  mockPrepareNewDir.mockResolvedValue({ dir: "/etc/nix-darwin", changed: true });
+  mockBootstrapDefault.mockResolvedValue();
+  mockCreateFromTemplate.mockResolvedValue({ dir: "/etc/nix-darwin", changed: true });
+  mockSetHostAttr.mockResolvedValue();
+  mockGetThisHostname.mockResolvedValue("demo-mac");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CreateSource", () => {
+  it("scaffolds the default bundled template", async () => {
+    const onCreated = vi.fn<() => void>();
+    renderCreateSource(onCreated);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-default-config-button"));
+    });
+
+    await waitFor(() =>
+      expect(mockBootstrapDefault).toHaveBeenCalledWith(
+        expect.any(String),
+        "nix-darwin-determinate",
+      ),
+    );
+    expect(mockPrepareNewDir).toHaveBeenCalled();
+    expect(mockCreateFromTemplate).not.toHaveBeenCalled();
+    expect(onCreated).toHaveBeenCalled();
+  });
+
+  it("blocks custom-template creation until the ref is valid", async () => {
+    renderCreateSource();
+
+    fireEvent.click(screen.getByTestId("create-custom-template-card"));
+    const createButton = screen.getByTestId("create-default-config-button");
+    expect(createButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Template repository"), {
+      target: { value: "github:owner/repo/branch" },
+    });
+    expect(createButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Template repository"), {
+      target: { value: "github:owner/repo?dir=templates/mac" },
+    });
+    expect(createButton).toBeEnabled();
+  });
+
+  it("creates from a custom template atomically", async () => {
+    const onCreated = vi.fn<() => void>();
+    renderCreateSource(onCreated);
+
+    fireEvent.click(screen.getByTestId("create-custom-template-card"));
+    fireEvent.change(screen.getByLabelText("Template repository"), {
+      target: { value: "github:owner/repo?dir=templates/mac" },
+    });
+    fireEvent.change(screen.getByLabelText("Name this Mac"), {
+      target: { value: "my-mac" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-default-config-button"));
+    });
+
+    await waitFor(() =>
+      expect(mockCreateFromTemplate).toHaveBeenCalledWith(
+        "github:owner/repo?dir=templates/mac",
+        "my-mac",
+        "/etc/nix-darwin",
+      ),
+    );
+    // The atomic command owns target preparation; prepareNewDir must not run.
+    expect(mockPrepareNewDir).not.toHaveBeenCalled();
+    expect(mockBootstrapDefault).not.toHaveBeenCalled();
+    expect(onCreated).toHaveBeenCalled();
+  });
+
+  it("surfaces custom-template errors inline", async () => {
+    const onCreated = vi.fn<() => void>();
+    mockCreateFromTemplate.mockRejectedValue(
+      new Error("No flake.nix found in the template repository."),
+    );
+    renderCreateSource(onCreated);
+
+    fireEvent.click(screen.getByTestId("create-custom-template-card"));
+    fireEvent.change(screen.getByLabelText("Template repository"), {
+      target: { value: "owner/repo" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-default-config-button"));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/No flake.nix found/i)).toBeInTheDocument(),
+    );
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/apps/native/src/components/widget/onboarding/source/create-source.tsx
+++ b/apps/native/src/components/widget/onboarding/source/create-source.tsx
@@ -231,6 +231,8 @@ export function CreateSource({ onCreated }: CreateSourceProps) {
         />
         <p className="text-muted-foreground text-xs">
           We&apos;ll write a <code className="font-mono">flake.nix</code> here and initialize git.
+          Any path in your home directory works, <code className="font-mono">~</code> included
+          (e.g. <code className="font-mono">~/dev/nix-darwin</code>); missing folders are created.
           Custom paths are symlinked to <code className="font-mono">/etc/nix-darwin</code>.
         </p>
       </div>

--- a/apps/native/src/components/widget/onboarding/source/create-source.tsx
+++ b/apps/native/src/components/widget/onboarding/source/create-source.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Check, Loader2, Sparkles } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Check, GitBranch, Loader2, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { RepoRefInput } from "@/components/widget/controls/repo-ref-input";
 import {
   DEFAULT_CONFIG_DIR,
   STARTER_TEMPLATES,
+  parseFlakeRef,
   type StarterTemplateId,
 } from "@/components/widget/onboarding/lib/flake-ref";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
@@ -18,13 +20,19 @@ interface CreateSourceProps {
   onCreated?: () => void;
 }
 
+/** The bundled starter templates, or a user-provided template repository. */
+type TemplateChoice = StarterTemplateId | "custom";
+
 /**
- * Scaffold a starter configuration: create an empty config dir, then copy the
- * selected bundled template into it for the named host.
+ * Scaffold a starter configuration for the named host: a bundled template
+ * copied into a fresh config dir, or — via "Custom template" — any repository
+ * (or subdirectory of one), whose files are copied without inheriting the
+ * template's git history.
  */
 export function CreateSource({ onCreated }: CreateSourceProps) {
-  const { prepareNewDir, bootstrap } = useDarwinConfig();
-  const [templateId, setTemplateId] = useState<StarterTemplateId>("nix-darwin-determinate");
+  const { prepareNewDir, bootstrap, createFromTemplate } = useDarwinConfig();
+  const [templateId, setTemplateId] = useState<TemplateChoice>("nix-darwin-determinate");
+  const [templateRef, setTemplateRef] = useState("");
   const [hostName, setHostName] = useState("");
   const [dir, setDir] = useState(DEFAULT_CONFIG_DIR);
   const [creating, setCreating] = useState(false);
@@ -38,20 +46,30 @@ export function CreateSource({ onCreated }: CreateSourceProps) {
   }, [fetchedHost]);
 
   const host = (hostName.trim() || "this-mac").replace(/[^\w-]/g, "-");
+  const parsedTemplateRef = useMemo(() => parseFlakeRef(templateRef), [templateRef]);
+  const customRefReady = parsedTemplateRef.valid && parsedTemplateRef.importable;
+  const canCreate = !creating && (templateId !== "custom" || customRefReady);
 
   async function create() {
+    if (!canCreate) return;
     setError(null);
     setCreating(true);
     try {
       const normalized = await client.path.normalize({
         input: dir.trim() || DEFAULT_CONFIG_DIR,
       });
-      await prepareNewDir(normalized);
-      await bootstrap(host, templateId);
-      const storeError = useUiState.getState().error;
-      if (storeError) {
-        setError(storeError);
-        return;
+      if (templateId === "custom") {
+        // Atomic on the backend: clone + validation happen before the config
+        // dir is selected, so failures land here while we're still mounted.
+        await createFromTemplate(templateRef.trim(), host, normalized);
+      } else {
+        await prepareNewDir(normalized);
+        await bootstrap(host, templateId);
+        const storeError = useUiState.getState().error;
+        if (storeError) {
+          setError(storeError);
+          return;
+        }
       }
       onCreated?.();
     } catch (e: unknown) {
@@ -115,6 +133,71 @@ export function CreateSource({ onCreated }: CreateSourceProps) {
               </button>
             );
           })}
+
+          {/* Custom remote template */}
+          <button
+            type="button"
+            aria-pressed={templateId === "custom"}
+            onClick={() => setTemplateId("custom")}
+            data-testid="create-custom-template-card"
+            className={cn(
+              "flex items-start gap-3 rounded-xl border p-3.5 text-left transition-colors",
+              templateId === "custom"
+                ? "border-primary bg-primary/5"
+                : "border-border bg-card hover:bg-accent",
+            )}
+          >
+            <span
+              className={cn(
+                "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border",
+                templateId === "custom"
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-input",
+              )}
+              aria-hidden="true"
+            >
+              {templateId === "custom" ? <Check className="size-3.5" /> : null}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <GitBranch className="size-3.5 text-muted-foreground" aria-hidden="true" />
+                <span className="font-medium text-sm">Custom template</span>
+              </div>
+              <p className="mt-0.5 text-pretty text-muted-foreground text-sm">
+                Start from any GitHub repository, or a subdirectory of one. Files are copied — the
+                template&apos;s git history is not.
+              </p>
+            </div>
+          </button>
+
+          {templateId === "custom" ? (
+            <div className="rounded-xl border border-primary/40 bg-card p-3.5">
+              <label
+                htmlFor="custom-template-ref"
+                className="mb-1.5 block font-medium text-sm"
+              >
+                Template repository
+              </label>
+              <RepoRefInput
+                id="custom-template-ref"
+                value={templateRef}
+                parsed={parsedTemplateRef}
+                onChange={(next) => {
+                  setTemplateRef(next);
+                  setError(null);
+                }}
+                onSubmit={() => void create()}
+                placeholder="github:owner/repo?dir=templates/mac"
+                idleHint={
+                  <>
+                    e.g. <code className="font-mono">github:owner/repo?dir=templates/mac</code> —
+                    supports <code className="font-mono">?ref=</code> and{" "}
+                    <code className="font-mono">?dir=</code>.
+                  </>
+                }
+              />
+            </div>
+          ) : null}
         </div>
       </fieldset>
 
@@ -154,7 +237,7 @@ export function CreateSource({ onCreated }: CreateSourceProps) {
 
       <Button
         onClick={create}
-        disabled={creating}
+        disabled={!canCreate}
         className="self-start"
         data-testid="create-default-config-button"
       >

--- a/apps/native/src/components/widget/onboarding/source/flake-ref-source.tsx
+++ b/apps/native/src/components/widget/onboarding/source/flake-ref-source.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Check, FileArchive, Link2, Loader2, TriangleAlert } from "lucide-react";
+import { FileArchive, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FlakeDirChooser } from "@/components/widget/controls/flake-dir-chooser";
+import { RepoRefInput } from "@/components/widget/controls/repo-ref-input";
 import { EXAMPLE_REFS, parseFlakeRef } from "@/components/widget/onboarding/lib/flake-ref";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
 import { useImportConfig } from "@/hooks/use-import-config";
 import { client } from "@/lib/orpc";
-import { cn } from "@/lib/utils";
 
 interface FlakeRefSourceProps {
   onImported?: () => void;
@@ -27,7 +27,6 @@ export function FlakeRefSource({ onImported }: FlakeRefSourceProps) {
   const [error, setError] = useState<string | null>(null);
 
   const parsed = useMemo(() => parseFlakeRef(value), [value]);
-  const touched = value.trim().length > 0;
   const canUse = parsed.valid && parsed.importable;
   const importConfig = useImportConfig(onImported);
 
@@ -81,58 +80,16 @@ export function FlakeRefSource({ onImported }: FlakeRefSourceProps) {
         <label htmlFor="flake-ref" className="mb-1.5 block font-medium text-sm">
           Repository reference
         </label>
-        <div
-          className={cn(
-            "flex items-center gap-2 rounded-lg border bg-background px-3 py-2 transition-colors focus-within:ring-2 focus-within:ring-ring",
-            touched && !parsed.valid ? "border-destructive" : "border-input",
-          )}
-        >
-          <Link2 className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          <input
-            id="flake-ref"
-            value={value}
-            onChange={(e) => {
-              setValue(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") void use();
-            }}
-            spellCheck={false}
-            autoCapitalize="off"
-            autoComplete="off"
-            placeholder="owner/repo?ref=main&dir=hosts/work"
-            className="w-full bg-transparent font-mono text-sm outline-none placeholder:text-muted-foreground"
-          />
-        </div>
-
-        <div className="mt-2 min-h-5 text-xs" aria-live="polite">
-          {touched && parsed.valid ? (
-            <span
-              className={cn(
-                "flex items-center gap-1.5",
-                parsed.importable ? "text-success" : "text-warning",
-              )}
-            >
-              {parsed.importable ? (
-                <Check className="size-3.5" aria-hidden="true" />
-              ) : (
-                <TriangleAlert className="size-3.5" aria-hidden="true" />
-              )}
-              <span className="font-medium">{parsed.label}</span>
-              <span className="text-muted-foreground">— {parsed.hint}</span>
-            </span>
-          ) : touched && !parsed.valid ? (
-            <span className="flex items-center gap-1.5 text-destructive">
-              <TriangleAlert className="size-3.5" aria-hidden="true" />
-              {parsed.hint}
-            </span>
-          ) : (
-            <span className="text-muted-foreground">
-              Supports <code className="font-mono">owner/repo</code>, GitHub URLs, SSH URLs, and optional <code className="font-mono">?ref=</code>/<code className="font-mono">?dir=</code>.
-            </span>
-          )}
-        </div>
+        <RepoRefInput
+          id="flake-ref"
+          value={value}
+          parsed={parsed}
+          onChange={(next) => {
+            setValue(next);
+            setError(null);
+          }}
+          onSubmit={() => void use()}
+        />
       </div>
 
       <div className="flex flex-col gap-1.5">

--- a/apps/native/src/components/widget/onboarding/source/flake-ref-source.tsx
+++ b/apps/native/src/components/widget/onboarding/source/flake-ref-source.tsx
@@ -107,7 +107,9 @@ export function FlakeRefSource({ onImported }: FlakeRefSourceProps) {
           className="w-full rounded-lg border border-input bg-background px-3 py-2 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
         <p className="text-muted-foreground text-xs">
-          Imports into this directory, then selects it as your active config directory.
+          Imports into this directory, then selects it as your active config directory. Any path
+          in your home directory works, <code className="font-mono">~</code> included; missing
+          folders are created.
         </p>
       </div>
 

--- a/apps/native/src/hooks/use-darwin-config.ts
+++ b/apps/native/src/hooks/use-darwin-config.ts
@@ -86,16 +86,17 @@ const pickZip = () => client.config.pickZip();
 
 /**
  * Scaffolds a new configuration from a remote template repository. Atomic on
- * the backend: the config dir is only selected on success.
+ * the backend: the config dir is only selected on success. No applyDirResult
+ * here — the backend owns the host attribute for template creates (it adopts
+ * the chosen hostname when the template is host-parameterized, and clears it
+ * otherwise), so a client-side reset would wipe that decision.
  */
 const createFromTemplate = async (templateRef: string, hostname: string, dirName?: string) => {
-  const result = await client.config.createFromTemplate({
+  return client.config.createFromTemplate({
     templateRef,
     hostname,
     dirName: dirName ?? null,
   });
-  await applyDirResult(result);
-  return result;
 };
 
 const saveHost = async (host: string) => {

--- a/apps/native/src/hooks/use-darwin-config.ts
+++ b/apps/native/src/hooks/use-darwin-config.ts
@@ -14,6 +14,11 @@ interface DarwinConfigActions {
   importGithub: (repoRef: string, dirName?: string) => Promise<ImportConfigResult>;
   importZip: (zipPath: string, dirName?: string) => Promise<ImportConfigResult>;
   pickZip: () => Promise<string | null>;
+  createFromTemplate: (
+    templateRef: string,
+    hostname: string,
+    dirName?: string,
+  ) => Promise<SetDirResult>;
 }
 
 // Config dir/host/hosts and the evolve/git mirrors are no longer written
@@ -79,6 +84,20 @@ const importZip = async (zipPath: string, dirName?: string) => {
 
 const pickZip = () => client.config.pickZip();
 
+/**
+ * Scaffolds a new configuration from a remote template repository. Atomic on
+ * the backend: the config dir is only selected on success.
+ */
+const createFromTemplate = async (templateRef: string, hostname: string, dirName?: string) => {
+  const result = await client.config.createFromTemplate({
+    templateRef,
+    hostname,
+    dirName: dirName ?? null,
+  });
+  await applyDirResult(result);
+  return result;
+};
+
 const saveHost = async (host: string) => {
   try {
     await client.config.setHostAttr({ host });
@@ -131,5 +150,6 @@ export function useDarwinConfig(): DarwinConfigActions {
     importGithub,
     importZip,
     pickZip,
+    createFromTemplate,
   };
 }

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -266,6 +266,12 @@ configDir: string;
  */
 hostAttr: string | null }
 
+export type ConfigCreateFromTemplateInput = { 
+/**
+ * Repository reference for the template, e.g. `github:owner/repo?dir=templates/mac`.
+ */
+templateRef: string; hostname: string; dirName: string | null }
+
 export type ConfigDiscardImportInput = { dir: string }
 
 /**
@@ -1794,6 +1800,7 @@ export type Procedures = {
     listModels: Client<Record<never, never>, ListModelsInput, string[], Error>
   }
   config: {
+    createFromTemplate: Client<Record<never, never>, ConfigCreateFromTemplateInput, SetDirResult, Error>
     discardImport: Client<Record<never, never>, ConfigDiscardImportInput, OkResult, Error>
     finalizeImport: Client<Record<never, never>, ConfigFinalizeImportInput, ImportConfigResult, Error>
     get: Client<Record<never, never>, void, Config, Error>

--- a/apps/native/templates/README.md
+++ b/apps/native/templates/README.md
@@ -24,8 +24,12 @@ Conventions for template authors:
   chosen machine name, `aarch64-darwin`/`x86_64-darwin`, and the macOS
   username. In **file and directory names**, `{{hostname}}` and the same
   placeholder tokens are substituted for *every* file, not just `.nix` ones.
-- Templates that skip the hostname placeholder work too: nixmac then asks the
-  user to pick among the template's actual `darwinConfigurations` hosts.
+- Using the hostname placeholder implies the convention that
+  `darwinConfigurations.HOSTNAME_PLACEHOLDER` names the machine's
+  configuration: nixmac then selects the chosen machine name as the host
+  automatically, exactly like the bundled templates. Templates that skip the
+  placeholder work too — nixmac instead asks the user to pick among the
+  template's actual `darwinConfigurations` hosts.
 - Symlinks are **skipped** (with a warning) — don't rely on them.
 - `.git` and `.DS_Store` entries are never copied.
 - A shipped `flake.lock` is kept and committed, pinning the template author's

--- a/apps/native/templates/README.md
+++ b/apps/native/templates/README.md
@@ -2,6 +2,38 @@
 
 This directory contains some starter and notable templates.
 
+## Custom remote templates
+
+Besides the bundled templates below, onboarding's "Start from scratch" accepts
+a **custom template** from any git repository — `owner/repo`,
+`github:owner/repo`, full git URLs, with optional `?ref=<branch-or-tag>` and
+`?dir=<subdirectory>` (e.g. `github:owner/repo?dir=templates/mac`). Private
+GitHub repos work through the GitHub App connection.
+
+Template semantics differ deliberately from *imports* ("I already have a
+flake"): the referenced directory's files are **copied** into a fresh config
+dir with a brand-new git history (single initial commit, tagged
+`nixmac-base-<hash>`) — the template's own `.git` history and origin are never
+inherited. The referenced directory must contain a `flake.nix`.
+
+Conventions for template authors:
+
+- Remote templates are processed as **nixmac templates**, not arbitrary
+  flakes. In `.nix` file *contents*, `HOSTNAME_PLACEHOLDER`,
+  `PLATFORM_PLACEHOLDER`, and `USERNAME_PLACEHOLDER` are substituted with the
+  chosen machine name, `aarch64-darwin`/`x86_64-darwin`, and the macOS
+  username. In **file and directory names**, `{{hostname}}` and the same
+  placeholder tokens are substituted for *every* file, not just `.nix` ones.
+- Templates that skip the hostname placeholder work too: nixmac then asks the
+  user to pick among the template's actual `darwinConfigurations` hosts.
+- Symlinks are **skipped** (with a warning) — don't rely on them.
+- `.git` and `.DS_Store` entries are never copied.
+- A shipped `flake.lock` is kept and committed, pinning the template author's
+  inputs; `nix flake lock` only rewrites it when incomplete.
+
+Known limitation: the repository is fully cloned (no shallow clone, no
+progress UI), so huge repositories make poor templates.
+
 ## nixos-unified Template
 
 `nixos-unified` is a cross-platform flake template (Linux + macOS) based on


### PR DESCRIPTION
## Summary

#470 changed `?dir=` imports to clone the whole repo and point the config dir at the subdirectory — right for imports (preserves `.git`/origin/sync), but it removed the workflow of using `github:user/repo?dir=<path-to-template>` as a **template** (copy the files, no history). As discussed, that use-case belongs in **"Start from scratch"**, not import: importing adopts a repo's identity; a template only seeds a new one.

## What

"Start from scratch" gains a **Custom template** card accepting the same repo-ref syntax as imports (`owner/repo`, `github:owner/repo`, git URLs, `?ref=`, `?dir=`), with template semantics:

- the repo is cloned into a **tempdir** (GitHub App token → private repos work) and the referenced directory — which must contain a `flake.nix` — is copied into a fresh config dir;
- placeholders are rendered exactly like bundled templates (`HOSTNAME_PLACEHOLDER` etc. in `.nix` contents, `{{hostname}}`/placeholders in all file names);
- git history is **not** inherited: fresh repo, single initial commit tagged `nixmac-base-<hash>`, `flake.lock` finalized non-fatally (a shipped lock is kept — the author's pins);
- wrong/missing `?dir=` errors list the flake locations actually found in the repo.

Additionally, this allows when importing a template to specify a subfolder in home of arbitrary depths (e.g. `~/configs/nix-darwin`) which before was not allowed.



### Design notes

- **Atomic command** (`config.createFromTemplate`): clone + validation happen before the config dir is selected, so failures surface inline on the still-mounted create screen instead of advancing onboarding to a broken state (the bundled `prepareNewDir` → `bootstrap` split would set `configDir` before the slow clone).
- **Host attribute**: when the template consumes the hostname placeholder (contents or file names) it is host-parameterized per the conventions, so the chosen machine name is adopted directly — same skip-Choose-Machine UX as bundled templates. Templates without the placeholder leave it empty and route through the Choose Machine host picker. Either way, no `nix eval` probe runs inside the create spinner; the backend owns the host attribute for template creates end to end.
- **Hardening** (also covers bundled templates): template copy now skips `.git`/`.DS_Store` and symlinks (a hostile template could previously loop forever via `ln -s . self` or copy out-of-tree file contents into a repo the user may later push), and the hostname is validated at the scaffold boundary — it is spliced into file names through `Path::join`, so a crafted value via the raw `flake.bootstrapDefault` endpoint could escape the destination.
- `github:owner/repo` is now accepted as sugar by both ref parsers (imports too); `github:o/r/<ref>` errors with a pointer to `?ref=`.

## Follow-ups (out of scope)

- Preserving validated in-tree symlinks in templates, if a real template ever needs it
- Shallow clone / progress UI for huge repos (limitation shared with imports)
- 
## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
