### PR TITLE
Fix checkmarks in "Import customizations" onboarding page

### DIFF
--- a/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
+++ b/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
@@ -411,7 +411,7 @@ function GroupCard({
     >
       <div className="flex w-full items-start gap-3 p-4 text-left">
         <Checkbox
-          checked={allTracked}
+          checked={allTracked ? true : trackedIds.length > 0 ? "indeterminate" : false}
           onCheckedChange={(checked) => (checked === true ? onTrack(group.items) : onUntrack(ids))}
           aria-label={`Track all ${group.title}`}
           className="mt-1 size-4"

--- a/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
+++ b/apps/native/src/components/widget/onboarding/steps/customizations-step.tsx
@@ -414,7 +414,7 @@ function GroupCard({
           checked={allTracked}
           onCheckedChange={(checked) => (checked === true ? onTrack(group.items) : onUntrack(ids))}
           aria-label={`Track all ${group.title}`}
-          className={cn("mt-1 size-4 border-none", allTracked ? "bg-white" : "bg-zinc-700")}
+          className="mt-1 size-4"
         />
         <button
           type="button"
@@ -461,10 +461,7 @@ function GroupCard({
                       checked === true ? onTrack([item]) : onUntrack([item.id])
                     }
                     aria-label={`Track ${item.label}`}
-                    className={cn(
-                      "mt-0.5 size-4 border-none",
-                      isTracked ? "bg-white" : "bg-zinc-700",
-                    )}
+                    className="mt-0.5 size-4"
                   />
                   <div className="min-w-0 flex-1">
                     <p className="text-pretty font-medium text-sm">{item.label}</p>

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 // biome-ignore lint/performance/noNamespaceImport: Radix namespace import keeps API names grouped
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, MinusIcon } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -11,7 +11,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:data-[state=checked]:bg-primary dark:aria-invalid:ring-destructive/40",
+        "group/checkbox peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground dark:bg-input/30 dark:data-[state=checked]:bg-primary dark:data-[state=indeterminate]:bg-primary dark:aria-invalid:ring-destructive/40",
         className,
       )}
       data-slot="checkbox"
@@ -21,7 +21,8 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
         className="flex items-center justify-center text-current transition-none"
         data-slot="checkbox-indicator"
       >
-        <CheckIcon className="size-3.5" />
+        <CheckIcon className="size-3.5 group-data-[state=indeterminate]/checkbox:hidden" />
+        <MinusIcon className="hidden size-3.5 group-data-[state=indeterminate]/checkbox:block" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );


### PR DESCRIPTION
## Summary

Fix a couple of issues:

- They would have no border, meaning they would look almost invisible in dark mode.

- Properly render hierarchical check-marks (show "indeterminate" state for parent marks with _some_ children marked).

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
