### PR TITLE
fix(release): root updater tarball at app bundle

### DIFF
--- a/ops/scripts/release/check-portable-macos-app.sh
+++ b/ops/scripts/release/check-portable-macos-app.sh
@@ -344,9 +344,21 @@ check_updater_tarball() {
 	mkdir -p "$extract_dir"
 	tar -xzf "$tar_path" -C "$extract_dir"
 
-	app_count=$(find "$extract_dir" -maxdepth 3 -name "*.app" -type d | wc -l | tr -d '[:space:]')
-	if [ "$app_count" -eq 0 ]; then
-		echo "ERROR: no .app bundle found in $tar_path" >&2
+	# tauri-plugin-updater strips exactly one leading path component from every
+	# entry, so the archive MUST be rooted at `AppName.app/`. A `./`-rooted
+	# archive (e.g. from `tar -czf ... -C dir .`) installs a nested
+	# `nixmac.app/nixmac.app/...` bundle and corrupts the app on auto-update.
+	local bad_roots
+	bad_roots=$(tar -tzf "$tar_path" | sed -E 's|/.*$|/|' | sort -u | grep -Ev '^[^/.][^/]*\.app/$' || true)
+	if [ -n "$bad_roots" ]; then
+		echo "ERROR: updater tarball entries must be rooted at 'AppName.app/'; found roots:" >&2
+		echo "$bad_roots" >&2
+		exit 2
+	fi
+
+	app_count=$(find "$extract_dir" -maxdepth 1 -name "*.app" -type d | wc -l | tr -d '[:space:]')
+	if [ "$app_count" -ne 1 ]; then
+		echo "ERROR: expected exactly one top-level .app bundle in $tar_path, found $app_count" >&2
 		exit 2
 	fi
 

--- a/ops/scripts/release/check-portable-macos-app.test.sh
+++ b/ops/scripts/release/check-portable-macos-app.test.sh
@@ -143,6 +143,10 @@ assert_passes "$TMP_DIR/Clean.app"
 assert_passes "$TMP_DIR/SystemRpath.app"
 tar -czf "$TMP_DIR/Clean.app.tar.gz" -C "$TMP_DIR" Clean.app
 assert_passes "$TMP_DIR/Clean.app.tar.gz"
+mkdir -p "$TMP_DIR/dot-rooted"
+cp -R "$TMP_DIR/Clean.app" "$TMP_DIR/dot-rooted/Clean.app"
+tar -czf "$TMP_DIR/DotRooted.app.tar.gz" -C "$TMP_DIR/dot-rooted" .
+assert_fails_with "rooted at 'AppName.app/'" "$TMP_DIR/DotRooted.app.tar.gz"
 assert_fails_with "/nix/store/example-libiconv" "$TMP_DIR/NixStore.app"
 assert_fails_with ".devenv/profile/lib/libcustom.dylib" "$TMP_DIR/Devenv.app"
 assert_fails_with "/Users/runner/work/nixmac/build/libcustom.dylib" "$TMP_DIR/Absolute.app"

--- a/ops/scripts/release/normalize-macos-install-names.sh
+++ b/ops/scripts/release/normalize-macos-install-names.sh
@@ -307,6 +307,8 @@ normalize_updater_tarball() {
 	local extract_dir
 	local tar_name
 	local app_count
+	local app_dir
+	local app_name
 
 	if [ ! -f "$tar_path" ]; then
 		echo "ERROR: updater tarball path does not exist: $tar_path" >&2
@@ -320,11 +322,19 @@ normalize_updater_tarball() {
 	echo "Extracting updater archive for install-name normalization: $tar_path"
 	tar -xzf "$tar_path" -C "$extract_dir"
 
-	app_count=$(find "$extract_dir" -maxdepth 3 -name "*.app" -type d | wc -l | tr -d '[:space:]')
-	if [ "$app_count" -eq 0 ]; then
-		echo "ERROR: no .app bundle found in $tar_path" >&2
+	# tauri-plugin-updater strips exactly one leading path component from every
+	# archive entry (entry.path().iter().skip(1)) before renaming the extraction
+	# dir over the installed bundle. Entries therefore MUST be rooted at
+	# `AppName.app/`; a `./`-rooted archive installs a nested
+	# `nixmac.app/nixmac.app/...` and corrupts the app. Enforce exactly one
+	# top-level .app and repack by its basename.
+	app_count=$(find "$extract_dir" -maxdepth 1 -name "*.app" -type d | wc -l | tr -d '[:space:]')
+	if [ "$app_count" -ne 1 ]; then
+		echo "ERROR: expected exactly one top-level .app bundle in $tar_path, found $app_count" >&2
 		exit 2
 	fi
+	app_dir=$(find "$extract_dir" -maxdepth 1 -name "*.app" -type d)
+	app_name=$(basename "$app_dir")
 
 	while IFS= read -r app_path; do
 		normalize_app "$app_path"
@@ -332,7 +342,7 @@ normalize_updater_tarball() {
 	done < <(find "$extract_dir" -maxdepth 3 -name "*.app" -type d)
 
 	echo "Repacking normalized updater archive: $tar_path"
-	tar -czf "$tar_path" -C "$extract_dir" .
+	tar -czf "$tar_path" -C "$extract_dir" "$app_name"
 	refresh_updater_signature "$tar_path"
 }
 

--- a/ops/scripts/release/normalize-macos-install-names.test.sh
+++ b/ops/scripts/release/normalize-macos-install-names.test.sh
@@ -234,6 +234,13 @@ if ! grep -F "fresh signature" "$TMP_DIR/nixmac.app.tar.gz.sig" >/dev/null; then
 	exit 1
 fi
 
+TAR_ROOTS=$(tar -tzf "$TMP_DIR/nixmac.app.tar.gz" | sed -E 's|/.*$|/|' | sort -u)
+if [ "$TAR_ROOTS" != "NixIconvUpdater.app/" ]; then
+	echo "expected repacked updater archive rooted at NixIconvUpdater.app/ (tauri updater strips one leading path component); got:" >&2
+	echo "$TAR_ROOTS" >&2
+	exit 1
+fi
+
 : >"$CODESIGN_LOG"
 make_app "$TMP_DIR/AdhocFallback.app" nix-iconv-adhoc
 (


### PR DESCRIPTION
## Problem
Auto-update corrupts the installed app ("nixmac.app may be damaged or incomplete") while the DMG works fine.

`normalize_updater_tarball` repacked the updater archive with `tar -czf ... -C "$extract_dir" .`, producing `./`-rooted entries (verified on the shipped `0.27.2/nixmac.app.tar.gz` — all 155 entries). tauri-plugin-updater 2.10.0 strips exactly one leading path component (`entry.path()?.iter().skip(1)`) and then renames the extraction dir over the installed bundle; Rust path iteration keeps a leading `.` as a real component, so `skip(1)` ate `.` instead of `nixmac.app`, installing a nested `/Applications/nixmac.app/nixmac.app/Contents/...` — unlaunchable.

Reproduced three ways: a sandboxed end-to-end run of the real updater plugin (check → minisign verify → download → install), a live machine hitting the stable channel, and the tar listing itself.

## Fix
- `normalize-macos-install-names.sh`: repack rooted at the app basename (`tar -czf "$tar_path" -C "$extract_dir" "$app_name"`), enforce exactly one top-level `.app`.
- `check-portable-macos-app.sh`: reject archives whose entries are not rooted at `AppName.app/` — this checker runs in the release workflow, so a regression fails the release before upload.
- Both `.test.sh` suites updated (root assertion + `./`-rooted failure case); run locally, both pass. Note: the `.test.sh` suites are not wired into CI.

## Ship note
Stable `latest.json` still points at the corrupting `0.27.2` tarball; versioned R2 artifacts are immutable-cached (`max-age=31536000`), so the remediation is tagging a new release (v0.27.3) after this merges — not overwriting `0.27.2`.

Recovery for affected users: the auto-update actually delivers a complete valid bundle one level deep — promote `/Applications/nixmac.app/nixmac.app` to `/Applications/nixmac.app` (or reinstall from DMG).