### PR TITLE
Fix `desktop:build` would cause full (non incremental) rebuilds

### DIFF
--- a/apps/native/scripts/build-tauri-sidecars.mjs
+++ b/apps/native/scripts/build-tauri-sidecars.mjs
@@ -1,5 +1,5 @@
 import { execa } from "execa";
-import { copyFile, mkdir } from "node:fs/promises";
+import { copyFile, mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,6 +7,19 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const manifestPath = path.join(root, "src-tauri", "Cargo.toml");
 const binariesDir = path.join(root, "src-tauri", "binaries");
 const bins = ["nixmac-helper", "nixmac-sync-agent"];
+
+// `tauri build` compiles with MACOSX_DEPLOYMENT_TARGET set to the bundle's
+// minimumSystemVersion. This cargo invocation must use the same value, or the
+// two builds keep flipping the variable and invalidate the entire dependency
+// graph on every run (ring, cc-built C deps, and everything above them).
+const tauriConf = JSON.parse(
+  await readFile(path.join(root, "src-tauri", "tauri.conf.json"), "utf8"),
+);
+const minimumSystemVersion = tauriConf.bundle?.macOS?.minimumSystemVersion;
+const cargoEnv =
+  process.platform === "darwin" && minimumSystemVersion
+    ? { MACOSX_DEPLOYMENT_TARGET: minimumSystemVersion }
+    : {};
 
 const targetTriple = await rustTargetTriple();
 const { stdout: metadataJson } = await execa("cargo", [
@@ -22,7 +35,7 @@ const targetDir = metadata.target_directory;
 await execa(
   "cargo",
   ["build", "--manifest-path", manifestPath, "--release", ...bins.flatMap((bin) => ["--bin", bin])],
-  { stdio: "inherit" },
+  { stdio: "inherit", env: cargoEnv },
 );
 
 await mkdir(binariesDir, { recursive: true });


### PR DESCRIPTION
## Summary

When building via `bun desktop:build` it would rebuild the whole Rust universe every single time.

The problme is that the sidecar cargo build inherited MACOSX_DEPLOYMENT_TARGET from the devenv shell (14.0 via apple-sdk_15), while tauri build sets it to bundle.macOS.minimumSystemVersion (10.13). Every desktop:build run flipped the variable twice, and crates whose build scripts track it (ring, all cc-built C deps) invalidated the entire dependency graph both times.

Pin the sidecar build to the same value, read from tauri.conf.json so the two invocations cannot drift apart.

## Test Plan

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [ ] No docs update needed
