### PR TITLE
fix(template): fix(template): pin recommended template inputs

### DIFF
--- a/apps/native/templates/nix-darwin-determinate/flake.nix
+++ b/apps/native/templates/nix-darwin-determinate/flake.nix
@@ -1,10 +1,12 @@
 {
-  # Result of `nix flake init -t nix-darwin/master` command as documented in nix-darwin setup.
+  # Result of `nix flake init -t nix-darwin/master` command as documented in nix-darwin setup,
+  # with inputs pinned to the matched stable release pair: a fresh install must not depend
+  # on nixpkgs-unstable and nix-darwin master happening to be compatible on install day.
   description = "Example nix-darwin system flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nix-darwin.url = "github:nix-darwin/nix-darwin/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    nix-darwin.url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     sops-nix = {


### PR DESCRIPTION
## Summary

Pins the inputs in the recommended template, to avoid dependency failure. 
During step 7 of the setup, I ran into build failure after selecting the default template.

Same issue was fixed by adding this to the flake manually. 

```
documentation.enable = false;
system.tools.darwin-uninstaller.enable = false; 
```

## Test Plan

Could use more testing. 

What I did to produce the bug: 

- pull latest tahoe base from tart
- clone and run the vm
- install nixmac from nixmac.com
- follow instructions to install nix determinate 
- select default template 
- step 7 failed 

What I did to test this fix: 

- clone the same vm
- copy the `templates/nix-darwin-determinate` into `etc/nix-darwin`
- git init and commit
- install nixmac from nixmac.com
- follow instructions to install nix determinate 
- select existing repo from file `etc/nix-darwin`
- otherwise followed same instuctions
- step 7 succeeded 

**note**: after selecting the repo folder manually, the host detection was a bit slow, could probably rescan on input

## Docs

- [X] No docs update needed
