### PR TITLE
chore: comment out noisy `completion_log` info log by default

### DIFF
--- a/apps/native/src-tauri/src/state/completion_log.rs
+++ b/apps/native/src-tauri/src/state/completion_log.rs
@@ -89,7 +89,8 @@ pub async fn append_event_jsonl<T: Serialize>(
     // Mirror the JSONL line to stderr so it appears in the console alongside
     // other `tracing` output. Gated by the same `NIXMAC_RECORD_COMPLETIONS`
     // flag as the file write — no extra env var needed.
-    info!("[completion_log] {line}");
+    // This swamps other output and therefore is commented out by default, but can be uncommented for debugging.
+    //info!("[completion_log] {line}");
 
     let path = log_path_for_today(prefix);
     // Build the complete line buffer before entering spawn_blocking.


### PR DESCRIPTION
## Summary

@czxtm I noticed this was recently added...but it really swamps the Process Explorer logs when developing and makes it hard to track possibly-more-important things like the tool calls. So I'd like to comment it out by default. Let me know what you think, thanks!

<!-- What does this PR do? Why? -->

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed