### PR TITLE
Fix import finalization hardening

### DIFF
--- a/apps/native/src-tauri/src/bootstrap/import.rs
+++ b/apps/native/src-tauri/src/bootstrap/import.rs
@@ -72,33 +72,55 @@ fn is_github_clone_url(clone_url: &str) -> bool {
 /// Parses one of our repository locator forms into an owner/repo pair, stripping any `.git` suffix and optional `github.com/` prefix.
 /// This is used to populate the `owner` and `repo` fields of `RepoRef`, which are actually only necessary for the GitHub App token retrieval logic.
 fn owner_and_repo(locator: &str) -> Result<(String, String)> {
-    let path = if ["https://", "http://", "ssh://"]
+    let (path, require_exact_github_path) = if ["https://", "http://", "ssh://"]
         .iter()
         .any(|scheme| locator.starts_with(scheme))
     {
         let url = url::Url::parse(locator)
             .with_context(|| format!("Invalid repository URL: '{}'", locator))?;
-        url.path().trim_matches('/').to_string()
+        let require_exact = url
+            .host_str()
+            .map(|host| {
+                let host = host.to_ascii_lowercase();
+                host == "github.com" || host == "www.github.com"
+            })
+            .unwrap_or(false);
+        (url.path().trim_matches('/').to_string(), require_exact)
     } else if let Some((_, path)) = locator
         .split_once(':')
         .filter(|_| locator.starts_with("git@"))
     {
-        path.trim_matches('/').to_string()
+        (
+            path.trim_matches('/').to_string(),
+            locator.starts_with("git@github.com:"),
+        )
     } else {
-        locator
+        let github_host_prefixed =
+            locator.starts_with("github.com/") || locator.starts_with("www.github.com/");
+        let path = locator
             .strip_prefix("github.com/")
             .or_else(|| locator.strip_prefix("www.github.com/"))
             .unwrap_or(locator)
             .trim_matches('/')
-            .to_string()
+            .to_string();
+        (path, github_host_prefixed)
     };
 
-    let mut parts = path.rsplit('/');
-    let repo = parts
-        .next()
-        .map(|repo| repo.strip_suffix(".git").unwrap_or(repo))
-        .unwrap_or_default();
-    let owner = parts.next().unwrap_or_default();
+    let (owner, repo) = if require_exact_github_path {
+        let mut parts = path.split('/');
+        let (Some(owner), Some(repo), None) = (parts.next(), parts.next(), parts.next()) else {
+            bail!("Expected a repository reference like 'owner/repo'");
+        };
+        (owner, repo.strip_suffix(".git").unwrap_or(repo))
+    } else {
+        let mut parts = path.rsplit('/');
+        let repo = parts
+            .next()
+            .map(|repo| repo.strip_suffix(".git").unwrap_or(repo))
+            .unwrap_or_default();
+        let owner = parts.next().unwrap_or_default();
+        (owner, repo)
+    };
 
     if !is_valid_segment(owner) || !is_valid_segment(repo) {
         bail!("Expected a repository reference like 'owner/repo'");
@@ -817,6 +839,18 @@ mod tests {
         assert_eq!(r.subdir.as_deref(), Some("mac"));
         assert_eq!(r.owner, "czxtm");
         assert_eq!(r.repo, "darwin");
+    }
+
+    #[test]
+    fn rejects_github_urls_with_extra_path_segments() {
+        for input in [
+            "https://github.com/czxtm/darwin/tree/main",
+            "https://github.com/czxtm/darwin/tree/main?dir=hosts/work",
+            "git@github.com:czxtm/darwin/tree/main.git",
+            "github.com/czxtm/darwin/tree/main",
+        ] {
+            assert!(parse_repo_ref(input).is_err(), "accepted {input}");
+        }
     }
 
     #[test]

--- a/apps/native/src-tauri/src/storage/canonical_config.rs
+++ b/apps/native/src-tauri/src/storage/canonical_config.rs
@@ -132,9 +132,9 @@ fn directory_has_entries(path: &Path) -> Result<bool, String> {
 
 fn ensure_canonical_directory_owned() -> Result<(), String> {
     let user = whoami::username().map_err(|e| format!("Failed to resolve username: {e}"))?;
-    let script = format!(
-        "set -e\nmkdir -p '{CANONICAL_CONFIG_DIR}'\nchown -R '{user}' '{CANONICAL_CONFIG_DIR}'"
-    );
+    let canonical_dir = shell_literal(CANONICAL_CONFIG_DIR);
+    let owner = shell_literal(&user);
+    let script = format!("set -e\nmkdir -p {canonical_dir}\nchown -R {owner} {canonical_dir}");
     run_privileged_shell(&script)
 }
 
@@ -142,13 +142,23 @@ fn ensure_symlink_to(target: &Path) -> Result<(), String> {
     let target = target
         .to_str()
         .ok_or_else(|| "Configuration directory path is not valid UTF-8".to_string())?;
-    let script = format!(
-        "set -e\nTARGET='{target}'\nLINK='{CANONICAL_CONFIG_DIR}'\n\
+    let script = symlink_script(target, CANONICAL_CONFIG_DIR);
+    run_privileged_shell(&script)
+}
+
+fn symlink_script(target: &str, link: &str) -> String {
+    let target = shell_literal(target);
+    let link = shell_literal(link);
+    format!(
+        "set -e\nTARGET={target}\nLINK={link}\n\
          if [ -L \"$LINK\" ] && [ \"$(readlink \"$LINK\")\" = \"$TARGET\" ]; then exit 0; fi\n\
          if [ -e \"$LINK\" ] && [ ! -L \"$LINK\" ]; then rm -rf \"$LINK\"; fi\n\
          ln -sfn \"$TARGET\" \"$LINK\""
-    );
-    run_privileged_shell(&script)
+    )
+}
+
+fn shell_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn run_privileged_shell(script: &str) -> Result<(), String> {
@@ -214,5 +224,34 @@ mod tests {
         std::os::unix::fs::symlink(&target, &link).expect("create symlink");
 
         assert!(symlink_points_to(&link, &target).expect("check symlink"));
+    }
+
+    #[test]
+    fn symlink_script_treats_shell_metacharacters_as_path_data() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let injected_marker = temp.path().join("injected");
+        let target = format!(
+            "{}/'; touch {}; echo '",
+            temp.path().display(),
+            injected_marker.display()
+        );
+        let link = temp.path().join("nix-darwin");
+
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(symlink_script(&target, link.to_str().expect("utf-8 link")))
+            .output()
+            .expect("run symlink script");
+
+        assert!(
+            output.status.success(),
+            "script failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!injected_marker.exists());
+        assert_eq!(
+            fs::read_link(link).expect("read symlink"),
+            PathBuf::from(target)
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Shell-quotes path and user data before invoking the privileged `/etc/nix-darwin` setup script.
- Rejects ambiguous GitHub URL/path forms with extra path segments before GitHub App token minting, so imports cannot silently clone the wrong repository.
- Split out from #490 for focused review.

## Reproduction / verification steps

### Privileged `/etc/nix-darwin` symlink shell injection

Regression being verified: a repo path containing shell metacharacters must be treated as path data, not executed inside the administrator script.

```bash
cargo +stable test --manifest-path apps/native/src-tauri/Cargo.toml symlink_script_treats_shell_metacharacters_as_path_data
```

Expected result: the test passes. It executes the generated shell script with a target path containing `'; touch <marker>; echo '` and verifies the marker file is not created while the symlink target remains the exact malicious-looking path string.

Manual macOS check, if desired:

1. Pick/import a config directory whose path contains shell metacharacters, for example a directory name containing `' ; touch /tmp/nixmac-injected ; echo '`.
2. Complete import/apply so the app configures `/etc/nix-darwin`.
3. Verify `/tmp/nixmac-injected` was not created.
4. Verify `/etc/nix-darwin` points at the selected config directory.

### Ambiguous GitHub URL/path import forms

Regression being verified: GitHub locators with extra path segments such as `/tree/main` are rejected instead of being reduced to the wrong `owner/repo` for GitHub App token minting.

```bash
cargo +stable test --manifest-path apps/native/src-tauri/Cargo.toml rejects_github_urls_with_extra_path_segments
```

Expected result: the test passes. It rejects all of these forms:

- `https://github.com/czxtm/darwin/tree/main`
- `https://github.com/czxtm/darwin/tree/main?dir=hosts/work`
- `git@github.com:czxtm/darwin/tree/main.git`
- `github.com/czxtm/darwin/tree/main`

Manual app check, if desired:

1. Start onboarding import from GitHub.
2. Enter `https://github.com/czxtm/darwin/tree/main`.
3. Expected: import validation fails instead of cloning `czxtm/darwin` silently.
4. Enter a supported equivalent such as `czxtm/darwin?ref=main&dir=hosts/work` when a branch/subdirectory is intended.

## Test Plan

- [x] `cargo +stable test --manifest-path apps/native/src-tauri/Cargo.toml symlink_script_treats_shell_metacharacters_as_path_data`
- [x] `cargo +stable test --manifest-path apps/native/src-tauri/Cargo.toml rejects_github_urls_with_extra_path_segments`

## Docs

- [x] No docs update needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db43c2a7-3109-44b0-bc98-f5605c93c635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db43c2a7-3109-44b0-bc98-f5605c93c635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

