### PR TITLE
Fix CLI inference onboarding readiness

### DIFF
--- a/apps/native/src/components/widget/onboarding/lib/inference.ts
+++ b/apps/native/src/components/widget/onboarding/lib/inference.ts
@@ -15,6 +15,16 @@ interface ApiKeyProviderLike {
 	};
 }
 
+interface InferenceProvider {
+	id: string;
+	name: string;
+	defaultModel: string;
+	prefsKeyField: "openrouterApiKey" | "openaiApiKey";
+	keyPrefix: string;
+	keyPlaceholder: string;
+	docsHint: string;
+}
+
 /**
  * Bring-your-own-key providers, aligned to what the native backend actually
  * supports (OpenRouter + OpenAI direct). Keys persist to UiPrefs and the

--- a/apps/native/src/components/widget/onboarding/onboarding-step-content.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-step-content.tsx
@@ -7,6 +7,7 @@ import { NixSetupStep } from "@/components/widget/onboarding/steps/nix-setup-ste
 import { PermissionsStep } from "@/components/widget/onboarding/steps/permissions-step";
 import { SetupStep } from "@/components/widget/onboarding/steps/setup-step";
 import { useOnboardingProgress } from "@/hooks/use-onboarding-progress";
+import { isInferenceConfigured } from "@/lib/providers/ai-models";
 import { onboardingActions, useOnboarding, useViewModel } from "@nixmac/state";
 
 interface OnboardingStepContentProps {
@@ -22,7 +23,7 @@ export function OnboardingStepContent({ currentStep, title }: OnboardingStepCont
   // separately. The build step only needs to know inference is configured.
   const evolveProvider = useViewModel((s) => s.preferences?.evolveProvider ?? null);
   const evolveModel = useViewModel((s) => s.preferences?.evolveModel ?? null);
-  const hasInference = Boolean(evolveProvider) && Boolean(evolveModel);
+  const hasInference = isInferenceConfigured(evolveProvider, evolveModel);
   const { markMacScanned, markLoginDecided } = useOnboardingProgress();
 
   return (

--- a/apps/native/src/components/widget/onboarding/use-onboarding-flow.ts
+++ b/apps/native/src/components/widget/onboarding/use-onboarding-flow.ts
@@ -6,6 +6,7 @@ import {
   type StepId,
 } from "@/components/widget/onboarding/lib/onboarding";
 import { settings } from "@/lib/env";
+import { isInferenceConfigured } from "@/lib/providers/ai-models";
 import { onboardingActions, useOnboarding, useViewModel } from "@nixmac/state";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
@@ -54,7 +55,7 @@ export function useOnboardingFlow(): {
         flakeReady,
         macScanned: macScannedAt !== null,
         loginDecided,
-        hasInference: Boolean(evolveProvider) && Boolean(evolveModel),
+        hasInference: isInferenceConfigured(evolveProvider, evolveModel),
         buildComplete: lastBuildAt !== null,
         inferenceDeferred,
       }),

--- a/apps/native/src/components/widget/settings/ai-models-tab.tsx
+++ b/apps/native/src/components/widget/settings/ai-models-tab.tsx
@@ -31,12 +31,6 @@ interface AiModelsTabProps {
   form: ReactFormExtendedApi<any, any, any, any, any, any, any, any, any, any, any, any>;
 }
 
-const CLI_PROVIDERS = [
-  { value: "claude", label: "Claude CLI" },
-  { value: "codex", label: "Codex CLI" },
-  { value: "opencode", label: "OpenCode CLI" },
-] as const;
-
 function isPlainInputCliProvider(provider: string): boolean {
   return provider === "claude" || provider === "codex";
 }

--- a/apps/native/src/lib/providers/ai-models.test.ts
+++ b/apps/native/src/lib/providers/ai-models.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { isInferenceConfigured } from "./ai-models";
+
+describe("isInferenceConfigured", () => {
+	it("treats CLI providers as configured without an explicit model", () => {
+		expect(isInferenceConfigured("claude", "")).toBe(true);
+		expect(isInferenceConfigured("codex", null)).toBe(true);
+		expect(isInferenceConfigured("opencode", undefined)).toBe(true);
+	});
+
+	it("requires a non-empty model for non-CLI providers", () => {
+		expect(isInferenceConfigured("openrouter", "")).toBe(false);
+		expect(isInferenceConfigured("openai", "gpt-4o")).toBe(true);
+	});
+});

--- a/apps/native/src/lib/providers/ai-models.ts
+++ b/apps/native/src/lib/providers/ai-models.ts
@@ -154,6 +154,17 @@ export function getAiModelProvider(id: string): AiModelProvider {
 	);
 }
 
+export function isInferenceConfigured(
+	providerId: string | null | undefined,
+	model: string | null | undefined,
+): boolean {
+	if (!providerId) return false;
+	const provider = AI_MODEL_PROVIDERS.find((candidate) => candidate.id === providerId);
+	if (!provider) return false;
+	if (provider.setup.kind === "cli") return true;
+	return Boolean(model?.trim());
+}
+
 export function isPlainInputCliProvider(provider: string): boolean {
 	const setup = getAiModelProvider(provider).setup;
 	return setup.kind === "cli" && setup.plainModelInput;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Aligns frontend onboarding readiness with backend CLI provider defaults.
- Treats Claude, Codex, and OpenCode as configured even when the explicit model field is empty.
- Keeps non-CLI providers requiring a non-empty model.
- Includes the TypeScript build fixups needed for this split to stand alone.
- Split out from #490 for focused review.

## Reproduction / verification steps

Regression being verified: Claude, Codex, and OpenCode are CLI-backed providers whose backend defaults allow an empty model, so onboarding readiness should not block on an explicit model for those providers.

```bash
cd apps/native
bun run test:unit src/lib/providers/ai-models.test.ts
```

Expected result: the test passes. It verifies:

- `claude` + empty string is configured.
- `codex` + `null` is configured.
- `opencode` + `undefined` is configured.
- Non-CLI providers still require a non-empty model.

Manual app check, if desired:

1. Start onboarding.
2. Choose Claude, Codex, or OpenCode as the inference provider.
3. Leave the model field empty.
4. Expected: onboarding can proceed once the provider-specific non-model requirements are satisfied.
5. Switch to a non-CLI provider such as OpenAI/OpenRouter and leave model empty.
6. Expected: onboarding still requires a model for that provider.

Broader TypeScript check:

```bash
cd apps/native
bun run build
```

## Test Plan

- [x] `cd apps/native && bun run test:unit src/lib/providers/ai-models.test.ts`
- [x] `cd apps/native && bun run build`

## Docs

- [x] No docs update needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db43c2a7-3109-44b0-bc98-f5605c93c635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db43c2a7-3109-44b0-bc98-f5605c93c635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

