### PR TITLE
Fix Storybook model cache mocks

### DIFF
--- a/apps/native/.storybook/mocks/tauri-runtime.ts
+++ b/apps/native/.storybook/mocks/tauri-runtime.ts
@@ -253,7 +253,7 @@ export const orpcHandlers: Record<string, OrpcHandler> = {
   "git.state": async () => {
     const { viewModelActions } = await import("@nixmac/state");
     const vm = viewModelActions.getState();
-    return baseGitState(vm.git, vm.build?.externalBuildDetected ?? false);
+    return baseGitState(vm.git ?? baseGitStatus(), vm.build?.externalBuildDetected ?? false);
   },
   "git.status": async () => {
     const { viewModelActions } = await import("@nixmac/state");
@@ -340,6 +340,25 @@ export const orpcHandlers: Record<string, OrpcHandler> = {
   ],
   "billing.checkout": async () => ({ url: "https://polar.sh/demo-checkout" }),
   "billing.portal": async () => ({ url: "https://polar.sh/demo-portal" }),
+  "models.getCached": async (input) => {
+    const provider = (input as { provider?: string } | undefined)?.provider;
+    return provider ? (cachedModels.get(provider) ?? null) : null;
+  },
+  "models.setCached": async (input) => {
+    const { provider, models } =
+      (input as { provider?: string; models?: string[] } | undefined) ?? {};
+    if (provider) {
+      cachedModels.set(provider, [...(models ?? [])]);
+    }
+    return okResult();
+  },
+  "models.clearCached": async (input) => {
+    const provider = (input as { provider?: string } | undefined)?.provider;
+    if (provider) {
+      cachedModels.delete(provider);
+    }
+    return okResult();
+  },
   "preferences.get": async () => {
     const { viewModelActions } = await import("@nixmac/state");
     return viewModelActions.getState().preferences;

--- a/apps/native/src/storybook-tauri-runtime.test.ts
+++ b/apps/native/src/storybook-tauri-runtime.test.ts
@@ -29,4 +29,15 @@ describe("Storybook Tauri oRPC mocks", () => {
       },
     });
   });
+
+  it("handles model cache oRPC calls used by provider selectors", async () => {
+    await orpcHandlers["models.setCached"]?.({
+      provider: "claude",
+      models: ["sonnet"],
+    });
+
+    expect(await orpcHandlers["models.getCached"]?.({ provider: "claude" })).toEqual(["sonnet"]);
+    expect(await orpcHandlers["models.clearCached"]?.({ provider: "claude" })).toEqual({ ok: true });
+    expect(await orpcHandlers["models.getCached"]?.({ provider: "claude" })).toBeNull();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds Storybook Tauri runtime oRPC mocks for model-cache calls used by provider selectors.
- Covers `models.setCached`, `models.getCached`, and `models.clearCached`.
- Split out from #490 for focused review.

## Reproduction / verification steps

Regression being verified: provider selectors can call the Storybook model-cache oRPC mock methods used by the app.

```bash
cd apps/native
bun run test:unit src/storybook-tauri-runtime.test.ts
```

Expected result: the test passes and covers `models.setCached`, `models.getCached`, and `models.clearCached` in the Storybook Tauri runtime mock.

Manual Storybook check, if desired:

1. Start Storybook with `cd apps/native && bun run storybook`.
2. Open a story containing provider/model selectors.
3. Select a CLI/provider model option that causes model-cache calls.
4. Expected: the story remains interactive; no missing `models.*Cached` oRPC handler error is thrown in the browser console.

## Test Plan

- [x] `cd apps/native && bun run test:unit src/storybook-tauri-runtime.test.ts`

## Docs

- [x] No docs update needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db43c2a7-3109-44b0-bc98-f5605c93c635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db43c2a7-3109-44b0-bc98-f5605c93c635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

