### PR TITLE
Fix blank screen after onboarding + flicker on start

### DIFF
--- a/apps/native/src/components/widget/utils.ts
+++ b/apps/native/src/components/widget/utils.ts
@@ -41,7 +41,7 @@ export function computeCurrentStep(state: CurrentStepState): WidgetStep {
   }
 
   if (
-    (state.nixInstalled !== true || state.darwinRebuildAvailable !== true) &&
+    state.nixInstalled !== true &&
     settings.nixInstalledOverride !== true // bypass used for testing
   ) {
     return "nix-setup";

--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -167,6 +167,13 @@ export function DarwinWidget() {
 
       case "filesystem":
         return <FilesystemStep />;
+
+      // Defensive fallback: permissions/nix-setup/setup are owned by
+      // OnboardingFlow, which takes over the window via showOnboarding when
+      // those gates are unsatisfied. If a gate mismatch ever routes here
+      // anyway, fall back to the prompt step instead of rendering nothing.
+      default:
+        return <BeginStep />;
     }
   };
 

--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -30,10 +30,10 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { useTrayEvents } from "@/hooks/use-tray-events";
 import { markBootRenderStage, markBootStage } from "@/lib/boot-diagnostics";
 import { useEvolveMascot } from "@/hooks/use-evolve-mascot";
-import { useUiState } from "@nixmac/state";
+import { useUiState, useViewModel } from "@nixmac/state";
 import { useCurrentStep } from "@/hooks/use-current-step";
 import { UpdateBanner } from "@/components/widget/layout/update-banner";
-import { startViewModelSync } from "@/viewmodel";
+import { markViewModelHydrated, startViewModelSync } from "@/viewmodel";
 import { setupErrorTestHelpers } from "@/utils/error-test-helpers";
 import { setupWidgetTestHelpers } from "@/utils/widget-test-helpers";
 import { useEffect } from "react";
@@ -128,6 +128,13 @@ export function DarwinWidget() {
         uiActions.setError((e as Error)?.message || String(e));
       }
 
+      // Mark hydration complete only after the explicit probes (nix check,
+      // permissions, git status) have written their real values. The nix
+      // install cell is NOT persisted — it defaults to null on every launch —
+      // so flipping `hydrated` before checkNix runs would let the onboarding
+      // gate see a stale null and flash OnboardingFlow for a frame.
+      markViewModelHydrated();
+
       if (cancelled) return;
       surfaceRecoveryReport();
     })();
@@ -144,6 +151,15 @@ export function DarwinWidget() {
   // preferences) by useOnboardingFlow, so a finished user never re-enters it
   // across restarts.
   const { showFlow: showOnboarding } = useOnboardingFlow();
+  // Suppress the boot flash: before the ViewModel hydrates, every gate input
+  // is a default (null preferences/nixInstall), so both OnboardingFlow and the
+  // main widget would render against stale state for a frame. Hold a neutral
+  // container until hydration completes, then render the correct path directly.
+  const hydrated = useViewModel((s) => s.hydrated);
+
+  if (!hydrated) {
+    return <div className="flex h-full w-full flex-col bg-background/60" />;
+  }
 
   // Routing mechanism
   const getActiveStepComponent = () => {

--- a/apps/native/src/viewmodel/index.ts
+++ b/apps/native/src/viewmodel/index.ts
@@ -19,6 +19,17 @@ import { startPermissionsSync } from "./permissions";
 import { startPreferencesSync } from "./preferences";
 import { startPromptHistorySync } from "./prompt-history";
 import { startRebuildSync } from "./rebuild";
+import { viewModelActions } from "@nixmac/state";
+
+/**
+ * Mark the initial hydration pass complete. Called by the app mount effect
+ * after `startViewModelSync` AND the explicit probes (nix check, permissions,
+ * git status) have written their real values, so non-persisted slices are
+ * loaded before any gate reads them.
+ */
+export function markViewModelHydrated(): void {
+  viewModelActions.setState({ hydrated: true });
+}
 
 export async function startViewModelSync(): Promise<() => void> {
   const unlisteners: Array<() => void> = [];

--- a/packages/state/src/viewmodel/store.ts
+++ b/packages/state/src/viewmodel/store.ts
@@ -27,6 +27,7 @@ export const initialViewModelState: ViewModelState = {
   hosts: [],
   permissions: null,
   permissionsHydrated: false,
+  hydrated: false,
   promptHistory: [],
   nixInstall: null,
   rebuildStatus: null,

--- a/packages/state/src/viewmodel/types.ts
+++ b/packages/state/src/viewmodel/types.ts
@@ -38,6 +38,8 @@ export type ViewModelState = {
   permissions: PermissionsState | null;
   /** True once the permissions slice has hydrated (even to null). */
   permissionsHydrated: boolean;
+  /** True once the initial viewmodel hydration pass completes. */
+  hydrated: boolean;
   promptHistory: string[];
   /** Mirrored nix / darwin-rebuild installation status; null until hydrated. */
   nixInstall: NixInstallState | null;


### PR DESCRIPTION
## Summary

This addresses two main issues:

- The more serious one: I would not get to the `Begin` screen at all, I would just see the onboarding and begin step flash before getting to a completely blank page (see screenshot).

- Even after addressing that, the screen would flicker the onboarding process before actually showing the first screen.

<img width="803" height="810" alt="Screenshot 2026-07-06 at 21 04 15" src="https://github.com/user-attachments/assets/7379ef56-df90-4cc0-a354-78085bad7d39" />



## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
