### PR TITLE
feat: gate feedback dialog behind `isAvailable` check, show sign-in alert if unavailable

### DIFF
--- a/apps/native/src-tauri/src/commands/feedback.rs
+++ b/apps/native/src-tauri/src/commands/feedback.rs
@@ -18,3 +18,9 @@ pub async fn feedback_submit(app: AppHandle, payload: String) -> Result<bool, St
         .await
         .map_err(|e| capture_err("feedback_submit", e))
 }
+
+/// Checks to see if the feedback system is set up correctly.
+#[tauri::command]
+pub async fn feedback_is_available(app: AppHandle) -> Result<bool, String> {
+    Ok(feedback::is_available(&app))
+}

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -706,6 +706,14 @@ pub async fn retry_pending(app: &AppHandle) -> Result<usize> {
 // Main Entry Point
 // =============================================================================
 
+/// Check if feedback submission is available (configured and signed in).
+/// We'll reuse the feedback_destination function and if it does not return an
+/// error AND the destination is Some, then feedback is available.
+pub fn is_available(app: &AppHandle) -> bool {
+    let dest = feedback_destination(app);
+    dest.is_ok() && dest.unwrap().is_some()
+}
+
 /// Master function to gather all requested feedback metadata
 pub fn gather_metadata(
     app: &AppHandle,

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -565,6 +565,7 @@ fn run_gui_mode(
             // Feedback
             commands::feedback::feedback_gather_metadata,
             commands::feedback::feedback_submit,
+            commands::feedback::feedback_is_available,
             #[cfg(debug_assertions)]
             commands::debug::trigger_test_panic,
             commands::debug::developer_clear_tauri_state,

--- a/apps/native/src-tauri/src/orpc/feedback.rs
+++ b/apps/native/src-tauri/src/orpc/feedback.rs
@@ -28,12 +28,21 @@ async fn submit(ctx: OrpcCtx, payload: String) -> Result<bool, ORPCError> {
         .map_err(|e| internal_err("feedback.submit", e))
 }
 
+async fn is_available(ctx: OrpcCtx, _input: ()) -> Result<bool, ORPCError> {
+    cmd::feedback_is_available(ctx.app)
+        .await
+        .map_err(|e| internal_err("feedback.isAvailable", e))
+}
+
 pub fn routes() -> Router<OrpcCtx> {
     router! {
         "gatherMetadata" => os::<OrpcCtx>()
             .input(orpc_specta::specta::<GatherMetadataInput>())
             .output(orpc_specta::specta::<FeedbackMetadata>())
             .handler(gather_metadata),
+        "isAvailable" => os::<OrpcCtx>()
+            .output(orpc_specta::specta::<bool>())
+            .handler(is_available),
         "submit" => os::<OrpcCtx>()
             .input(orpc_specta::specta::<String>())
             .output(orpc_specta::specta::<bool>())

--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -3,6 +3,15 @@ import { useEffect, useState } from "react";
 import { uiActions, useUiState } from "@nixmac/state";
 import { useCurrentStep } from "@/hooks/use-current-step";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -26,7 +35,7 @@ import {
 import { Lightbulb, Bug, MessageCircle, Info, Loader2 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Feedback as FeedbackModel, FeedbackType, ShareOptions } from "@/types/feedback";
-import { tauriAPI } from "@/ipc/api";
+import { client } from "@/lib/orpc";
 import { toast } from "sonner";
 import { getTelemetry } from "@/lib/telemetry/instance";
 
@@ -276,12 +285,14 @@ function shouldShowAppLogs(
 
 export function FeedbackDialog() {
   const feedbackOpen = useUiState((s) => s.feedbackOpen);
-    const feedbackTypeOverride = useUiState((s) => s.feedbackTypeOverride);
+  const feedbackTypeOverride = useUiState((s) => s.feedbackTypeOverride);
   const feedbackInitialText = useUiState((s) => s.feedbackInitialText);
   const panicDetails = useUiState((s) => s.panicDetails);
-    const step = useCurrentStep();
+  const step = useCurrentStep();
   const mainWindowError = useUiState((s) => s.error) ?? undefined;
 
+  const [feedbackAvailable, setFeedbackAvailable] = useState(false);
+  const [signInAlertOpen, setSignInAlertOpen] = useState(false);
   const [feedbackType, setFeedbackType] = useState<FeedbackType>(FeedbackType.Suggestion);
   const [feedbackText, setFeedbackText] = useState("");
   const [expectedText, setExpectedText] = useState("");
@@ -293,13 +304,57 @@ export function FeedbackDialog() {
   const [previewReportText, setPreviewReportText] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
+  const resetFeedbackState = () => {
+    setFeedbackAvailable(false);
+    setFeedbackType(FeedbackType.Suggestion);
+    setFeedbackText("");
+    setExpectedText("");
+    setEmail("");
+    setRelatedPrompt("");
+    setShareOptions(DEFAULT_SHARE_OPTIONS);
+    setIsPreviewingReport(false);
+    setPreviewReportText("");
+    uiActions.setFeedbackTypeOverride(null);
+    uiActions.setState({ feedbackInitialText: null, panicDetails: null });
+  };
+
+  const cancelOpenForSignIn = () => {
+    uiActions.setFeedbackOpen(false);
+    resetFeedbackState();
+    setSignInAlertOpen(true);
+  };
+
   useEffect(() => {
     if (!feedbackOpen) {
+      setFeedbackAvailable(false);
       return;
     }
 
-    // deprecated(orpc): replace with client/orpc from @/lib/orpc
-    tauriAPI.promptHistory.get().then(setPromptHistory).catch(console.error);
+    let cancelled = false;
+
+    client.feedback
+      .isAvailable()
+      .then((available) => {
+        if (cancelled) return;
+
+        if (!available) {
+          cancelOpenForSignIn();
+          return;
+        }
+
+        setFeedbackAvailable(true);
+        client.promptHistory.get().then(setPromptHistory).catch(console.error);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+
+        console.error(err);
+        cancelOpenForSignIn();
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [feedbackOpen]);
 
   useEffect(() => {
@@ -344,24 +399,15 @@ export function FeedbackDialog() {
 
   const handleClose = () => {
     uiActions.setFeedbackOpen(false);
-    // Reset state
-    setFeedbackType(FeedbackType.Suggestion);
-    setFeedbackText("");
-    setExpectedText("");
-    setEmail("");
-    setRelatedPrompt("");
-    setShareOptions(DEFAULT_SHARE_OPTIONS);
-    setIsPreviewingReport(false);
-    setPreviewReportText("");
-    uiActions.setFeedbackTypeOverride(null);
-    uiActions.setState({ feedbackInitialText: null, panicDetails: null });
+    resetFeedbackState();
   };
 
   const buildFeedbackPayload = async () => {
-    let metadata: Awaited<ReturnType<typeof tauriAPI.feedback.gatherMetadata>> | null = null;
+    let metadata: Awaited<ReturnType<typeof client.feedback.gatherMetadata>> | null = null;
     try {
-      // deprecated(orpc): replace with client/orpc from @/lib/orpc
-      metadata = await tauriAPI.feedback.gatherMetadata(feedbackType, shareOptions);
+      metadata = await client.feedback.gatherMetadata({
+        request: { feedbackType, share: shareOptions },
+      });
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn("Failed to gather feedback metadata:", err);
@@ -403,8 +449,7 @@ export function FeedbackDialog() {
   };
 
   const submitPayload = async (payload: string) => {
-    // deprecated(orpc): replace with client/orpc from @/lib/orpc
-    const sent = await tauriAPI.feedback.submit(payload);
+    const sent = await client.feedback.submit(payload);
 
     if (sent) {
       getTelemetry().captureEvent({ name: "feedback_submitted", props: { type: feedbackType } });
@@ -469,18 +514,34 @@ export function FeedbackDialog() {
   const dialogDescription = hasAutoFilledError
     ? "An error was detected. The details have been pre-filled below. Please review and submit to help us fix this issue."
     : "Help us make nixmac better";
+  const feedbackDialogOpen = feedbackOpen && feedbackAvailable;
 
   return (
-    <Dialog
-      open={feedbackOpen}
-      onOpenChange={(open: boolean) => {
-        if (!open) {
-          handleClose();
-          return;
-        }
-        uiActions.setFeedbackOpen(true);
-      }}
-    >
+    <>
+      <AlertDialog open={signInAlertOpen} onOpenChange={setSignInAlertOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Sign in to send feedback</AlertDialogTitle>
+            <AlertDialogDescription>
+              Sign in to your nixmac account before sending feedback.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog
+        open={feedbackDialogOpen}
+        onOpenChange={(open: boolean) => {
+          if (!open) {
+            handleClose();
+            return;
+          }
+          uiActions.setFeedbackOpen(true);
+        }}
+      >
       <DialogContent className="max-w-2xl h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className={hasAutoFilledError ? "flex items-center gap-2" : ""}>
@@ -985,6 +1046,7 @@ export function FeedbackDialog() {
           )}
         </DialogFooter>
       </DialogContent>
-    </Dialog>
+      </Dialog>
+    </>
   );
 }

--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -63,6 +63,8 @@ const ISSUE_SHARE_OPTIONS: ShareOptions = {
   appLogs: true,
 };
 
+type FeedbackAvailability = "idle" | "checking" | "available";
+
 // Visibility helper functions for share options checkboxes
 // Each function returns a boolean indicating whether the checkbox should be visible
 // Parameters: feedbackType, step, mainWindowError
@@ -286,15 +288,17 @@ function shouldShowAppLogs(
 export function FeedbackDialog() {
   const feedbackOpen = useUiState((s) => s.feedbackOpen);
   const feedbackTypeOverride = useUiState((s) => s.feedbackTypeOverride);
-  const feedbackInitialText = useUiState((s) => s.feedbackInitialText);
+  const pendingFeedbackInitialText = useUiState((s) => s.feedbackInitialText);
   const panicDetails = useUiState((s) => s.panicDetails);
   const step = useCurrentStep();
   const mainWindowError = useUiState((s) => s.error) ?? undefined;
 
-  const [feedbackAvailable, setFeedbackAvailable] = useState(false);
+  const [feedbackAvailability, setFeedbackAvailability] =
+    useState<FeedbackAvailability>("idle");
   const [signInAlertOpen, setSignInAlertOpen] = useState(false);
   const [feedbackType, setFeedbackType] = useState<FeedbackType>(FeedbackType.Suggestion);
   const [feedbackText, setFeedbackText] = useState("");
+  const [feedbackInitialText, setFeedbackInitialText] = useState<string | null>(null);
   const [expectedText, setExpectedText] = useState("");
   const [email, setEmail] = useState("");
   const [promptHistory, setPromptHistory] = useState<string[]>([]);
@@ -305,17 +309,21 @@ export function FeedbackDialog() {
   const [submitting, setSubmitting] = useState(false);
 
   const resetFeedbackState = () => {
-    setFeedbackAvailable(false);
+    setFeedbackAvailability("idle");
     setFeedbackType(FeedbackType.Suggestion);
     setFeedbackText("");
+    setFeedbackInitialText(null);
     setExpectedText("");
     setEmail("");
     setRelatedPrompt("");
     setShareOptions(DEFAULT_SHARE_OPTIONS);
     setIsPreviewingReport(false);
     setPreviewReportText("");
-    uiActions.setFeedbackTypeOverride(null);
-    uiActions.setState({ feedbackInitialText: null, panicDetails: null });
+    uiActions.setState({
+      feedbackTypeOverride: null,
+      feedbackInitialText: null,
+      panicDetails: null,
+    });
   };
 
   const cancelOpenForSignIn = () => {
@@ -326,11 +334,12 @@ export function FeedbackDialog() {
 
   useEffect(() => {
     if (!feedbackOpen) {
-      setFeedbackAvailable(false);
+      setFeedbackAvailability("idle");
       return;
     }
 
     let cancelled = false;
+    setFeedbackAvailability("checking");
 
     client.feedback
       .isAvailable()
@@ -342,7 +351,7 @@ export function FeedbackDialog() {
           return;
         }
 
-        setFeedbackAvailable(true);
+        setFeedbackAvailability("available");
         client.promptHistory.get().then(setPromptHistory).catch(console.error);
       })
       .catch((err) => {
@@ -358,27 +367,30 @@ export function FeedbackDialog() {
   }, [feedbackOpen]);
 
   useEffect(() => {
-    if (!feedbackOpen || !feedbackTypeOverride) {
+    if (!feedbackOpen || (!feedbackTypeOverride && !pendingFeedbackInitialText)) {
       return;
     }
 
-    setFeedbackType(feedbackTypeOverride);
-    if (
-      feedbackTypeOverride === FeedbackType.Issue ||
-      feedbackTypeOverride === FeedbackType.Error
-    ) {
-      setShareOptions(ISSUE_SHARE_OPTIONS);
-    }
-  }, [feedbackOpen, feedbackTypeOverride]);
-
-  // Pre-populate feedback text when opening with initial text (e.g., from panic)
-  useEffect(() => {
-    if (!feedbackOpen || !feedbackInitialText) {
-      return;
+    if (feedbackTypeOverride) {
+      setFeedbackType(feedbackTypeOverride);
+      if (
+        feedbackTypeOverride === FeedbackType.Issue ||
+        feedbackTypeOverride === FeedbackType.Error
+      ) {
+        setShareOptions(ISSUE_SHARE_OPTIONS);
+      }
     }
 
-    setFeedbackText(feedbackInitialText);
-  }, [feedbackOpen, feedbackInitialText]);
+    if (pendingFeedbackInitialText) {
+      setFeedbackText(pendingFeedbackInitialText);
+      setFeedbackInitialText(pendingFeedbackInitialText);
+    }
+
+    uiActions.setState({
+      feedbackTypeOverride: null,
+      feedbackInitialText: null,
+    });
+  }, [feedbackOpen, feedbackTypeOverride, pendingFeedbackInitialText]);
 
   // When the user actively selects a feedback type, reset the evolutionLog
   // share option to the sensible default for that type. It's acceptable to
@@ -514,7 +526,8 @@ export function FeedbackDialog() {
   const dialogDescription = hasAutoFilledError
     ? "An error was detected. The details have been pre-filled below. Please review and submit to help us fix this issue."
     : "Help us make nixmac better";
-  const feedbackDialogOpen = feedbackOpen && feedbackAvailable;
+  const feedbackDialogOpen = feedbackOpen;
+  const checkingFeedbackAvailability = feedbackAvailability !== "available";
 
   return (
     <>
@@ -543,6 +556,20 @@ export function FeedbackDialog() {
         }}
       >
       <DialogContent className="max-w-2xl h-[85vh] flex flex-col">
+        {checkingFeedbackAvailability ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Checking feedback availability</DialogTitle>
+              <DialogDescription>
+                Verifying that feedback can be sent from this device.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-1 items-center justify-center">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          </>
+        ) : (
+          <>
         <DialogHeader>
           <DialogTitle className={hasAutoFilledError ? "flex items-center gap-2" : ""}>
             {hasAutoFilledError && <span className="text-red-500">⚠️</span>}
@@ -1045,6 +1072,8 @@ export function FeedbackDialog() {
             </>
           )}
         </DialogFooter>
+          </>
+        )}
       </DialogContent>
       </Dialog>
     </>

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -1874,6 +1874,7 @@ export type Procedures = {
   }
   feedback: {
     gatherMetadata: Client<Record<never, never>, GatherMetadataInput, FeedbackMetadata, Error>
+    isAvailable: Client<Record<never, never>, void, boolean, Error>
     submit: Client<Record<never, never>, string, boolean, Error>
   }
   flake: {


### PR DESCRIPTION
## Summary

The previous behavior was, you'd go to all the work to type your feedback and we'd error at the end. It seems like better UX to proactively warn you that we require you to be "signed in". Currently this will prevent the dialog from even opening up. @fkb032 if we want we can maybe just warn and collect the feedback for later sending (although I'm not very familiar with how that functionality works, it may have other issues).

<!-- What does this PR do? Why? -->

## ![Screenshot 2026-07-07 at 3.07.21 PM.png](https://app.graphite.com/user-attachments/assets/31de00e2-fd49-4ca7-b9c0-d53946064371.png)



## Test Plan

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed