### PR TITLE
feat: git upstream fetch/check logic for auto-update, wire into existing git watcher

### DIFF
--- a/apps/native/src-tauri/src/bootstrap/import.rs
+++ b/apps/native/src-tauri/src/bootstrap/import.rs
@@ -9,7 +9,6 @@
 //! had selected an existing flake.
 
 use anyhow::{Context, Result, anyhow, bail};
-use git2::{Cred, FetchOptions, RemoteCallbacks};
 use std::fs::File;
 use std::path::{Component, Path, PathBuf};
 use tauri::AppHandle;
@@ -17,6 +16,9 @@ use tauri::AppHandle;
 use crate::bootstrap::default_config::{detect_hostname, detect_username};
 use crate::bootstrap::detect_darwin_platform;
 use crate::bootstrap::template::apply_template_placeholders_in_dir;
+use crate::git::auth::{
+    authenticated_fetch_options, is_github_clone_url, sanitize_clone_url_for_logs,
+};
 
 /// A parsed GitHub/git reference ready to clone.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,40 +35,11 @@ pub struct RepoRef {
     pub repo: String,
 }
 
-/// Sanitize a clone URL for logging, removing any embedded credentials.
-fn sanitize_clone_url_for_logs(clone_url: &str) -> String {
-    if let Ok(mut url) = url::Url::parse(clone_url) {
-        let _ = url.set_username("");
-        let _ = url.set_password(None);
-        return url.to_string();
-    }
-
-    if let Some((_, rest)) = clone_url.split_once('@') {
-        if rest.contains(':') {
-            return format!("***@{}", rest);
-        }
-    }
-
-    clone_url.to_string()
-}
-
 fn is_valid_segment(segment: &str) -> bool {
     !segment.is_empty()
         && segment
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
-}
-
-/// Checks if the given clone URL is a GitHub URL, either in HTTPS or SSH form.
-fn is_github_clone_url(clone_url: &str) -> bool {
-    if clone_url.starts_with("git@github.com:") {
-        return true;
-    }
-
-    url::Url::parse(clone_url)
-        .ok()
-        .and_then(|url| url.host_str().map(|h| h.to_ascii_lowercase()))
-        .is_some_and(|host| host == "github.com" || host == "www.github.com")
 }
 
 /// Parses one of our repository locator forms into an owner/repo pair, stripping any `.git` suffix and optional `github.com/` prefix.
@@ -329,56 +302,7 @@ fn clone_repo(spec: &RepoRef, dest: &Path, token: Option<&str>) -> Result<()> {
         builder.branch(branch);
     }
 
-    let git_config = git2::Config::open_default().ok();
-    let mut token_attempted = false;
-    let mut ssh_agent_attempted = false;
-    let mut credential_helper_attempted = false;
-    let mut callbacks = RemoteCallbacks::new();
-    callbacks.credentials(move |url, username_from_url, allowed| {
-        if allowed.contains(git2::CredentialType::USERNAME)
-            && !allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT)
-            && !allowed.contains(git2::CredentialType::SSH_KEY)
-            && !allowed.contains(git2::CredentialType::DEFAULT)
-        {
-            return Cred::username(username_from_url.unwrap_or("git"));
-        }
-
-        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) && !token_attempted {
-            token_attempted = true;
-            if let Some(token) = token {
-                return Cred::userpass_plaintext("x-access-token", token);
-            }
-        }
-
-        if allowed.contains(git2::CredentialType::SSH_KEY) && !ssh_agent_attempted {
-            ssh_agent_attempted = true;
-            return Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"));
-        }
-
-        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT)
-            && !credential_helper_attempted
-        {
-            credential_helper_attempted = true;
-            if let Some(config) = &git_config {
-                if let Ok(credential) = Cred::credential_helper(config, url, username_from_url) {
-                    return Ok(credential);
-                }
-            }
-        }
-
-        if allowed.contains(git2::CredentialType::DEFAULT) {
-            return Cred::default();
-        }
-
-        Err(git2::Error::from_str(
-            "no supported authentication methods succeeded",
-        ))
-    });
-
-    let mut fetch_options = FetchOptions::new();
-    fetch_options.remote_callbacks(callbacks);
-
-    builder.fetch_options(fetch_options);
+    builder.fetch_options(authenticated_fetch_options(token.map(str::to_string)));
 
     if let Err(error) = builder.clone(&spec.clone_url, dest) {
         log::error!(
@@ -969,29 +893,5 @@ mod tests {
         assert!(txt.contains("HOSTNAME_PLACEHOLDER"));
         assert!(txt.contains("PLATFORM_PLACEHOLDER"));
         assert!(txt.contains("USERNAME_PLACEHOLDER"));
-    }
-
-    #[test]
-    fn test_sanitize_clone_url_for_logs() {
-        let url = "https://user:password@github.com/repo.git";
-        let sanitized = sanitize_clone_url_for_logs(url);
-        assert_eq!(sanitized, "https://github.com/repo.git");
-
-        // SSH
-        let url = "ssh://user:password@github.com/repo.git";
-        let sanitized = sanitize_clone_url_for_logs(url);
-        assert_eq!(sanitized, "ssh://github.com/repo.git");
-
-        // SCP-style with git://.
-        let url = "git://user:password@github.com/repo.git";
-        let sanitized = sanitize_clone_url_for_logs(url);
-        assert_eq!(sanitized, "git://github.com/repo.git");
-    }
-
-    #[test]
-    fn test_is_github_clone_url() {
-        assert!(is_github_clone_url("https://github.com/repo.git"));
-        assert!(is_github_clone_url("https://www.github.com/repo.git"));
-        assert!(!is_github_clone_url("https://gitlab.com/repo.git"));
     }
 }

--- a/apps/native/src-tauri/src/git/auth.rs
+++ b/apps/native/src-tauri/src/git/auth.rs
@@ -1,0 +1,119 @@
+//! Shared libgit2 authentication helpers.
+
+use git2::{Cred, FetchOptions, RemoteCallbacks};
+
+/// Sanitize a clone URL for logging, removing any embedded credentials.
+pub fn sanitize_clone_url_for_logs(clone_url: &str) -> String {
+    if let Ok(mut url) = url::Url::parse(clone_url) {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+        return url.to_string();
+    }
+
+    if let Some((_, rest)) = clone_url.split_once('@') {
+        if rest.contains(':') {
+            return format!("***@{}", rest);
+        }
+    }
+
+    clone_url.to_string()
+}
+
+/// Checks if the given clone URL is a GitHub URL, either in HTTPS or SSH form.
+pub fn is_github_clone_url(clone_url: &str) -> bool {
+    if clone_url.starts_with("git@github.com:") {
+        return true;
+    }
+
+    url::Url::parse(clone_url)
+        .ok()
+        .and_then(|url| url.host_str().map(|h| h.to_ascii_lowercase()))
+        .is_some_and(|host| host == "github.com" || host == "www.github.com")
+}
+
+/// Build fetch options with the standard nixmac libgit2 credential flow.
+///
+/// If `token` is provided, it is attempted first for HTTPS username/password
+/// authentication using GitHub App's `x-access-token` convention. After that,
+/// the callback falls back to SSH agent credentials, the user's git credential
+/// helper, and libgit2 defaults.
+pub fn authenticated_fetch_options(token: Option<String>) -> FetchOptions<'static> {
+    let git_config = git2::Config::open_default().ok();
+    let mut token_attempted = false;
+    let mut ssh_agent_attempted = false;
+    let mut credential_helper_attempted = false;
+    let mut callbacks = RemoteCallbacks::new();
+
+    callbacks.credentials(move |url, username_from_url, allowed| {
+        if allowed.contains(git2::CredentialType::USERNAME)
+            && !allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT)
+            && !allowed.contains(git2::CredentialType::SSH_KEY)
+            && !allowed.contains(git2::CredentialType::DEFAULT)
+        {
+            return Cred::username(username_from_url.unwrap_or("git"));
+        }
+
+        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) && !token_attempted {
+            token_attempted = true;
+            if let Some(token) = token.as_deref() {
+                return Cred::userpass_plaintext("x-access-token", token);
+            }
+        }
+
+        if allowed.contains(git2::CredentialType::SSH_KEY) && !ssh_agent_attempted {
+            ssh_agent_attempted = true;
+            return Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"));
+        }
+
+        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT)
+            && !credential_helper_attempted
+        {
+            credential_helper_attempted = true;
+            if let Some(config) = &git_config {
+                if let Ok(credential) = Cred::credential_helper(config, url, username_from_url) {
+                    return Ok(credential);
+                }
+            }
+        }
+
+        if allowed.contains(git2::CredentialType::DEFAULT) {
+            return Cred::default();
+        }
+
+        Err(git2::Error::from_str(
+            "no supported authentication methods succeeded",
+        ))
+    });
+
+    let mut fetch_options = FetchOptions::new();
+    fetch_options.remote_callbacks(callbacks);
+    fetch_options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_clone_url_for_logs() {
+        let url = "https://user:password@github.com/repo.git";
+        let sanitized = sanitize_clone_url_for_logs(url);
+        assert_eq!(sanitized, "https://github.com/repo.git");
+
+        let url = "ssh://user:password@github.com/repo.git";
+        let sanitized = sanitize_clone_url_for_logs(url);
+        assert_eq!(sanitized, "ssh://github.com/repo.git");
+
+        let url = "git://user:password@github.com/repo.git";
+        let sanitized = sanitize_clone_url_for_logs(url);
+        assert_eq!(sanitized, "git://github.com/repo.git");
+    }
+
+    #[test]
+    fn test_is_github_clone_url() {
+        assert!(is_github_clone_url("https://github.com/repo.git"));
+        assert!(is_github_clone_url("https://www.github.com/repo.git"));
+        assert!(is_github_clone_url("git@github.com:owner/repo.git"));
+        assert!(!is_github_clone_url("https://gitlab.com/repo.git"));
+    }
+}

--- a/apps/native/src-tauri/src/git/auto_update.rs
+++ b/apps/native/src-tauri/src/git/auto_update.rs
@@ -1,0 +1,587 @@
+//! Git auto-update has a lot of purpose-built logic for nixmac, so it lives in its own module.
+//! It is not intended to be a part of the more general-purpose git library, although some
+//! of the helper methods in here may be appropriate to migrate to query.rs if they are needed,
+//! for example `upstream_for_current_branch` and `remote_name_for_current_branch`.
+//!
+
+use anyhow::{Context, Result};
+use git2::{AutotagOption, BranchType, MergeAnalysis, Repository};
+
+use crate::git::auth::authenticated_fetch_options;
+use crate::git::init::require_repo;
+use crate::git::query::{current_branch, head_oid};
+
+/// Relative position of the checked-out branch and its upstream tracking branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchSyncState {
+    UpToDate,
+    Behind,
+    Ahead,
+    Diverged,
+}
+
+/// Snapshot of the local/upstream state used to decide whether auto-update is safe.
+/// Includes additional information to facilitate the update if it is safe to proceed.
+#[derive(Debug)]
+pub struct AutoUpdateGitStatus {
+    pub branch: String,
+    /// Included in the decision now so the later update/rebuild flow can report
+    /// exactly which upstream ref it is applying.
+    pub upstream_name: String,
+    pub local_oid: git2::Oid,
+    pub upstream_oid: git2::Oid,
+    pub state: BranchSyncState,
+}
+
+/// Action the auto-update flow should take after inspecting Git state.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum AutoUpdateDecision {
+    Noop(String),
+    UpdateAndRebuild {
+        local_oid: git2::Oid,
+        upstream_oid: git2::Oid,
+        /// Plan is to use this for user-facing progress and logs.
+        upstream_name: String,
+    },
+    WarnAndSkip(String),
+}
+
+/// User/configuration guardrails that constrain when auto-update may run.
+#[allow(dead_code)]
+pub struct AutoUpdateConfig {
+    pub enabled: bool,
+    pub repo_path: std::path::PathBuf,
+    pub branch: Option<String>,
+    pub remote: Option<String>,
+    pub require_clean_worktree: bool,
+    pub block_untracked_files: bool,
+}
+
+/// Fast-forwards the current local branch to an already-fetched upstream commit.
+///
+/// TODO: This is not hooked up yet but will be the next step in implementing the actual update
+/// after the check decision is made.
+#[allow(dead_code)]
+pub fn fast_forward_to_upstream(repo: &Repository, upstream_oid: git2::Oid) -> Result<()> {
+    let branch_name = current_branch(repo).context("repository is in detached HEAD state")?;
+
+    let annotated = repo
+        .find_annotated_commit(upstream_oid)
+        .context("failed to find upstream annotated commit")?;
+
+    let (analysis, _preference) = repo
+        .merge_analysis(&[&annotated])
+        .context("failed to analyze merge")?;
+
+    if analysis.contains(MergeAnalysis::ANALYSIS_UP_TO_DATE) {
+        return Ok(());
+    }
+
+    if !analysis.contains(MergeAnalysis::ANALYSIS_FASTFORWARD) {
+        anyhow::bail!("upstream update is not a fast-forward");
+    }
+
+    let refname = format!("refs/heads/{branch_name}");
+
+    let mut reference = repo
+        .find_reference(&refname)
+        .with_context(|| format!("failed to find local branch ref {refname}"))?;
+
+    reference
+        .set_target(
+            upstream_oid,
+            &format!("nixmac auto-update: fast-forward to {upstream_oid}"),
+        )
+        .context("failed to update local branch ref")?;
+
+    repo.set_head(&refname)
+        .with_context(|| format!("failed to set HEAD to {refname}"))?;
+
+    let mut checkout_builder = git2::build::CheckoutBuilder::new();
+
+    checkout_builder
+        .safe()
+        .recreate_missing(true)
+        .remove_untracked(false);
+
+    repo.checkout_head(Some(&mut checkout_builder))
+        .context("failed to check out updated HEAD")?;
+
+    Ok(())
+}
+
+/// Converts an inspected branch state into the high-level auto-update action.
+fn decide_auto_update(status: &AutoUpdateGitStatus) -> AutoUpdateDecision {
+    match status.state {
+        BranchSyncState::UpToDate => AutoUpdateDecision::Noop(format!(
+            "Branch {} is already up to date with {}.",
+            status.branch, status.upstream_name
+        )),
+
+        BranchSyncState::Behind => AutoUpdateDecision::UpdateAndRebuild {
+            local_oid: status.local_oid,
+            upstream_oid: status.upstream_oid,
+            upstream_name: status.upstream_name.clone(),
+        },
+
+        BranchSyncState::Ahead => AutoUpdateDecision::WarnAndSkip(format!(
+            "Local branch {} is ahead of {}. Skipping automatic update.",
+            status.branch, status.upstream_name
+        )),
+
+        BranchSyncState::Diverged => AutoUpdateDecision::WarnAndSkip(format!(
+            "Local branch {} has diverged from {}. Skipping automatic update.",
+            status.branch, status.upstream_name
+        )),
+    }
+}
+
+/// For auto-update, we have strict requirements for the working tree to be clean, including:
+/// 1. No uncommitted changes in tracked files.
+/// 2. No untracked files or directories.
+/// 3. No ignored files or directories.
+fn is_worktree_clean_for_auto_update(dir: &str) -> anyhow::Result<bool> {
+    crate::git::init::require_repo(dir)?;
+
+    let repo = git2::Repository::discover(dir)?;
+
+    let head_tree = repo
+        .head()
+        .ok()
+        .and_then(|h| h.peel_to_commit().ok())
+        .and_then(|c| c.tree().ok());
+
+    let mut opts = git2::DiffOptions::new();
+
+    opts.include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_ignored(false)
+        .include_unmodified(false);
+
+    let diff = repo.diff_tree_to_workdir_with_index(head_tree.as_ref(), Some(&mut opts))?;
+
+    Ok(diff.deltas().len() == 0)
+}
+
+/// Get the upstream tracking branch for the current branch, and its OID.
+fn upstream_for_current_branch(repo: &Repository) -> Result<(String, git2::Oid)> {
+    let branch_name = current_branch(repo).context("repository is in detached HEAD state")?;
+
+    let local_branch = repo
+        .find_branch(&branch_name, BranchType::Local)
+        .with_context(|| format!("failed to find local branch {branch_name}"))?;
+
+    let upstream = local_branch
+        .upstream()
+        .with_context(|| format!("branch {branch_name} has no upstream tracking branch"))?;
+
+    let upstream_name = upstream
+        .name()?
+        .context("upstream branch name is not valid UTF-8")?
+        .to_string();
+
+    let upstream_oid = upstream
+        .get()
+        .target()
+        .context("upstream branch does not point to a commit")?;
+
+    Ok((upstream_name, upstream_oid))
+}
+
+/// Returns the configured remote name for the current branch's upstream.
+fn remote_name_for_current_branch(repo: &Repository) -> Result<String> {
+    let branch_name = current_branch(repo).context("repository is in detached HEAD state")?;
+
+    let local_branch = repo
+        .find_branch(&branch_name, BranchType::Local)
+        .with_context(|| format!("failed to find local branch {branch_name}"))?;
+
+    let upstream_ref = local_branch
+        .upstream()
+        .with_context(|| format!("branch {branch_name} has no upstream tracking branch"))?;
+
+    let upstream_ref_name = upstream_ref
+        .get()
+        .name()
+        .context("upstream ref has no name")?;
+
+    // Usually refs/remotes/origin/main
+    let Some(stripped) = upstream_ref_name.strip_prefix("refs/remotes/") else {
+        anyhow::bail!("upstream ref is not a remote-tracking ref: {upstream_ref_name}");
+    };
+
+    let Some((remote_name, _remote_branch)) = stripped.split_once('/') else {
+        anyhow::bail!("could not parse remote name from upstream ref: {upstream_ref_name}");
+    };
+
+    Ok(remote_name.to_string())
+}
+
+/// Fetches the already-resolved upstream remote for the current branch.
+fn fetch_upstream(repo: &Repository, remote_name: &str) -> Result<()> {
+    let mut fetch_options = authenticated_fetch_options(None);
+    fetch_options.download_tags(AutotagOption::Unspecified);
+
+    let mut remote = repo
+        .find_remote(&remote_name)
+        .with_context(|| format!("failed to find remote {remote_name}"))?;
+
+    // Empty refspecs means use the remote's configured fetch refspecs.
+    remote
+        .fetch(&[] as &[&str], Some(&mut fetch_options), None)
+        .with_context(|| format!("failed to fetch remote {remote_name}"))?;
+
+    Ok(())
+}
+
+/// Classify the relationship between the current branch and its upstream tracking branch.
+fn classify_branch_state(
+    repo: &Repository,
+    local_oid: git2::Oid,
+    upstream_oid: git2::Oid,
+) -> Result<BranchSyncState> {
+    if local_oid == upstream_oid {
+        return Ok(BranchSyncState::UpToDate);
+    }
+
+    let base_oid = repo
+        .merge_base(local_oid, upstream_oid)
+        .context("failed to find merge-base between local HEAD and upstream")?;
+
+    if base_oid == local_oid {
+        Ok(BranchSyncState::Behind)
+    } else if base_oid == upstream_oid {
+        Ok(BranchSyncState::Ahead)
+    } else {
+        Ok(BranchSyncState::Diverged)
+    }
+}
+
+/// Builds the auto-update status snapshot after refs have been fetched.
+fn inspect_git_status(repo: &Repository) -> Result<AutoUpdateGitStatus> {
+    let branch = current_branch(repo).context("repository is in detached HEAD state")?;
+    let local_oid = head_oid(repo)?;
+
+    let (upstream_name, upstream_oid) = upstream_for_current_branch(repo)?;
+
+    let state = classify_branch_state(repo, local_oid, upstream_oid)?;
+
+    Ok(AutoUpdateGitStatus {
+        branch,
+        upstream_name,
+        local_oid,
+        upstream_oid,
+        state,
+    })
+}
+
+/// Main entry point for checking whether an auto-update is possible.
+///
+/// This is the guts of the "checking" portion of this module.
+pub fn check_auto_update(config_dir: &str) -> Result<AutoUpdateDecision> {
+    require_repo(config_dir)?;
+    let repo = Repository::discover(config_dir)?;
+
+    log::debug!(
+        "[git::auto_update] checking auto-update for repo at {}",
+        config_dir
+    );
+
+    // 1. Auto-update only runs from a clean worktree.
+    match is_worktree_clean_for_auto_update(config_dir) {
+        Ok(true) => {}
+        Ok(false) => {
+            log::warn!("[git::auto_update] Skipping auto-update: worktree is not clean");
+            return Ok(AutoUpdateDecision::WarnAndSkip(
+                "Worktree is not clean.".to_string(),
+            ));
+        }
+        Err(err) => {
+            log::warn!("[git::auto_update] Skipping auto-update: {err}");
+            return Ok(AutoUpdateDecision::WarnAndSkip(format!(
+                "Failed to check worktree cleanliness: {err}"
+            )));
+        }
+    }
+
+    // 2. Require HEAD to be attached to a local branch.
+    if current_branch(&repo).is_none() {
+        log::warn!("[git::auto_update] Skipping auto-update: repository is in detached HEAD state");
+        return Ok(AutoUpdateDecision::WarnAndSkip(
+            "Repository is in detached HEAD state.".to_string(),
+        ));
+    }
+
+    // 3. Resolve the remote backing the branch's upstream tracking ref.
+    let remote_name = match remote_name_for_current_branch(&repo) {
+        Ok(remote_name) => remote_name,
+        Err(err) => {
+            log::warn!(
+                "[git::auto_update] Skipping auto-update: failed to get upstream remote: {err}"
+            );
+            return Ok(AutoUpdateDecision::WarnAndSkip(format!(
+                "Failed to get upstream remote: {err}"
+            )));
+        }
+    };
+
+    // 4. Fetch the current branch's configured upstream remote.
+    if let Err(err) = fetch_upstream(&repo, &remote_name) {
+        log::warn!("[git::auto_update] Skipping auto-update: failed to fetch upstream: {err}");
+        return Ok(AutoUpdateDecision::WarnAndSkip(format!(
+            "Failed to fetch upstream: {err}"
+        )));
+    }
+
+    // 5. Compare local HEAD with the freshly fetched upstream ref.
+    let status = match inspect_git_status(&repo) {
+        Ok(status) => status,
+        Err(err) => {
+            log::warn!(
+                "[git::auto_update] Skipping auto-update: failed to inspect Git state: {err}"
+            );
+            return Ok(AutoUpdateDecision::WarnAndSkip(format!(
+                "Failed to inspect Git state: {err}"
+            )));
+        }
+    };
+
+    // 6. Convert the sync state into the action the caller should take.
+    Ok(decide_auto_update(&status))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::git::init::init_repo;
+
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn make_initial_commit(repo_dir: &str) {
+        fs::write(format!("{}/flake.nix", repo_dir), "{ }\n").unwrap();
+        crate::git::commit_all(repo_dir, "initial").unwrap();
+    }
+
+    fn repo_with_initial_commit() -> (TempDir, Repository, git2::Oid) {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::init(temp_dir.path()).unwrap();
+        let commit_id = create_commit(
+            &repo,
+            temp_dir.path(),
+            "flake.nix",
+            "{ }\n",
+            "initial",
+            None,
+            Some("HEAD"),
+        );
+
+        (temp_dir, repo, commit_id)
+    }
+
+    fn create_commit(
+        repo: &Repository,
+        repo_dir: &Path,
+        path: &str,
+        contents: &str,
+        message: &str,
+        parent: Option<git2::Oid>,
+        update_ref: Option<&str>,
+    ) -> git2::Oid {
+        fs::write(repo_dir.join(path), contents).unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(path)).unwrap();
+        index.write().unwrap();
+
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = git2::Signature::now("nixmac", "nixmac@local").unwrap();
+
+        if let Some(parent_id) = parent {
+            let parent_commit = repo.find_commit(parent_id).unwrap();
+            repo.commit(update_ref, &sig, &sig, message, &tree, &[&parent_commit])
+                .unwrap()
+        } else {
+            repo.commit(update_ref, &sig, &sig, message, &tree, &[])
+                .unwrap()
+        }
+    }
+
+    fn configure_origin_upstream(repo: &Repository, target_oid: git2::Oid) {
+        repo.remote("origin", "https://example.invalid/nixmac.git")
+            .unwrap();
+        repo.reference(
+            "refs/remotes/origin/main",
+            target_oid,
+            true,
+            "create remote-tracking branch",
+        )
+        .unwrap();
+
+        let branch_name = current_branch(repo).unwrap();
+        let mut branch = repo.find_branch(&branch_name, BranchType::Local).unwrap();
+        branch.set_upstream(Some("origin/main")).unwrap();
+    }
+
+    #[test]
+    fn decide_auto_update_noops_when_up_to_date() {
+        let oid = git2::Oid::from_str("1111111111111111111111111111111111111111").unwrap();
+        let status = AutoUpdateGitStatus {
+            branch: "main".to_string(),
+            upstream_name: "origin/main".to_string(),
+            local_oid: oid,
+            upstream_oid: oid,
+            state: BranchSyncState::UpToDate,
+        };
+
+        let AutoUpdateDecision::Noop(message) = decide_auto_update(&status) else {
+            panic!("expected noop decision");
+        };
+
+        assert!(message.contains("already up to date"));
+    }
+
+    #[test]
+    fn decide_auto_update_updates_when_behind() {
+        let local_oid = git2::Oid::from_str("1111111111111111111111111111111111111111").unwrap();
+        let upstream_oid = git2::Oid::from_str("2222222222222222222222222222222222222222").unwrap();
+        let status = AutoUpdateGitStatus {
+            branch: "main".to_string(),
+            upstream_name: "origin/main".to_string(),
+            local_oid,
+            upstream_oid,
+            state: BranchSyncState::Behind,
+        };
+
+        let AutoUpdateDecision::UpdateAndRebuild {
+            local_oid: actual_local_oid,
+            upstream_oid: actual_upstream_oid,
+            upstream_name,
+        } = decide_auto_update(&status)
+        else {
+            panic!("expected update decision");
+        };
+
+        assert_eq!(actual_local_oid, local_oid);
+        assert_eq!(actual_upstream_oid, upstream_oid);
+        assert_eq!(upstream_name, "origin/main");
+    }
+
+    #[test]
+    fn decide_auto_update_warns_and_skips_when_ahead() {
+        let oid = git2::Oid::from_str("1111111111111111111111111111111111111111").unwrap();
+        let status = AutoUpdateGitStatus {
+            branch: "main".to_string(),
+            upstream_name: "origin/main".to_string(),
+            local_oid: oid,
+            upstream_oid: oid,
+            state: BranchSyncState::Ahead,
+        };
+
+        let AutoUpdateDecision::WarnAndSkip(message) = decide_auto_update(&status) else {
+            panic!("expected warning decision");
+        };
+
+        assert!(message.contains("ahead of origin/main"));
+    }
+
+    #[test]
+    fn classify_branch_state_covers_common_relationships() {
+        let (temp_dir, repo, initial_oid) = repo_with_initial_commit();
+
+        assert_eq!(
+            classify_branch_state(&repo, initial_oid, initial_oid).unwrap(),
+            BranchSyncState::UpToDate
+        );
+
+        let local_oid = create_commit(
+            &repo,
+            temp_dir.path(),
+            "flake.nix",
+            "{ local = true; }\n",
+            "local",
+            Some(initial_oid),
+            Some("HEAD"),
+        );
+
+        assert_eq!(
+            classify_branch_state(&repo, local_oid, initial_oid).unwrap(),
+            BranchSyncState::Ahead
+        );
+        assert_eq!(
+            classify_branch_state(&repo, initial_oid, local_oid).unwrap(),
+            BranchSyncState::Behind
+        );
+
+        let upstream_oid = create_commit(
+            &repo,
+            temp_dir.path(),
+            "flake.nix",
+            "{ upstream = true; }\n",
+            "upstream",
+            Some(initial_oid),
+            None,
+        );
+
+        assert_eq!(
+            classify_branch_state(&repo, local_oid, upstream_oid).unwrap(),
+            BranchSyncState::Diverged
+        );
+    }
+
+    #[test]
+    fn upstream_and_remote_use_current_branch_tracking_config() {
+        let (_temp_dir, repo, initial_oid) = repo_with_initial_commit();
+        configure_origin_upstream(&repo, initial_oid);
+
+        let (upstream_name, upstream_oid) = upstream_for_current_branch(&repo).unwrap();
+
+        assert_eq!(upstream_name, "origin/main");
+        assert_eq!(upstream_oid, initial_oid);
+        assert_eq!(remote_name_for_current_branch(&repo).unwrap(), "origin");
+    }
+
+    #[test]
+    fn inspect_git_status_reports_current_tracking_state() {
+        let (_temp_dir, repo, initial_oid) = repo_with_initial_commit();
+        configure_origin_upstream(&repo, initial_oid);
+
+        let status = inspect_git_status(&repo).unwrap();
+
+        assert_eq!(status.upstream_name, "origin/main");
+        assert_eq!(status.local_oid, initial_oid);
+        assert_eq!(status.upstream_oid, initial_oid);
+        assert_eq!(status.state, BranchSyncState::UpToDate);
+    }
+
+    #[test]
+    fn test_is_worktree_clean_for_auto_update_yes() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+
+        init_repo(&repo_dir_str).unwrap();
+        make_initial_commit(&repo_dir_str);
+
+        assert!(is_worktree_clean_for_auto_update(&repo_dir_str).unwrap());
+    }
+
+    #[test]
+    fn test_is_worktree_clean_for_auto_update_no() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+
+        init_repo(&repo_dir_str).unwrap();
+        make_initial_commit(&repo_dir_str);
+
+        // Create an untracked file
+        let file_path = repo_dir.join("untracked_file.txt");
+        fs::write(&file_path, "content").unwrap();
+
+        assert!(!is_worktree_clean_for_auto_update(&repo_dir_str).unwrap());
+    }
+}

--- a/apps/native/src-tauri/src/git/auto_update.rs
+++ b/apps/native/src-tauri/src/git/auto_update.rs
@@ -139,8 +139,7 @@ fn decide_auto_update(status: &AutoUpdateGitStatus) -> AutoUpdateDecision {
 
 /// For auto-update, we have strict requirements for the working tree to be clean, including:
 /// 1. No uncommitted changes in tracked files.
-/// 2. No untracked files or directories.
-/// 3. No ignored files or directories.
+/// 2. No untracked files or directories (ignored files are not considered).
 fn is_worktree_clean_for_auto_update(dir: &str) -> anyhow::Result<bool> {
     crate::git::init::require_repo(dir)?;
 

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -1,5 +1,7 @@
 //! Git module: low-level subprocess wrappers and diff parsing.
 
+pub mod auth;
+pub mod auto_update;
 pub mod exec;
 pub mod init;
 pub mod query;

--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use git2::{DiffOptions, Oid, Repository};
 use tauri::AppHandle;
 
@@ -79,21 +79,61 @@ pub fn repo_root(dir: &str) -> PathBuf {
     }
 }
 
+/// Input types supported by [`current_branch`].
+pub trait CurrentBranchSource {
+    fn current_branch(self) -> Option<String>;
+}
+
+impl CurrentBranchSource for &Repository {
+    fn current_branch(self) -> Option<String> {
+        let head = self.head().ok()?;
+        let name = head.shorthand().ok()?;
+
+        match name {
+            "HEAD" => None,
+            other => Some(other.to_string()),
+        }
+    }
+}
+
+macro_rules! impl_current_branch_for_path_source {
+    ($source_type:ty) => {
+        impl CurrentBranchSource for $source_type {
+            fn current_branch(self) -> Option<String> {
+                let repo = git2::Repository::discover(self).ok()?;
+                current_branch(&repo)
+            }
+        }
+    };
+}
+
+impl_current_branch_for_path_source!(&str);
+impl_current_branch_for_path_source!(String);
+impl_current_branch_for_path_source!(&String);
+impl_current_branch_for_path_source!(&Path);
+impl_current_branch_for_path_source!(PathBuf);
+impl_current_branch_for_path_source!(&PathBuf);
+
 /// Returns the current branch name (None if detached HEAD or not a repo).
 ///
 /// This is equivalent to:
 ///     git rev-parse --abbrev-ref HEAD
-pub fn current_branch(dir: &str) -> Option<String> {
-    let repo = git2::Repository::discover(dir).ok()?;
+pub fn current_branch<S: CurrentBranchSource>(source: S) -> Option<String> {
+    source.current_branch()
+}
 
-    let head = repo.head().ok()?;
-
-    let name = head.shorthand().ok()?;
-
-    match name {
-        "HEAD" => None,
-        other => Some(other.to_string()),
-    }
+/// Returns the commit OID that HEAD currently resolves to.
+///
+/// This is intentionally repository-based so callers that already opened a repo
+/// do not need to rediscover it just to inspect HEAD.
+/// (It's possible that some of our other helper methods would benefit from this technique, too.)
+pub fn head_oid(repo: &Repository) -> Result<Oid> {
+    Ok(repo
+        .head()
+        .context("failed to read repository HEAD")?
+        .peel_to_commit()
+        .context("HEAD does not resolve to a commit")?
+        .id())
 }
 
 /// Resolves a Git reference (branch, tag, HEAD, or full ref name) to its commit SHA.
@@ -630,9 +670,35 @@ mod tests {
     }
 
     #[test]
+    fn current_branch_accepts_open_repository() {
+        let (temp, _) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+        let repo = git2::Repository::discover(&path).expect("discover repo");
+
+        assert_eq!(current_branch(&repo), current_branch(&path));
+    }
+
+    #[test]
     fn current_branch_none_for_non_repo() {
         let temp = TempDir::new().expect("create temp dir");
-        assert_eq!(current_branch(&temp.path().to_string_lossy()), None);
+        assert_eq!(current_branch(temp.path()), None);
+    }
+
+    #[test]
+    fn head_oid_resolves_head_commit() {
+        let (temp, commit_id) = repo_with_initial_commit();
+        let path = temp.path().to_string_lossy().to_string();
+        let repo = git2::Repository::discover(&path).expect("discover repo");
+
+        assert_eq!(head_oid(&repo).expect("read HEAD oid"), commit_id);
+    }
+
+    #[test]
+    fn head_oid_errors_for_unborn_head() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = git2::Repository::init(temp.path()).expect("init repo");
+
+        assert!(head_oid(&repo).is_err());
     }
 
     #[test]

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -189,10 +189,14 @@ where
                 // Detect upstream git commits we may want to offer to pull.
                 // This is a fire-and-forget, best-effort check; if it fails,
                 // we just try again on the next scheduled check.
-                if let Some(ref dir) = current_dir {
-                    if should_check_auto_update(dir, Instant::now()) {
-                        let decision = git::auto_update::check_auto_update(dir);
-                        log::debug!("[watcher] git auto-update check result: {:?}", decision);
+                if let Some(dir) = current_dir.clone() {
+                    if should_check_auto_update(&dir, Instant::now()) {
+                        // Use a separate thread so we don't block the crazy-fast 100ms loop. The check itself is a git fetch
+                        // which is more like order-of-seconds (usually about 1-2 seconds in practice).
+                        std::thread::spawn(move || {
+                            let decision = git::auto_update::check_auto_update(&dir);
+                            log::debug!("[watcher] git auto-update check result: {:?}", decision);
+                        });
                     }
                 }
 

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -12,7 +12,7 @@ use crate::state::{
 use crate::{db, git, summarize};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 /// Set to `false` by `start_watching` to stop the old thread before starting a new one.
@@ -23,6 +23,29 @@ static WATCH_DIR: Mutex<Option<String>> = Mutex::new(None);
 
 /// Holds handle to current watcher so we can wait for it to stop on restart.
 static WATCHER_THREAD: Mutex<Option<std::thread::JoinHandle<()>>> = Mutex::new(None);
+
+/// Last auto-update check by watched directory.
+///
+/// This is process-global rather than thread-local so focus-driven watcher
+/// restarts do not reset the five-minute throttle.
+static LAST_AUTO_UPDATE_CHECK: Mutex<Option<(String, Instant)>> = Mutex::new(None);
+
+/// Check the upstream git repo for new commits that we might be able to pull
+/// every 5 minutes.
+const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+fn should_check_auto_update(dir: &str, now: Instant) -> bool {
+    let mut last_check = LAST_AUTO_UPDATE_CHECK.lock().unwrap();
+
+    if let Some((last_dir, checked_at)) = last_check.as_ref() {
+        if last_dir == dir && now.duration_since(*checked_at) < AUTO_UPDATE_CHECK_INTERVAL {
+            return false;
+        }
+    }
+
+    *last_check = Some((dir.to_string(), now));
+    true
+}
 
 /// Stops the git status watcher, if one is running, and waits for it to exit.
 /// Used when the config directory is cleared (onboarding reset) — without a
@@ -162,6 +185,17 @@ where
                 if !WATCHER_ACTIVE.load(Ordering::SeqCst) {
                     break;
                 }
+
+                // Detect upstream git commits we may want to offer to pull.
+                // This is a fire-and-forget, best-effort check; if it fails,
+                // we just try again on the next scheduled check.
+                if let Some(ref dir) = current_dir {
+                    if should_check_auto_update(dir, Instant::now()) {
+                        let decision = git::auto_update::check_auto_update(dir);
+                        log::debug!("[watcher] git auto-update check result: {:?}", decision);
+                    }
+                }
+
                 std::thread::sleep(Duration::from_millis(100));
             }
         }


### PR DESCRIPTION
## Summary

This is the first step in implementing functionality to automatically do a git-pull-and-darwin-rebuild workflow:

- Implements several "safety checks" like:
    - local modifications, staged changes, untracked files
    - not detached-HEAD
    - upstream tracking branch exists
    - can fetch the upstream
- If the local branch is ahead, diverged, dirty, detacted, or unable to fetch, we indicate that an update is not possible.
- Refactored the git auth logic out of "onboarding" and into the "git" module which seems more like where it belongs.
- Wired up the auto-update decision logic to the git watcher where for now it just logs. The check can take long enough that the watcher 100ms interval is way too frequent so I made it on a 5-minute interval instead.

If your branch is up-to-date, you will see a debug log message like this:

```
[watcher] git auto-update check result: Ok(Noop("Branch main is already up to date with origin/main."))
```

If you're behind, you will see something like:

```
[watcher] git auto-update check result: Ok(UpdateAndRebuild { local_oid: 3ed846b579b01a4cf01762a1e342588300425041, upstream_oid: 9a5779d0166945a8568e32203b43a986af1293e7, upstream_name: "origin/main" })
```

I will follow up with probably some kind of design doc for how we actually finish exposing this as a user feature.

<!-- What does this PR do? Why? -->

## Test Plan

Manual testing with my own (private, yay auth) git repo, several new unit tests.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed