### PR TITLE
fix(onboarding): accept CLI providers without a model

### DIFF
--- a/apps/native/src-tauri/src/ai/providers/cli.rs
+++ b/apps/native/src-tauri/src/ai/providers/cli.rs
@@ -31,7 +31,12 @@ impl CliTool {
         }
     }
 
-    /// Whether this tool should be passed a model name, and if so via which flag.
+    /// CLI flag used to pass a model name, for tools that accept one.
+    /// Claude and Codex accept a model but do not require it: when the
+    /// configured model is empty (or the sentinel equal to the binary
+    /// name, substituted by the provider-selection code when no model is
+    /// set), no flag is passed and the CLI's own default model is used.
+    /// OpenCode takes no model flag.
     pub fn model_flag(&self) -> Option<&str> {
         match self {
             CliTool::Claude => Some("--model"),

--- a/apps/native/src/components/widget/onboarding/onboarding-step-content.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-step-content.tsx
@@ -7,6 +7,7 @@ import { NixSetupStep } from "@/components/widget/onboarding/steps/nix-setup-ste
 import { PermissionsStep } from "@/components/widget/onboarding/steps/permissions-step";
 import { SetupStep } from "@/components/widget/onboarding/steps/setup-step";
 import { useOnboardingProgress } from "@/hooks/use-onboarding-progress";
+import { isInferenceConfigured } from "@/lib/providers/ai-provider-validation";
 import { onboardingActions, useOnboarding, useViewModel } from "@nixmac/state";
 
 interface OnboardingStepContentProps {
@@ -22,7 +23,7 @@ export function OnboardingStepContent({ currentStep, title }: OnboardingStepCont
   // separately. The build step only needs to know inference is configured.
   const evolveProvider = useViewModel((s) => s.preferences?.evolveProvider ?? null);
   const evolveModel = useViewModel((s) => s.preferences?.evolveModel ?? null);
-  const hasInference = Boolean(evolveProvider) && Boolean(evolveModel);
+  const hasInference = isInferenceConfigured(evolveProvider, evolveModel);
   const { markMacScanned, markLoginDecided } = useOnboardingProgress();
 
   return (

--- a/apps/native/src/components/widget/onboarding/use-onboarding-flow.ts
+++ b/apps/native/src/components/widget/onboarding/use-onboarding-flow.ts
@@ -6,6 +6,7 @@ import {
   type StepId,
 } from "@/components/widget/onboarding/lib/onboarding";
 import { settings } from "@/lib/env";
+import { isInferenceConfigured } from "@/lib/providers/ai-provider-validation";
 import { onboardingActions, useOnboarding, useViewModel } from "@nixmac/state";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
@@ -54,7 +55,7 @@ export function useOnboardingFlow(): {
         flakeReady,
         macScanned: macScannedAt !== null,
         loginDecided,
-        hasInference: Boolean(evolveProvider) && Boolean(evolveModel),
+        hasInference: isInferenceConfigured(evolveProvider, evolveModel),
         buildComplete: lastBuildAt !== null,
         inferenceDeferred,
       }),

--- a/apps/native/src/lib/providers/ai-provider-validation.test.ts
+++ b/apps/native/src/lib/providers/ai-provider-validation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getProviderConfigInvalidReason,
+  isInferenceConfigured,
   resolveOpenAiCompatibleProvider,
 } from "./ai-provider-validation";
 
@@ -12,6 +13,26 @@ const EMPTY_PREFS = {
 };
 
 const NO_CLI_TOOLS = { claude: false, codex: false, opencode: false };
+
+describe("isInferenceConfigured", () => {
+  it("accepts CLI providers without a model (empty means CLI default)", () => {
+    expect(isInferenceConfigured("codex", "")).toBe(true);
+    expect(isInferenceConfigured("claude", null)).toBe(true);
+    expect(isInferenceConfigured("opencode", undefined)).toBe(true);
+  });
+
+  it("requires a model for non-CLI providers", () => {
+    expect(isInferenceConfigured("openrouter", "")).toBe(false);
+    expect(isInferenceConfigured("openrouter", "   ")).toBe(false);
+    expect(isInferenceConfigured("openrouter", "openai/gpt-4o-mini")).toBe(true);
+    expect(isInferenceConfigured("nixmac", "openai/gpt-4o-mini")).toBe(true);
+  });
+
+  it("requires a provider", () => {
+    expect(isInferenceConfigured(null, "openai/gpt-4o-mini")).toBe(false);
+    expect(isInferenceConfigured(undefined, undefined)).toBe(false);
+  });
+});
 
 describe("getProviderConfigInvalidReason", () => {
   it("accepts nixmac hosted inference without BYOK credentials", () => {

--- a/apps/native/src/lib/providers/ai-provider-validation.ts
+++ b/apps/native/src/lib/providers/ai-provider-validation.ts
@@ -12,6 +12,19 @@ export function isCliProvider(provider: string): boolean {
   return CLI_PROVIDER_VALUES.includes(provider as (typeof CLI_PROVIDER_VALUES)[number]);
 }
 
+/**
+ * Whether persisted prefs describe a usable inference setup. CLI providers
+ * (claude/codex/opencode) accept an optional model — an empty model means
+ * "use the CLI's own default" — so only non-CLI providers require a model.
+ */
+export function isInferenceConfigured(
+  provider: string | null | undefined,
+  model: string | null | undefined,
+): boolean {
+  if (!provider) return false;
+  return isCliProvider(provider) || hasValue(model);
+}
+
 export function resolveOpenAiCompatibleProvider(
   provider: string | null | undefined,
   prefs: Pick<DarwinPrefs, "openrouterApiKey" | "openaiApiKey">,


### PR DESCRIPTION
Empty model means "use the CLI default" for claude/codex/opencode,
but step readiness required a non-empty evolveModel, so saving a CLI
provider silently kept the flow on the inference step.