### PR TITLE
fix(gitignore): delegate gitignore checks to libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,7 +3583,6 @@ dependencies = [
  "hex",
  "hmac",
  "http",
- "ignore",
  "libc",
  "libsqlite3-sys",
  "log",

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -48,7 +48,6 @@ tempfile = "3.23.0"
 async-openai = "0.30.1"
 async-trait = "0.1"
 glob = "0.3"
-ignore = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 once_cell = "1.21.3"

--- a/apps/native/src-tauri/src/evolve/config_dir_context.rs
+++ b/apps/native/src-tauri/src/evolve/config_dir_context.rs
@@ -1,9 +1,8 @@
 // Builds a picture of the config_dir for the evolve provider to use as context.
 // This is used to DRAMATICALLY cut down on the amount of file system exploration
 // that the agent needs to do using the `list_files` tool.
-use super::gitignore::{is_ignored_by_matcher, load_gitignore_matcher};
+use super::gitignore::{GitignoreChecker, VisibleFiles};
 use anyhow::{Context, Result};
-use ignore::gitignore::Gitignore;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -75,14 +74,16 @@ pub fn format_config_dir_context_with_max_depth(
     }
 
     // Use the repo root for the ignore base since we may have ignored things at a higher level than the nix config dir.
-    let gitignore = load_gitignore_matcher(repo_root)?;
+    let visible = GitignoreChecker::new(repo_root)?
+        .map(|checker| checker.visible_files())
+        .transpose()?;
 
     let mut output_paths = Vec::new();
     let mut rendered_entries = 0usize;
     collect_file_paths(
         repo_root,
         config_dir_path,
-        gitignore.as_ref(),
+        visible.as_ref(),
         0,
         max_depth,
         &mut output_paths,
@@ -97,13 +98,13 @@ pub fn format_config_dir_context_with_max_depth(
 fn collect_file_paths(
     repo_root: &Path,
     dir: &Path,
-    gitignore: Option<&Gitignore>,
+    visible: Option<&VisibleFiles>,
     depth: usize,
     max_depth: usize,
     output_paths: &mut Vec<String>,
     rendered_entries: &mut usize,
 ) -> Result<()> {
-    let mut entries = collect_filtered_entries(repo_root, dir, gitignore)?;
+    let mut entries = collect_filtered_entries(repo_root, dir, visible)?;
     entries.sort_by(|a, b| a.name.cmp(&b.name));
 
     for entry in entries {
@@ -117,7 +118,7 @@ fn collect_file_paths(
                 collect_file_paths(
                     repo_root,
                     &entry.path,
-                    gitignore,
+                    visible,
                     depth + 1,
                     max_depth,
                     output_paths,
@@ -160,7 +161,7 @@ fn collect_file_paths(
 fn collect_filtered_entries(
     repo_root: &Path,
     dir: &Path,
-    gitignore: Option<&Gitignore>,
+    visible: Option<&VisibleFiles>,
 ) -> Result<Vec<DirEntryView>> {
     let mut out = Vec::new();
     for entry in
@@ -186,8 +187,15 @@ fn collect_filtered_entries(
             continue;
         }
 
-        if is_ignored_by_matcher(gitignore, relative_for_gitignore, file_type.is_dir()) {
-            continue;
+        if let Some(visible) = visible {
+            let is_visible = if file_type.is_dir() {
+                visible.contains_dir(relative_for_gitignore)
+            } else {
+                visible.contains_file(relative_for_gitignore)
+            };
+            if !is_visible {
+                continue;
+            }
         }
 
         if !file_type.is_dir() && !is_allowed_file(&name, &path) {
@@ -276,6 +284,7 @@ mod tests {
         let repo_root = tmp.path().join("repo");
         let config_dir = repo_root.join("nix/os");
         fs::create_dir_all(&config_dir)?;
+        git2::Repository::init(&repo_root)?;
 
         fs::write(repo_root.join(".gitignore"), "nix/os/secret.txt\n")?;
         fs::write(config_dir.join("visible.txt"), "hello")?;
@@ -295,6 +304,7 @@ mod tests {
         let repo_root = tmp.path().join("repo");
         let config_dir = repo_root.join("nix/os");
         fs::create_dir_all(config_dir.join("nested"))?;
+        git2::Repository::init(&repo_root)?;
         fs::write(config_dir.join("nested/.gitignore"), "secret.txt\n")?;
         fs::write(config_dir.join("nested/visible.txt"), "hello")?;
         fs::write(config_dir.join("nested/secret.txt"), "hidden")?;

--- a/apps/native/src-tauri/src/evolve/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/ensure_secret.rs
@@ -8,8 +8,8 @@ use crate::evolve::sops::{
 };
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 
+use super::gitignore::GitignoreChecker;
 use anyhow::{Result, anyhow};
-use ignore::gitignore::Gitignore;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 
@@ -80,7 +80,7 @@ pub fn execute_ensure_secret(
     base: &Path,
     args: &serde_json::Value,
     auto_format: bool,
-    gitignore_matcher: Option<&Gitignore>,
+    gitignore_matcher: Option<&GitignoreChecker>,
 ) -> Result<EnsureSecretResult> {
     let parsed: EnsureSecretArgs = serde_json::from_value(args.clone()).map_err(|error| {
         anyhow!(
@@ -160,7 +160,7 @@ fn inject_secret(
     secret_path: &str,
     inject: &SecretInject,
     auto_format: bool,
-    gitignore_matcher: Option<&Gitignore>,
+    gitignore_matcher: Option<&GitignoreChecker>,
 ) -> Result<()> {
     if inject.file.trim().is_empty() {
         return Err(anyhow!(

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -7,9 +7,9 @@
 
 use crate::shared_types::FileEdit;
 
-use super::gitignore::is_ignored_by_matcher;
+use super::gitignore::GitignoreChecker;
+use super::gitignore::is_path_ignored;
 use super::utils::normalize_relative_path;
-use ignore::gitignore::Gitignore;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -93,7 +93,7 @@ pub(crate) fn rewrite_existing_file_in_dir<F>(
     base: &Path,
     rel: &str,
     operation: &str,
-    gitignore_matcher: Option<&Gitignore>,
+    gitignore_matcher: Option<&GitignoreChecker>,
     edit: F,
 ) -> anyhow::Result<()>
 where
@@ -370,7 +370,7 @@ pub(crate) fn validate_file_content(file_path: &str, content: &str) -> anyhow::R
 pub fn apply_file_edits(
     base: &Path,
     edit: &FileEdit,
-    gitignore_matcher: Option<&Gitignore>,
+    gitignore_matcher: Option<&GitignoreChecker>,
 ) -> anyhow::Result<()> {
     reject_gitignored_edit_path(base, &edit.path, "apply file edit", gitignore_matcher)?;
 
@@ -439,10 +439,10 @@ fn reject_gitignored_edit_path(
     _base: &Path,
     rel: &str,
     operation: &str,
-    gitignore_matcher: Option<&Gitignore>,
+    gitignore_matcher: Option<&GitignoreChecker>,
 ) -> anyhow::Result<()> {
     let normalized_rel = normalize_relative_path(Path::new(rel))?;
-    let is_ignored = is_ignored_by_matcher(gitignore_matcher, &normalized_rel, false);
+    let is_ignored = is_path_ignored(gitignore_matcher, &normalized_rel)?;
 
     if is_ignored {
         return Err(anyhow::anyhow!(
@@ -458,7 +458,7 @@ fn reject_gitignored_edit_path(
 #[cfg(test)]
 mod tests {
     use super::{apply_file_edits, rewrite_existing_file_in_dir};
-    use crate::evolve::gitignore::load_gitignore_matcher;
+    use crate::evolve::gitignore::GitignoreChecker;
     use crate::shared_types::FileEdit;
     use std::fs;
 
@@ -536,8 +536,9 @@ mod tests {
     fn apply_file_edits_rejects_gitignored_target() {
         let temp = tempfile::tempdir().expect("create temp dir");
         let base = temp.path();
+        git2::Repository::init(base).expect("init git repo");
         fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
-        let gitignore_matcher = load_gitignore_matcher(base).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(base).expect("load matcher");
 
         let edit = FileEdit {
             path: "secret.txt".to_string(),
@@ -554,9 +555,10 @@ mod tests {
     fn rewrite_existing_file_in_dir_rejects_gitignored_target() {
         let temp = tempfile::tempdir().expect("create temp dir");
         let base = temp.path();
+        git2::Repository::init(base).expect("init git repo");
         fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(base.join("secret.txt"), "old").expect("seed file");
-        let gitignore_matcher = load_gitignore_matcher(base).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(base).expect("load matcher");
 
         let err = rewrite_existing_file_in_dir(
             base,

--- a/apps/native/src-tauri/src/evolve/gitignore.rs
+++ b/apps/native/src-tauri/src/evolve/gitignore.rs
@@ -1,248 +1,266 @@
-use anyhow::{Result, anyhow};
-use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use log::warn;
-use std::fs;
+//! Git-backed ignore checks for the evolve tools.
+//!
+//! Ignore semantics are delegated entirely to libgit2 (`git2`) instead of
+//! reimplementing `.gitignore` matching: nested `.gitignore` files scope to
+//! their own subtree, `.git/info/exclude` and the user's global excludes are
+//! honored, and — matching real git — tracked files are never ignored even
+//! when a pattern matches them.
+
+use anyhow::{Context, Result};
+use git2::Repository;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-/// Load all `.gitignore` files under the base config directory.
-pub(crate) fn load_gitignore_matcher(base: &Path) -> Result<Option<Gitignore>> {
-    let mut gitignore_paths = Vec::new();
-    collect_gitignore_files(base, &mut gitignore_paths);
-
-    if gitignore_paths.is_empty() {
-        return Ok(None);
-    }
-
-    gitignore_paths.sort();
-
-    build_matcher(base, &gitignore_paths)
+pub(crate) struct GitignoreChecker {
+    repo_root: PathBuf,
 }
 
-/// Returns true when `relative_path` is ignored by the provided gitignore matcher.
-pub(crate) fn is_ignored_by_matcher(
-    matcher: Option<&Gitignore>,
-    relative_path: &Path,
-    is_dir: bool,
-) -> bool {
-    matcher
-        .map(|m| {
-            m.matched_path_or_any_parents(relative_path, is_dir)
-                .is_ignore()
+impl GitignoreChecker {
+    /// Returns `Ok(None)` when `repo_root` is not a git repository (no ignore
+    /// filtering applies), and an error when it looks like a repository but
+    /// cannot be opened, so ignore protections fail closed.
+    pub(crate) fn new(repo_root: &Path) -> Result<Option<Self>> {
+        if !repo_root.join(".git").exists() {
+            return Ok(None);
+        }
+        Repository::open(repo_root).with_context(|| {
+            format!(
+                "failed to open git repository at {} for gitignore checks",
+                repo_root.display()
+            )
+        })?;
+        Ok(Some(Self {
+            repo_root: repo_root.to_path_buf(),
+        }))
+    }
+
+    /// Re-open per call so the checker stays cheap to share and picks up
+    /// index changes made while an evolution is running.
+    fn repo(&self) -> Result<Repository> {
+        Repository::open(&self.repo_root).with_context(|| {
+            format!(
+                "failed to open git repository at {}",
+                self.repo_root.display()
+            )
         })
-        .unwrap_or(false)
-}
+    }
 
-fn collect_gitignore_files(dir: &Path, out: &mut Vec<PathBuf>) {
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(e) => {
-            warn!(
-                "Unable to read directory {} while collecting .gitignore files: {}",
-                dir.display(),
-                e
-            );
-            return;
+    /// Returns true when git would ignore `relative_path`. Tracked files are
+    /// never ignored, regardless of `.gitignore` patterns.
+    pub(crate) fn is_ignored(&self, relative_path: &Path) -> Result<bool> {
+        let repo = self.repo()?;
+        let index = repo.index().context("failed to read git index")?;
+        if index.get_path(relative_path, 0).is_some() {
+            return Ok(false);
         }
-    };
+        repo.is_path_ignored(relative_path).with_context(|| {
+            format!(
+                "failed to check gitignore status of {}",
+                relative_path.display()
+            )
+        })
+    }
 
-    for entry in entries {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(e) => {
-                warn!(
-                    "Unable to read directory entry in {} while collecting .gitignore files: {}",
-                    dir.display(),
-                    e
-                );
-                continue;
+    /// Every file git considers part of the working tree: tracked files plus
+    /// untracked files that are not ignored.
+    pub(crate) fn visible_files(&self) -> Result<VisibleFiles> {
+        let repo = self.repo()?;
+
+        let mut files: HashSet<PathBuf> = HashSet::new();
+        for entry in repo.index().context("failed to read git index")?.iter() {
+            files.insert(PathBuf::from(String::from_utf8_lossy(&entry.path).as_ref()));
+        }
+
+        let mut opts = git2::StatusOptions::new();
+        opts.include_untracked(true)
+            .recurse_untracked_dirs(true)
+            .include_ignored(false);
+        let statuses = repo
+            .statuses(Some(&mut opts))
+            .context("failed to compute git status")?;
+        for status in statuses.iter() {
+            if status.status().contains(git2::Status::WT_NEW) {
+                files.insert(PathBuf::from(
+                    String::from_utf8_lossy(status.path_bytes()).as_ref(),
+                ));
             }
-        };
-
-        let file_type = match entry.file_type() {
-            Ok(t) => t,
-            Err(e) => {
-                warn!(
-                    "Unable to get file type for {} while collecting .gitignore files: {}",
-                    entry.path().display(),
-                    e
-                );
-                continue;
-            }
-        };
-
-        let path = entry.path();
-        let name = entry.file_name();
-
-        if file_type.is_file() && name == ".gitignore" {
-            out.push(path);
-            continue;
         }
 
-        if !file_type.is_dir() || file_type.is_symlink() {
-            continue;
-        }
-
-        if super::IGNORED_DIRS.contains(&name.to_string_lossy().as_ref()) {
-            continue;
-        }
-
-        collect_gitignore_files(&path, out);
+        Ok(VisibleFiles::new(files))
     }
 }
 
-/// Build a Gitignore matcher from the provided `.gitignore` paths.
-/// If building with the full set fails, this attempts to salvage as many valid
-/// files as possible. If none can be loaded, this returns an error to fail
-/// closed instead of silently disabling ignore protections.
-fn build_matcher(base: &Path, gitignore_paths: &[PathBuf]) -> Result<Option<Gitignore>> {
-    // Pre-scan files: read contents where possible and classify files as
-    // valid, malformed (obvious unbalanced bracket heuristics), or unreadable.
-    let mut valid_paths: Vec<PathBuf> = Vec::new();
-    let mut malformed_paths: Vec<PathBuf> = Vec::new();
-    let mut unreadable_paths: Vec<PathBuf> = Vec::new();
+/// The set of non-ignored files in a repository, with directory containment
+/// queries so tree walks can prune subtrees that hold no visible files.
+pub(crate) struct VisibleFiles {
+    files: HashSet<PathBuf>,
+    dirs: HashSet<PathBuf>,
+}
 
-    for path in gitignore_paths {
-        match fs::read_to_string(path) {
-            Ok(contents) => {
-                let open_brackets = contents.matches('[').count();
-                let close_brackets = contents.matches(']').count();
-                if open_brackets != close_brackets {
-                    malformed_paths.push(path.clone());
-                    warn!(
-                        "Detected malformed .gitignore (unbalanced brackets) {}: skipping",
-                        path.display()
-                    );
-                } else {
-                    valid_paths.push(path.clone());
+impl VisibleFiles {
+    fn new(files: HashSet<PathBuf>) -> Self {
+        let mut dirs = HashSet::new();
+        for file in &files {
+            let mut ancestor = file.as_path();
+            while let Some(parent) = ancestor.parent() {
+                if parent.as_os_str().is_empty() || !dirs.insert(parent.to_path_buf()) {
+                    break;
                 }
-            }
-            Err(e) => {
-                warn!(
-                    "Unable to read .gitignore {}: {} (skipping)",
-                    path.display(),
-                    e
-                );
-                unreadable_paths.push(path.clone());
+                ancestor = parent;
             }
         }
+        Self { files, dirs }
     }
 
-    if valid_paths.is_empty() {
-        // No valid files to build from; fail closed.
-        return Err(anyhow::anyhow!(
-            "Failed to build gitignore matcher for {}: no valid .gitignore files could be loaded. Fix or remove malformed/unreadable .gitignore files before running evolve.",
-            base.display()
-        ));
+    pub(crate) fn contains_file(&self, relative_path: &Path) -> bool {
+        self.files.contains(relative_path)
     }
 
-    // Try to build a matcher from the valid paths only.
-    let mut final_builder = GitignoreBuilder::new(base);
-    for accepted in &valid_paths {
-        final_builder.add(accepted);
+    pub(crate) fn contains_dir(&self, relative_path: &Path) -> bool {
+        self.dirs.contains(relative_path)
     }
+}
 
-    match final_builder.build() {
-        Ok(matcher) => Ok(Some(matcher)),
-        Err(e) => Err(anyhow!(
-            "Failed to build final gitignore matcher for {}: {}",
-            base.display(),
-            e
-        )),
+/// Returns true when `relative_path` is ignored, treating "no repository" as
+/// nothing ignored.
+pub(crate) fn is_path_ignored(
+    checker: Option<&GitignoreChecker>,
+    relative_path: &Path,
+) -> Result<bool> {
+    match checker {
+        Some(checker) => checker.is_ignored(relative_path),
+        None => Ok(false),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{is_ignored_by_matcher, load_gitignore_matcher};
+    use super::{GitignoreChecker, is_path_ignored};
     use std::fs;
     use std::path::Path;
     use tempfile::tempdir;
 
-    #[test]
-    fn loads_matcher_when_subdir_is_unreadable() {
-        let temp = tempdir().expect("create temp dir");
-        let base = temp.path();
-        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write root .gitignore");
+    fn init_repo(base: &Path) -> git2::Repository {
+        git2::Repository::init(base).expect("init git repo")
+    }
 
-        let blocked = base.join("blocked");
-        fs::create_dir_all(&blocked).expect("create blocked dir");
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&blocked).expect("metadata").permissions();
-            perms.set_mode(0o000);
-            fs::set_permissions(&blocked, perms).expect("make blocked dir unreadable");
-        }
-
-        let matcher = load_gitignore_matcher(base).expect("load matcher should not fail");
-        assert!(matcher.is_some(), "expected matcher from root .gitignore");
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&blocked).expect("metadata").permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&blocked, perms).expect("restore permissions for cleanup");
-        }
+    fn checker(base: &Path) -> GitignoreChecker {
+        GitignoreChecker::new(base)
+            .expect("create checker")
+            .expect("base is a git repo")
     }
 
     #[test]
-    fn malformed_gitignore_fails_closed() {
+    fn non_git_directory_yields_no_checker() {
         let temp = tempdir().expect("create temp dir");
-        let base = temp.path();
-        fs::write(base.join(".gitignore"), "[unterminated").expect("write malformed .gitignore");
-
-        let err =
-            load_gitignore_matcher(base).expect_err("malformed .gitignore should fail closed");
+        let checker = GitignoreChecker::new(temp.path()).expect("no error for plain dir");
+        assert!(checker.is_none(), "expected None for a non-repo directory");
         assert!(
-            err.to_string()
-                .contains("no valid .gitignore files could be loaded"),
-            "unexpected error: {err:#}"
+            !is_path_ignored(None, Path::new("anything.txt")).expect("check"),
+            "no checker means nothing is ignored"
         );
     }
 
     #[test]
-    fn preserves_valid_rules_when_some_gitignore_files_unreadable() {
+    fn root_gitignore_rules_apply() {
         let temp = tempdir().expect("create temp dir");
         let base = temp.path();
-        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write root .gitignore");
+        init_repo(base);
+        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        fs::write(base.join("secret.txt"), "x").expect("write secret");
+        fs::write(base.join("visible.txt"), "x").expect("write visible");
 
-        let nested = base.join("nested");
-        fs::create_dir_all(&nested).expect("create nested dir");
-        let nested_gitignore = nested.join(".gitignore");
-        fs::write(&nested_gitignore, "ignored-in-nested.txt\n").expect("write nested .gitignore");
+        let checker = checker(base);
+        assert!(checker.is_ignored(Path::new("secret.txt")).expect("check"));
+        assert!(!checker.is_ignored(Path::new("visible.txt")).expect("check"));
+    }
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&nested_gitignore)
-                .expect("metadata")
-                .permissions();
-            perms.set_mode(0o000);
-            fs::set_permissions(&nested_gitignore, perms)
-                .expect("make nested .gitignore unreadable");
-        }
+    #[test]
+    fn nested_rules_apply_only_within_their_subtree() {
+        let temp = tempdir().expect("create temp dir");
+        let base = temp.path();
+        init_repo(base);
+        fs::create_dir_all(base.join("nested")).expect("create nested dir");
+        fs::write(base.join("nested/.gitignore"), "secret.txt\n").expect("write nested ignore");
 
-        let matcher = load_gitignore_matcher(base).expect("matcher load should not fail");
+        let checker = checker(base);
         assert!(
-            matcher.is_some(),
-            "expected matcher from readable .gitignore files"
+            checker
+                .is_ignored(Path::new("nested/secret.txt"))
+                .expect("check"),
+            "nested rule must apply inside its subtree"
         );
-
         assert!(
-            is_ignored_by_matcher(matcher.as_ref(), Path::new("secret.txt"), false),
-            "expected root rule to still apply"
+            !checker.is_ignored(Path::new("secret.txt")).expect("check"),
+            "nested rule must not apply to the repo root"
         );
+    }
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&nested_gitignore)
-                .expect("metadata")
-                .permissions();
-            perms.set_mode(0o644);
-            fs::set_permissions(&nested_gitignore, perms).expect("restore permissions for cleanup");
-        }
+    #[test]
+    fn nested_catch_all_does_not_ignore_repo_root() {
+        // Regression test: jj writes `.jj/.gitignore` containing `/*`. The old
+        // hand-rolled matcher applied that pattern repo-wide, blocking
+        // read_file/list_files/search_code entirely.
+        let temp = tempdir().expect("create temp dir");
+        let base = temp.path();
+        init_repo(base);
+        fs::create_dir_all(base.join(".jj")).expect("create .jj dir");
+        fs::write(base.join(".jj/.gitignore"), "/*\n").expect("write .jj ignore");
+        fs::write(base.join("flake.nix"), "{ }").expect("write flake");
+
+        let checker = checker(base);
+        assert!(
+            !checker.is_ignored(Path::new("flake.nix")).expect("check"),
+            "root files must stay visible"
+        );
+        assert!(
+            checker
+                .is_ignored(Path::new(".jj/repo/store"))
+                .expect("check"),
+            "the catch-all must still apply within .jj"
+        );
+    }
+
+    #[test]
+    fn tracked_files_are_never_ignored() {
+        let temp = tempdir().expect("create temp dir");
+        let base = temp.path();
+        let repo = init_repo(base);
+        fs::write(base.join("home.nix"), "{ }").expect("write file");
+        let mut index = repo.index().expect("open index");
+        index.add_path(Path::new("home.nix")).expect("track file");
+        index.write().expect("write index");
+        // Pattern matches the tracked file; git ignores the pattern for it.
+        fs::write(base.join(".gitignore"), "home.nix\n").expect("write .gitignore");
+
+        let checker = checker(base);
+        assert!(
+            !checker.is_ignored(Path::new("home.nix")).expect("check"),
+            "tracked files must never be ignored"
+        );
+    }
+
+    #[test]
+    fn visible_files_lists_tracked_and_untracked_but_not_ignored() {
+        let temp = tempdir().expect("create temp dir");
+        let base = temp.path();
+        let repo = init_repo(base);
+        fs::write(base.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
+        fs::write(base.join("tracked.txt"), "x").expect("write tracked");
+        fs::write(base.join("untracked.txt"), "x").expect("write untracked");
+        fs::write(base.join("secret.txt"), "x").expect("write secret");
+        fs::create_dir_all(base.join("sub")).expect("create sub");
+        fs::write(base.join("sub/inner.txt"), "x").expect("write inner");
+        let mut index = repo.index().expect("open index");
+        index.add_path(Path::new("tracked.txt")).expect("track");
+        index.write().expect("write index");
+
+        let visible = checker(base).visible_files().expect("visible files");
+        assert!(visible.contains_file(Path::new("tracked.txt")));
+        assert!(visible.contains_file(Path::new("untracked.txt")));
+        assert!(visible.contains_file(Path::new("sub/inner.txt")));
+        assert!(!visible.contains_file(Path::new("secret.txt")));
+        assert!(visible.contains_dir(Path::new("sub")));
+        assert!(!visible.contains_dir(Path::new("elsewhere")));
     }
 }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -1047,7 +1047,7 @@ pub async fn generate_evolution<R: Runtime>(
         None,
     ));
 
-    let gitignore_matcher = gitignore::load_gitignore_matcher(repo_root.as_path())?;
+    let gitignore_matcher = gitignore::GitignoreChecker::new(repo_root.as_path())?;
 
     // Track whether we've made any actual edits and/or build checks
     let mut made_edit = false;

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -11,9 +11,9 @@ use rowan::ast::AstNode;
 use rowan::{TextRange, TextSize};
 use std::path::Path;
 
+use super::gitignore::GitignoreChecker;
 use crate::evolve::file_ops::rewrite_existing_file_in_dir;
 use crate::evolve::types::FileEditAction;
-use ignore::gitignore::Gitignore;
 
 /// Internal marker key used in JSON edit payloads to request a raw Nix path literal.
 ///
@@ -339,7 +339,7 @@ pub fn apply_semantic_edit(
     base: &Path,
     edit: &SemanticFileEdit,
     auto_format: bool,
-    gitignore_matcher: Option<&Gitignore>,
+    gitignore_matcher: Option<&GitignoreChecker>,
 ) -> anyhow::Result<()> {
     rewrite_existing_file_in_dir(
         base,

--- a/apps/native/src-tauri/src/evolve/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/search_code.rs
@@ -1,6 +1,6 @@
+use super::gitignore::{GitignoreChecker, VisibleFiles};
 use super::utils::truncate_error;
 use anyhow::{Result, anyhow};
-use ignore::gitignore::Gitignore;
 use log::info;
 use serde_json::Value;
 use std::path::{Component, Path, PathBuf};
@@ -14,9 +14,13 @@ pub fn execute_search_code(
     base: &Path,
     pattern: &str,
     file_pattern: Option<&str>,
-    gitignore: Option<&Gitignore>,
+    gitignore: Option<&GitignoreChecker>,
 ) -> Result<String> {
     info!("Searching for pattern: {}", pattern);
+
+    let visible = gitignore
+        .map(|checker| checker.visible_files())
+        .transpose()?;
 
     let mut cmd = Command::new("rg");
     cmd.args([
@@ -59,7 +63,7 @@ pub fn execute_search_code(
         Ok(out) => {
             let status = out.status;
             if status.success() {
-                let formatted = format_rg_json_matches(&out.stdout, gitignore);
+                let formatted = format_rg_json_matches(&out.stdout, visible.as_ref());
                 if formatted.is_empty() {
                     Ok("No matches found.".to_string())
                 } else {
@@ -97,7 +101,7 @@ pub fn execute_search_code(
             }
             let output = grep_cmd.arg(pattern).arg(".").current_dir(base).output()?;
             let stdout = String::from_utf8_lossy(&output.stdout);
-            let filtered = filter_grep_matches(&stdout, gitignore);
+            let filtered = filter_grep_matches(&stdout, visible.as_ref());
             if filtered.trim().is_empty() {
                 Ok("No matches found.".to_string())
             } else {
@@ -107,7 +111,7 @@ pub fn execute_search_code(
     }
 }
 
-fn format_rg_json_matches(stdout: &[u8], gitignore: Option<&Gitignore>) -> String {
+fn format_rg_json_matches(stdout: &[u8], visible: Option<&VisibleFiles>) -> String {
     let mut lines: Vec<String> = Vec::new();
 
     for json_line in String::from_utf8_lossy(stdout).lines() {
@@ -129,7 +133,7 @@ fn format_rg_json_matches(stdout: &[u8], gitignore: Option<&Gitignore>) -> Strin
             continue;
         };
 
-        if is_ignored_match(path, false, gitignore) {
+        if is_hidden_match(path, visible) {
             continue;
         }
 
@@ -145,7 +149,7 @@ fn format_rg_json_matches(stdout: &[u8], gitignore: Option<&Gitignore>) -> Strin
     lines.join("\n")
 }
 
-fn filter_grep_matches(stdout: &str, gitignore: Option<&Gitignore>) -> String {
+fn filter_grep_matches(stdout: &str, visible: Option<&VisibleFiles>) -> String {
     let mut lines: Vec<String> = Vec::new();
 
     for line in stdout.lines() {
@@ -168,7 +172,7 @@ fn filter_grep_matches(stdout: &str, gitignore: Option<&Gitignore>) -> String {
             continue;
         }
 
-        if is_ignored_match(path, false, gitignore) {
+        if is_hidden_match(path, visible) {
             continue;
         }
 
@@ -178,9 +182,11 @@ fn filter_grep_matches(stdout: &str, gitignore: Option<&Gitignore>) -> String {
     lines.join("\n")
 }
 
-fn is_ignored_match(path: &str, is_dir: bool, gitignore: Option<&Gitignore>) -> bool {
+fn is_hidden_match(path: &str, visible: Option<&VisibleFiles>) -> bool {
     let rel = normalize_match_path(path);
-    super::gitignore::is_ignored_by_matcher(gitignore, &rel, is_dir)
+    visible
+        .map(|visible| !visible.contains_file(&rel))
+        .unwrap_or(false)
 }
 
 fn normalize_match_path(path: &str) -> PathBuf {
@@ -197,7 +203,7 @@ fn normalize_match_path(path: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{execute_search_code, filter_grep_matches};
-    use crate::evolve::gitignore::load_gitignore_matcher;
+    use crate::evolve::gitignore::GitignoreChecker;
     use std::fs;
     use tempfile::tempdir;
 
@@ -205,10 +211,11 @@ mod tests {
     fn search_code_skips_files_ignored_by_base_gitignore() {
         let binding = tempdir().expect("tempdir");
         let tmp = binding.path();
+        git2::Repository::init(tmp).expect("init git repo");
         fs::write(tmp.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(tmp.join("visible.txt"), "NEEDLE").expect("write visible file");
         fs::write(tmp.join("secret.txt"), "NEEDLE").expect("write secret file");
-        let gitignore_matcher = load_gitignore_matcher(tmp).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp).expect("load matcher");
 
         let output = execute_search_code(tmp, "NEEDLE", None, gitignore_matcher.as_ref())
             .expect("search should succeed");
@@ -221,9 +228,10 @@ mod tests {
     fn search_code_respects_gitignore_even_with_file_pattern() {
         let binding = tempdir().expect("tempdir");
         let tmp = binding.path();
+        git2::Repository::init(tmp).expect("init git repo");
         fs::write(tmp.join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(tmp.join("secret.txt"), "NEEDLE").expect("write secret file");
-        let gitignore_matcher = load_gitignore_matcher(tmp).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp).expect("load matcher");
 
         let output = execute_search_code(
             tmp,
@@ -240,11 +248,12 @@ mod tests {
     fn search_code_skips_files_ignored_by_subdir_gitignore() {
         let binding = tempdir().expect("tempdir");
         let tmp = binding.path();
+        git2::Repository::init(tmp).expect("init git repo");
         fs::create_dir_all(tmp.join("nested")).expect("make nested dir");
         fs::write(tmp.join("nested/.gitignore"), "secret.txt\n").expect("write nested .gitignore");
         fs::write(tmp.join("nested/visible.txt"), "NEEDLE").expect("write nested visible file");
         fs::write(tmp.join("nested/secret.txt"), "NEEDLE").expect("write nested secret file");
-        let gitignore_matcher = load_gitignore_matcher(tmp).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp).expect("load matcher");
 
         let output = execute_search_code(tmp, "NEEDLE", None, gitignore_matcher.as_ref())
             .expect("search should succeed");

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -28,8 +28,8 @@ use crate::evolve::types::SemanticFileEdit;
 use crate::evolve::utils::normalize_relative_path;
 use crate::shared_types::FileEdit;
 
+use super::gitignore::GitignoreChecker;
 use anyhow::{Result, anyhow};
-use ignore::gitignore::Gitignore;
 use std::path::{Component, Path};
 
 // =============================================================================
@@ -69,7 +69,7 @@ pub(crate) struct ToolCtx<'a> {
     pub(crate) config_dir: &'a str,
     pub(crate) host_attr: &'a str,
     pub(crate) args: &'a serde_json::Value,
-    pub(crate) gitignore_matcher: Option<&'a Gitignore>,
+    pub(crate) gitignore_matcher: Option<&'a GitignoreChecker>,
     pub(crate) auto_format: bool,
 }
 
@@ -114,7 +114,7 @@ pub fn execute_tool(
     name: &str,
     args: &serde_json::Value,
     auto_format: bool,
-    gitignore_matcher: Option<&Gitignore>,
+    gitignore_matcher: Option<&GitignoreChecker>,
 ) -> Result<ToolResult> {
     let ctx = ToolCtx {
         repo_root,
@@ -214,7 +214,7 @@ pub(crate) fn ensure_nixmac_edit_allowed(tool: &str, path: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{ToolResult, execute_tool, is_editing_tool, truncate_for_log};
-    use crate::evolve::gitignore::load_gitignore_matcher;
+    use crate::evolve::gitignore::GitignoreChecker;
     use serde_json::json;
     use std::fs;
     use tempfile::tempdir;
@@ -261,9 +261,10 @@ mod tests {
     #[test]
     fn read_file_rejects_base_gitignored_files() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
         fs::write(tmp.path().join("secret.txt"), "top secret").expect("write secret file");
-        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path(),
@@ -285,12 +286,13 @@ mod tests {
     #[test]
     fn read_file_rejects_subdir_gitignored_files() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::create_dir_all(tmp.path().join("nested")).expect("make nested dir");
         fs::write(tmp.path().join("nested/.gitignore"), "secret.txt\n")
             .expect("write nested .gitignore");
         fs::write(tmp.path().join("nested/secret.txt"), "top secret")
             .expect("write nested secret file");
-        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path(),
@@ -312,13 +314,14 @@ mod tests {
     #[test]
     fn list_files_skips_base_gitignored_files() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::write(tmp.path().join(".gitignore"), "secret.txt\nignored-dir/\n")
             .expect("write .gitignore");
         fs::write(tmp.path().join("visible.txt"), "visible").expect("write visible file");
         fs::write(tmp.path().join("secret.txt"), "secret").expect("write secret file");
         fs::create_dir_all(tmp.path().join("ignored-dir")).expect("make ignored dir");
         fs::write(tmp.path().join("ignored-dir/file.txt"), "ignored").expect("write ignored file");
-        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path(),
@@ -343,8 +346,9 @@ mod tests {
     #[test]
     fn edit_file_rejects_base_gitignored_paths() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("write .gitignore");
-        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path(),
@@ -371,9 +375,10 @@ mod tests {
     #[test]
     fn edit_nix_file_rejects_base_gitignored_paths() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::write(tmp.path().join(".gitignore"), "ignored.nix\n").expect("write .gitignore");
         fs::write(tmp.path().join("ignored.nix"), "{ ... }: { }\n").expect("write nix file");
-        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path(),
@@ -500,6 +505,7 @@ mod tests {
     #[test]
     fn edit_nix_file_reports_shorthand_action_missing_attr_path() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::write(tmp.path().join("services.nix"), "{ ... }: { }\n").expect("write nix file");
 
         let result = execute_tool(
@@ -534,6 +540,7 @@ mod tests {
     #[test]
     fn edit_nix_file_reports_non_object_action_payload() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::write(tmp.path().join("services.nix"), "{ ... }: { }\n").expect("write nix file");
 
         let result = execute_tool(
@@ -822,6 +829,7 @@ mod tests {
     #[test]
     fn edit_file_rejects_stray_nixmac_data_json() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::create_dir_all(tmp.path().join(".nixmac")).expect("make nixmac dir");
         fs::write(tmp.path().join(".nixmac/data.json"), "{}\n").expect("write stray data");
 
@@ -900,10 +908,11 @@ mod tests {
     #[test]
     fn edit_file_rejects_subdir_gitignored_paths() {
         let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
         fs::create_dir_all(tmp.path().join("nested")).expect("make nested dir");
         fs::write(tmp.path().join("nested/.gitignore"), "secret.txt\n")
             .expect("write nested .gitignore");
-        let gitignore_matcher = load_gitignore_matcher(tmp.path()).expect("load matcher");
+        let gitignore_matcher = GitignoreChecker::new(tmp.path()).expect("load matcher");
 
         let result = execute_tool(
             tmp.path(),

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -3,7 +3,7 @@
 use anyhow::{Result, anyhow};
 
 use crate::evolve::file_ops::resolve_existing_path_in_dir;
-use crate::evolve::gitignore::is_ignored_by_matcher;
+use crate::evolve::gitignore::is_path_ignored;
 use crate::evolve::messages::Tool;
 use crate::evolve::nix_file_editor::{apply_semantic_edit, infer_single_list_attrpath};
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
@@ -199,7 +199,7 @@ fn sibling_attr_path(args: &serde_json::Value) -> Option<String> {
 
 fn infer_attr_path_from_file(ctx: &ToolCtx, path: &str) -> Result<Option<String>> {
     let normalized_path = normalize_relative_path(std::path::Path::new(path))?;
-    if is_ignored_by_matcher(ctx.gitignore_matcher, &normalized_path, false) {
+    if is_path_ignored(ctx.gitignore_matcher, &normalized_path)? {
         return Err(anyhow!(
             "edit_nix_file: '{}' is ignored by .gitignore in git repository; refusing to infer action path",
             path

--- a/apps/native/src-tauri/src/evolve/tools/list_files.rs
+++ b/apps/native/src-tauri/src/evolve/tools/list_files.rs
@@ -6,7 +6,6 @@ use std::path::Component;
 
 use crate::evolve::IGNORED_DIRS;
 use crate::evolve::file_ops::{ensure_path_under_base, join_in_dir};
-use crate::evolve::gitignore::is_ignored_by_matcher;
 use crate::evolve::messages::Tool;
 
 use super::{ToolCtx, ToolResult};
@@ -38,6 +37,11 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     let full_pattern = join_in_dir(repo_root, pattern)?;
     info!("Listing files matching: {}", full_pattern.display());
 
+    let visible = ctx
+        .gitignore_matcher
+        .map(|checker| checker.visible_files())
+        .transpose()?;
+
     let ignored_dirs = IGNORED_DIRS;
     let matched_files = glob::glob(full_pattern.to_str().unwrap())
         .map_err(|e| anyhow!("Invalid glob pattern: {}", e))?
@@ -66,8 +70,10 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             }
         }
 
-        if is_ignored_by_matcher(ctx.gitignore_matcher, rel, false) {
-            continue;
+        if let Some(visible) = &visible {
+            if !visible.contains_file(rel) {
+                continue;
+            }
         }
 
         files.push(rel.to_string_lossy().to_string());

--- a/apps/native/src-tauri/src/evolve/tools/read_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/read_file.rs
@@ -5,7 +5,7 @@ use log::info;
 use std::path::Path;
 
 use crate::evolve::file_ops::resolve_existing_path_in_dir;
-use crate::evolve::gitignore::is_ignored_by_matcher;
+use crate::evolve::gitignore::is_path_ignored;
 use crate::evolve::messages::Tool;
 use crate::evolve::utils::normalize_relative_path;
 
@@ -33,7 +33,7 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
         .as_str()
         .ok_or_else(|| anyhow!("read_file: missing path"))?;
     let normalized_rel = normalize_relative_path(Path::new(path))?;
-    if is_ignored_by_matcher(ctx.gitignore_matcher, &normalized_rel, false) {
+    if is_path_ignored(ctx.gitignore_matcher, &normalized_rel)? {
         return Err(anyhow!(
             "read_file: '{}' is ignored by .gitignore in git repository at '{}'",
             path,


### PR DESCRIPTION
## Summary

I hit a curious bug:
I'm using jujutsu and it's setting up its own little `.gitignore` with `/*`.
Because of this, the previous manual implementation refused to read any files in my repo.

Anchored patterns applied repo-wide: `/*` in `.jj/.gitignore` ignored every file, blanking `repo_view` and blocking `read_file`, `list_files`, and `search_code`.

Replaced with git2: index-aware point checks (tracked files are never ignored) plus a visible-files set from the index plus untracked-not-ignored status. Drops the `ignore` crate.

## Test Plan

- `cargo test --manifest-path apps/native/src-tauri/Cargo.toml evolve`
- [x] manual test in my repo

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #___)
- [x] No docs update needed