### PR TITLE
feat: add telemtry consent prompt

### DIFF
--- a/apps/native/src-tauri/src/shared_types/prefs.rs
+++ b/apps/native/src-tauri/src/shared_types/prefs.rs
@@ -43,6 +43,8 @@ pub struct UiPrefs {
     pub max_output_tokens: Option<usize>,
     /// Whether diagnostic feedback may be sent.
     pub send_diagnostics: bool,
+    /// Whether the one-time diagnostics consent notice has been shown.
+    pub diagnostics_notice_acknowledged: bool,
     /// Whether to confirm before running build/apply.
     pub confirm_build: bool,
     /// Whether to confirm before clearing changes.
@@ -104,6 +106,8 @@ pub struct UiPrefsUpdate {
     pub openai_compatible_api_key: Option<String>,
     /// Diagnostics sharing preference update.
     pub send_diagnostics: Option<bool>,
+    /// Diagnostics notice acknowledgement update.
+    pub diagnostics_notice_acknowledged: Option<bool>,
     /// Build confirmation preference update.
     pub confirm_build: Option<bool>,
     /// Clear confirmation preference update.
@@ -156,6 +160,9 @@ pub struct GlobalPreferences {
     pub config_dir: Option<String>,
     pub repo_root: Option<String>,
     pub send_diagnostics: bool,
+    /// True once the user has seen the one-time diagnostics consent notice
+    /// (first launch after the default-on telemetry change).
+    pub diagnostics_notice_acknowledged: bool,
     pub evolve_provider: Option<String>,
     pub evolve_model: Option<String>,
     pub summary_provider: Option<String>,
@@ -203,7 +210,11 @@ impl Default for GlobalPreferences {
             host_attr: None,
             config_dir: None,
             repo_root: None,
-            send_diagnostics: false,
+            // Default-on with disclosure: a one-time notice is shown on first
+            // launch (diagnostics_notice_acknowledged) and opt-out lives in
+            // settings. PostHog only ever receives sanitized product events.
+            send_diagnostics: true,
+            diagnostics_notice_acknowledged: false,
             evolve_provider: None,
             evolve_model: None,
             summary_provider: None,
@@ -254,6 +265,13 @@ impl GlobalPreferences {
         }
         if let Some(v) = update.send_diagnostics {
             self.send_diagnostics = v;
+            // An explicit choice supersedes the one-time notice: without this,
+            // the default-on migration in `state::preferences` would flip an
+            // un-acknowledged opt-out back on at next launch.
+            self.diagnostics_notice_acknowledged = true;
+        }
+        if let Some(v) = update.diagnostics_notice_acknowledged {
+            self.diagnostics_notice_acknowledged = v;
         }
         if let Some(v) = update.confirm_build {
             self.confirm_build = v;
@@ -316,6 +334,7 @@ impl GlobalPreferences {
             max_build_attempts: None,
             max_output_tokens: None,
             send_diagnostics: self.send_diagnostics,
+            diagnostics_notice_acknowledged: self.diagnostics_notice_acknowledged,
             confirm_build: self.confirm_build,
             confirm_clear: self.confirm_clear,
             confirm_rollback: self.confirm_rollback,

--- a/apps/native/src-tauri/src/state/preferences.rs
+++ b/apps/native/src-tauri/src/state/preferences.rs
@@ -31,7 +31,9 @@ pub fn load_global_observable<R: Runtime>(
         Arc::new(AppDataJson::for_app(app, GLOBAL_PREFERENCES_PATH)?);
     let mut initial = load_or_default::<GlobalPreferences>(persistence.as_ref())?;
 
-    if migrate_from_legacy_store(app, &mut initial)? {
+    let mut dirty = migrate_from_legacy_store(app, &mut initial)?;
+    dirty |= migrate_diagnostics_default_on(&mut initial);
+    if dirty {
         persistence.flush(&serde_json::to_value(&initial)?)?;
     }
 
@@ -102,6 +104,28 @@ fn migrate_from_legacy_store<R: Runtime>(
     store.set(LEGACY_MIGRATED_MARKER, serde_json::Value::Bool(true));
     store.save()?;
     Ok(true)
+}
+
+/// One-shot flip to default-on diagnostics for installs that predate the
+/// change. Existing installs have `sendDiagnostics: false` persisted (the old
+/// default) even though most users never made an explicit choice. Until the
+/// one-time consent notice has been acknowledged, `send_diagnostics: false`
+/// is treated as "never chose" and flipped on; the notice (shown by the
+/// frontend while `diagnostics_notice_acknowledged` is false) discloses this
+/// and offers opt-out.
+///
+/// Known trade-off: pre-change installs where the user *explicitly* toggled
+/// diagnostics off are indistinguishable from never-chose (both persisted
+/// `false`, and the ack flag didn't exist yet), so those installs get flipped
+/// on once and re-disclosed via the notice. Choices made after this shipped
+/// are safe: any explicit `send_diagnostics` update also sets the acknowledged
+/// flag (see `GlobalPreferences::apply_ui_update`), which makes this a no-op.
+fn migrate_diagnostics_default_on(prefs: &mut GlobalPreferences) -> bool {
+    if prefs.diagnostics_notice_acknowledged || prefs.send_diagnostics {
+        return false;
+    }
+    prefs.send_diagnostics = true;
+    true
 }
 
 pub(crate) fn load_or_default<T>(persistence: &dyn Persistence) -> Result<T>
@@ -213,6 +237,46 @@ mod tests {
         let prefs = load_or_default::<GlobalPreferences>(&persistence).unwrap();
 
         assert_eq!(prefs, GlobalPreferences::default());
+    }
+
+    #[test]
+    fn diagnostics_default_on_flips_unacknowledged_opt_out() {
+        // Pre-change install: persisted false only because the old default
+        // was false and the user never saw a consent prompt.
+        let mut prefs = GlobalPreferences {
+            send_diagnostics: false,
+            diagnostics_notice_acknowledged: false,
+            ..GlobalPreferences::default()
+        };
+        assert!(migrate_diagnostics_default_on(&mut prefs));
+        assert!(prefs.send_diagnostics);
+        // The notice stays un-acknowledged so the frontend still shows it.
+        assert!(!prefs.diagnostics_notice_acknowledged);
+    }
+
+    #[test]
+    fn diagnostics_default_on_respects_explicit_opt_out() {
+        let mut prefs = GlobalPreferences {
+            send_diagnostics: false,
+            diagnostics_notice_acknowledged: true,
+            ..GlobalPreferences::default()
+        };
+        assert!(!migrate_diagnostics_default_on(&mut prefs));
+        assert!(!prefs.send_diagnostics);
+    }
+
+    #[test]
+    fn explicit_send_diagnostics_update_acknowledges_notice() {
+        let mut prefs = GlobalPreferences::default();
+        prefs.apply_ui_update(&crate::shared_types::UiPrefsUpdate {
+            send_diagnostics: Some(false),
+            ..Default::default()
+        });
+        assert!(!prefs.send_diagnostics);
+        assert!(prefs.diagnostics_notice_acknowledged);
+        // Idempotent at next load: the migration must not flip it back.
+        assert!(!migrate_diagnostics_default_on(&mut prefs));
+        assert!(!prefs.send_diagnostics);
     }
 
     #[test]

--- a/apps/native/src-tauri/src/telemetry/ipc.rs
+++ b/apps/native/src-tauri/src/telemetry/ipc.rs
@@ -9,6 +9,7 @@ use tauri::command;
 
 /// Serialized span data received from the WebView's ForwardingSpanProcessor.
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ForwardedSpan {
     pub name: String,
     pub trace_id: String,

--- a/apps/native/src/App.tsx
+++ b/apps/native/src/App.tsx
@@ -1,12 +1,15 @@
+import { useDiagnosticsNotice } from "@/hooks/use-diagnostics-notice";
 import { useAuthDeepLink } from "@/lib/auth-deep-link";
 import { bootBreadcrumb, clearBootStage, markBootStage } from "@/lib/boot-diagnostics";
 import { useTelemetry } from "@/lib/telemetry/context";
 import { RouterProvider, router } from "@/router";
+import { AlertTriangle, Check, Info } from "lucide-react";
 import { useEffect } from "react";
 import { Toaster } from "sonner";
 
 export default function App() {
   useAuthDeepLink();
+  useDiagnosticsNotice();
   const telemetry = useTelemetry();
 
   useEffect(() => {
@@ -37,13 +40,19 @@ export default function App() {
       />
       <RouterProvider router={router} />
       <Toaster
-        position="top-center"
+        position="bottom-right"
+        icons={{
+          success: <Check className="h-4 w-4" />,
+          info: <Info className="h-4 w-4" />,
+          warning: <AlertTriangle className="h-4 w-4" />,
+          error: <AlertTriangle className="h-4 w-4" />,
+        }}
         theme="dark"
         toastOptions={{
           classNames: {
-            success: "bg-teal-900! border-teal-500/50! text-teal-100!",
-            title: "text-teal-100!",
-            description: "text-teal-200!",
+            // success: "bg-emerald-900! border-emerald-500/50! text-emerald-100!",
+            // title: "text-foreground!",
+            description: "text-muted-foreground!",
           },
         }}
       />

--- a/apps/native/src/hooks/use-diagnostics-notice.ts
+++ b/apps/native/src/hooks/use-diagnostics-notice.ts
@@ -1,0 +1,57 @@
+import { tauriAPI } from "@/ipc/api";
+import { getTelemetry } from "@/lib/telemetry/instance";
+import { useViewModel } from "@nixmac/state";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+/**
+ * One-time disclosure that anonymous diagnostics are enabled by default.
+ *
+ * Shown once per install (gated on `diagnosticsNoticeAcknowledged`). The
+ * acknowledgement is only persisted once the toast leaves the screen
+ * (dismissed, auto-closed, or acted on) — if the app quits while the notice
+ * is still up, it re-appears on the next launch instead of being silently
+ * marked as seen.
+ */
+export function useDiagnosticsNotice(): void {
+  // Ref guard: StrictMode double-invokes effects in dev, and the ack write
+  // round-trips through the backend before the viewmodel mirror updates.
+  const shown = useRef(false);
+
+  const hydrated = useViewModel((s) => s.preferences !== null && s.preferences !== undefined);
+  const acknowledged = useViewModel(
+    (s) => s.preferences?.diagnosticsNoticeAcknowledged ?? true,
+  );
+
+  useEffect(() => {
+    if (!hydrated || acknowledged || shown.current) return;
+    shown.current = true;
+
+    const acknowledge = () => {
+      void tauriAPI.ui.setPrefs({ diagnosticsNoticeAcknowledged: true });
+    };
+
+    toast.info("Anonymous diagnostics are enabled", {
+      description:
+        "It would help us a lot if you kept this enabled. No file contents or personal data are ever sent. However, you can turn this off anytime in Settings → General.",
+      duration: 30000,
+      // sonner fires exactly one of these: onDismiss for manual close,
+      // onAutoClose for duration expiry. An action click closes the toast
+      // without firing either, but that path acknowledges via setPrefs below.
+      onDismiss: acknowledge,
+      onAutoClose: acknowledge,
+      action: {
+        label: "Turn off",
+        onClick: () => {
+          // setPrefs also marks the notice acknowledged backend-side.
+          void tauriAPI.ui.setPrefs({ sendDiagnostics: false });
+          getTelemetry().setEnabled(false);
+          // The Rust OTEL pipeline reads the pref once at startup, so error
+          // reporting keeps running until relaunch (same caveat as the
+          // Settings toggle, which discloses "Restart required").
+          toast.info("Diagnostics turned off. Restart nixmac to fully stop background reporting.");
+        },
+      },
+    });
+  }, [hydrated, acknowledged]);
+}

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -1093,7 +1093,12 @@ installationId: number }
  * Hydrated via `get_global_preferences`; every mutation emits
  * `global_preferences_changed` with the full struct as payload.
  */
-export type GlobalPreferences = { hostAttr: string | null; configDir: string | null; repoRoot: string | null; sendDiagnostics: boolean; evolveProvider: string | null; evolveModel: string | null; summaryProvider: string | null; summaryModel: string | null; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
+export type GlobalPreferences = { hostAttr: string | null; configDir: string | null; repoRoot: string | null; sendDiagnostics: boolean; 
+/**
+ * True once the user has seen the one-time diagnostics consent notice
+ * (first launch after the default-on telemetry change).
+ */
+diagnosticsNoticeAcknowledged: boolean; evolveProvider: string | null; evolveModel: string | null; summaryProvider: string | null; summaryModel: string | null; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
 /**
  * Timestamp (unix secs) of the last onboarding "scan this Mac" / customizations review.
  */

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1231,7 +1231,12 @@ installationId: number }
  * Hydrated via `get_global_preferences`; every mutation emits
  * `global_preferences_changed` with the full struct as payload.
  */
-export type GlobalPreferences = { hostAttr: string | null; configDir: string | null; repoRoot: string | null; sendDiagnostics: boolean; evolveProvider: string | null; evolveModel: string | null; summaryProvider: string | null; summaryModel: string | null; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
+export type GlobalPreferences = { hostAttr: string | null; configDir: string | null; repoRoot: string | null; sendDiagnostics: boolean; 
+/**
+ * True once the user has seen the one-time diagnostics consent notice
+ * (first launch after the default-on telemetry change).
+ */
+diagnosticsNoticeAcknowledged: boolean; evolveProvider: string | null; evolveModel: string | null; summaryProvider: string | null; summaryModel: string | null; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
 /**
  * Timestamp (unix secs) of the last onboarding "scan this Mac" / customizations review.
  */
@@ -1244,6 +1249,22 @@ onboardingLoginDecided: boolean;
  * Timestamp (unix secs) of the last successful build/evolution apply. Set by `finalize_apply`.
  */
 onboardingLastBuildAt: number | null; 
+/**
+ * Root directory the app materialized during onboarding (import/scaffold)
+ * and still owns: until the first successful apply clears this, restart
+ * and re-import may wipe and re-create it. Never set for user-selected
+ * pre-existing directories. Not writable via `UiPrefsUpdate` — backend
+ * code paths only, like `onboarding_last_build_at`.
+ */
+onboardingProvisionalConfigDir: string | null; 
+/**
+ * Root of an import clone parked on the "which flake dir?" choice
+ * (`NeedsFlakeDirChoice`). Recorded so an abandoned choice can be
+ * discarded by the next import or an onboarding reset instead of
+ * orphaning the tree. Cleared on finalize/discard. Not writable via
+ * `UiPrefsUpdate`.
+ */
+pendingImportDir: string | null; 
 /**
  * Whether or not to auto-format Nix files when making changes to the flakes.
  */
@@ -2066,6 +2087,10 @@ maxOutputTokens: number | null;
  */
 sendDiagnostics: boolean; 
 /**
+ * Whether the one-time diagnostics consent notice has been shown.
+ */
+diagnosticsNoticeAcknowledged: boolean; 
+/**
  * Whether to confirm before running build/apply.
  */
 confirmBuild: boolean; 
@@ -2177,6 +2202,10 @@ openaiCompatibleApiKey: string | null;
  * Diagnostics sharing preference update.
  */
 sendDiagnostics: boolean | null; 
+/**
+ * Diagnostics notice acknowledgement update.
+ */
+diagnosticsNoticeAcknowledged: boolean | null; 
 /**
  * Build confirmation preference update.
  */

--- a/apps/native/src/lib/orpc.ts
+++ b/apps/native/src/lib/orpc.ts
@@ -171,31 +171,8 @@ import { QueryClient } from "@tanstack/react-query";
 
 export type {
   AccountBilling,
-  
   BillingProductInfo,
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  PreviewIndicatorState,
-  
-  
-  
-  
+  PreviewIndicatorState
 } from "@/ipc/orpc-bindings";
 
 /** Routes RPC calls through Tauri IPC (`plugin:orpc|handle_rpc`), not HTTP. */
@@ -221,3 +198,13 @@ export const queryClient = new QueryClient({
     },
   },
 });
+
+
+if (import.meta.env.DEV) {
+  // oxlint-disable-next-line no-unused-expressions
+  (window as any).__NIXMAC_ORPC__ = {
+    client,
+    queryUtils: orpc,
+    queryClient,
+  }
+}

--- a/apps/native/src/lib/providers/ai-provider-migration.test.ts
+++ b/apps/native/src/lib/providers/ai-provider-migration.test.ts
@@ -17,6 +17,7 @@ const PREFS: UiPrefs = {
 	maxBuildAttempts: null,
 	maxOutputTokens: null,
 	sendDiagnostics: false,
+	diagnosticsNoticeAcknowledged: false,
 	confirmBuild: false,
 	confirmClear: false,
 	confirmRollback: false,

--- a/apps/native/src/utils/test-fixtures.ts
+++ b/apps/native/src/utils/test-fixtures.ts
@@ -1,10 +1,10 @@
-import { viewModelActions } from "@nixmac/state";
 import type {
 	GlobalPreferences,
 	NixInstallState,
 	PermissionsState,
 	RebuildStatus,
 } from "@/ipc/types";
+import { viewModelActions } from "@nixmac/state";
 
 /**
  * Full `GlobalPreferences` value for tests and stories. Matches the backend
@@ -17,7 +17,8 @@ export function makeGlobalPreferences(
 		hostAttr: null,
 		configDir: null,
 		repoRoot: null,
-		sendDiagnostics: false,
+		sendDiagnostics: true,
+		diagnosticsNoticeAcknowledged: true,
 		evolveProvider: null,
 		evolveModel: null,
 		summaryProvider: null,
@@ -38,6 +39,8 @@ export function makeGlobalPreferences(
 		onboardingMacScannedAt: null,
 		onboardingLoginDecided: false,
 		onboardingLastBuildAt: null,
+		onboardingProvisionalConfigDir: null,
+		pendingImportDir: null,
 		autoFormatNixFiles: false,
 		...overrides,
 	};


### PR DESCRIPTION
## Summary

Adds a consent alert for telemetry, and enables by default. Currently all our in-app telemetry is empty so we cant debug a lot of issues. Also, this is the only way to get onboarding telemetry currently since settings is inaccessible from onboarding. This does not affect existing users with telemetry off.

## Test Plan

open app, you'll see the consent window once

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [ ] No docs update needed
