### PR TITLE
fix(feedback): stabilize dialog footer during preview/submit

### DIFF
--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { uiActions, useUiState } from "@nixmac/state";
 import { useCurrentStep } from "@/hooks/use-current-step";
@@ -309,6 +309,16 @@ export function FeedbackDialog() {
   const [submitting, setSubmitting] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
   const busy = submitting || previewLoading;
+  const feedbackTextRef = useRef<HTMLTextAreaElement>(null);
+
+  // The dialog opens on the availability-check spinner, so Radix's own
+  // open-autofocus (suppressed below — it would land on the X close button)
+  // can't target the textarea; focus it once the form actually renders.
+  useEffect(() => {
+    if (feedbackOpen && feedbackAvailability === "available") {
+      feedbackTextRef.current?.focus();
+    }
+  }, [feedbackOpen, feedbackAvailability]);
 
   const resetFeedbackState = () => {
     setFeedbackAvailability("idle");
@@ -557,7 +567,10 @@ export function FeedbackDialog() {
           uiActions.setFeedbackOpen(true);
         }}
       >
-      <DialogContent className="max-w-2xl h-[85vh] flex flex-col">
+      <DialogContent
+        className="max-w-2xl h-[85vh] flex flex-col"
+        onOpenAutoFocus={(e: Event) => e.preventDefault()}
+      >
         {checkingFeedbackAvailability ? (
           <>
             <DialogHeader>
@@ -651,6 +664,7 @@ export function FeedbackDialog() {
                 </Label>
                 <Textarea
                   id="feedback-text"
+                  ref={feedbackTextRef}
                   value={feedbackText}
                   onChange={(e) => setFeedbackText(e.target.value)}
                   placeholder="Tell us more..."

--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -307,6 +307,8 @@ export function FeedbackDialog() {
   const [isPreviewingReport, setIsPreviewingReport] = useState(false);
   const [previewReportText, setPreviewReportText] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const busy = submitting || previewLoading;
 
   const resetFeedbackState = () => {
     setFeedbackAvailability("idle");
@@ -474,7 +476,7 @@ export function FeedbackDialog() {
   };
 
   const handleSubmit = async () => {
-    if (submitting) return;
+    if (busy) return;
 
     setSubmitting(true);
     try {
@@ -490,15 +492,15 @@ export function FeedbackDialog() {
   };
 
   const handlePreview = async () => {
-    if (submitting || isPreviewingReport) return;
+    if (busy || isPreviewingReport) return;
 
-    setSubmitting(true);
+    setPreviewLoading(true);
     try {
       const payload = await buildFeedbackPayload();
       setPreviewReportText(payload);
       setIsPreviewingReport(true);
     } finally {
-      setSubmitting(false);
+      setPreviewLoading(false);
     }
   };
 
@@ -1038,35 +1040,87 @@ export function FeedbackDialog() {
           )}
         </div>
 
+        {/* The footer buttons must never change size across loading states:
+            a resize reflows the right-justified footer and shifts the other
+            buttons. The label therefore stays in the layout (invisible while
+            loading) to freeze the button's footprint, and the spinner is
+            absolutely positioned on top of it. The spinner must be wrapped in
+            a span: a direct svg child triggers the Button's has-[>svg]:px-3
+            variant, which narrows the padding and resizes the button. */}
         <DialogFooter>
+          {/* Keys prevent React from reusing a button's DOM node across the
+              preview/edit footer swap: a reused node animates its old variant
+              styles away (transition-all), flashing e.g. a white Preview
+              button where the primary Send button was. */}
           {isPreviewingReport ? (
             <>
               <Button
+                key="preview-cancel"
                 variant="outline"
                 onClick={() => setIsPreviewingReport(false)}
-                disabled={submitting}
+                disabled={busy}
+                className="disabled:transition-none"
               >
                 Cancel
               </Button>
-              <Button onClick={handleSubmit} disabled={submitting} aria-label="Send feedback">
-                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Send"}
+              <Button
+                key="preview-send"
+                onClick={handleSubmit}
+                disabled={busy}
+                aria-label="Send feedback"
+                className="relative disabled:transition-none"
+              >
+                <span className={submitting ? "invisible" : undefined}>Send</span>
+                {submitting && (
+                  <span className="absolute inset-0 flex items-center justify-center">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  </span>
+                )}
               </Button>
             </>
           ) : (
             <>
-              <Button variant="outline" onClick={handleClose} disabled={submitting}>
+              {/* disabled:transition-none — the buttons dim together the
+                  instant a footer action starts; transition-all would ease
+                  the opacity and make the outline buttons look like they
+                  disable later than the filled one. */}
+              <Button
+                key="edit-cancel"
+                variant="outline"
+                onClick={handleClose}
+                disabled={busy}
+                className="disabled:transition-none"
+              >
                 Cancel
               </Button>
-              <Button variant="outline" onClick={handlePreview} disabled={submitting}>
-                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Preview"}
+              <Button
+                key="edit-preview"
+                variant="outline"
+                onClick={handlePreview}
+                disabled={busy}
+                className="relative disabled:transition-none"
+              >
+                <span className={previewLoading ? "invisible" : undefined}>Preview</span>
+                {previewLoading && (
+                  <span className="absolute inset-0 flex items-center justify-center">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  </span>
+                )}
               </Button>
-              <Button onClick={handleSubmit} disabled={submitting} aria-label="Send feedback">
-                {submitting ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : isReportMode ? (
-                  "Send Report"
-                ) : (
-                  "Send Feedback"
+              <Button
+                key="edit-send"
+                onClick={handleSubmit}
+                disabled={busy}
+                aria-label="Send feedback"
+                className="relative disabled:transition-none"
+              >
+                <span className={submitting ? "invisible" : undefined}>
+                  {isReportMode ? "Send Report" : "Send Feedback"}
+                </span>
+                {submitting && (
+                  <span className="absolute inset-0 flex items-center justify-center">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  </span>
                 )}
               </Button>
             </>

--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -668,7 +668,10 @@ export function FeedbackDialog() {
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder="Select a prompt (optional)" />
                   </SelectTrigger>
-                  <SelectContent>
+                  {/* Cap the popper at the trigger's width; prompts are long
+                      and would otherwise blow the menu out much wider than
+                      the control. Items wrap via line-clamp instead. */}
+                  <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-trigger-width)]">
                     {promptHistory.length > 0 ? (
                       promptHistory.map((prompt) => (
                         <SelectItem key={prompt} value={prompt}>
@@ -719,7 +722,9 @@ export function FeedbackDialog() {
               {/* Share with team */}
               <div className="space-y-2">
                 <Label className="text-foreground">SHARE WITH THE TEAM</Label>
-                <div className="space-y-2 max-h-[28vh] overflow-y-auto pr-2">
+                {/* py-1/pl-1 keep the checkboxes' focus ring from being
+                    clipped by this scroll container's edges */}
+                <div className="space-y-2 max-h-[28vh] overflow-y-auto py-1 pl-1 pr-2">
                   {shouldShowCurrentAppState(feedbackType, step, mainWindowError) && (
                     <div className="flex items-center gap-2">
                       <Checkbox
@@ -742,7 +747,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -777,7 +782,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -812,7 +817,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -847,7 +852,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -882,7 +887,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -917,7 +922,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -952,7 +957,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -987,7 +992,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />
@@ -1022,7 +1027,7 @@ export function FeedbackDialog() {
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group"
+                            className="p-1 h-5 w-5 inline-flex items-center justify-center rounded-md hover:bg-accent/50 transition-colors shrink-0 group outline-none focus-visible:bg-accent/50"
                             aria-label="More information"
                           >
                             <Info className="h-4 w-4 text-muted-foreground group-hover:text-foreground/70 transition-colors" />

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -30,7 +30,7 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        "flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[size=default]:h-9 data-[size=sm]:h-8 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[size=default]:h-9 data-[size=sm]:h-8 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-size={size}

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
     return (
       <textarea
         className={cn(
-          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}


### PR DESCRIPTION
## Summary

Fixes a cluster of visual glitches in the Give feedback dialog footer when pressing Preview/Send:

- Preview and Send shared one `submitting` flag, so both buttons showed spinners at once — split into `previewLoading` + `submitting`, with a combined `busy` guard.
- Loading buttons resized (label swapped for spinner), reflowing the right-justified footer and shifting Cancel — the label now stays in-flow but invisible, with the spinner absolutely positioned over it.
- The spinner svg as a direct button child triggered the Button's `has-[>svg]:px-3` variant, shrinking padding by 8px and shifting the footer even with frozen content — the svg is now wrapped in a span.
- Leaving preview mode flashed a white Preview button: React reused the primary Send button's DOM node and `transition-all` animated the stale variant styles out — footer buttons now have per-mode `key`s.
- `transition-all` eased `disabled:opacity-50`, making the outline Cancel appear to disable later than the filled Send — added `disabled:transition-none` for an instant, simultaneous dim.

## Test Plan

- [x] Manually exercised the dialog: Preview shows a spinner only on the Preview button with no layout shift; Cancel/Send dim instantly; returning from preview no longer flashes; `tsc --noEmit` passes.

## Docs

- [x] No docs update needed