### PR TITLE
feat(ai-models): centralize all the info

### DIFF
--- a/apps/native/shared/ai-defaults.json
+++ b/apps/native/shared/ai-defaults.json
@@ -1,0 +1,34 @@
+{
+  "$comment": "Single source of truth for hardcoded per-provider default models and static model suggestions. Consumed by the frontend via src/lib/providers/ai-defaults.ts and by the backend via src-tauri/src/ai/defaults.rs. Providers without suggestedModels fetch their model list dynamically.",
+  "providers": {
+    "nixmac": {
+      "evolveModel": "auto",
+      "summaryModel": "flash",
+      "suggestedModels": ["auto", "flash"]
+    },
+    "openrouter": {
+      "$comment": "Claude for evolution: better reasoning without strict content policies.",
+      "evolveModel": "~anthropic/claude-sonnet-latest",
+      "summaryModel": "openai/gpt-oss-120b"
+    },
+    "openai": {
+      "evolveModel": "gpt-5.6-terra",
+      "summaryModel": "gpt-5.6-luna",
+      "suggestedModels": [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.1"
+      ]
+    },
+    "ollama": { "evolveModel": "", "summaryModel": "llama3.1" },
+    "openai_compatible": {
+      "evolveModel": "gpt-oss-120b",
+      "summaryModel": "gpt-oss-120b"
+    },
+    "claude": { "evolveModel": "", "summaryModel": "" },
+    "codex": { "evolveModel": "", "summaryModel": "" },
+    "opencode": { "evolveModel": "", "summaryModel": "" }
+  }
+}

--- a/apps/native/src-tauri/src/ai/defaults.rs
+++ b/apps/native/src-tauri/src/ai/defaults.rs
@@ -1,0 +1,91 @@
+//! Per-provider default models, embedded from `apps/native/shared/ai-defaults.json`.
+//!
+//! That JSON is the single source of truth shared with the frontend
+//! (`src/lib/providers/ai-defaults.ts`) — edit the JSON, not this module.
+
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+const RAW_DEFAULTS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../shared/ai-defaults.json"
+));
+
+#[derive(Debug, Deserialize)]
+struct AiDefaultsFile {
+    providers: ProviderDefaults,
+}
+
+/// Declaring every provider as a required field makes serde reject a JSON
+/// that drops one, keeping the file in sync with what the frontend expects.
+#[derive(Debug, Deserialize)]
+struct ProviderDefaults {
+    nixmac: ProviderModelDefaults,
+    openrouter: ProviderModelDefaults,
+    openai: ProviderModelDefaults,
+    #[allow(dead_code)]
+    ollama: ProviderModelDefaults,
+    #[allow(dead_code)]
+    openai_compatible: ProviderModelDefaults,
+    #[allow(dead_code)]
+    claude: ProviderModelDefaults,
+    #[allow(dead_code)]
+    codex: ProviderModelDefaults,
+    #[allow(dead_code)]
+    opencode: ProviderModelDefaults,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProviderModelDefaults {
+    evolve_model: String,
+    summary_model: String,
+}
+
+fn providers() -> &'static ProviderDefaults {
+    static PROVIDERS: OnceLock<ProviderDefaults> = OnceLock::new();
+    PROVIDERS.get_or_init(|| {
+        // The JSON is embedded at compile time and covered by the unit test
+        // below, so a parse failure can only come from an unbuildable tree.
+        serde_json::from_str::<AiDefaultsFile>(RAW_DEFAULTS)
+            .expect("shared/ai-defaults.json must parse")
+            .providers
+    })
+}
+
+pub fn openrouter_evolve_model() -> &'static str {
+    &providers().openrouter.evolve_model
+}
+
+pub fn openrouter_summary_model() -> &'static str {
+    &providers().openrouter.summary_model
+}
+
+pub fn openai_evolve_model() -> &'static str {
+    &providers().openai.evolve_model
+}
+
+pub fn openai_summary_model() -> &'static str {
+    &providers().openai.summary_model
+}
+
+/// The nixmac hosted service routes `"auto"` server-side; the settings UI
+/// additionally defaults summaries to the JSON's `summaryModel` ("flash").
+pub fn nixmac_model() -> &'static str {
+    &providers().nixmac.evolve_model
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_defaults_json_parses_with_known_providers() {
+        assert!(openrouter_evolve_model().contains('/'));
+        assert!(openrouter_summary_model().contains('/'));
+        assert!(!openai_evolve_model().is_empty());
+        assert!(!openai_summary_model().is_empty());
+        assert!(!nixmac_model().is_empty());
+    }
+}

--- a/apps/native/src-tauri/src/ai/mod.rs
+++ b/apps/native/src-tauri/src/ai/mod.rs
@@ -1,3 +1,4 @@
+pub mod defaults;
 pub mod log_summarizer;
 pub mod model_capabilities;
 pub mod provider_errors;

--- a/apps/native/src-tauri/src/ai/model_capabilities.rs
+++ b/apps/native/src-tauri/src/ai/model_capabilities.rs
@@ -58,12 +58,13 @@ fn context_window_tokens(model: &str) -> u32 {
 
     if model == "flash"
         || model.contains("gpt-oss")
+        || model.contains("gpt-5")
         || model.contains("o1")
         || model.contains("o3")
+        || model.contains("o4")
         || model.contains("gpt-4.1")
-        || model.contains("claude-3")
-        || model.contains("gemini-1.5")
-        || model.contains("gemini-2")
+        || model.contains("claude")
+        || model.contains("gemini")
     {
         return 32768;
     }
@@ -183,10 +184,18 @@ mod tests {
         for model in [
             "flash",
             "gpt-oss-120b",
+            "openai/gpt-oss-120b",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
             "o1-preview",
             "o3-mini",
+            "o4-mini",
             "gpt-4.1-mini",
             "claude-3-5-sonnet",
+            "claude-sonnet-4.5",
+            "~anthropic/claude-sonnet-latest",
             "gemini-1.5-pro",
             "gemini-2.5-pro",
             "my-qwen-finetune",
@@ -235,6 +244,10 @@ mod tests {
             "o4-mini",
             "gpt-5",
             "gpt-5.1",
+            "gpt-5.5",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "openai/gpt-5.6-luna",
             "openai/gpt-oss-20b",
             "openai/o3",
         ] {
@@ -252,6 +265,7 @@ mod tests {
             "gpt-4o-mini",
             "gpt-4.1",
             "claude-3-5-sonnet",
+            "~anthropic/claude-sonnet-latest",
             "gemini-2.5-pro",
             "llama3:8b-instruct",
             "unknown-model",

--- a/apps/native/src-tauri/src/ai/providers/mod.rs
+++ b/apps/native/src-tauri/src/ai/providers/mod.rs
@@ -10,11 +10,8 @@ use tauri::{AppHandle, Runtime};
 
 use async_trait::async_trait;
 
-const DEFAULT_SUMMARY_MODEL: &str = "openai/gpt-4o-mini";
-const DEFAULT_OPENAI_SUMMARY_MODEL: &str = "gpt-4o-mini";
 const DEFAULT_OLLAMA_API_BASE: &str = "http://localhost:11434";
 pub(crate) const NIXMAC_PROVIDER: &str = "nixmac";
-pub(crate) const DEFAULT_NIXMAC_MODEL: &str = "auto";
 
 pub(crate) fn nixmac_llm_api_base(web_server_url: &str) -> String {
     format!("{}/api/llm/v1", web_server_url.trim_end_matches('/'))
@@ -262,14 +259,14 @@ pub fn create_provider<R: Runtime>(
             let api_key = crate::storage::store::get_device_api_key(app)?
                 .ok_or_else(|| anyhow::anyhow!("Sign in to nixmac hosted inference first."))?;
             let base_url = nixmac_llm_api_base(&crate::storage::store::get_web_server_url()?);
-            let model =
-                configured_summary_model.unwrap_or_else(|| DEFAULT_NIXMAC_MODEL.to_string());
+            let model = configured_summary_model
+                .unwrap_or_else(|| crate::ai::defaults::nixmac_model().to_string());
 
             Ok(Box::new(OpenAIClient::new(&api_key, &base_url, &model)))
         }
         "openai" => {
             let model = configured_summary_model
-                .unwrap_or_else(|| DEFAULT_OPENAI_SUMMARY_MODEL.to_string());
+                .unwrap_or_else(|| crate::ai::defaults::openai_summary_model().to_string());
 
             let (key, base_url) = if let Some(app) = app_handle {
                 crate::storage::store::get_effective_openai_provider_credential(app)?
@@ -287,10 +284,11 @@ pub fn create_provider<R: Runtime>(
             Ok(Box::new(OpenAIClient::new(&key, base_url, &model)))
         }
         _ => {
+            let default_summary_model = crate::ai::defaults::openrouter_summary_model();
             let model = if used_legacy_openai_fallback {
-                openrouter_model_slug_or_default(configured_summary_model, DEFAULT_SUMMARY_MODEL)
+                openrouter_model_slug_or_default(configured_summary_model, default_summary_model)
             } else {
-                configured_summary_model.unwrap_or_else(|| DEFAULT_SUMMARY_MODEL.to_string())
+                configured_summary_model.unwrap_or_else(|| default_summary_model.to_string())
             };
 
             let (key, base_url) = if let Some(app) = app_handle {
@@ -328,7 +326,7 @@ mod tests {
     fn legacy_openai_provider_falls_back_to_openrouter_for_openrouter_model_slug() {
         let provider = resolve_legacy_openai_provider(
             "openai".to_string(),
-            Some("anthropic/claude-sonnet-4"),
+            Some("~anthropic/claude-sonnet-latest"),
             true,
             true,
         );
@@ -395,7 +393,7 @@ mod tests {
     fn openrouter_model_slug_is_preserved() {
         let model = openrouter_model_slug_or_default(
             Some("google/gemini-2.5-pro".to_string()),
-            "anthropic/claude-sonnet-4",
+            "~anthropic/claude-sonnet-latest",
         );
 
         assert_eq!(model, "google/gemini-2.5-pro");
@@ -405,9 +403,9 @@ mod tests {
     fn bare_openai_model_uses_openrouter_default() {
         let model = openrouter_model_slug_or_default(
             Some("gpt-4o".to_string()),
-            "anthropic/claude-sonnet-4",
+            "~anthropic/claude-sonnet-latest",
         );
 
-        assert_eq!(model, "anthropic/claude-sonnet-4");
+        assert_eq!(model, "~anthropic/claude-sonnet-latest");
     }
 }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -316,9 +316,6 @@ fn log_api_error(
     report_provider_error(err, provider, model, messages, iteration);
 }
 
-// Use OpenRouter with Claude for evolution - better reasoning without strict content policies
-const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4";
-const DEFAULT_OPENAI_MODEL: &str = "gpt-4o";
 const DEFAULT_OLLAMA_API_BASE: &str = "http://localhost:11434";
 
 // Percentage of max_iterations after which we require at least one edit/build_check.
@@ -872,7 +869,7 @@ pub async fn generate_evolution<R: Runtime>(
             .ok_or_else(|| anyhow!("Sign in to nixmac hosted inference first."))?;
         let base_url = crate::ai::providers::nixmac_llm_api_base(&store::get_web_server_url()?);
         let model = configured_evolve_model
-            .unwrap_or_else(|| crate::ai::providers::DEFAULT_NIXMAC_MODEL.to_string());
+            .unwrap_or_else(|| crate::ai::defaults::nixmac_model().to_string());
         info!(
             "Using nixmac hosted provider | Model: {} | Max output tokens: {}",
             model, max_output_tokens_for_request
@@ -891,7 +888,8 @@ pub async fn generate_evolution<R: Runtime>(
                 )
             })?;
 
-        let model = configured_evolve_model.unwrap_or_else(|| DEFAULT_OPENAI_MODEL.to_string());
+        let model = configured_evolve_model
+            .unwrap_or_else(|| crate::ai::defaults::openai_evolve_model().to_string());
         let model = model.strip_prefix("openai/").unwrap_or(&model).to_string();
         let openai_max_output_tokens_for_request =
             normalize_openai_max_output_tokens(&model, max_output_tokens);
@@ -911,13 +909,14 @@ pub async fn generate_evolution<R: Runtime>(
                 anyhow!("No OpenRouter API key found. Please add your API key in Settings to get started.")
             })?;
 
+        let default_evolve_model = crate::ai::defaults::openrouter_evolve_model();
         let model = if used_legacy_openai_fallback {
             crate::ai::providers::openrouter_model_slug_or_default(
                 configured_evolve_model,
-                DEFAULT_MODEL,
+                default_evolve_model,
             )
         } else {
-            configured_evolve_model.unwrap_or_else(|| DEFAULT_MODEL.to_string())
+            configured_evolve_model.unwrap_or_else(|| default_evolve_model.to_string())
         };
         info!(
             "Using OpenRouter provider | Model: {} | Max output tokens: {}",

--- a/apps/native/src/components/widget/controls/model-combobox.tsx
+++ b/apps/native/src/components/widget/controls/model-combobox.tsx
@@ -4,7 +4,8 @@ import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { DEFAULT_NIXMAC_MODEL, NIXMAC_PROVIDER } from "@/components/widget/onboarding/lib/inference";
+import { NIXMAC_PROVIDER } from "@/components/widget/onboarding/lib/inference";
+import { suggestedModels } from "@/lib/providers/ai-defaults";
 import {
   Command,
   CommandEmpty,
@@ -38,8 +39,6 @@ interface OllamaModel {
 interface OpenAiCompatibleModel {
   id: string;
 }
-
-const OPENAI_MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini"] as const;
 
 async function fetchOpenRouterModels(): Promise<string[]> {
   try {
@@ -118,13 +117,13 @@ type ModelProvider = ModelComboboxProps["provider"];
 
 async function fetchFreshModels(provider: ModelProvider): Promise<string[]> {
   if (provider === NIXMAC_PROVIDER) {
-    return [DEFAULT_NIXMAC_MODEL];
+    return suggestedModels(NIXMAC_PROVIDER);
   }
   if (provider === "openrouter") {
     return fetchOpenRouterModels();
   }
   if (provider === "openai") {
-    return [...OPENAI_MODELS];
+    return suggestedModels("openai");
   }
   if (provider === "ollama") {
     // deprecated(orpc): replace with client/orpc from @/lib/orpc
@@ -149,11 +148,11 @@ async function loadProviderModels(
   applyModels: (models: string[]) => void,
 ) {
   if (provider === "openai") {
-    applyModels([...OPENAI_MODELS]);
+    applyModels(suggestedModels("openai"));
     return;
   }
   if (provider === NIXMAC_PROVIDER) {
-    applyModels([DEFAULT_NIXMAC_MODEL]);
+    applyModels(suggestedModels(NIXMAC_PROVIDER));
     return;
   }
 

--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
@@ -233,9 +233,9 @@ describe("InferenceSetup", () => {
       expect(mocks.setPrefs).toHaveBeenCalledWith(
         expect.objectContaining({
           evolveProvider: "openrouter",
-          evolveModel: "anthropic/claude-sonnet-4",
+          evolveModel: "~anthropic/claude-sonnet-latest",
           summaryProvider: "openrouter",
-          summaryModel: "anthropic/claude-sonnet-4",
+          summaryModel: "~anthropic/claude-sonnet-latest",
           openrouterApiKey: "sk-or-v1-test-key-with-enough-length",
         }),
       ),

--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
@@ -810,7 +810,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
               }
               value={model}
               onChange={setModel}
-              placeholder={modelPlaceholder(provider.id, provider.defaultEvolveModel || "gpt-4o")}
+              placeholder={modelPlaceholder(provider.id, "evolve")}
             />
           )}
         </div>

--- a/apps/native/src/components/widget/onboarding/lib/inference.ts
+++ b/apps/native/src/components/widget/onboarding/lib/inference.ts
@@ -1,8 +1,10 @@
+import { providerModelDefaults } from "@/lib/providers/ai-defaults";
+
 export type { InferenceConfig, InferenceMode } from "@nixmac/state";
 
 export const NIXMAC_PROVIDER = "nixmac";
-export const DEFAULT_NIXMAC_MODEL = "auto";
-export const DEFAULT_NIXMAC_SUMMARY_MODEL = "flash";
+export const DEFAULT_NIXMAC_MODEL =
+	providerModelDefaults(NIXMAC_PROVIDER).evolveModel;
 
 /** Checkout product identifiers exposed by the billing API. */
 export type CheckoutProduct = "pro" | "credits";

--- a/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
+++ b/apps/native/src/components/widget/onboarding/onboarding-flow.stories.tsx
@@ -193,7 +193,7 @@ function installBackend(startAt: string) {
     flakeExists: startIdx >= 3,
     macScannedAt: (startIdx >= 5 ? 1_700_000_000 : null) as number | null,
     evolveProvider: (startIdx >= 6 ? "openrouter" : null) as string | null,
-    evolveModel: (startIdx >= 6 ? "anthropic/claude-sonnet-4" : null) as string | null,
+    evolveModel: (startIdx >= 6 ? "~anthropic/claude-sonnet-latest" : null) as string | null,
     loginDecided: startIdx >= 6,
     lastBuildAt: null as number | null,
     githubConnected: false,

--- a/apps/native/src/components/widget/settings/ai-models-tab.tsx
+++ b/apps/native/src/components/widget/settings/ai-models-tab.tsx
@@ -8,12 +8,15 @@ import {
 } from "@/components/ui/select";
 import { ModelCombobox } from "@/components/widget/controls/model-combobox";
 import { ProviderIcon } from "@/components/widget/controls/provider-icons/provider-icon";
-import { DEFAULT_NIXMAC_MODEL, DEFAULT_NIXMAC_SUMMARY_MODEL, NIXMAC_PROVIDER } from "@/components/widget/onboarding/lib/inference";
 import { tauriAPI } from "@/ipc/api";
 import type { CliToolsState } from "@/ipc/types";
 import { getProviderConfigInvalidReason, isCliProvider } from "@/lib/providers/ai-provider-validation";
 import {
   AI_MODEL_PROVIDERS,
+  DEFAULT_EVOLVE_MODEL,
+  DEFAULT_SUMMARY_MODEL,
+  isPlainInputCliProvider,
+  modelPlaceholder,
 } from "@/lib/providers/ai-models";
 import type { AnyFieldApi, ReactFormExtendedApi } from "@tanstack/react-form";
 import { useEffect, useState } from "react";
@@ -29,51 +32,6 @@ interface AiModelsTabProps {
   summaryModelField: AnyFieldApi;
   // biome-ignore lint/suspicious/noExplicitAny: tanstack form types are complex
   form: ReactFormExtendedApi<any, any, any, any, any, any, any, any, any, any, any, any>;
-}
-
-function isPlainInputCliProvider(provider: string): boolean {
-  return provider === "claude" || provider === "codex";
-}
-
-const DEFAULT_EVOLVE_MODEL: Record<string, string> = {
-  [NIXMAC_PROVIDER]: DEFAULT_NIXMAC_MODEL,
-  openrouter: "anthropic/claude-sonnet-4",
-  openai: "gpt-4o",
-  ollama: "",
-  openai_compatible: "",
-  claude: "",
-  codex: "",
-  opencode: "",
-};
-
-const DEFAULT_SUMMARY_MODEL: Record<string, string> = {
-  [NIXMAC_PROVIDER]: DEFAULT_NIXMAC_SUMMARY_MODEL,
-  openrouter: "openai/gpt-4o-mini",
-  openai: "gpt-4o-mini",
-  ollama: "llama3.1",
-  openai_compatible: "",
-  claude: "",
-  codex: "",
-  opencode: "",
-};
-
-function modelPlaceholder(provider: string, fallback: string): string {
-  if (provider === NIXMAC_PROVIDER) {
-    return DEFAULT_NIXMAC_MODEL;
-  }
-  if (provider === "openai") {
-    return fallback;
-  }
-  if (provider === "ollama") {
-    return fallback === "gpt-4o" ? "" : "llama3.1";
-  }
-  if (provider === "openai_compatible") {
-    return "gpt-oss-120b";
-  }
-  if (provider === "opencode") {
-    return "Leave empty for CLI default";
-  }
-  return fallback === "gpt-4o" ? "anthropic/claude-sonnet-4" : "openai/gpt-4o-mini";
 }
 
 function useCliToolStatus() {
@@ -248,7 +206,7 @@ export function AiModelsTab({
                             await tauriAPI.ui.setPrefs({ evolveModel: value });
                           }}
                           onBlur={evolveModelField.handleBlur}
-                          placeholder={modelPlaceholder(evolveProvider, "gpt-4o")}
+                          placeholder={modelPlaceholder(evolveProvider, "evolve")}
                         />
                       )}
                     </>
@@ -342,7 +300,7 @@ export function AiModelsTab({
                             await tauriAPI.ui.setPrefs({ summaryModel: value });
                           }}
                           onBlur={summaryModelField.handleBlur}
-                          placeholder={modelPlaceholder(summaryProvider, "gpt-4o-mini")}
+                          placeholder={modelPlaceholder(summaryProvider, "summary")}
                         />
                       )}
                     </>

--- a/apps/native/src/components/widget/settings/settings-dialog.tsx
+++ b/apps/native/src/components/widget/settings/settings-dialog.tsx
@@ -9,6 +9,7 @@ import { TuningTab } from "@/components/widget/settings/tuning-tab";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
 import { tauriAPI } from "@/ipc/api";
 import { resolveOpenAiCompatibleProvider } from "@/lib/providers/ai-provider-validation";
+import { DEFAULT_EVOLVE_MODEL, DEFAULT_SUMMARY_MODEL } from "@/lib/providers/ai-models";
 import {
   createVerifiedApiKeyHandler,
   verifyOpenaiApiKey,
@@ -139,9 +140,9 @@ export function SettingsDialog() {
       openaiCompatibleApiBaseUrl: "",
       openaiCompatibleApiKey: "",
       summaryProvider: "openrouter",
-      summaryModel: "openai/gpt-4o-mini",
+      summaryModel: DEFAULT_SUMMARY_MODEL.openrouter,
       evolveProvider: "openrouter",
-      evolveModel: "anthropic/claude-sonnet-4",
+      evolveModel: DEFAULT_EVOLVE_MODEL.openrouter,
       sendDiagnostics: false,
     },
   });
@@ -166,13 +167,15 @@ export function SettingsDialog() {
           form.setFieldValue(
             "summaryModel",
             prefs.summaryModel ??
-            (summaryProvider === "openai" ? "gpt-4o-mini" : "openai/gpt-4o-mini"),
+            DEFAULT_SUMMARY_MODEL[summaryProvider] ??
+            DEFAULT_SUMMARY_MODEL.openrouter,
           );
           form.setFieldValue("evolveProvider", evolveProvider);
           form.setFieldValue(
             "evolveModel",
             prefs.evolveModel ??
-            (evolveProvider === "openai" ? "gpt-4o" : "anthropic/claude-sonnet-4"),
+            DEFAULT_EVOLVE_MODEL[evolveProvider] ??
+            DEFAULT_EVOLVE_MODEL.openrouter,
           );
           form.setFieldValue("sendDiagnostics", prefs.sendDiagnostics ?? false);
 

--- a/apps/native/src/ipc/api.test.ts
+++ b/apps/native/src/ipc/api.test.ts
@@ -1,5 +1,8 @@
 import type { UiPrefs } from "@/ipc/types";
+import { providerModelDefaults } from "@/lib/providers/ai-defaults";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const OPENROUTER_DEFAULTS = providerModelDefaults("openrouter");
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn<(command: string, args?: Record<string, unknown>) => Promise<unknown>>(),
@@ -31,9 +34,9 @@ const prefs = (overrides: Partial<UiPrefs> = {}): UiPrefs =>
     openaiCompatibleApiBaseUrl: null,
     openaiCompatibleApiKey: null,
     summaryProvider: "openrouter",
-    summaryModel: "openai/gpt-4o-mini",
+    summaryModel: OPENROUTER_DEFAULTS.summaryModel,
     evolveProvider: "openrouter",
-    evolveModel: "anthropic/claude-sonnet-4",
+    evolveModel: OPENROUTER_DEFAULTS.evolveModel,
     maxIterations: 25,
     maxTokenBudget: 50000,
     maxOutputTokens: 32768,
@@ -87,16 +90,16 @@ describe("tauriAPI.ui.getPrefs", () => {
     const migrated = await tauriAPI.ui.getPrefs();
 
     expect(migrated.evolveProvider).toBe("openrouter");
-    expect(migrated.evolveModel).toBe("anthropic/claude-sonnet-4");
+    expect(migrated.evolveModel).toBe(OPENROUTER_DEFAULTS.evolveModel);
     expect(migrated.summaryProvider).toBe("openrouter");
-    expect(migrated.summaryModel).toBe("openai/gpt-4o-mini");
+    expect(migrated.summaryModel).toBe(OPENROUTER_DEFAULTS.summaryModel);
     expect(mocks.invoke).toHaveBeenNthCalledWith(1, "ui_get_prefs");
     expect(mocks.invoke).toHaveBeenNthCalledWith(2, "ui_set_prefs", {
       prefs: {
         evolveProvider: "openrouter",
-        evolveModel: "anthropic/claude-sonnet-4",
+        evolveModel: OPENROUTER_DEFAULTS.evolveModel,
         summaryProvider: "openrouter",
-        summaryModel: "openai/gpt-4o-mini",
+        summaryModel: OPENROUTER_DEFAULTS.summaryModel,
       },
     });
   });
@@ -116,13 +119,13 @@ describe("tauriAPI.ui.getPrefs", () => {
     const migrated = await tauriAPI.ui.getPrefs();
 
     expect(migrated.evolveProvider).toBe("openrouter");
-    expect(migrated.evolveModel).toBe("anthropic/claude-sonnet-4");
+    expect(migrated.evolveModel).toBe(OPENROUTER_DEFAULTS.evolveModel);
     expect(migrated.summaryProvider).toBe("ollama");
     expect(migrated.summaryModel).toBeNull();
     expect(mocks.invoke).toHaveBeenNthCalledWith(2, "ui_set_prefs", {
       prefs: {
         evolveProvider: "openrouter",
-        evolveModel: "anthropic/claude-sonnet-4",
+        evolveModel: OPENROUTER_DEFAULTS.evolveModel,
       },
     });
   });

--- a/apps/native/src/lib/providers/ai-defaults.ts
+++ b/apps/native/src/lib/providers/ai-defaults.ts
@@ -1,0 +1,30 @@
+import aiDefaults from "../../../shared/ai-defaults.json";
+
+/** Derived from the JSON keys, so provider renames there surface as type errors here. */
+export type AiProviderId = keyof typeof aiDefaults.providers;
+
+export interface ProviderModelDefaults {
+	evolveModel: string;
+	summaryModel: string;
+	/** Static picker suggestions; providers without this fetch their list dynamically. */
+	suggestedModels?: string[];
+}
+
+/** Per-provider default models, loaded from shared/ai-defaults.json (also embedded by the Rust backend). */
+export const PROVIDER_MODEL_DEFAULTS: Record<string, ProviderModelDefaults> =
+	aiDefaults.providers;
+
+const EMPTY_DEFAULTS: ProviderModelDefaults = {
+	evolveModel: "",
+	summaryModel: "",
+};
+
+export function providerModelDefaults(
+	providerId: string,
+): ProviderModelDefaults {
+	return PROVIDER_MODEL_DEFAULTS[providerId] ?? EMPTY_DEFAULTS;
+}
+
+export function suggestedModels(providerId: string): string[] {
+	return providerModelDefaults(providerId).suggestedModels ?? [];
+}

--- a/apps/native/src/lib/providers/ai-models.test.ts
+++ b/apps/native/src/lib/providers/ai-models.test.ts
@@ -1,0 +1,15 @@
+import { PROVIDER_MODEL_DEFAULTS } from "@/lib/providers/ai-defaults";
+import { AI_MODEL_PROVIDERS } from "@/lib/providers/ai-models";
+import { describe, expect, it } from "vitest";
+
+describe("AI_MODEL_PROVIDERS", () => {
+	it("covers every provider declared in shared/ai-defaults.json", () => {
+		// The other direction (an AI_MODEL_PROVIDERS id missing from the JSON)
+		// is a compile error: AiModelProviderId is derived from the JSON keys.
+		const uiProviderIds = AI_MODEL_PROVIDERS.map((provider) => provider.id);
+
+		expect(uiProviderIds.sort()).toEqual(
+			Object.keys(PROVIDER_MODEL_DEFAULTS).sort(),
+		);
+	});
+});

--- a/apps/native/src/lib/providers/ai-models.ts
+++ b/apps/native/src/lib/providers/ai-models.ts
@@ -1,18 +1,12 @@
 import type { ProviderIconId } from "@/components/widget/controls/provider-icons/provider-icon";
+import {
+	type AiProviderId,
+	providerModelDefaults,
+} from "@/lib/providers/ai-defaults";
 
 const NIXMAC_PROVIDER = "nixmac";
-const DEFAULT_NIXMAC_MODEL = "openai/gpt-4o-mini";
-const DEFAULT_OLLAMA_MODEL = "llama3.1";
 
-type AiModelProviderId =
-	| "nixmac"
-	| "openrouter"
-	| "openai"
-	| "ollama"
-	| "openai_compatible"
-	| "claude"
-	| "codex"
-	| "opencode";
+type AiModelProviderId = AiProviderId;
 
 type ApiKeyPrefsField = "openrouterApiKey" | "openaiApiKey";
 
@@ -43,21 +37,30 @@ interface AiModelProvider {
 		| { kind: "cli"; plainModelInput: boolean };
 }
 
+function modelDefaults(id: AiModelProviderId): {
+	defaultEvolveModel: string;
+	defaultSummaryModel: string;
+} {
+	const defaults = providerModelDefaults(id);
+	return {
+		defaultEvolveModel: defaults.evolveModel,
+		defaultSummaryModel: defaults.summaryModel,
+	};
+}
+
 export const AI_MODEL_PROVIDERS: readonly AiModelProvider[] = [
 	{
 		id: NIXMAC_PROVIDER,
 		name: "nixmac hosted",
 		icon: "nixmac",
-		defaultEvolveModel: DEFAULT_NIXMAC_MODEL,
-		defaultSummaryModel: DEFAULT_NIXMAC_MODEL,
+		...modelDefaults(NIXMAC_PROVIDER),
 		setup: { kind: "hosted" },
 	},
 	{
 		id: "openrouter",
 		name: "OpenRouter",
 		icon: "openrouter",
-		defaultEvolveModel: "anthropic/claude-sonnet-4",
-		defaultSummaryModel: "openai/gpt-4o-mini",
+		...modelDefaults("openrouter"),
 		setup: {
 			kind: "apiKey",
 			prefsKeyField: "openrouterApiKey",
@@ -70,8 +73,7 @@ export const AI_MODEL_PROVIDERS: readonly AiModelProvider[] = [
 		id: "openai",
 		name: "OpenAI",
 		icon: "openai",
-		defaultEvolveModel: "gpt-4o",
-		defaultSummaryModel: "gpt-4o-mini",
+		...modelDefaults("openai"),
 		setup: {
 			kind: "apiKey",
 			prefsKeyField: "openaiApiKey",
@@ -84,16 +86,14 @@ export const AI_MODEL_PROVIDERS: readonly AiModelProvider[] = [
 		id: "ollama",
 		name: "Ollama",
 		icon: "ollama",
-		defaultEvolveModel: "",
-		defaultSummaryModel: "llama3.1",
+		...modelDefaults("ollama"),
 		setup: { kind: "local" },
 	},
 	{
 		id: "openai_compatible",
 		name: "OpenAI Compatible",
 		icon: "openai_compatible",
-		defaultEvolveModel: "gpt-oss-120b",
-		defaultSummaryModel: "gpt-oss-120b",
+		...modelDefaults("openai_compatible"),
 		setup: {
 			kind: "baseUrl",
 			prefsBaseUrlField: "openaiCompatibleApiBaseUrl",
@@ -107,24 +107,21 @@ export const AI_MODEL_PROVIDERS: readonly AiModelProvider[] = [
 		id: "claude",
 		name: "Claude CLI",
 		icon: "claude",
-		defaultEvolveModel: "",
-		defaultSummaryModel: "",
+		...modelDefaults("claude"),
 		setup: { kind: "cli", plainModelInput: true },
 	},
 	{
 		id: "codex",
 		name: "Codex CLI",
 		icon: "codex",
-		defaultEvolveModel: "",
-		defaultSummaryModel: "",
+		...modelDefaults("codex"),
 		setup: { kind: "cli", plainModelInput: true },
 	},
 	{
 		id: "opencode",
 		name: "OpenCode CLI",
 		icon: "opencode",
-		defaultEvolveModel: "",
-		defaultSummaryModel: "",
+		...modelDefaults("opencode"),
 		setup: { kind: "cli", plainModelInput: false },
 	},
 ];
@@ -159,24 +156,15 @@ export function isPlainInputCliProvider(provider: string): boolean {
 	return setup.kind === "cli" && setup.plainModelInput;
 }
 
-export function modelPlaceholder(provider: string, fallback: string): string {
+export function modelPlaceholder(
+	provider: string,
+	kind: "evolve" | "summary",
+): string {
 	const config = getAiModelProvider(provider);
-	if (config.id === NIXMAC_PROVIDER) {
-		return DEFAULT_NIXMAC_MODEL;
-	}
-	if (config.id === "openai") {
-		return fallback;
-	}
-	if (config.id === "ollama") {
-		return DEFAULT_OLLAMA_MODEL;
-	}
-	if (config.id === "openai_compatible") {
-		return "gpt-oss-120b";
-	}
-	if (config.id === "opencode" || config.setup.kind === "cli") {
+	if (config.setup.kind === "cli") {
 		return "Leave empty for CLI default";
 	}
-	return fallback === "gpt-4o"
-		? "anthropic/claude-sonnet-4"
-		: "openai/gpt-4o-mini";
+	const defaultModel =
+		kind === "evolve" ? config.defaultEvolveModel : config.defaultSummaryModel;
+	return defaultModel || "Select model...";
 }

--- a/apps/native/src/lib/providers/ai-provider-migration.test.ts
+++ b/apps/native/src/lib/providers/ai-provider-migration.test.ts
@@ -1,6 +1,9 @@
 import type { UiPrefs } from "@/ipc/types";
+import { providerModelDefaults } from "@/lib/providers/ai-defaults";
 import { migrateLegacyOpenaiProviderPrefs } from "@/lib/providers/ai-provider-migration";
 import { describe, expect, it } from "vitest";
+
+const OPENROUTER_DEFAULTS = providerModelDefaults("openrouter");
 
 const PREFS: UiPrefs = {
 	openrouterApiKey: "",
@@ -9,9 +12,9 @@ const PREFS: UiPrefs = {
 	openaiCompatibleApiBaseUrl: "",
 	openaiCompatibleApiKey: "",
 	summaryProvider: "openrouter",
-	summaryModel: "openai/gpt-4o-mini",
+	summaryModel: OPENROUTER_DEFAULTS.summaryModel,
 	evolveProvider: "openrouter",
-	evolveModel: "anthropic/claude-sonnet-4",
+	evolveModel: OPENROUTER_DEFAULTS.evolveModel,
 	maxIterations: null,
 	maxTokenBudget: null,
 	maxBuildAttempts: null,
@@ -68,9 +71,9 @@ describe("migrateLegacyOpenaiProviderPrefs", () => {
 
 		expect(result.values).toEqual({
 			evolveProvider: "openrouter",
-			evolveModel: "anthropic/claude-sonnet-4",
+			evolveModel: OPENROUTER_DEFAULTS.evolveModel,
 			summaryProvider: "openrouter",
-			summaryModel: "openai/gpt-4o-mini",
+			summaryModel: OPENROUTER_DEFAULTS.summaryModel,
 		});
 		expect(result.update).toEqual(result.values);
 	});
@@ -81,14 +84,14 @@ describe("migrateLegacyOpenaiProviderPrefs", () => {
 			openrouterApiKey: "sk-or-key",
 			openaiApiKey: "sk-openai-key",
 			evolveProvider: "openai",
-			evolveModel: "anthropic/claude-sonnet-4",
+			evolveModel: "~anthropic/claude-sonnet-latest",
 			summaryProvider: "openai",
 			summaryModel: "gpt-4o-mini",
 		});
 
 		expect(result.values).toEqual({
 			evolveProvider: "openrouter",
-			evolveModel: "anthropic/claude-sonnet-4",
+			evolveModel: "~anthropic/claude-sonnet-latest",
 			summaryProvider: "openai",
 			summaryModel: "gpt-4o-mini",
 		});

--- a/apps/native/src/lib/providers/ai-provider-migration.ts
+++ b/apps/native/src/lib/providers/ai-provider-migration.ts
@@ -1,9 +1,12 @@
 import type { UiPrefs, UiPrefsUpdate } from "@/ipc/types";
+import { providerModelDefaults } from "@/lib/providers/ai-defaults";
 
 const OPENROUTER_PROVIDER = "openrouter";
 const OPENAI_PROVIDER = "openai";
-const DEFAULT_OPENROUTER_EVOLVE_MODEL = "anthropic/claude-sonnet-4";
-const DEFAULT_OPENROUTER_SUMMARY_MODEL = "openai/gpt-4o-mini";
+const DEFAULT_OPENROUTER_EVOLVE_MODEL =
+  providerModelDefaults(OPENROUTER_PROVIDER).evolveModel;
+const DEFAULT_OPENROUTER_SUMMARY_MODEL =
+  providerModelDefaults(OPENROUTER_PROVIDER).summaryModel;
 
 interface ProviderMigrationValues {
   evolveProvider: string;

--- a/apps/native/src/lib/providers/ai-provider-validation.test.ts
+++ b/apps/native/src/lib/providers/ai-provider-validation.test.ts
@@ -24,12 +24,12 @@ describe("isInferenceConfigured", () => {
   it("requires a model for non-CLI providers", () => {
     expect(isInferenceConfigured("openrouter", "")).toBe(false);
     expect(isInferenceConfigured("openrouter", "   ")).toBe(false);
-    expect(isInferenceConfigured("openrouter", "openai/gpt-4o-mini")).toBe(true);
-    expect(isInferenceConfigured("nixmac", "openai/gpt-4o-mini")).toBe(true);
+    expect(isInferenceConfigured("openrouter", "openai/gpt-oss-120b")).toBe(true);
+    expect(isInferenceConfigured("nixmac", "openai/gpt-oss-120b")).toBe(true);
   });
 
   it("requires a provider", () => {
-    expect(isInferenceConfigured(null, "openai/gpt-4o-mini")).toBe(false);
+    expect(isInferenceConfigured(null, "openai/gpt-oss-120b")).toBe(false);
     expect(isInferenceConfigured(undefined, undefined)).toBe(false);
   });
 });
@@ -37,7 +37,7 @@ describe("isInferenceConfigured", () => {
 describe("getProviderConfigInvalidReason", () => {
   it("accepts nixmac hosted inference without BYOK credentials", () => {
     expect(
-      getProviderConfigInvalidReason("nixmac", EMPTY_PREFS, NO_CLI_TOOLS, "openai/gpt-4o-mini"),
+      getProviderConfigInvalidReason("nixmac", EMPTY_PREFS, NO_CLI_TOOLS, "openai/gpt-oss-120b"),
     ).toBeNull();
   });
 

--- a/apps/native/src/stories/landing-page.stories.tsx
+++ b/apps/native/src/stories/landing-page.stories.tsx
@@ -55,7 +55,7 @@ const EVOLVE_EVENTS: EvolveEvent[] = [
   {
     eventType: "start",
     summary: "Starting AI evolution",
-    raw: "Starting evolution with model anthropic/claude-sonnet-4.5",
+    raw: "Starting evolution with model ~anthropic/claude-sonnet-latest",
     iteration: null,
     timestampMs: 0,
   },
@@ -194,7 +194,7 @@ function seedWidgetState(preset: WidgetPreset) {
       hostAttr: "Demo-MacBook-Pro",
       repoRoot: "/Users/demo/.darwin",
       evolveProvider: "openrouter",
-      evolveModel: "anthropic/claude-sonnet-4.5",
+      evolveModel: "~anthropic/claude-sonnet-latest",
       onboardingMacScannedAt: 1_767_200_000,
       onboardingLoginDecided: true,
       onboardingLastBuildAt: 1_767_200_300,


### PR DESCRIPTION
Models keep evolving; give provider defaults and static model lists a single home (shared/ai-defaults.json) so supporting new ones is a one-file edit picked up by both the frontend and the Rust backend.

## Summary

Default evolve/summary models per provider are hardcoded in ~8 places across TS and Rust, and the copies have already drifted:

[ai-models.ts:4](https://file+.vscode-resource.vscode-cdn.net/Users/alex/.claude/plans/apps/native/src/lib/providers/ai-models.ts#L4) says nixmac default is openai/gpt-4o-mini, while [inference.ts:4-5](https://file+.vscode-resource.vscode-cdn.net/Users/alex/.claude/plans/apps/native/src/components/widget/onboarding/lib/inference.ts#L4-L5) and Rust [providers/mod.rs:17](https://file+.vscode-resource.vscode-cdn.net/Users/alex/.claude/plans/apps/native/src-tauri/src/ai/providers/mod.rs#L17) say auto/flash.
ai-models-tab.tsx duplicates the entire DEFAULT_EVOLVE_MODEL / DEFAULT_SUMMARY_MODEL tables and modelPlaceholder() from ai-models.ts, with slightly different values (openai_compatible: "" vs gpt-oss-120b).
The openrouter defaults (anthropic/claude-sonnet-4, openai/gpt-4o-mini) that the user wants changed to ~anthropic/claude-sonnet-latest / openai/gpt-oss-120b appear in 5 production files plus tests/stories.

Goal: one source of truth both the TS frontend and Rust backend read, then flip the openrouter values in exactly one place.

## Test Plan

- [x] Unit tests
- [x] Manual inspection of models in settings

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
