### PR TITLE
Notify #nixmac-support about external GitHub activity

### DIFF
--- a/.github/scripts/notify-new-issue.mjs
+++ b/.github/scripts/notify-new-issue.mjs
@@ -1,0 +1,156 @@
+import { fileURLToPath } from "node:url";
+
+const GITHUB_API_URL = "https://api.github.com";
+const LINEAR_BACKLINK_ATTEMPTS = 20;
+const LINEAR_BACKLINK_INTERVAL_MS = 3_000;
+const LINEAR_ISSUE_URL =
+  /https:\/\/linear\.app\/[A-Za-z0-9_-]+\/issue\/([A-Za-z][A-Za-z0-9]*-\d+)(?:\/[A-Za-z0-9-]+)?/i;
+
+function escapeSlackText(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const payload = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      `Request to ${url} failed (${response.status}): ${JSON.stringify(payload)}`,
+    );
+  }
+
+  return payload;
+}
+
+export function extractLinearIssueLink(comments) {
+  for (const comment of comments) {
+    if (comment.user?.login !== "linear-code[bot]") {
+      continue;
+    }
+
+    const match = comment.body?.match(LINEAR_ISSUE_URL);
+    if (match) {
+      return {
+        identifier: match[1].toUpperCase(),
+        url: match[0],
+      };
+    }
+  }
+
+  return null;
+}
+
+export function buildSlackMessage(githubIssue, linearIssue) {
+  const title = escapeSlackText(githubIssue.title);
+  const author = escapeSlackText(githubIssue.user.login);
+
+  return {
+    text: [
+      `New GitHub issue #${githubIssue.number}: ${title}`,
+      `GitHub: ${githubIssue.html_url}`,
+      `Linear ${linearIssue.identifier}: ${linearIssue.url}`,
+    ].join("\n"),
+    unfurl_links: false,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*New GitHub issue #${githubIssue.number}*\n${title}\nOpened by <${githubIssue.user.html_url}|@${author}>`,
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `*GitHub:* <${githubIssue.html_url}|#${githubIssue.number}>  |  *Linear:* <${linearIssue.url}|${linearIssue.identifier}>`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export async function postSlackWebhook(webhookUrl, message, fetchImpl = fetch) {
+  const response = await fetchImpl(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify(message),
+  });
+  const responseBody = await response.text();
+
+  if (!response.ok || responseBody !== "ok") {
+    throw new Error(
+      `Slack rejected the notification (${response.status}): ${responseBody}`,
+    );
+  }
+}
+
+export async function waitForLinearIssue({
+  fetchComments,
+  attempts = LINEAR_BACKLINK_ATTEMPTS,
+  intervalMs = LINEAR_BACKLINK_INTERVAL_MS,
+  sleep = (duration) => new Promise((resolve) => setTimeout(resolve, duration)),
+}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const linearIssue = extractLinearIssueLink(await fetchComments());
+    if (linearIssue) {
+      return linearIssue;
+    }
+
+    if (attempt < attempts) {
+      await sleep(intervalMs);
+    }
+  }
+
+  throw new Error(
+    `Linear backlink did not appear after ${attempts} attempts; Slack notification was not sent`,
+  );
+}
+
+async function main() {
+  const githubToken = requiredEnvironment("GITHUB_TOKEN");
+  const repository = requiredEnvironment("GITHUB_REPOSITORY");
+  const issueNumber = requiredEnvironment("ISSUE_NUMBER");
+  const slackWebhookUrl = requiredEnvironment("SLACK_WEBHOOK_URL");
+  const githubHeaders = {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${githubToken}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  const issue = await requestJson(
+    `${GITHUB_API_URL}/repos/${repository}/issues/${issueNumber}`,
+    { headers: githubHeaders },
+  );
+  const linearIssue = await waitForLinearIssue({
+    fetchComments: () =>
+      requestJson(
+        `${GITHUB_API_URL}/repos/${repository}/issues/${issueNumber}/comments?per_page=100`,
+        { headers: githubHeaders },
+      ),
+  });
+  const slackMessage = buildSlackMessage(issue, linearIssue);
+  await postSlackWebhook(slackWebhookUrl, slackMessage);
+
+  console.log(
+    `Posted GitHub issue #${issue.number} and Linear issue ${linearIssue.identifier} to Slack`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/.github/scripts/notify-new-issue.mjs
+++ b/.github/scripts/notify-new-issue.mjs
@@ -5,6 +5,7 @@ const LINEAR_BACKLINK_ATTEMPTS = 20;
 const LINEAR_BACKLINK_INTERVAL_MS = 3_000;
 const LINEAR_ISSUE_URL =
   /https:\/\/linear\.app\/[A-Za-z0-9_-]+\/issue\/([A-Za-z][A-Za-z0-9]*-\d+)(?:\/[A-Za-z0-9-]+)?/i;
+const INTERNAL_AUTHOR_ASSOCIATIONS = new Set(["MEMBER", "OWNER"]);
 
 function escapeSlackText(value) {
   return String(value)
@@ -21,6 +22,27 @@ function requiredEnvironment(name) {
   return value;
 }
 
+export function shouldNotifyActivity({
+  actorType,
+  authorAssociation,
+  eventName,
+  isPullRequest,
+}) {
+  if (eventName === "workflow_dispatch") {
+    return true;
+  }
+
+  if (!["issues", "issue_comment"].includes(eventName)) {
+    return false;
+  }
+
+  if (actorType === "Bot" || INTERNAL_AUTHOR_ASSOCIATIONS.has(authorAssociation)) {
+    return false;
+  }
+
+  return eventName !== "issue_comment" || !isPullRequest;
+}
+
 async function requestJson(url, options = {}) {
   const response = await fetch(url, options);
   const payload = await response.json();
@@ -35,7 +57,8 @@ async function requestJson(url, options = {}) {
 }
 
 export function extractLinearIssueLink(comments) {
-  for (const comment of comments) {
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
     if (comment.user?.login !== "linear-code[bot]") {
       continue;
     }
@@ -52,9 +75,44 @@ export function extractLinearIssueLink(comments) {
   return null;
 }
 
-export function buildSlackMessage(githubIssue, linearIssue) {
+export function buildSlackMessage(githubIssue, linearIssue, githubComment = null) {
   const title = escapeSlackText(githubIssue.title);
-  const author = escapeSlackText(githubIssue.user.login);
+  const activityAuthor = githubComment?.user ?? githubIssue.user;
+  const author = escapeSlackText(activityAuthor.login);
+
+  if (githubComment) {
+    const escapedBody = escapeSlackText(githubComment.body?.trim() || "(No comment text)");
+    const bodyPreview =
+      escapedBody.length > 1_200 ? `${escapedBody.slice(0, 1_197)}...` : escapedBody;
+
+    return {
+      text: [
+        `New GitHub comment on issue #${githubIssue.number}: ${title}`,
+        `Comment: ${githubComment.html_url}`,
+        `GitHub issue: ${githubIssue.html_url}`,
+        `Linear ${linearIssue.identifier}: ${linearIssue.url}`,
+      ].join("\n"),
+      unfurl_links: false,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*New GitHub comment on issue #${githubIssue.number}*\n*${title}*\nCommented by <${activityAuthor.html_url}|@${author}>\n\n${bodyPreview}`,
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `*Comment:* <${githubComment.html_url}|View comment>  |  *GitHub:* <${githubIssue.html_url}|#${githubIssue.number}>  |  *Linear:* <${linearIssue.url}|${linearIssue.identifier}>`,
+            },
+          ],
+        },
+      ],
+    };
+  }
 
   return {
     text: [
@@ -106,9 +164,13 @@ export async function waitForLinearIssue({
   sleep = (duration) => new Promise((resolve) => setTimeout(resolve, duration)),
 }) {
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const linearIssue = extractLinearIssueLink(await fetchComments());
-    if (linearIssue) {
-      return linearIssue;
+    try {
+      const linearIssue = extractLinearIssueLink(await fetchComments());
+      if (linearIssue) {
+        return linearIssue;
+      }
+    } catch {
+      // A later poll can recover from transient GitHub API failures.
     }
 
     if (attempt < attempts) {
@@ -122,10 +184,30 @@ export async function waitForLinearIssue({
 }
 
 async function main() {
+  const eventName = requiredEnvironment("GITHUB_EVENT_NAME");
+  const actorType = process.env.ACTOR_TYPE ?? "";
+  const authorAssociation = process.env.AUTHOR_ASSOCIATION ?? "";
+  const isPullRequest = process.env.IS_PULL_REQUEST === "true";
+
+  if (
+    !shouldNotifyActivity({
+      actorType,
+      authorAssociation,
+      eventName,
+      isPullRequest,
+    })
+  ) {
+    console.log(
+      `Skipped ${eventName} activity from ${actorType || "unknown actor"} with ${authorAssociation || "no"} association`,
+    );
+    return;
+  }
+
   const githubToken = requiredEnvironment("GITHUB_TOKEN");
   const repository = requiredEnvironment("GITHUB_REPOSITORY");
   const issueNumber = requiredEnvironment("ISSUE_NUMBER");
   const slackWebhookUrl = requiredEnvironment("SLACK_WEBHOOK_URL");
+  const commentId = process.env.COMMENT_ID;
   const githubHeaders = {
     Accept: "application/vnd.github+json",
     Authorization: `Bearer ${githubToken}`,
@@ -143,11 +225,17 @@ async function main() {
         { headers: githubHeaders },
       ),
   });
-  const slackMessage = buildSlackMessage(issue, linearIssue);
+  const comment = commentId
+    ? await requestJson(
+        `${GITHUB_API_URL}/repos/${repository}/issues/comments/${commentId}`,
+        { headers: githubHeaders },
+      )
+    : null;
+  const slackMessage = buildSlackMessage(issue, linearIssue, comment);
   await postSlackWebhook(slackWebhookUrl, slackMessage);
 
   console.log(
-    `Posted GitHub issue #${issue.number} and Linear issue ${linearIssue.identifier} to Slack`,
+    `Posted GitHub ${comment ? "comment on " : ""}issue #${issue.number} and Linear issue ${linearIssue.identifier} to Slack`,
   );
 }
 

--- a/.github/scripts/notify-new-issue.test.mjs
+++ b/.github/scripts/notify-new-issue.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSlackMessage,
+  extractLinearIssueLink,
+  postSlackWebhook,
+  waitForLinearIssue,
+} from "./notify-new-issue.mjs";
+
+test("extractLinearIssueLink finds Linear's GitHub backlink", () => {
+  const result = extractLinearIssueLink([
+    {
+      body: "Fake https://linear.app/darkmatter/issue/ENG-1/not-the-synced-issue",
+      user: { login: "someone-else" },
+    },
+    {
+      body: "This issue is synced to [ENG-593](https://linear.app/darkmatter/issue/ENG-593/nixmac-fails-to-start).",
+      user: { login: "linear-code[bot]" },
+    },
+  ]);
+
+  assert.deepEqual(result, {
+    identifier: "ENG-593",
+    url: "https://linear.app/darkmatter/issue/ENG-593/nixmac-fails-to-start",
+  });
+});
+
+test("extractLinearIssueLink returns null when no Linear backlink exists", () => {
+  assert.equal(
+    extractLinearIssueLink([
+      { body: "Still investigating", user: { login: "linear-code[bot]" } },
+    ]),
+    null,
+  );
+});
+
+test("buildSlackMessage includes both issue links and escapes untrusted text", () => {
+  const githubIssue = {
+    html_url: "https://github.com/darkmatter/nixmac/issues/510",
+    number: 510,
+    title: "Nix <fails> & hangs",
+    user: {
+      html_url: "https://github.com/example-user",
+      login: "example-user",
+    },
+  };
+  const linearIssue = {
+    identifier: "ENG-593",
+    url: "https://linear.app/darkmatter/issue/ENG-593/nixmac-fails-to-start",
+  };
+
+  const message = buildSlackMessage(githubIssue, linearIssue);
+  const serializedBlocks = JSON.stringify(message.blocks);
+
+  assert.equal("channel" in message, false);
+  assert.match(message.text, /https:\/\/github\.com\/darkmatter\/nixmac\/issues\/510/);
+  assert.match(message.text, /https:\/\/linear\.app\/darkmatter\/issue\/ENG-593/);
+  assert.doesNotMatch(message.text, /Nix <fails> & hangs/);
+  assert.match(message.text, /Nix &lt;fails&gt; &amp; hangs/);
+  assert.match(serializedBlocks, /Nix &lt;fails&gt; &amp; hangs/);
+  assert.match(serializedBlocks, /github\.com\/darkmatter\/nixmac\/issues\/510/);
+  assert.match(serializedBlocks, /linear\.app\/darkmatter\/issue\/ENG-593/);
+});
+
+test("waitForLinearIssue retries until the backlink appears", async () => {
+  const responses = [
+    [],
+    [
+      {
+        body: "Synced to https://linear.app/darkmatter/issue/ENG-593/nixmac-fails-to-start",
+        user: { login: "linear-code[bot]" },
+      },
+    ],
+  ];
+  let calls = 0;
+
+  const result = await waitForLinearIssue({
+    attempts: 3,
+    fetchComments: async () => responses[calls++] ?? [],
+    sleep: async () => {},
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.identifier, "ENG-593");
+});
+
+test("waitForLinearIssue fails instead of posting without a Linear link", async () => {
+  await assert.rejects(
+    waitForLinearIssue({
+      attempts: 2,
+      fetchComments: async () => [],
+      sleep: async () => {},
+    }),
+    /Linear backlink did not appear/,
+  );
+});
+
+test("postSlackWebhook requires Slack's explicit ok response", async () => {
+  let request;
+  await postSlackWebhook("https://hooks.slack.test/example", { text: "hello" }, async (...args) => {
+    request = args;
+    return {
+      ok: true,
+      status: 200,
+      text: async () => "ok",
+    };
+  });
+
+  assert.equal(request[0], "https://hooks.slack.test/example");
+  assert.equal(JSON.parse(request[1].body).text, "hello");
+
+  await assert.rejects(
+    postSlackWebhook("https://hooks.slack.test/example", { text: "hello" }, async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "invalid_token",
+    })),
+    /Slack rejected the notification \(403\): invalid_token/,
+  );
+});

--- a/.github/scripts/notify-new-issue.test.mjs
+++ b/.github/scripts/notify-new-issue.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import * as notifier from "./notify-new-issue.mjs";
 import {
   buildSlackMessage,
   extractLinearIssueLink,
@@ -37,6 +38,24 @@ test("extractLinearIssueLink supports Linear's production linkback format", () =
   assert.deepEqual(result, {
     identifier: "ENG-593",
     url: "https://linear.app/darkmatterlabs/issue/ENG-593",
+  });
+});
+
+test("extractLinearIssueLink uses the newest Linear backlink", () => {
+  const result = extractLinearIssueLink([
+    {
+      body: '<!-- linear-linkback -->\n<p><a href="https://linear.app/darkmatterlabs/issue/ENG-100">ENG-100</a></p>',
+      user: { login: "linear-code[bot]" },
+    },
+    {
+      body: '<!-- linear-linkback -->\n<p><a href="https://linear.app/darkmatterlabs/issue/ENG-200">ENG-200</a></p>',
+      user: { login: "linear-code[bot]" },
+    },
+  ]);
+
+  assert.deepEqual(result, {
+    identifier: "ENG-200",
+    url: "https://linear.app/darkmatterlabs/issue/ENG-200",
   });
 });
 
@@ -77,6 +96,133 @@ test("buildSlackMessage includes both issue links and escapes untrusted text", (
   assert.match(serializedBlocks, /linear\.app\/darkmatter\/issue\/ENG-593/);
 });
 
+test("buildSlackMessage describes an external issue comment", () => {
+  const githubIssue = {
+    html_url: "https://github.com/darkmatter/nixmac/issues/510",
+    number: 510,
+    title: "Login fails",
+    user: {
+      html_url: "https://github.com/issue-author",
+      login: "issue-author",
+    },
+  };
+  const linearIssue = {
+    identifier: "ENG-593",
+    url: "https://linear.app/darkmatterlabs/issue/ENG-593",
+  };
+  const githubComment = {
+    body: "Still broken <@channel> & waiting",
+    html_url: "https://github.com/darkmatter/nixmac/issues/510#issuecomment-123",
+    user: {
+      html_url: "https://github.com/comment-author",
+      login: "comment-author",
+    },
+  };
+
+  const message = buildSlackMessage(githubIssue, linearIssue, githubComment);
+  const serializedBlocks = JSON.stringify(message.blocks);
+
+  assert.match(message.text, /New GitHub comment on issue #510/);
+  assert.match(message.text, /issues\/510#issuecomment-123/);
+  assert.match(message.text, /issues\/510/);
+  assert.match(message.text, /linear\.app\/darkmatterlabs\/issue\/ENG-593/);
+  assert.match(serializedBlocks, /Commented by/);
+  assert.match(serializedBlocks, /@comment-author/);
+  assert.match(serializedBlocks, /Still broken &lt;@channel&gt; &amp; waiting/);
+  assert.doesNotMatch(serializedBlocks, /Still broken <@channel> & waiting/);
+});
+
+test("shouldNotifyActivity excludes members, owners, bots, and pull request comments", () => {
+  assert.equal(typeof notifier.shouldNotifyActivity, "function");
+
+  const cases = [
+    {
+      expected: true,
+      label: "external issue",
+      value: {
+        actorType: "User",
+        authorAssociation: "NONE",
+        eventName: "issues",
+        isPullRequest: false,
+      },
+    },
+    {
+      expected: true,
+      label: "external comment on a team-created issue",
+      value: {
+        actorType: "User",
+        authorAssociation: "CONTRIBUTOR",
+        eventName: "issue_comment",
+        isPullRequest: false,
+      },
+    },
+    {
+      expected: true,
+      label: "outside collaborator",
+      value: {
+        actorType: "User",
+        authorAssociation: "COLLABORATOR",
+        eventName: "issue_comment",
+        isPullRequest: false,
+      },
+    },
+    {
+      expected: false,
+      label: "organization member",
+      value: {
+        actorType: "User",
+        authorAssociation: "MEMBER",
+        eventName: "issue_comment",
+        isPullRequest: false,
+      },
+    },
+    {
+      expected: false,
+      label: "repository owner",
+      value: {
+        actorType: "User",
+        authorAssociation: "OWNER",
+        eventName: "issues",
+        isPullRequest: false,
+      },
+    },
+    {
+      expected: false,
+      label: "bot",
+      value: {
+        actorType: "Bot",
+        authorAssociation: "NONE",
+        eventName: "issue_comment",
+        isPullRequest: false,
+      },
+    },
+    {
+      expected: false,
+      label: "pull request comment",
+      value: {
+        actorType: "User",
+        authorAssociation: "NONE",
+        eventName: "issue_comment",
+        isPullRequest: true,
+      },
+    },
+    {
+      expected: true,
+      label: "manual dispatch",
+      value: {
+        actorType: "",
+        authorAssociation: "",
+        eventName: "workflow_dispatch",
+        isPullRequest: false,
+      },
+    },
+  ];
+
+  for (const { expected, label, value } of cases) {
+    assert.equal(notifier.shouldNotifyActivity(value), expected, label);
+  }
+});
+
 test("waitForLinearIssue retries until the backlink appears", async () => {
   const responses = [
     [],
@@ -96,6 +242,38 @@ test("waitForLinearIssue retries until the backlink appears", async () => {
   });
 
   assert.equal(calls, 2);
+  assert.equal(result.identifier, "ENG-593");
+});
+
+test("waitForLinearIssue retries after a comments fetch failure", async () => {
+  const responses = [
+    new Error("temporary GitHub API failure"),
+    [
+      {
+        body: '<!-- linear-linkback -->\n<p><a href="https://linear.app/darkmatterlabs/issue/ENG-593">ENG-593</a></p>',
+        user: { login: "linear-code[bot]" },
+      },
+    ],
+  ];
+  let calls = 0;
+  let sleeps = 0;
+
+  const result = await waitForLinearIssue({
+    attempts: 3,
+    fetchComments: async () => {
+      const response = responses[calls++];
+      if (response instanceof Error) {
+        throw response;
+      }
+      return response;
+    },
+    sleep: async () => {
+      sleeps += 1;
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(sleeps, 1);
   assert.equal(result.identifier, "ENG-593");
 });
 

--- a/.github/scripts/notify-new-issue.test.mjs
+++ b/.github/scripts/notify-new-issue.test.mjs
@@ -26,6 +26,20 @@ test("extractLinearIssueLink finds Linear's GitHub backlink", () => {
   });
 });
 
+test("extractLinearIssueLink supports Linear's production linkback format", () => {
+  const result = extractLinearIssueLink([
+    {
+      body: '<!-- linear-linkback -->\n<p><a href="https://linear.app/darkmatterlabs/issue/ENG-593">ENG-593</a></p>',
+      user: { login: "linear-code[bot]" },
+    },
+  ]);
+
+  assert.deepEqual(result, {
+    identifier: "ENG-593",
+    url: "https://linear.app/darkmatterlabs/issue/ENG-593",
+  });
+});
+
 test("extractLinearIssueLink returns null when no Linear backlink exists", () => {
   assert.equal(
     extractLinearIssueLink([

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -16,6 +16,16 @@ permissions:
   packages: read
 
 jobs:
+  github-issue-notifier:
+    name: GitHub Issue Notifier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Test notifier
+        run: node --test .github/scripts/notify-new-issue.test.mjs
+
   rust-check:
     name: Rust Check
     runs-on: arc

--- a/.github/workflows/notify-new-issue.yml
+++ b/.github/workflows/notify-new-issue.yml
@@ -1,0 +1,34 @@
+name: Notify Slack of new GitHub issues
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Existing GitHub issue number to notify
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  notify:
+    name: Post issue links to Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Test notifier
+        run: node --test .github/scripts/notify-new-issue.test.mjs
+
+      - name: Notify nixmac support
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          SLACK_WEBHOOK_URL: ${{ secrets.NIXMAC_SUPPORT_SLACK_WEBHOOK_URL }}
+        run: node .github/scripts/notify-new-issue.mjs

--- a/.github/workflows/notify-new-issue.yml
+++ b/.github/workflows/notify-new-issue.yml
@@ -1,12 +1,14 @@
-name: Notify Slack of new GitHub issues
+name: Notify Slack of external GitHub activity
 
 on:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       issue_number:
-        description: Existing GitHub issue number to notify
+        description: Existing issue number to notify; may duplicate a completed post
         required: true
         type: string
 
@@ -16,19 +18,21 @@ permissions:
 
 jobs:
   notify:
-    name: Post issue links to Slack
+    name: Post external activity to Slack
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Test notifier
-        run: node --test .github/scripts/notify-new-issue.test.mjs
-
       - name: Notify nixmac support
         env:
+          ACTOR_TYPE: ${{ github.event.comment.user.type || github.event.issue.user.type || '' }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || github.event.issue.author_association || '' }}
+          COMMENT_ID: ${{ github.event.comment.id || '' }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
+          IS_PULL_REQUEST: ${{ github.event.issue.pull_request && 'true' || 'false' }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
           SLACK_WEBHOOK_URL: ${{ secrets.NIXMAC_SUPPORT_SLACK_WEBHOOK_URL }}
         run: node .github/scripts/notify-new-issue.mjs


### PR DESCRIPTION
## Summary

- notify `#nixmac-support` when an external user opens a GitHub issue or comments on any GitHub issue, including team-created issues
- exclude bots plus organization `OWNER`/`MEMBER` activity; keep `COLLABORATOR`, contributor, and first-time-user activity
- exclude pull request comments from the support feed
- wait for Linear's `linear-code[bot]` backlink, then include the activity, GitHub issue, and Linear issue links in Slack
- select the newest Linear backlink and retry transient GitHub comment-fetch failures
- run notifier tests in PR CI; manual dispatch remains available and may duplicate a completed post
- use the channel-bound `NIXMAC_SUPPORT_SLACK_WEBHOOK_URL`

## Test Plan

- [x] `node --test .github/scripts/notify-new-issue.test.mjs` (11 tests)
- [x] `node --check .github/scripts/notify-new-issue.mjs`
- [x] `actionlint .github/workflows/notify-new-issue.yml`
- [x] `actionlint -ignore 'label "arc" is unknown' .github/workflows/evaluate.yml`
- [x] `bunx oxlint .github/scripts/notify-new-issue.mjs .github/scripts/notify-new-issue.test.mjs`
- [x] bot/member/collaborator environment-filter smoke tests
- [x] live issue delivery to `#nixmac-support` using GitHub #510 and Linear ENG-593
- [ ] post-merge external-comment smoke test

## Docs

- [x] No docs update needed