### PR TITLE
chore(feedback): reset busy flags in resetFeedbackState

### DIFF
--- a/apps/native/src/components/widget/feedback/feedback-dialog.tsx
+++ b/apps/native/src/components/widget/feedback/feedback-dialog.tsx
@@ -331,6 +331,8 @@ export function FeedbackDialog() {
     setShareOptions(DEFAULT_SHARE_OPTIONS);
     setIsPreviewingReport(false);
     setPreviewReportText("");
+    setSubmitting(false);
+    setPreviewLoading(false);
     uiActions.setState({
       feedbackTypeOverride: null,
       feedbackInitialText: null,


### PR DESCRIPTION
submitting/previewLoading were only healed by their handlers' finally blocks; reset them explicitly so the footer can't stay locked if a future change breaks that implicit invariant.

## Summary

Follow-up to https://github.com/darkmatter/nixmac/pull/514 to address resetting missed flags.

Not changing any behavior yet but it's there for correctness and future possible changes.

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
