### PR TITLE
fix(providers): hide broken CLI providers outside developer mode

### DIFF
--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
@@ -24,9 +24,11 @@ import {
   getAiModelProvider,
   isPlainInputCliProvider,
   modelPlaceholder,
+  visibleModelProviders,
 } from "@/lib/providers/ai-models";
 import { prefillModel } from "@/lib/providers/ai-defaults";
 import { providerRequiresModel } from "@/lib/providers/ai-provider-validation";
+import { useCliProvidersVisible } from "@/lib/providers/cli-providers-flag";
 import type { AccountBilling, BillingProductInfo } from "@/lib/orpc";
 import { client, orpc } from "@/lib/orpc";
 import { getTelemetry } from "@/lib/telemetry/instance";
@@ -700,6 +702,11 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
   const [baseUrl, setBaseUrl] = useState("");
   const [keyState, setKeyState] = useState<KeyState>("idle");
   const [serverError, setServerError] = useState("");
+  const cliProvidersVisible = useCliProvidersVisible();
+  const byokProviders = useMemo(
+    () => visibleModelProviders(cliProvidersVisible, providerId, BYOK_MODEL_PROVIDERS),
+    [cliProvidersVisible, providerId],
+  );
 
   const format = useMemo(() => validateKeyFormat(provider, key), [provider, key]);
   const touched = key.trim().length > 0;
@@ -785,7 +792,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
               <SelectValue placeholder="Select provider" />
             </SelectTrigger>
             <SelectContent>
-              {BYOK_MODEL_PROVIDERS.map((p) => (
+              {byokProviders.map((p) => (
                 <SelectItem key={p.id} value={p.id}>
                   <span className="flex items-center gap-2">
                     <ProviderIcon provider={p.icon} size={14} />

--- a/apps/native/src/components/widget/settings/ai-models-tab.tsx
+++ b/apps/native/src/components/widget/settings/ai-models-tab.tsx
@@ -16,11 +16,12 @@ import {
   providerRequiresModel,
 } from "@/lib/providers/ai-provider-validation";
 import {
-  AI_MODEL_PROVIDERS,
   isPlainInputCliProvider,
   modelForProvider,
   modelPlaceholder,
+  visibleModelProviders,
 } from "@/lib/providers/ai-models";
+import { useCliProvidersVisible } from "@/lib/providers/cli-providers-flag";
 import type { AnyFieldApi, ReactFormExtendedApi } from "@tanstack/react-form";
 import { useEffect, useState } from "react";
 
@@ -88,11 +89,12 @@ export function AiModelsTab({
 }: AiModelsTabProps) {
   const cliStatus = useCliToolStatus();
   const providerPrefs = useProviderPrefs(form);
+  const cliProvidersVisible = useCliProvidersVisible();
 
-  const renderProviderItems = () => {
+  const renderProviderItems = (selectedProvider: string) => {
     return (
       <>
-        {AI_MODEL_PROVIDERS.map((provider) => (
+        {visibleModelProviders(cliProvidersVisible, selectedProvider).map((provider) => (
           <SelectItem key={provider.id} value={provider.id}>
             <span className="flex items-center gap-2">
               <ProviderIcon provider={provider.icon} size={14} />
@@ -164,7 +166,7 @@ export function AiModelsTab({
                   <SelectTrigger id="evolveProvider">
                     <SelectValue placeholder="Select provider" />
                   </SelectTrigger>
-                  <SelectContent>{renderProviderItems()}</SelectContent>
+                  <SelectContent>{renderProviderItems(evolveProviderField.state.value)}</SelectContent>
                 </Select>
                 {evolveProviderError && (
                   <p className="text-destructive text-xs">{evolveProviderError}</p>
@@ -277,7 +279,7 @@ export function AiModelsTab({
                   <SelectTrigger id="summaryProvider">
                     <SelectValue placeholder="Select provider" />
                   </SelectTrigger>
-                  <SelectContent>{renderProviderItems()}</SelectContent>
+                  <SelectContent>{renderProviderItems(summaryProviderField.state.value)}</SelectContent>
                 </Select>
                 {summaryProviderError && (
                   <p className="text-destructive text-xs">{summaryProviderError}</p>

--- a/apps/native/src/components/widget/settings/overridable-flags.ts
+++ b/apps/native/src/components/widget/settings/overridable-flags.ts
@@ -2,6 +2,10 @@ import {
   EVOLVE_PROMPT_SUGGESTIONS_FLAG,
   PROMPT_SUGGESTIONS_VARIANTS,
 } from "@/components/widget/promptinput/prompt-suggestions-variant";
+import {
+  CLI_PROVIDERS_FLAG,
+  CLI_PROVIDERS_VARIANTS,
+} from "@/lib/providers/cli-providers-flag";
 
 /** One selectable override value for a flag, plus its human-facing label. */
 type FlagOverrideOption = { value: string; label: string };
@@ -34,6 +38,13 @@ export const OVERRIDABLE_FLAGS: readonly OverridableFlag[] = [
   {
     key: EVOLVE_PROMPT_SUGGESTIONS_FLAG,
     options: PROMPT_SUGGESTIONS_VARIANTS.map((variant) => ({
+      value: variant,
+      label: variant,
+    })),
+  },
+  {
+    key: CLI_PROVIDERS_FLAG,
+    options: CLI_PROVIDERS_VARIANTS.map((variant) => ({
       value: variant,
       label: variant,
     })),

--- a/apps/native/src/lib/providers/ai-models.ts
+++ b/apps/native/src/lib/providers/ai-models.ts
@@ -17,6 +17,8 @@ interface AiModelProvider {
 	icon: ProviderIconId;
 	defaultEvolveModel: string;
 	defaultSummaryModel: string;
+	/** Hidden from provider pickers unless the `cli-providers` flag enables them. */
+	developerOnly?: boolean;
 	setup:
 		| { kind: "hosted" }
 		| {
@@ -104,12 +106,14 @@ export const AI_MODEL_PROVIDERS: readonly AiModelProvider[] = [
 			docsHint: "Your OpenAI-compatible /v1 endpoint.",
 		},
 	},
+	// CLI providers don't currently work; hidden unless the `cli-providers` flag enables them.
 	{
 		id: "claude",
 		name: "Claude CLI",
 		icon: "claude",
 		...modelDefaults("claude"),
 		setup: { kind: "cli", plainModelInput: true },
+		developerOnly: true,
 	},
 	{
 		id: "codex",
@@ -117,6 +121,7 @@ export const AI_MODEL_PROVIDERS: readonly AiModelProvider[] = [
 		icon: "codex",
 		...modelDefaults("codex"),
 		setup: { kind: "cli", plainModelInput: true },
+		developerOnly: true,
 	},
 	{
 		id: "opencode",
@@ -124,8 +129,27 @@ export const AI_MODEL_PROVIDERS: readonly AiModelProvider[] = [
 		icon: "opencode",
 		...modelDefaults("opencode"),
 		setup: { kind: "cli", plainModelInput: false },
+		developerOnly: true,
 	},
 ];
+
+/**
+ * Providers to show in a picker: developer-only providers are hidden unless
+ * the `cli-providers` feature flag enables them (see useCliProvidersVisible)
+ * or one is already selected (so the picker stays valid).
+ */
+export function visibleModelProviders(
+	showDeveloperOnly: boolean,
+	selectedId?: string,
+	providers: readonly AiModelProvider[] = AI_MODEL_PROVIDERS,
+): readonly AiModelProvider[] {
+	return providers.filter(
+		(provider) =>
+			!provider.developerOnly ||
+			showDeveloperOnly ||
+			provider.id === selectedId,
+	);
+}
 
 export const BYOK_MODEL_PROVIDERS = AI_MODEL_PROVIDERS.filter(
 	(provider) => provider.setup.kind !== "hosted",

--- a/apps/native/src/lib/providers/cli-providers-flag.ts
+++ b/apps/native/src/lib/providers/cli-providers-flag.ts
@@ -1,0 +1,29 @@
+import { useFeatureFlag } from "@/lib/telemetry/use-feature-flag";
+
+/**
+ * PostHog multivariate flag controlling whether the CLI providers (Claude,
+ * Codex, OpenCode) appear in provider pickers. They are currently broken, so
+ * the default is to hide them.
+ *
+ * Configure in PostHog with these variant keys:
+ * - `hidden`  — CLI providers are hidden from pickers (control / safe default)
+ * - `visible` — CLI providers are selectable
+ */
+export const CLI_PROVIDERS_FLAG = "cli-providers";
+
+export const CLI_PROVIDERS_VARIANTS: readonly string[] = ["hidden", "visible"];
+
+/**
+ * Map a raw flag value to visibility, hiding while the flag is unset, loading,
+ * or unrecognized (tests, Storybook, diagnostics off).
+ */
+export function resolveCliProvidersVisible(
+	flag: boolean | string | undefined,
+): boolean {
+	return flag === "visible";
+}
+
+/** Reactive hook: whether CLI providers should be offered in pickers. */
+export function useCliProvidersVisible(): boolean {
+	return resolveCliProvidersVisible(useFeatureFlag(CLI_PROVIDERS_FLAG));
+}


### PR DESCRIPTION
## Summary

Claude/Codex/OpenCode CLI providers don't currently work.

Mark them developerOnly in ai-models.ts and filter them from the settings AI Models pickers and the onboarding BYOK provider picker unless developer mode is on (or one is already selected).

## Test Plan

- [x] Verified manually the behavior works as designed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
