### PR TITLE
fix(promptinput): fix waiting after the pharse is "typed"

### DIFF
--- a/apps/native/src/components/widget/promptinput/starter-prompts.ts
+++ b/apps/native/src/components/widget/promptinput/starter-prompts.ts
@@ -70,12 +70,40 @@ export const STARTER_PROMPT_CHIPS = STARTER_PROMPT_ARCHETYPES.flatMap((archetype
  * animated placeholder hint (e.g. the part before the first `:` or `,`),
  * capped at a word boundary so the typewriter stays snappy.
  */
+const DANGLING_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "at",
+  "by",
+  "for",
+  "from",
+  "in",
+  "into",
+  "my",
+  "of",
+  "on",
+  "or",
+  "over",
+  "the",
+  "to",
+  "with",
+]);
+
 function toPlaceholderPhrase(prompt: string, maxLength = 64): string {
   const lead = prompt.split(/[:,]/, 1)[0]?.trim() ?? prompt.trim();
   if (lead.length <= maxLength) return lead;
   const truncated = lead.slice(0, maxLength);
   const lastSpace = truncated.lastIndexOf(" ");
-  return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated).trim();
+  const words = (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated)
+    .trim()
+    .split(" ");
+  // A cut can land right after a connector ("… with Tailscale or"), which reads
+  // as if the typewriter stalled mid-sentence — drop such trailing words.
+  while (words.length > 1 && DANGLING_WORDS.has(words[words.length - 1]!.toLowerCase())) {
+    words.pop();
+  }
+  return words.join(" ");
 }
 
 /**

--- a/apps/native/src/components/widget/promptinput/use-typewriter-placeholder.ts
+++ b/apps/native/src/components/widget/promptinput/use-typewriter-placeholder.ts
@@ -27,15 +27,20 @@ export function useTypewriterPlaceholder(
     const full = examples[idx % examples.length] ?? "";
     charRef.current = 0;
     setTyped("");
+    // The hold must start only once the phrase is fully typed, otherwise the
+    // typing time eats into the hold and long phrases advance almost instantly.
+    let next: ReturnType<typeof setTimeout> | undefined;
     const typer = setInterval(() => {
       charRef.current += 1;
       setTyped(full.slice(0, charRef.current));
-      if (charRef.current >= full.length) clearInterval(typer);
+      if (charRef.current >= full.length) {
+        clearInterval(typer);
+        next = setTimeout(() => setIdx((i) => (i + 1) % examples.length), holdMs);
+      }
     }, charMs);
-    const next = setTimeout(() => setIdx((i) => (i + 1) % examples.length), holdMs);
     return () => {
       clearInterval(typer);
-      clearTimeout(next);
+      if (next !== undefined) clearTimeout(next);
     };
   }, [idx, paused, charMs, holdMs, examples]);
 


### PR DESCRIPTION
## Summary

- Always wait after the phrase is fully "typed"
- Avoid dangling phrases like
> Tunnel a local service automatically on boot with Tailscale or

## Test Plan

- [x] Manually confirmed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
