### PR TITLE
fix(secret-scanner): compile all gitleaks rules via ASCII rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,6 +3597,7 @@ dependencies = [
  "plist",
  "r2d2",
  "regex",
+ "regex-syntax",
  "reqwest 0.12.28",
  "reqwest-middleware",
  "reqwest-tracing",

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -69,6 +69,7 @@ hex = "0.4.3"
 regex = "1.12.3"
 tauri-plugin-http = "2"
 fancy-regex = "0.17.0"
+regex-syntax = "0.8"
 toml = "1.0.3"
 backtrace = "0.3"
 clap = { version = "4", features = ["derive"] }

--- a/apps/native/src-tauri/src/system/mod.rs
+++ b/apps/native/src-tauri/src/system/mod.rs
@@ -11,5 +11,6 @@ pub mod launchd_scanner;
 pub mod nix;
 pub mod nix_ast_lists;
 pub mod permissions;
+pub mod re2_ascii;
 pub mod scanner;
 pub mod secret_scanner;

--- a/apps/native/src-tauri/src/system/re2_ascii.rs
+++ b/apps/native/src-tauri/src/system/re2_ascii.rs
@@ -1,0 +1,202 @@
+//! Rewrites Go/RE2 regex patterns into exact Rust-compilable equivalents.
+//!
+//! Gitleaks patterns are written for Go's RE2, where the Perl classes and
+//! word boundaries are ASCII-only. Compiled with the Rust regex crates they
+//! get Unicode semantics instead, and patterns with large bounded repetitions
+//! of `\w` can exceed NFA size limits and fail to compile entirely. Rewriting
+//! those constructs to their explicit ASCII definitions reproduces exactly
+//! what gitleaks executes, and compiles cheaply.
+
+use regex_syntax::ast::{AssertionKind, Ast, ClassPerlKind, ClassSet, ClassSetItem};
+use std::ops::Range;
+
+// Go/RE2 definitions of the Perl classes:
+//   \w = [0-9A-Za-z_]   \d = [0-9]   \s = [\t\n\f\r ]
+// The negated variants are the full complement, including all of non-ASCII.
+const ASCII_WORD: &str = "0-9A-Za-z_";
+const ASCII_NOT_WORD: &str = r"\x00-\x2f\x3a-\x40\x5b-\x5e\x60\x7b-\x{10FFFF}";
+const ASCII_DIGIT: &str = "0-9";
+const ASCII_NOT_DIGIT: &str = r"\x00-\x2f\x3a-\x{10FFFF}";
+const ASCII_SPACE: &str = r"\t\n\x0c\r\x20";
+const ASCII_NOT_SPACE: &str = r"\x00-\x08\x0b\x0e-\x1f\x21-\x{10FFFF}";
+
+// Go's `\b` is an ASCII word boundary; the regex crate's is Unicode-aware and
+// `(?-u)` is unsupported by fancy_regex, so express it with lookarounds.
+const ASCII_WORD_BOUNDARY: &str =
+    "(?:(?<![0-9A-Za-z_])(?=[0-9A-Za-z_])|(?<=[0-9A-Za-z_])(?![0-9A-Za-z_]))";
+const ASCII_NOT_WORD_BOUNDARY: &str =
+    "(?:(?<=[0-9A-Za-z_])(?=[0-9A-Za-z_])|(?<![0-9A-Za-z_])(?![0-9A-Za-z_]))";
+
+fn perl_class_ranges(kind: &ClassPerlKind, negated: bool) -> &'static str {
+    match (kind, negated) {
+        (ClassPerlKind::Word, false) => ASCII_WORD,
+        (ClassPerlKind::Word, true) => ASCII_NOT_WORD,
+        (ClassPerlKind::Digit, false) => ASCII_DIGIT,
+        (ClassPerlKind::Digit, true) => ASCII_NOT_DIGIT,
+        (ClassPerlKind::Space, false) => ASCII_SPACE,
+        (ClassPerlKind::Space, true) => ASCII_NOT_SPACE,
+    }
+}
+
+fn collect_ascii_replacements(node: &Ast, out: &mut Vec<(Range<usize>, String)>) {
+    match node {
+        Ast::ClassPerl(p) => {
+            let ranges = perl_class_ranges(&p.kind, p.negated);
+            out.push((
+                p.span.start.offset..p.span.end.offset,
+                format!("[{ranges}]"),
+            ));
+        }
+        Ast::Assertion(a) => {
+            let replacement = match a.kind {
+                AssertionKind::WordBoundary => ASCII_WORD_BOUNDARY,
+                AssertionKind::NotWordBoundary => ASCII_NOT_WORD_BOUNDARY,
+                _ => return,
+            };
+            out.push((a.span.start.offset..a.span.end.offset, replacement.to_string()));
+        }
+        Ast::ClassBracketed(c) => collect_class_set(&c.kind, out),
+        Ast::Repetition(r) => collect_ascii_replacements(&r.ast, out),
+        Ast::Group(g) => collect_ascii_replacements(&g.ast, out),
+        Ast::Alternation(a) => {
+            for ast in &a.asts {
+                collect_ascii_replacements(ast, out);
+            }
+        }
+        Ast::Concat(c) => {
+            for ast in &c.asts {
+                collect_ascii_replacements(ast, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_class_set(set: &ClassSet, out: &mut Vec<(Range<usize>, String)>) {
+    match set {
+        ClassSet::Item(item) => collect_class_item(item, out),
+        ClassSet::BinaryOp(op) => {
+            collect_class_set(&op.lhs, out);
+            collect_class_set(&op.rhs, out);
+        }
+    }
+}
+
+fn collect_class_item(item: &ClassSetItem, out: &mut Vec<(Range<usize>, String)>) {
+    match item {
+        // Inside a bracketed class, splice in bare ranges (no brackets).
+        ClassSetItem::Perl(p) => {
+            let ranges = perl_class_ranges(&p.kind, p.negated);
+            out.push((p.span.start.offset..p.span.end.offset, ranges.to_string()));
+        }
+        ClassSetItem::Bracketed(b) => collect_class_set(&b.kind, out),
+        ClassSetItem::Union(u) => {
+            for item in &u.items {
+                collect_class_item(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite the unicode-dependent constructs (`\w` `\d` `\s` `\b` and their
+/// negations) into their exact Go/RE2 ASCII equivalents, using the parsed AST
+/// so escaped literals and class-internal contexts are handled correctly.
+/// Returns None if the pattern doesn't parse or contains nothing to rewrite.
+pub fn ascii_rewrite(pattern: &str) -> Option<String> {
+    let ast = regex_syntax::ast::parse::Parser::new().parse(pattern).ok()?;
+    let mut replacements: Vec<(Range<usize>, String)> = Vec::new();
+    collect_ascii_replacements(&ast, &mut replacements);
+    if replacements.is_empty() {
+        return None;
+    }
+    replacements.sort_by_key(|(range, _)| range.start);
+    let mut result = pattern.to_string();
+    for (range, replacement) in replacements.into_iter().rev() {
+        result.replace_range(range, &replacement);
+    }
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fancy_regex::Regex;
+
+    #[test]
+    fn maps_perl_classes_and_boundaries() {
+        for (pattern, expected) in [
+            (r"\w+", Some("[0-9A-Za-z_]+")),
+            (r"[\w-]{3}", Some("[0-9A-Za-z_-]{3}")),
+            (r"\d\D", Some(r"[0-9][\x00-\x2f\x3a-\x{10FFFF}]")),
+            (r"[\s;]", Some(r"[\t\n\x0c\r\x20;]")),
+            (
+                r"[^\W]",
+                Some(r"[^\x00-\x2f\x3a-\x40\x5b-\x5e\x60\x7b-\x{10FFFF}]"),
+            ),
+            // Escaped backslash followed by a literal `w` is not a Perl class.
+            (r"\\w", None),
+            (r"plain literal", None),
+        ] {
+            assert_eq!(
+                ascii_rewrite(pattern).as_deref(),
+                expected,
+                "pattern: {pattern}"
+            );
+        }
+
+        let boundary = ascii_rewrite(r"\bhvb").unwrap();
+        assert_eq!(boundary, format!("{ASCII_WORD_BOUNDARY}hvb"));
+    }
+
+    #[test]
+    fn output_compiles_and_matches_go_boundary_semantics() {
+        let vault_original = r#"\b(hvb\.[\w-]{138,300})(?:[\x60'"\s;]|\\[nr]|$)"#;
+        let rewritten = ascii_rewrite(vault_original).unwrap();
+        let re = Regex::new(&rewritten).expect("rewrite compiles at default size limit");
+
+        let token = format!("hvb.{}", "Ab1-".repeat(36));
+        // Go's ASCII \b sees a boundary after a CJK char; Rust's unicode \b
+        // would not, silently missing the secret.
+        assert!(re.is_match(&format!("token: {token} end")).unwrap());
+        assert!(re.is_match(&format!("密码{token} end")).unwrap());
+        // No boundary when the token abuts ASCII word characters.
+        assert!(!re.is_match(&format!("xyz{token} end")).unwrap());
+    }
+
+    #[test]
+    fn rewrite_is_equivalent_to_originals_on_ascii_input() {
+        // Real gitleaks patterns whose originals CAN compile if given a large
+        // enough delegate size limit — compare behavior against the rewrite.
+        // (ASCII-only corpus: on non-ASCII input the rewrite is intentionally
+        // MORE faithful to gitleaks than the unicode original.)
+        let originals = [
+            r#"pypi-AgEIcHlwaS5vcmc[\w-]{50,1000}"#,
+            r#"(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passw(?:or)?d|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3})(?:[\x60'"\s;]|\\[nr]|$)"#,
+        ];
+        let corpus = [
+            format!("pypi-AgEIcHlwaS5vcmc{}", "Ab1-".repeat(15)),
+            format!("pypi-AgEIcHlwaS5vcmc{}", "a".repeat(49)),
+            r#"api_key = "zaCELgL0imfnc8mVLWwsAawjYr4Rx""#.to_string(),
+            r#"my_secret_token: 'abcd1234efgh5678'"#.to_string(),
+            "password: hunter2".to_string(),
+            "AUTH-CREDS := `Xy9_k2mQ8vL4nP7r`; next".to_string(),
+            "no secrets here at all".to_string(),
+        ];
+
+        for pattern in originals {
+            let original = fancy_regex::RegexBuilder::new(pattern)
+                .delegate_size_limit(64 << 20)
+                .build()
+                .expect("original compiles at raised limit");
+            let rewritten =
+                Regex::new(&ascii_rewrite(pattern).unwrap()).expect("rewrite compiles");
+
+            for hay in &corpus {
+                let a = original.find(hay).unwrap().map(|m| (m.start(), m.end()));
+                let b = rewritten.find(hay).unwrap().map(|m| (m.start(), m.end()));
+                assert_eq!(a, b, "divergence on {hay:?} for pattern {pattern}");
+            }
+        }
+    }
+}

--- a/apps/native/src-tauri/src/system/secret_scanner.rs
+++ b/apps/native/src-tauri/src/system/secret_scanner.rs
@@ -1,11 +1,12 @@
 use fancy_regex::Regex;
-use log::warn;
+use log::{debug, warn};
 use serde::Deserialize;
 use serde_json::Value;
 use std::sync::OnceLock;
 use tauri::{AppHandle, Manager};
 
 use crate::commands::debug::TimerGuard;
+use crate::system::re2_ascii::ascii_rewrite;
 
 static SECRET_SCANNER: OnceLock<SecretScanner> = OnceLock::new();
 
@@ -18,6 +19,7 @@ struct GitleaksConfig {
 struct GitleaksRule {
     id: String,
     regex: Option<String>,
+    path: Option<String>,
 }
 
 pub struct SecretScanner {
@@ -77,37 +79,54 @@ impl SecretScanner {
                 let regex = match rule.regex {
                     Some(regex) => regex,
                     None => {
-                        warn!("Skipping gitleaks rule without regex: {}", rule.id);
+                        // Path-only rules (e.g. pkcs12-file) match filenames, which
+                        // doesn't apply to scanning JSON values.
+                        if rule.path.is_none() {
+                            warn!("Skipping gitleaks rule without regex: {}", rule.id);
+                        }
                         return None;
                     }
                 };
 
+                // Startup fast path: skip the original compile attempt when we
+                // know it fails — a failing NFA build takes ~0.3-1s per rule.
+                // Purely advisory: a stale hint falls through to the normal path.
+                if prefers_ascii_rewrite(&rule.id) {
+                    if let Some(Ok(compiled)) = ascii_rewrite(&regex).map(|p| Regex::new(&p)) {
+                        return Some((rule.id, compiled));
+                    }
+                }
+
                 match Regex::new(&regex) {
                     Ok(compiled) => Some((rule.id, compiled)),
                     Err(err) => {
-                        if let Some(fallback) = fallback_regex_for(&rule.id) {
-                            match Regex::new(fallback) {
-                                Ok(compiled) => {
-                                    warn!(
-                                        "Using fallback regex for gitleaks rule: {} (original error: {})",
-                                        rule.id, err
-                                    );
-                                    Some((rule.id, compiled))
-                                }
-                                Err(fallback_err) => {
-                                    warn!(
-                                        "Skipping gitleaks rule with invalid regex: {} (original: {}, fallback: {})",
-                                        rule.id, err, fallback_err
-                                    );
-                                    None
-                                }
+                        // Patterns with large bounded repetitions of `\w` blow past
+                        // the regex crate's compiled-size limits. Gitleaks runs on
+                        // Go's RE2 where `\w`/`\d`/`\s`/`\b` are ASCII-only, so the
+                        // ASCII rewrite is exactly what gitleaks executes — and it
+                        // compiles cheaply.
+                        match ascii_rewrite(&regex).map(|p| Regex::new(&p)) {
+                            Some(Ok(compiled)) => {
+                                debug!(
+                                    "Compiled ASCII rewrite for gitleaks rule: {} (original error: {})",
+                                    rule.id, err
+                                );
+                                Some((rule.id, compiled))
                             }
-                        } else {
-                            warn!(
-                                "Skipping gitleaks rule with invalid regex: {} ({})",
-                                rule.id, err
-                            );
-                            None
+                            Some(Err(rewrite_err)) => {
+                                warn!(
+                                    "Skipping gitleaks rule with invalid regex: {} (original: {}, ascii rewrite: {})",
+                                    rule.id, err, rewrite_err
+                                );
+                                None
+                            }
+                            None => {
+                                warn!(
+                                    "Skipping gitleaks rule with invalid regex: {} ({})",
+                                    rule.id, err
+                                );
+                                None
+                            }
                         }
                     }
                 }
@@ -285,15 +304,95 @@ fn is_entropy_candidate_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || matches!(ch, '+' | '/' | '=' | '-' | '_')
 }
 
-fn fallback_regex_for(id: &str) -> Option<&'static str> {
-    match id {
-        // Broad, simpler fallback for generic API-style secrets since the ones in gitleaks have very complex regexes that can fail to compile in Rust.
-        // This is a best-effort backup to catch obvious secrets without crashing the scanner.
-        "generic-api-key" => Some(
-            r#"(?i)(?:access|auth|api|credential|creds|key|password|secret|token)[\w .-]{0,20}[:=][ \t\"']{0,5}([A-Za-z0-9_\-]{12,})"#,
-        ),
-        "pypi-upload-token" => Some(r#"pypi-AgEIcHlwaS5vcmc[\w-]{50,}"#),
-        "vault-batch-token" => Some(r#"\bhvb\.[A-Za-z0-9+/=]{20,}"#),
-        _ => None,
+/// Rules whose patterns are known to exceed the regex crate's NFA size limits
+/// (as of the currently bundled gitleaks.toml), so compilation goes straight
+/// to the ASCII rewrite. Kept exact by the `hint_list_is_exact` test; a stale
+/// entry only affects startup speed, never redaction.
+fn prefers_ascii_rewrite(id: &str) -> bool {
+    matches!(
+        id,
+        "generic-api-key" | "pypi-upload-token" | "vault-batch-token"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bundled_scanner() -> &'static SecretScanner {
+        static SCANNER: OnceLock<SecretScanner> = OnceLock::new();
+        SCANNER
+            .get_or_init(|| SecretScanner::from_toml(include_str!("../../resources/gitleaks.toml")))
     }
+
+    fn bundled_config() -> GitleaksConfig {
+        toml::from_str(include_str!("../../resources/gitleaks.toml")).unwrap()
+    }
+
+    #[test]
+    fn no_bundled_rule_is_silently_lost() {
+        let scanner = bundled_scanner();
+        let ids: Vec<&str> = scanner
+            .compiled_rules
+            .iter()
+            .map(|(id, _)| id.as_str())
+            .collect();
+
+        // Every rule with a regex must compile, via the original or the
+        // ASCII rewrite. Catches gitleaks.toml bumps that introduce patterns
+        // neither path can handle.
+        for rule in bundled_config().rules {
+            if rule.regex.is_some() {
+                assert!(ids.contains(&rule.id.as_str()), "rule {} was lost", rule.id);
+            } else {
+                assert!(
+                    !ids.contains(&rule.id.as_str()),
+                    "regex-less rule {} unexpectedly compiled",
+                    rule.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hint_list_is_exact() {
+        // The fast-path hint must match reality in both directions: a hinted
+        // rule whose original now compiles means the hint is removable; an
+        // unhinted rule whose original fails means boot pays a slow failing
+        // compile attempt and the hint list should grow. Either way, update
+        // prefers_ascii_rewrite when this fails after a gitleaks.toml bump.
+        for rule in bundled_config().rules {
+            let Some(regex) = rule.regex else { continue };
+            let original_compiles = Regex::new(&regex).is_ok();
+            assert_eq!(
+                original_compiles,
+                !prefers_ascii_rewrite(&rule.id),
+                "hint list is stale for rule {}",
+                rule.id
+            );
+        }
+    }
+
+    #[test]
+    fn redacts_previously_failing_rules() {
+        let scanner = bundled_scanner();
+
+        let pypi = format!("pypi-AgEIcHlwaS5vcmc{}", "Ab1-".repeat(15));
+        let vault = format!("hvb.{}", "Ab1-".repeat(36));
+        let generic = r#"api_key = "zaCELgL0imfnc8mVLWwsAawjYr4Rx""#.to_string();
+
+        for (input, id) in [
+            (format!("token: {pypi} end"), "pypi-upload-token"),
+            (format!("token: {vault} end"), "vault-batch-token"),
+            (generic, "generic-api-key"),
+        ] {
+            let (redacted, changed) = scanner.redact_string(&input);
+            assert!(changed, "{id}: expected redaction in {input:?}");
+            assert!(
+                redacted.contains("[REDACTED]"),
+                "{id}: no [REDACTED] in {redacted:?}"
+            );
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Improve secrets scanning regex

I was addressing these scary-looking warning logs
```
2026-07-09T13:21:58.809020Z  WARN nixmac::system::secret_scanner: Using fallback regex for gitleaks rule: generic-api-key (original error: Error compiling regex: Regex error: error building NFA)
2026-07-09T13:22:02.412145Z  WARN nixmac::system::secret_scanner: Skipping gitleaks rule without regex: pkcs12-file
2026-07-09T13:22:03.527892Z  WARN nixmac::system::secret_scanner: Using fallback regex for gitleaks rule: pypi-upload-token (original error: Error compiling regex: Regex error: error building NFA)
2026-07-09T13:22:05.863293Z  WARN nixmac::system::secret_scanner: Using fallback regex for gitleaks rule: vault-batch-token (original error: Error compiling regex: Regex error: error building NFA)
```

and found out that there's a better way to handle those regexp-s. Additional bonus: the app starts faster, especially in debug (about 7 seconds faster for me)

Main reason: Gitleaks executes Go RE2, where \w \d \s \b are ASCII-only, so an AST-based rewrite of those constructs is exact and compiles in ms.



## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
