### PR TITLE
fix(model-input): make empty model track the default

### DIFF
--- a/apps/native/shared/ai-defaults.json
+++ b/apps/native/shared/ai-defaults.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Single source of truth for hardcoded per-provider default models and static model suggestions. Consumed by the frontend via src/lib/providers/ai-defaults.ts and by the backend via src-tauri/src/ai/defaults.rs. Providers without suggestedModels fetch their model list dynamically.",
+  "$comment": "Single source of truth for per-provider model configuration. evolveModel/summaryModel are runtime defaults: when the stored model is empty the backend falls back to them (CLI tools fall back to the CLI's own default), so an empty stored model means 'track the default'. Providers with requiresModel have no fallback — the app rejects an empty model and seeds prefillEvolveModel/prefillSummaryModel when the user switches to them. Consumed by the frontend via src/lib/providers/ai-defaults.ts and by the backend via src-tauri/src/ai/defaults.rs. Providers without suggestedModels fetch their model list dynamically.",
   "providers": {
     "nixmac": {
       "evolveModel": "auto",
@@ -22,10 +22,19 @@
         "gpt-5.1"
       ]
     },
-    "ollama": { "evolveModel": "", "summaryModel": "llama3.1" },
+    "ollama": {
+      "evolveModel": "",
+      "summaryModel": "",
+      "requiresModel": true,
+      "prefillEvolveModel": "llama3.1",
+      "prefillSummaryModel": "llama3.1"
+    },
     "openai_compatible": {
-      "evolveModel": "gpt-oss-120b",
-      "summaryModel": "gpt-oss-120b"
+      "evolveModel": "",
+      "summaryModel": "",
+      "requiresModel": true,
+      "prefillEvolveModel": "gpt-oss-120b",
+      "prefillSummaryModel": "gpt-oss-120b"
     },
     "claude": { "evolveModel": "", "summaryModel": "" },
     "codex": { "evolveModel": "", "summaryModel": "" },

--- a/apps/native/src-tauri/src/ai/defaults.rs
+++ b/apps/native/src-tauri/src/ai/defaults.rs
@@ -70,10 +70,13 @@ pub fn openai_summary_model() -> &'static str {
     &providers().openai.summary_model
 }
 
-/// The nixmac hosted service routes `"auto"` server-side; the settings UI
-/// additionally defaults summaries to the JSON's `summaryModel` ("flash").
+/// The nixmac hosted service routes `"auto"` server-side.
 pub fn nixmac_model() -> &'static str {
     &providers().nixmac.evolve_model
+}
+
+pub fn nixmac_summary_model() -> &'static str {
+    &providers().nixmac.summary_model
 }
 
 #[cfg(test)]

--- a/apps/native/src-tauri/src/ai/providers/mod.rs
+++ b/apps/native/src-tauri/src/ai/providers/mod.rs
@@ -260,7 +260,7 @@ pub fn create_provider<R: Runtime>(
                 .ok_or_else(|| anyhow::anyhow!("Sign in to nixmac hosted inference first."))?;
             let base_url = nixmac_llm_api_base(&crate::storage::store::get_web_server_url()?);
             let model = configured_summary_model
-                .unwrap_or_else(|| crate::ai::defaults::nixmac_model().to_string());
+                .unwrap_or_else(|| crate::ai::defaults::nixmac_summary_model().to_string());
 
             Ok(Box::new(OpenAIClient::new(&api_key, &base_url, &model)))
         }

--- a/apps/native/src/components/widget/controls/model-combobox.tsx
+++ b/apps/native/src/components/widget/controls/model-combobox.tsx
@@ -280,7 +280,9 @@ export function ModelCombobox({
           className="w-full justify-between font-normal"
           disabled={disabled}
         >
-          <span className="truncate">{inputValue || placeholder}</span>
+          <span className={cn("truncate", !inputValue && "text-muted-foreground")}>
+            {inputValue || placeholder}
+          </span>
           {isLoading ? (
             <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin opacity-50" />
           ) : (

--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
@@ -220,7 +220,7 @@ describe("InferenceSetup", () => {
     await waitFor(() => expect(mocks.billingCheckout).toHaveBeenCalledWith({ product: "pro" }));
   });
 
-  it("saves the selected BYOK model for both evolution and summary", async () => {
+  it("keeps the BYOK model empty so it tracks the provider default", async () => {
     renderSetup();
 
     fireEvent.click(screen.getByRole("tab", { name: /bring your own key/i }));
@@ -233,9 +233,9 @@ describe("InferenceSetup", () => {
       expect(mocks.setPrefs).toHaveBeenCalledWith(
         expect.objectContaining({
           evolveProvider: "openrouter",
-          evolveModel: "~anthropic/claude-sonnet-latest",
+          evolveModel: "",
           summaryProvider: "openrouter",
-          summaryModel: "~anthropic/claude-sonnet-latest",
+          summaryModel: "",
           openrouterApiKey: "sk-or-v1-test-key-with-enough-length",
         }),
       ),

--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
@@ -11,7 +11,6 @@ import {
 import { ModelCombobox } from "@/components/widget/controls/model-combobox";
 import { ProviderIcon } from "@/components/widget/controls/provider-icons/provider-icon";
 import {
-  DEFAULT_NIXMAC_MODEL,
   NIXMAC_PROVIDER,
   validateKeyFormat,
   type CheckoutProduct,
@@ -26,6 +25,8 @@ import {
   isPlainInputCliProvider,
   modelPlaceholder,
 } from "@/lib/providers/ai-models";
+import { prefillModel } from "@/lib/providers/ai-defaults";
+import { providerRequiresModel } from "@/lib/providers/ai-provider-validation";
 import type { AccountBilling, BillingProductInfo } from "@/lib/orpc";
 import { client, orpc } from "@/lib/orpc";
 import { getTelemetry } from "@/lib/telemetry/instance";
@@ -297,11 +298,12 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
   }
 
   async function finishHostedSetup(planSuffix: string) {
+    // Empty model tracks the hosted defaults at runtime.
     await tauriAPI.ui.setPrefs({
       evolveProvider: NIXMAC_PROVIDER,
-      evolveModel: DEFAULT_NIXMAC_MODEL,
+      evolveModel: "",
       summaryProvider: NIXMAC_PROVIDER,
-      summaryModel: DEFAULT_NIXMAC_MODEL,
+      summaryModel: "",
     });
     getTelemetry().captureEvent({
       name: "inference_configured",
@@ -692,7 +694,8 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
   const initialProvider = getAiModelProvider("openrouter");
   const [providerId, setProviderId] = useState(initialProvider.id);
   const provider = useMemo(() => getAiModelProvider(providerId), [providerId]);
-  const [model, setModel] = useState(initialProvider.defaultEvolveModel);
+  // Empty model tracks the provider default at runtime.
+  const [model, setModel] = useState("");
   const [key, setKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [keyState, setKeyState] = useState<KeyState>("idle");
@@ -703,7 +706,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
   const setup = provider.setup;
   const isApiKeyProvider = setup.kind === "apiKey";
   const isBaseUrlProvider = setup.kind === "baseUrl";
-  const requiresModel = provider.id === "ollama" || provider.id === "openai_compatible";
+  const requiresModel = providerRequiresModel(provider.id);
   const setupReady =
     isApiKeyProvider
       ? format.valid
@@ -715,7 +718,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
     const next = getAiModelProvider(id);
     await tauriAPI.models.clearCached(next.id);
     setProviderId(next.id);
-    setModel(next.defaultEvolveModel);
+    setModel(prefillModel(next.id, "evolve"));
     setKey("");
     setBaseUrl("");
     setKeyState("idle");

--- a/apps/native/src/components/widget/onboarding/lib/inference.ts
+++ b/apps/native/src/components/widget/onboarding/lib/inference.ts
@@ -1,10 +1,6 @@
-import { providerModelDefaults } from "@/lib/providers/ai-defaults";
-
 export type { InferenceConfig, InferenceMode } from "@nixmac/state";
 
 export const NIXMAC_PROVIDER = "nixmac";
-export const DEFAULT_NIXMAC_MODEL =
-	providerModelDefaults(NIXMAC_PROVIDER).evolveModel;
 
 /** Checkout product identifiers exposed by the billing API. */
 export type CheckoutProduct = "pro" | "credits";

--- a/apps/native/src/components/widget/settings/ai-models-tab.tsx
+++ b/apps/native/src/components/widget/settings/ai-models-tab.tsx
@@ -10,11 +10,13 @@ import { ModelCombobox } from "@/components/widget/controls/model-combobox";
 import { ProviderIcon } from "@/components/widget/controls/provider-icons/provider-icon";
 import { tauriAPI } from "@/ipc/api";
 import type { CliToolsState } from "@/ipc/types";
-import { getProviderConfigInvalidReason, isCliProvider } from "@/lib/providers/ai-provider-validation";
+import { prefillModel } from "@/lib/providers/ai-defaults";
+import {
+  getProviderConfigInvalidReason,
+  providerRequiresModel,
+} from "@/lib/providers/ai-provider-validation";
 import {
   AI_MODEL_PROVIDERS,
-  DEFAULT_EVOLVE_MODEL,
-  DEFAULT_SUMMARY_MODEL,
   isPlainInputCliProvider,
   modelPlaceholder,
 } from "@/lib/providers/ai-models";
@@ -141,12 +143,14 @@ export function AiModelsTab({
                     // deprecated(orpc): replace with client/orpc from @/lib/orpc
                     await tauriAPI.models.clearCached(value);
                     evolveProviderField.handleChange(value);
-                    const defaultModel = DEFAULT_EVOLVE_MODEL[value] ?? "";
-                    evolveModelField.handleChange(defaultModel);
+                    // Empty model tracks the provider default at runtime;
+                    // providers that require a model get a prefill to edit.
+                    const model = prefillModel(value, "evolve");
+                    evolveModelField.handleChange(model);
                     // deprecated(orpc): replace with client/orpc from @/lib/orpc
                     await tauriAPI.ui.setPrefs({
                       evolveProvider: value,
-                      evolveModel: defaultModel,
+                      evolveModel: model,
                     });
                   }}
                   value={evolveProviderField.state.value}
@@ -174,7 +178,7 @@ export function AiModelsTab({
                         className="text-xs font-medium text-muted-foreground"
                         htmlFor="evolveModel"
                       >
-                        Model Name{isCliProvider(evolveProvider) ? " (optional)" : ""}
+                        Model Name{providerRequiresModel(evolveProvider) ? "" : " (optional)"}
                       </label>
                       {isPlainInputCliProvider(evolveProvider) ? (
                         <Input
@@ -235,12 +239,14 @@ export function AiModelsTab({
                     // deprecated(orpc): replace with client/orpc from @/lib/orpc
                     await tauriAPI.models.clearCached(value);
                     summaryProviderField.handleChange(value);
-                    const defaultModel = DEFAULT_SUMMARY_MODEL[value] ?? "";
-                    summaryModelField.handleChange(defaultModel);
+                    // Empty model tracks the provider default at runtime;
+                    // providers that require a model get a prefill to edit.
+                    const model = prefillModel(value, "summary");
+                    summaryModelField.handleChange(model);
                     // deprecated(orpc): replace with client/orpc from @/lib/orpc
                     await tauriAPI.ui.setPrefs({
                       summaryProvider: value,
-                      summaryModel: defaultModel,
+                      summaryModel: model,
                     });
                   }}
                   value={summaryProviderField.state.value}
@@ -268,7 +274,7 @@ export function AiModelsTab({
                         className="text-xs font-medium text-muted-foreground"
                         htmlFor="summaryModel"
                       >
-                        Model Name{isCliProvider(summaryProvider) ? " (optional)" : ""}
+                        Model Name{providerRequiresModel(summaryProvider) ? "" : " (optional)"}
                       </label>
                       {isPlainInputCliProvider(summaryProvider) ? (
                         <Input

--- a/apps/native/src/components/widget/settings/settings-dialog.tsx
+++ b/apps/native/src/components/widget/settings/settings-dialog.tsx
@@ -9,7 +9,6 @@ import { TuningTab } from "@/components/widget/settings/tuning-tab";
 import { useDarwinConfig } from "@/hooks/use-darwin-config";
 import { tauriAPI } from "@/ipc/api";
 import { resolveOpenAiCompatibleProvider } from "@/lib/providers/ai-provider-validation";
-import { DEFAULT_EVOLVE_MODEL, DEFAULT_SUMMARY_MODEL } from "@/lib/providers/ai-models";
 import {
   createVerifiedApiKeyHandler,
   verifyOpenaiApiKey,
@@ -140,9 +139,9 @@ export function SettingsDialog() {
       openaiCompatibleApiBaseUrl: "",
       openaiCompatibleApiKey: "",
       summaryProvider: "openrouter",
-      summaryModel: DEFAULT_SUMMARY_MODEL.openrouter,
+      summaryModel: "",
       evolveProvider: "openrouter",
-      evolveModel: DEFAULT_EVOLVE_MODEL.openrouter,
+      evolveModel: "",
       sendDiagnostics: false,
     },
   });
@@ -164,19 +163,11 @@ export function SettingsDialog() {
           form.setFieldValue("openaiCompatibleApiBaseUrl", prefs.openaiCompatibleApiBaseUrl ?? "");
           form.setFieldValue("openaiCompatibleApiKey", prefs.openaiCompatibleApiKey ?? "");
           form.setFieldValue("summaryProvider", summaryProvider);
-          form.setFieldValue(
-            "summaryModel",
-            prefs.summaryModel ??
-            DEFAULT_SUMMARY_MODEL[summaryProvider] ??
-            DEFAULT_SUMMARY_MODEL.openrouter,
-          );
+          // Empty model is a real state (track the provider default) — don't
+          // dress it up as a concrete value.
+          form.setFieldValue("summaryModel", prefs.summaryModel ?? "");
           form.setFieldValue("evolveProvider", evolveProvider);
-          form.setFieldValue(
-            "evolveModel",
-            prefs.evolveModel ??
-            DEFAULT_EVOLVE_MODEL[evolveProvider] ??
-            DEFAULT_EVOLVE_MODEL.openrouter,
-          );
+          form.setFieldValue("evolveModel", prefs.evolveModel ?? "");
           form.setFieldValue("sendDiagnostics", prefs.sendDiagnostics ?? false);
 
           setOpenrouterKeyStatus(prefs.openrouterApiKey ? "valid" : "idle");

--- a/apps/native/src/ipc/api.test.ts
+++ b/apps/native/src/ipc/api.test.ts
@@ -90,16 +90,16 @@ describe("tauriAPI.ui.getPrefs", () => {
     const migrated = await tauriAPI.ui.getPrefs();
 
     expect(migrated.evolveProvider).toBe("openrouter");
-    expect(migrated.evolveModel).toBe(OPENROUTER_DEFAULTS.evolveModel);
+    expect(migrated.evolveModel).toBe("");
     expect(migrated.summaryProvider).toBe("openrouter");
-    expect(migrated.summaryModel).toBe(OPENROUTER_DEFAULTS.summaryModel);
+    expect(migrated.summaryModel).toBe("");
     expect(mocks.invoke).toHaveBeenNthCalledWith(1, "ui_get_prefs");
     expect(mocks.invoke).toHaveBeenNthCalledWith(2, "ui_set_prefs", {
       prefs: {
         evolveProvider: "openrouter",
-        evolveModel: OPENROUTER_DEFAULTS.evolveModel,
+        evolveModel: "",
         summaryProvider: "openrouter",
-        summaryModel: OPENROUTER_DEFAULTS.summaryModel,
+        summaryModel: "",
       },
     });
   });
@@ -119,13 +119,13 @@ describe("tauriAPI.ui.getPrefs", () => {
     const migrated = await tauriAPI.ui.getPrefs();
 
     expect(migrated.evolveProvider).toBe("openrouter");
-    expect(migrated.evolveModel).toBe(OPENROUTER_DEFAULTS.evolveModel);
+    expect(migrated.evolveModel).toBe("");
     expect(migrated.summaryProvider).toBe("ollama");
     expect(migrated.summaryModel).toBeNull();
     expect(mocks.invoke).toHaveBeenNthCalledWith(2, "ui_set_prefs", {
       prefs: {
         evolveProvider: "openrouter",
-        evolveModel: OPENROUTER_DEFAULTS.evolveModel,
+        evolveModel: "",
       },
     });
   });

--- a/apps/native/src/lib/providers/ai-defaults.ts
+++ b/apps/native/src/lib/providers/ai-defaults.ts
@@ -4,10 +4,16 @@ import aiDefaults from "../../../shared/ai-defaults.json";
 export type AiProviderId = keyof typeof aiDefaults.providers;
 
 export interface ProviderModelDefaults {
+	/** Runtime fallback for an empty stored model; empty means no fallback exists. */
 	evolveModel: string;
 	summaryModel: string;
 	/** Static picker suggestions; providers without this fetch their list dynamically. */
 	suggestedModels?: string[];
+	/** No runtime fallback exists: the app must not accept an empty model. */
+	requiresModel?: boolean;
+	/** Seeded on provider switch when the provider requires an explicit model. */
+	prefillEvolveModel?: string;
+	prefillSummaryModel?: string;
 }
 
 /** Per-provider default models, loaded from shared/ai-defaults.json (also embedded by the Rust backend). */
@@ -27,4 +33,16 @@ export function providerModelDefaults(
 
 export function suggestedModels(providerId: string): string[] {
 	return providerModelDefaults(providerId).suggestedModels ?? [];
+}
+
+export function prefillModel(
+	providerId: string,
+	kind: "evolve" | "summary",
+): string {
+	const defaults = providerModelDefaults(providerId);
+	return (
+		(kind === "evolve"
+			? defaults.prefillEvolveModel
+			: defaults.prefillSummaryModel) ?? ""
+	);
 }

--- a/apps/native/src/lib/providers/ai-models.ts
+++ b/apps/native/src/lib/providers/ai-models.ts
@@ -3,6 +3,7 @@ import {
 	type AiProviderId,
 	providerModelDefaults,
 } from "@/lib/providers/ai-defaults";
+import { providerRequiresModel } from "@/lib/providers/ai-provider-validation";
 
 const NIXMAC_PROVIDER = "nixmac";
 
@@ -130,20 +131,6 @@ export const BYOK_MODEL_PROVIDERS = AI_MODEL_PROVIDERS.filter(
 	(provider) => provider.setup.kind !== "hosted",
 );
 
-export const DEFAULT_EVOLVE_MODEL: Record<string, string> = Object.fromEntries(
-	AI_MODEL_PROVIDERS.map((provider) => [
-		provider.id,
-		provider.defaultEvolveModel,
-	]),
-);
-
-export const DEFAULT_SUMMARY_MODEL: Record<string, string> = Object.fromEntries(
-	AI_MODEL_PROVIDERS.map((provider) => [
-		provider.id,
-		provider.defaultSummaryModel,
-	]),
-);
-
 export function getAiModelProvider(id: string): AiModelProvider {
 	return (
 		AI_MODEL_PROVIDERS.find((provider) => provider.id === id) ??
@@ -156,6 +143,9 @@ export function isPlainInputCliProvider(provider: string): boolean {
 	return setup.kind === "cli" && setup.plainModelInput;
 }
 
+// The placeholder describes what an empty field means at runtime: providers
+// with a fallback name it explicitly; providers that require a model get a
+// plain prompt.
 export function modelPlaceholder(
 	provider: string,
 	kind: "evolve" | "summary",
@@ -164,7 +154,10 @@ export function modelPlaceholder(
 	if (config.setup.kind === "cli") {
 		return "Leave empty for CLI default";
 	}
+	if (providerRequiresModel(provider)) {
+		return "Select model...";
+	}
 	const defaultModel =
 		kind === "evolve" ? config.defaultEvolveModel : config.defaultSummaryModel;
-	return defaultModel || "Select model...";
+	return defaultModel ? `Default: ${defaultModel}` : "Select model...";
 }

--- a/apps/native/src/lib/providers/ai-provider-migration.test.ts
+++ b/apps/native/src/lib/providers/ai-provider-migration.test.ts
@@ -59,7 +59,7 @@ describe("migrateLegacyOpenaiProviderPrefs", () => {
 		});
 	});
 
-	it("uses OpenRouter defaults when migrated legacy openai models are bare or missing", () => {
+	it("clears bare or missing legacy openai models so they track the OpenRouter default", () => {
 		const result = migrateLegacyOpenaiProviderPrefs({
 			...PREFS,
 			openrouterApiKey: "sk-or-key",
@@ -72,9 +72,9 @@ describe("migrateLegacyOpenaiProviderPrefs", () => {
 
 		expect(result.values).toEqual({
 			evolveProvider: "openrouter",
-			evolveModel: OPENROUTER_DEFAULTS.evolveModel,
+			evolveModel: "",
 			summaryProvider: "openrouter",
-			summaryModel: OPENROUTER_DEFAULTS.summaryModel,
+			summaryModel: "",
 		});
 		expect(result.update).toEqual(result.values);
 	});

--- a/apps/native/src/lib/providers/ai-provider-migration.ts
+++ b/apps/native/src/lib/providers/ai-provider-migration.ts
@@ -1,12 +1,7 @@
 import type { UiPrefs, UiPrefsUpdate } from "@/ipc/types";
-import { providerModelDefaults } from "@/lib/providers/ai-defaults";
 
 const OPENROUTER_PROVIDER = "openrouter";
 const OPENAI_PROVIDER = "openai";
-const DEFAULT_OPENROUTER_EVOLVE_MODEL =
-  providerModelDefaults(OPENROUTER_PROVIDER).evolveModel;
-const DEFAULT_OPENROUTER_SUMMARY_MODEL =
-  providerModelDefaults(OPENROUTER_PROVIDER).summaryModel;
 
 interface ProviderMigrationValues {
   evolveProvider: string;
@@ -38,11 +33,12 @@ export function migrateLegacyOpenaiProviderPrefs(prefs: UiPrefs): {
   update: Partial<UiPrefsUpdate> | null;
 } {
   const update: Partial<UiPrefsUpdate> = {};
+  // Empty model means "track the provider default at runtime".
   const values = {
     evolveProvider: prefs.evolveProvider ?? OPENROUTER_PROVIDER,
-    evolveModel: prefs.evolveModel ?? DEFAULT_OPENROUTER_EVOLVE_MODEL,
+    evolveModel: prefs.evolveModel ?? "",
     summaryProvider: prefs.summaryProvider ?? OPENROUTER_PROVIDER,
-    summaryModel: prefs.summaryModel ?? DEFAULT_OPENROUTER_SUMMARY_MODEL,
+    summaryModel: prefs.summaryModel ?? "",
   };
 
   if (
@@ -52,7 +48,7 @@ export function migrateLegacyOpenaiProviderPrefs(prefs: UiPrefs): {
     values.evolveProvider = OPENROUTER_PROVIDER;
     update.evolveProvider = values.evolveProvider;
     if (!isOpenrouterModelSlug(prefs.evolveModel)) {
-      values.evolveModel = DEFAULT_OPENROUTER_EVOLVE_MODEL;
+      values.evolveModel = "";
       update.evolveModel = values.evolveModel;
     }
   }
@@ -64,7 +60,7 @@ export function migrateLegacyOpenaiProviderPrefs(prefs: UiPrefs): {
     values.summaryProvider = OPENROUTER_PROVIDER;
     update.summaryProvider = values.summaryProvider;
     if (!isOpenrouterModelSlug(prefs.summaryModel)) {
-      values.summaryModel = DEFAULT_OPENROUTER_SUMMARY_MODEL;
+      values.summaryModel = "";
       update.summaryModel = values.summaryModel;
     }
   }

--- a/apps/native/src/lib/providers/ai-provider-validation.test.ts
+++ b/apps/native/src/lib/providers/ai-provider-validation.test.ts
@@ -21,11 +21,17 @@ describe("isInferenceConfigured", () => {
     expect(isInferenceConfigured("opencode", undefined)).toBe(true);
   });
 
-  it("requires a model for non-CLI providers", () => {
-    expect(isInferenceConfigured("openrouter", "")).toBe(false);
-    expect(isInferenceConfigured("openrouter", "   ")).toBe(false);
+  it("accepts an empty model where the runtime falls back to a default", () => {
+    expect(isInferenceConfigured("openrouter", "")).toBe(true);
+    expect(isInferenceConfigured("openai", "   ")).toBe(true);
+    expect(isInferenceConfigured("nixmac", null)).toBe(true);
     expect(isInferenceConfigured("openrouter", "openai/gpt-oss-120b")).toBe(true);
-    expect(isInferenceConfigured("nixmac", "openai/gpt-oss-120b")).toBe(true);
+  });
+
+  it("requires a model where the runtime has no fallback", () => {
+    expect(isInferenceConfigured("ollama", "")).toBe(false);
+    expect(isInferenceConfigured("openai_compatible", "   ")).toBe(false);
+    expect(isInferenceConfigured("ollama", "llama3")).toBe(true);
   });
 
   it("requires a provider", () => {

--- a/apps/native/src/lib/providers/ai-provider-validation.ts
+++ b/apps/native/src/lib/providers/ai-provider-validation.ts
@@ -1,6 +1,5 @@
 import type { CliToolsState, UiPrefs as DarwinPrefs } from "@/ipc/types";
-
-const CLI_PROVIDER_VALUES = ["claude", "codex", "opencode"] as const;
+import { providerModelDefaults } from "@/lib/providers/ai-defaults";
 
 type OpenAiCompatibleProvider = "openrouter" | "openai";
 
@@ -8,21 +7,26 @@ function hasValue(value?: string | null): boolean {
   return Boolean(value?.trim());
 }
 
-export function isCliProvider(provider: string): boolean {
-  return CLI_PROVIDER_VALUES.includes(provider as (typeof CLI_PROVIDER_VALUES)[number]);
+/**
+ * Providers where the backend has no runtime fallback for an empty model.
+ * Everyone else falls back to a default when the model is empty: CLI
+ * providers to the CLI tool's own default, the rest to their default from
+ * shared/ai-defaults.json.
+ */
+export function providerRequiresModel(provider: string): boolean {
+  return providerModelDefaults(provider).requiresModel ?? false;
 }
 
 /**
- * Whether persisted prefs describe a usable inference setup. CLI providers
- * (claude/codex/opencode) accept an optional model — an empty model means
- * "use the CLI's own default" — so only non-CLI providers require a model.
+ * Whether persisted prefs describe a usable inference setup. An empty model
+ * means "use the runtime default", so only providers without one require it.
  */
 export function isInferenceConfigured(
   provider: string | null | undefined,
   model: string | null | undefined,
 ): boolean {
   if (!provider) return false;
-  return isCliProvider(provider) || hasValue(model);
+  return !providerRequiresModel(provider) || hasValue(model);
 }
 
 export function resolveOpenAiCompatibleProvider(
@@ -48,34 +52,26 @@ export function getProviderConfigInvalidReason(
 ): string | null {
   provider = resolveOpenAiCompatibleProvider(provider, prefs);
 
-  if (isCliProvider(provider) && cliStatus != null) {
-    const key = provider as keyof CliToolsState;
-    if (cliStatus[key] === false) {
+  if (cliStatus != null && provider in cliStatus) {
+    if (cliStatus[provider as keyof CliToolsState] === false) {
       return "CLI tool not found in PATH";
     }
   }
 
-  if (provider === "nixmac") {
-    return null;
+  if (provider === "openrouter" && !prefs.openrouterApiKey?.trim()) {
+    return "No OpenRouter API key set";
   }
 
-  if (provider === "openrouter") {
-    return prefs.openrouterApiKey?.trim() ? null : "No OpenRouter API key set";
+  if (provider === "openai" && !prefs.openaiApiKey?.trim()) {
+    return "No OpenAI API key set";
   }
 
-  if (provider === "openai") {
-    return prefs.openaiApiKey?.trim() ? null : "No OpenAI API key set";
+  if (provider === "openai_compatible" && !prefs.openaiCompatibleApiBaseUrl?.trim()) {
+    return "No base URL set";
   }
 
-  if (provider === "openai_compatible") {
-    if (!prefs.openaiCompatibleApiBaseUrl?.trim()) {
-      return "No base URL set";
-    }
-    return model?.trim() ? null : "No model set";
-  }
-
-  if (provider === "ollama") {
-    return model?.trim() ? null : "No model set";
+  if (providerRequiresModel(provider) && !hasValue(model)) {
+    return "No model set";
   }
 
   return null;


### PR DESCRIPTION
## Summary

Centralize the information about which providers require what and infer all the information from there.

Support "pre-filling the model" yet requiring it (no actual default): for `ollama` and `openai_compatible`

Explicitly handle the situation of "using default" by saving empty model name instead of populating it with the currently default one, therefore forever pinning the model (so if a user never changed anything, the model will be wrongly forever fixed).

## Test Plan

- [x] Manual test

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed

## Demos

https://github.com/user-attachments/assets/f648a042-a9ff-4b0e-94e9-662deeba84cf

https://github.com/user-attachments/assets/3c350e66-73d9-4226-8ba1-8d2a83904db1


