### PR TITLE
fix(native): embed the tray menu icon

### DIFF
--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -41,6 +41,7 @@ mod summarize;
 mod sync;
 mod system;
 mod telemetry;
+mod tray_icon;
 mod types;
 mod updater_pin;
 mod utils;
@@ -55,7 +56,6 @@ use std::sync::{
 use std::time::Duration;
 use tauri::{
     Emitter, Manager, RunEvent, WebviewUrl, WebviewWindow, WebviewWindowBuilder, WindowEvent,
-    image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
     webview::PageLoadEvent,
@@ -760,13 +760,7 @@ fn run_gui_mode(
             let log_guard_for_menu = log_guard.clone();
 
             let _tray = TrayIconBuilder::new()
-                .icon(
-                    Image::from_path("icons/outline@2x.png").unwrap_or_else(|_| {
-                        app.default_window_icon()
-                            .expect("app must have a default icon bundled")
-                            .clone()
-                    }),
-                )
+                .icon(tray_icon::load()?)
                 .icon_as_template(true)
                 .menu(&menu)
                 .show_menu_on_left_click(true)

--- a/apps/native/src-tauri/src/tray_icon.rs
+++ b/apps/native/src-tauri/src/tray_icon.rs
@@ -20,7 +20,7 @@ mod tests {
         let mut alpha = icon.rgba().chunks_exact(4).map(|pixel| pixel[3]);
         assert!(
             alpha.clone().any(|value| value == 0),
-            "template icon must contain transparent pixels",
+        let alpha = icon.rgba().chunks_exact(4).map(|pixel| pixel[3]);
         );
         assert!(
             alpha.any(|value| value > 0),

--- a/apps/native/src-tauri/src/tray_icon.rs
+++ b/apps/native/src-tauri/src/tray_icon.rs
@@ -19,8 +19,8 @@ mod tests {
 
         let mut alpha = icon.rgba().chunks_exact(4).map(|pixel| pixel[3]);
         assert!(
-            alpha.clone().any(|value| value == 0),
-        let alpha = icon.rgba().chunks_exact(4).map(|pixel| pixel[3]);
+            alpha.any(|value| value == 0),
+            "template icon must contain transparent pixels"
         );
         assert!(
             alpha.any(|value| value > 0),

--- a/apps/native/src-tauri/src/tray_icon.rs
+++ b/apps/native/src-tauri/src/tray_icon.rs
@@ -1,0 +1,30 @@
+use tauri::image::Image;
+
+const TRAY_ICON_BYTES: &[u8] = include_bytes!("../icons/outline@2x.png");
+
+pub(crate) fn load() -> tauri::Result<Image<'static>> {
+    Image::from_bytes(TRAY_ICON_BYTES)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_tray_icon_decodes_as_transparent_png() {
+        let icon = load().expect("embedded tray icon should decode");
+
+        assert!(icon.width() > 0, "tray icon must have a non-zero width");
+        assert!(icon.height() > 0, "tray icon must have a non-zero height");
+
+        let mut alpha = icon.rgba().chunks_exact(4).map(|pixel| pixel[3]);
+        assert!(
+            alpha.clone().any(|value| value == 0),
+            "template icon must contain transparent pixels",
+        );
+        assert!(
+            alpha.any(|value| value > 0),
+            "template icon must contain visible pixels",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- embed the existing transparent tray PNG in the native binary instead of loading it from the process working directory
- remove the fallback to the default application icon, which rendered as a blank rounded square when the packaged app launched outside the source tree
- add a regression test that decodes the embedded image and verifies it contains both transparent and visible pixels

## User impact

The macOS menu-bar item consistently renders the intended monochrome nixmac icon in packaged builds.

## Test Plan

- [x] `cargo fmt --all --check`
- [x] `cargo check --all-targets`
- [x] `cargo test` (655 passed, 0 failed)
- [x] Built the packaged macOS `.app`
- [x] Launched the packaged build and visually verified the icon in the real macOS menu bar

## Docs

- [x] No docs update needed

#no-linear