### PR TITLE
chore(format): auto-format

### DIFF
--- a/apps/native/src-tauri/src/summarize/model_calls.rs
+++ b/apps/native/src-tauri/src/summarize/model_calls.rs
@@ -100,11 +100,7 @@ fn strip_json_fences(raw: &str) -> &str {
         None => inner,
     };
     // Drop the closing fence.
-    inner
-        .trim_end()
-        .strip_suffix("```")
-        .unwrap_or(inner)
-        .trim()
+    inner.trim_end().strip_suffix("```").unwrap_or(inner).trim()
 }
 
 pub async fn generate_commit_message<R: Runtime>(


### PR DESCRIPTION
## Summary

- Corrects missed auto-formatting a file after https://github.com/darkmatter/nixmac/pull/522

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
