### PR TITLE
fix(router): pin router instance across HMR re-evaluations

### DIFF
--- a/apps/native/src/router.tsx
+++ b/apps/native/src/router.tsx
@@ -64,12 +64,32 @@ function RootLayout() {
 // Router instance
 // ---------------------------------------------------------------------------
 
-const memoryHistory = createMemoryHistory({ initialEntries: ["/"] });
+function createAppRouter() {
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+}
 
-export const router = createRouter({
-  routeTree,
-  history: memoryHistory,
-});
+// This module sits in an import cycle: route components (SettingsDialog,
+// DarwinWidget, header, tray hook, ...) import `nav` back from here. A Vite
+// hot update that re-evaluates this module would otherwise mint a fresh
+// router + memory history while mounted closures (Esc handler, tray listener,
+// RouterProvider) still hold the previous instance — `nav` calls then drive a
+// router that isn't rendered, so Close/reopen silently do nothing until a full
+// reload. Pin the instance in hot.data so every evaluation shares one router.
+const hotRouter = import.meta.hot?.data?.appRouter as
+  | ReturnType<typeof createAppRouter>
+  | undefined;
+
+// On reuse, still swap in this evaluation's route tree so route edits apply.
+hotRouter?.update({ routeTree });
+
+export const router = hotRouter ?? createAppRouter();
+
+if (import.meta.hot?.data) {
+  import.meta.hot.data.appRouter = router;
+}
 
 declare module "@tanstack/react-router" {
   interface Register {


### PR DESCRIPTION
router.tsx sits in an import cycle with its route components, so a hot update could mint a fresh router + memory history while mounted closures still drove the old one — settings Close/reopen silently did nothing until a full reload. Reuse the instance via import.meta.hot.data.

## Summary

- in a dev, hot-reload build, some edits would break the settings window - the Close button won't work and after closing it via ESC, it couldn't be reopened
- no effect on the prod build:

> No downside. I built the production bundle to confirm: appRouter and import.meta.hot appear zero times in the output — the entire pinning mechanism is stripped at build time.

> What happens per environment:

> Dev: import.meta.hot exists, the pin is active — that's the fix.
Production: Vite statically replaces import.meta.hot with undefined, so hotRouter is constant-undefined, the optional-chained update() call and the if block are dead code, and the minifier removes them entirely. What ships is semantically identical to the pre-fix code: one createRouter with a fresh memory history at module load. Since a production module only ever evaluates once, the duplicate-instance problem can't occur there anyway.

## Test Plan

- [x] Manually verified the Settings window works and the Close button seems to be working

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
