### PR TITLE
fix(model-combobox): dedupe load on provider change

### DIFF
--- a/apps/native/src/components/widget/controls/model-combobox.test.tsx
+++ b/apps/native/src/components/widget/controls/model-combobox.test.tsx
@@ -124,6 +124,20 @@ describe("ModelCombobox", () => {
     expect(options.map((o) => o.textContent)).toEqual(MODELS);
   });
 
+  it("regression: a provider change after an open starts a single load, not a duplicate", async () => {
+    const { rerender } = render(<Harness initial="model-b" />);
+
+    // Open once so the refresh path is armed (refreshTick > 0)
+    await openList();
+    fireEvent.keyDown(input(), { key: "Escape" });
+
+    mockGetCached.mockClear();
+    rerender(<Harness initial="model-b" provider="ollama" />);
+    await flushLoads();
+
+    expect(mockGetCached).toHaveBeenCalledExactlyOnceWith("ollama");
+  });
+
   it("regression: keeps the loaded models across close/reopen instead of clearing", async () => {
     render(<Harness initial="model-b" />);
 

--- a/apps/native/src/components/widget/controls/model-combobox.tsx
+++ b/apps/native/src/components/widget/controls/model-combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Combobox } from "@/components/ui/combobox";
 import { NIXMAC_PROVIDER } from "@/components/widget/onboarding/lib/inference";
@@ -230,9 +230,13 @@ export function ModelCombobox({
     };
   }, [provider]);
 
-  // Refresh models when the popover opens, keeping the current list meanwhile
+  // Refresh models when the popover opens, keeping the current list meanwhile.
+  // Compare against the previous tick so a provider change (new `loadModels`
+  // identity) doesn't start a duplicate load next to the clearing one below.
+  const prevRefreshTick = useRef(refreshTick);
   useEffect(() => {
-    if (refreshTick > 0) {
+    if (refreshTick !== prevRefreshTick.current) {
+      prevRefreshTick.current = refreshTick;
       return loadModels();
     }
   }, [loadModels, refreshTick]);


### PR DESCRIPTION
## Summary

- small fix addressing https://github.com/darkmatter/nixmac/pull/536#discussion_r3601387727

## Test Plan

- [x] Regression test added

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
