### PR TITLE
feat(combobox): add fzf-style fuzzy filtering

### DIFF
--- a/packages/ui/src/components/ui/combobox.test.tsx
+++ b/packages/ui/src/components/ui/combobox.test.tsx
@@ -122,6 +122,22 @@ describe("Combobox", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("matches scattered characters fuzzily and ranks contiguous matches first", () => {
+    render(
+      <Harness items={["google/gemini-flash-latest", "gfl-tool", "anthropic/claude-sonnet"]} />,
+    );
+
+    openList();
+    fireEvent.change(input(), { target: { value: "gfl" } });
+
+    // "gfl" is contiguous in gfl-tool and scattered in google/gemini-flash-latest;
+    // the contiguous match ranks first, the non-match is filtered out
+    expect(screen.getAllByRole("option").map((o) => o.textContent)).toEqual([
+      "gfl-tool",
+      "google/gemini-flash-latest",
+    ]);
+  });
+
   it("offers unmatched typed text as a custom row when allowed and commits it on select", () => {
     const onChangeSpy = vi.fn();
     render(<Harness allowCustomValue onChangeSpy={onChangeSpy} />);

--- a/packages/ui/src/components/ui/combobox.tsx
+++ b/packages/ui/src/components/ui/combobox.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { defaultFilter } from "cmdk";
 import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
 import { useRef, useState } from "react";
 import {
@@ -131,9 +132,16 @@ export function Combobox({
     }
   };
 
-  // Filter items based on what the user typed since opening
+  // Fuzzy-filter items based on what the user typed since opening: cmdk's
+  // command-score matches scattered characters (fzf-style) and ranks word
+  // boundaries and contiguous runs higher, so the best match comes first and
+  // Enter (which selects the auto-highlighted first row) picks it.
   const filteredItems = query
-    ? items.filter((item) => item.toLowerCase().includes(query.toLowerCase()))
+    ? items
+        .map((item) => [item, defaultFilter(item, query)] as const)
+        .filter(([, score]) => score > 0)
+        .sort((a, b) => b[1] - a[1])
+        .map(([item]) => item)
     : items;
 
   // Show typed text in list if it doesn't match any item


### PR DESCRIPTION
## Summary

- Fuzzy search for models
- Scattered characters match, contiguous runs and word boundaries rank higher


https://github.com/user-attachments/assets/9ae5fde5-22d9-4041-b57b-4b9b2220a991



## Test Plan

- [x] Manual testing

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
