### PR TITLE
ci(hooks): enforce clean hooks and clippy

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -10,7 +10,7 @@ if [ ! -x "$PREK" ]; then
     PREK="prek"
 fi
 
-exec "$PREK" hook-impl --hook-dir "$HERE" --script-version 4 --hook-type=pre-commit --config=".pre-commit-config.yaml" -- "$@"
+"$PREK" hook-impl --hook-dir "$HERE" --script-version 4 --hook-type=pre-commit --config=".pre-commit-config.yaml" -- "$@" || exit
 
 
 # --- BEGIN BEADS INTEGRATION v1.0.3 ---

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,38 @@ env:
   CARGO_TERM_COLOR: always
   SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
 jobs:
+  # Run the repo's git-hooks (treefmt, shellcheck) across the whole tree so a
+  # commit made with hooks skipped/broken still gets flagged. Intentionally
+  # not in any `needs` chain: a failure shows up as a red check on the PR but
+  # never blocks rust-tests/build from running.
+  git-hooks:
+    name: Git Hooks
+    runs-on: arc
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Nix and caches
+        uses: ./.github/actions/setup-nix
+        with:
+          darkmatter-cachix-auth-token: ${{ secrets.DARKMATTER_CACHIX_AUTH_TOKEN }}
+
+      # Pinned to match .github/actions/setup-devenv. The devenv CLI is needed
+      # here (not just the cached profile): entering the shell is what
+      # materializes the .pre-commit-config.yaml symlink that prek reads.
+      - name: Install devenv
+        run: nix build github:cachix/devenv/v2.1.2 --out-link "$RUNNER_TEMP/devenv-cli"
+
+      - name: Run git hooks on all files
+        env:
+          NIXPKGS_ALLOW_UNFREE: 1
+        run: |
+          "$RUNNER_TEMP/devenv-cli/bin/devenv" shell --impure -- \
+            prek run --all-files --show-diff-on-failure
+
   rust-tests:
     name: Rust Tests (Linux)
     runs-on: arc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,6 +140,17 @@ jobs:
         run: |
           cargo fetch --locked
           bash "$GITHUB_WORKSPACE/ops/scripts/ci/patch-passkey-swift.sh"
+
+      # Lint before the expensive release build. Runs here (not in a Linux
+      # job) because this runner already has the full devenv toolchain and
+      # macOS SDK, and clippy on macOS covers the cfg(target_os = "macos")
+      # code that actually ships. Placed before the sccache setup: sccache as
+      # RUSTC_WRAPPER does not reliably cache clippy-driver invocations.
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+        env:
+          NIXMAC_ENV: prod
+
       # Decide what kind of build this is:
       #   - tag:     push of refs/tags/v* → ship that exact version on stable
       #   - develop: push to main → ship on the develop channel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.lints.rust]
-unused = "deny"
+unused = { level = "deny", priority = -1 }
 unexpected_cfgs = { level = "allow" }
 
 [profile.profiling]

--- a/apps/native/src-tauri/configurable-derive/src/fields.rs
+++ b/apps/native/src-tauri/configurable-derive/src/fields.rs
@@ -183,10 +183,10 @@ fn generate_field(field: &syn::Field, scope: StoreScope) -> syn::Result<FieldCod
 /// Key used in `apps/native/env.*.json` and env JSON Schema. Env-scoped fields prefer
 /// their `env_var` name so profile files mirror process environment variables.
 fn profile_json_key(scope: StoreScope, ui_key: &str, cfg: &FieldConfig) -> String {
-    if matches!(scope, StoreScope::Env) {
-        if let Some(env_var) = &cfg.env_var {
-            return env_var.clone();
-        }
+    if matches!(scope, StoreScope::Env)
+        && let Some(env_var) = &cfg.env_var
+    {
+        return env_var.clone();
     }
     ui_key.to_string()
 }

--- a/apps/native/src-tauri/src/ai/providers/cli.rs
+++ b/apps/native/src-tauri/src/ai/providers/cli.rs
@@ -171,13 +171,13 @@ fn build_args(tool: &CliTool, model: Option<&str>) -> Vec<String> {
         CliTool::OpenCode => vec!["-p".into()],
     };
 
-    if let Some(flag) = tool.model_flag() {
-        if let Some(m) = model {
-            if !m.is_empty() && m != tool.binary_name() {
-                args.push(flag.into());
-                args.push(m.into());
-            }
-        }
+    if let Some(flag) = tool.model_flag()
+        && let Some(m) = model
+        && !m.is_empty()
+        && m != tool.binary_name()
+    {
+        args.push(flag.into());
+        args.push(m.into());
     }
 
     args

--- a/apps/native/src-tauri/src/ai/providers/openai.rs
+++ b/apps/native/src-tauri/src/ai/providers/openai.rs
@@ -110,10 +110,10 @@ fn extract_content_or_length_error(
         ));
     };
 
-    if let Some(content) = choice.message.content.clone() {
-        if !content.is_empty() {
-            return Ok(content);
-        }
+    if let Some(content) = choice.message.content.clone()
+        && !content.is_empty()
+    {
+        return Ok(content);
     }
 
     let finish_reason = choice.finish_reason;

--- a/apps/native/src-tauri/src/bootstrap/default_config.rs
+++ b/apps/native/src-tauri/src/bootstrap/default_config.rs
@@ -68,12 +68,11 @@ pub fn detect_hostname() -> Result<String, String> {
     if let Ok(output) = std::process::Command::new("scutil")
         .args(["--get", "LocalHostName"])
         .output()
+        && output.status.success()
     {
-        if output.status.success() {
-            let name = sanitize_hostname(&String::from_utf8_lossy(&output.stdout));
-            if !name.is_empty() {
-                return Ok(name);
-            }
+        let name = sanitize_hostname(&String::from_utf8_lossy(&output.stdout));
+        if !name.is_empty() {
+            return Ok(name);
         }
     }
 
@@ -228,12 +227,11 @@ fn is_dir_safe_for_bootstrap(path: &Path) -> Result<bool, String> {
     }
 
     // Only .git directory is safe
-    if entries.len() == 1 {
-        if let Some(name) = entries[0].file_name().to_str() {
-            if name == ".git" {
-                return Ok(true);
-            }
-        }
+    if entries.len() == 1
+        && let Some(name) = entries[0].file_name().to_str()
+        && name == ".git"
+    {
+        return Ok(true);
     }
 
     Ok(false)
@@ -355,10 +353,10 @@ pub fn bootstrap_with_template(
         &detect_username(),
     )?;
 
-    if nix::is_nix_installed() {
-        if let Err(e) = finalize_flake_lock(app) {
-            log::info!("Could not finalize flake.lock during bootstrap: {}", e);
-        }
+    if nix::is_nix_installed()
+        && let Err(e) = finalize_flake_lock(app)
+    {
+        log::info!("Could not finalize flake.lock during bootstrap: {}", e);
     }
 
     Ok(())

--- a/apps/native/src-tauri/src/commands/config.rs
+++ b/apps/native/src-tauri/src/commands/config.rs
@@ -91,10 +91,10 @@ fn is_dir_empty_or_only_git(path: &Path) -> Result<bool, String> {
         return Ok(true);
     }
 
-    if entries.len() == 1 {
-        if let Some(name) = entries[0].file_name().to_str() {
-            return Ok(name == ".git");
-        }
+    if entries.len() == 1
+        && let Some(name) = entries[0].file_name().to_str()
+    {
+        return Ok(name == ".git");
     }
 
     Ok(false)
@@ -410,10 +410,10 @@ pub async fn config_create_from_template(
 
     // Mirror the bundled bootstrap: generate and commit flake.lock once the
     // config dir is selected. Non-fatal — a template may ship its own lock.
-    if nix::is_nix_installed() {
-        if let Err(e) = default_config::finalize_flake_lock(&app) {
-            log::info!("Could not finalize flake.lock for the template: {}", e);
-        }
+    if nix::is_nix_installed()
+        && let Err(e) = default_config::finalize_flake_lock(&app)
+    {
+        log::info!("Could not finalize flake.lock for the template: {}", e);
     }
 
     Ok(result)
@@ -504,13 +504,13 @@ fn cascade_config_dir_replacement(app: &AppHandle, new_dir: &Path) {
         }
     }
 
-    if onboarding.mac_scanned_at.is_some() || onboarding.provisional_config_dir.is_some() {
-        if let Err(e) = crate::state::onboarding::write(app, |state| {
+    if (onboarding.mac_scanned_at.is_some() || onboarding.provisional_config_dir.is_some())
+        && let Err(e) = crate::state::onboarding::write(app, |state| {
             state.mac_scanned_at = None;
             state.provisional_config_dir = None;
-        }) {
-            log::warn!("Failed to cascade onboarding facts on config dir change: {e:#}");
-        }
+        })
+    {
+        log::warn!("Failed to cascade onboarding facts on config dir change: {e:#}");
     }
 }
 
@@ -651,14 +651,14 @@ pub(super) fn cleanup_import_target(target: &ImportTarget) {
             }
         }
     }
-    if target.created {
-        if let Err(e) = std::fs::remove_dir(&target.path) {
-            log::warn!(
-                "Failed to remove import target {}: {}",
-                target.path.display(),
-                e
-            );
-        }
+    if target.created
+        && let Err(e) = std::fs::remove_dir(&target.path)
+    {
+        log::warn!(
+            "Failed to remove import target {}: {}",
+            target.path.display(),
+            e
+        );
     }
 }
 

--- a/apps/native/src-tauri/src/docs/generated_docs.rs
+++ b/apps/native/src-tauri/src/docs/generated_docs.rs
@@ -50,7 +50,6 @@ fn now_unix_secs() -> u64 {
 
 /// Loader for runtime-generated option docs stored in the app data directory.
 /// The app persists the compact `*-docs.json` files in the format used by `search_docs`.
-
 pub struct GeneratedDocsIndexLoader {
     docs_dir: PathBuf,
 }
@@ -402,10 +401,8 @@ pub fn generate_docs_index_files(out_dir: &Path) -> Result<()> {
 /// The durable artifact is the compact `*-docs.json` file. The raw options JSON
 /// is generated, transformed, and then dropped.
 fn read_or_generate_docs_json(tool: OptionsTool, docs_dir: &Path, force: bool) -> Result<String> {
-    if !force {
-        if let Some(cached_json) = read_cached_docs_json(tool, docs_dir) {
-            return Ok(cached_json);
-        }
+    if !force && let Some(cached_json) = read_cached_docs_json(tool, docs_dir) {
+        return Ok(cached_json);
     }
 
     let docs_path = docs_dir.join(tool.docs_file_name());

--- a/apps/native/src-tauri/src/editor/lsp.rs
+++ b/apps/native/src-tauri/src/editor/lsp.rs
@@ -164,10 +164,10 @@ async fn read_lsp_message<R: tokio::io::AsyncRead + Unpin>(
             break;
         }
 
-        if let Some(value) = trimmed.strip_prefix("Content-Length:") {
-            if let Ok(len) = value.trim().parse::<usize>() {
-                content_length = Some(len);
-            }
+        if let Some(value) = trimmed.strip_prefix("Content-Length:")
+            && let Ok(len) = value.trim().parse::<usize>()
+        {
+            content_length = Some(len);
         }
     }
 

--- a/apps/native/src-tauri/src/editor/mod.rs
+++ b/apps/native/src-tauri/src/editor/mod.rs
@@ -39,11 +39,11 @@ fn write_file_in_repo_root(base: &Path, rel_path: &str, content: &str) -> Result
     // Validate syntax for known file types before writing
     file_ops::validate_file_content(rel_path, content).map_err(|e| e.to_string())?;
 
-    if let Some(parent) = full_path.parent() {
-        if !parent.exists() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create directories for {}: {}", rel_path, e))?;
-        }
+    if let Some(parent) = full_path.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create directories for {}: {}", rel_path, e))?;
     }
 
     std::fs::write(&full_path, content).map_err(|e| format!("Failed to write {}: {}", rel_path, e))

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -158,12 +158,11 @@ fn extract_error_metadata(error: &str) -> (Option<u16>, Option<String>, Option<S
         Regex::new(r"(?i)\bstatus(?:Code|_code|:)?\s*[:=]?\s*(\d{3})\b")
             .expect("Failed to compile status regex")
     });
-    if let Some(cap) = STATUS_RE.captures(error) {
-        if let Some(m) = cap.get(1) {
-            if let Ok(s) = m.as_str().parse::<u16>() {
-                return (Some(s), None, None, error.len());
-            }
-        }
+    if let Some(cap) = STATUS_RE.captures(error)
+        && let Some(m) = cap.get(1)
+        && let Ok(s) = m.as_str().parse::<u16>()
+    {
+        return (Some(s), None, None, error.len());
     }
 
     (None, None, None, error.len())
@@ -1518,16 +1517,15 @@ pub async fn generate_evolution<R: Runtime>(
                                     );
                                 }
                                 ToolResult::Continue(_content) => {
-                                    if tool_name == "read_file" {
-                                        if let Some(path) =
+                                    if tool_name == "read_file"
+                                        && let Some(path) =
                                             args.get("path").and_then(|v| v.as_str())
-                                        {
-                                            tool_key = read_file_dedup_key(path, &args);
-                                            emit_evolve_event(
-                                                app,
-                                                EvolveEvent::reading(start_time, iteration, path),
-                                            );
-                                        }
+                                    {
+                                        tool_key = read_file_dedup_key(path, &args);
+                                        emit_evolve_event(
+                                            app,
+                                            EvolveEvent::reading(start_time, iteration, path),
+                                        );
                                     }
                                 }
                                 ToolResult::Done(summary_text) => {
@@ -2113,20 +2111,17 @@ fn canonical_json(value: &serde_json::Value) -> String {
 fn sanitize_tool_args(tool_name: &str, args: &serde_json::Value) -> serde_json::Value {
     let mut sanitized = tools::coerce_stringified_args(tool_name, args.clone());
 
-    if tool_name == "ensure_secret" {
-        if let Some(args_obj) = sanitized.as_object_mut() {
-            if let Some(scaffold_obj) = args_obj
-                .get_mut("scaffold")
-                .and_then(serde_json::Value::as_object_mut)
-            {
-                if scaffold_obj.contains_key("content") {
-                    scaffold_obj.insert(
-                        "content".to_string(),
-                        serde_json::Value::String("[REDACTED]".to_string()),
-                    );
-                }
-            }
-        }
+    if tool_name == "ensure_secret"
+        && let Some(args_obj) = sanitized.as_object_mut()
+        && let Some(scaffold_obj) = args_obj
+            .get_mut("scaffold")
+            .and_then(serde_json::Value::as_object_mut)
+        && scaffold_obj.contains_key("content")
+    {
+        scaffold_obj.insert(
+            "content".to_string(),
+            serde_json::Value::String("[REDACTED]".to_string()),
+        );
     }
 
     sanitized

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -2181,10 +2181,6 @@ fn summarize_result(result: &ToolResult) -> (String, bool) {
     }
 }
 
-/// Process a successful tool result and return the appropriate response message.
-/// Returns `Ok(Some(true))` if the loop should break, `Ok(Some(false))` to continue,
-/// or `Ok(None)` to break the inner tool loop but continue the outer loop.
-#[allow(clippy::too_many_arguments)]
 /// Gate deciding whether `done` may complete the evolution.
 ///
 /// Kept as a struct (rather than a bare bool) so the completion rules —
@@ -2203,6 +2199,10 @@ struct DoneGate {
     last_build_error: Option<String>,
 }
 
+/// Process a successful tool result and return the appropriate response message.
+/// Returns `Ok(Some(true))` if the loop should break, `Ok(Some(false))` to continue,
+/// or `Ok(None)` to break the inner tool loop but continue the outer loop.
+#[allow(clippy::too_many_arguments)]
 fn process_tool_result(
     tool_call_id: &str,
     result: &ToolResult,

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -432,10 +432,10 @@ fn list_full_attrpath(content: &str, list_start: usize) -> Option<String> {
                 // Use the exact position from the iteration, not rfind, to avoid selecting
                 // the wrong brace if there are fully-closed { ... } blocks in between.
                 let brace_pos = *idx;
-                if let Some(parent_equals) = content.get(..brace_pos).and_then(|s| s.rfind('=')) {
-                    if let Some(parent_lhs) = assignment_lhs_at_equals(content, parent_equals) {
-                        path_segments.insert(0, parent_lhs.to_string());
-                    }
+                if let Some(parent_equals) = content.get(..brace_pos).and_then(|s| s.rfind('='))
+                    && let Some(parent_lhs) = assignment_lhs_at_equals(content, parent_equals)
+                {
+                    path_segments.insert(0, parent_lhs.to_string());
                 }
                 break;
             }
@@ -536,13 +536,12 @@ fn find_statement_end(content: &str, start: usize) -> Option<usize> {
         }
 
         if in_indented_string {
-            if ch == '\'' {
-                if let Some((_, next)) = iter.peek() {
-                    if *next == '\'' {
-                        iter.next();
-                        in_indented_string = false;
-                    }
-                }
+            if ch == '\''
+                && let Some((_, next)) = iter.peek()
+                && *next == '\''
+            {
+                iter.next();
+                in_indented_string = false;
             }
             continue;
         }
@@ -551,11 +550,11 @@ fn find_statement_end(content: &str, start: usize) -> Option<usize> {
             '#' => in_comment = true,
             '"' => in_double_string = true,
             '\'' => {
-                if let Some((_, next)) = iter.peek() {
-                    if *next == '\'' {
-                        iter.next();
-                        in_indented_string = true;
-                    }
+                if let Some((_, next)) = iter.peek()
+                    && *next == '\''
+                {
+                    iter.next();
+                    in_indented_string = true;
                 }
             }
             '[' => bracket_depth += 1,
@@ -674,10 +673,10 @@ fn resolve_in_attrset(attrset: &AttrSet, target: &[String]) -> Option<SyntaxNode
         }
         // Strict prefix: the remaining segments must resolve inside this
         // entry's attrset value (e.g. `dock` matched, `mru-spaces` is inside).
-        if let Some(inner) = AttrSet::cast(value_node) {
-            if let Some(found) = resolve_in_attrset(&inner, &target[key.len()..]) {
-                return Some(found);
-            }
+        if let Some(inner) = AttrSet::cast(value_node)
+            && let Some(found) = resolve_in_attrset(&inner, &target[key.len()..])
+        {
+            return Some(found);
         }
     }
     None

--- a/apps/native/src-tauri/src/evolve/providers/cli.rs
+++ b/apps/native/src-tauri/src/evolve/providers/cli.rs
@@ -285,11 +285,12 @@ impl AiProvider for CliProvider {
         };
 
         // Append model flag when applicable
-        if let Some(flag) = self.tool.model_flag() {
-            if !self.model.is_empty() && self.model != self.tool.binary_name() {
-                args.push(flag.to_string());
-                args.push(self.model.clone());
-            }
+        if let Some(flag) = self.tool.model_flag()
+            && !self.model.is_empty()
+            && self.model != self.tool.binary_name()
+        {
+            args.push(flag.to_string());
+            args.push(self.model.clone());
         }
 
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();

--- a/apps/native/src-tauri/src/evolve/providers/ollama.rs
+++ b/apps/native/src-tauri/src/evolve/providers/ollama.rs
@@ -331,10 +331,10 @@ fn convert_from_ollama_response(response: &ChatResponse) -> Message {
 
                         // Some models (e.g., command-r) wrap arguments in a "parameters" field
                         // Extract and unwrap if present
-                        if let Some(params) = args.get("parameters") {
-                            if params.is_object() {
-                                args = params.clone();
-                            }
+                        if let Some(params) = args.get("parameters")
+                            && params.is_object()
+                        {
+                            args = params.clone();
                         }
 
                         ToolCall {
@@ -351,43 +351,42 @@ fn convert_from_ollama_response(response: &ChatResponse) -> Message {
     };
 
     // Fallback: If no structured tool_calls but content looks like JSON tool invocation, parse it
-    if tool_calls.is_none() {
-        if let Some(ref text) = content {
-            if let Ok(json) = serde_json::from_str::<serde_json::Value>(text) {
-                if let (Some(name), Some(params)) = (
-                    json.get("name").and_then(|v| v.as_str()),
-                    json.get("parameters"),
-                ) {
-                    log::warn!(
-                        "Model returned text-based tool call ({}), converting to structured format",
-                        name
-                    );
-                    tool_calls = Some(vec![ToolCall {
-                        id: "call_ollama".to_string(),
-                        name: name.to_string(),
-                        arguments: params.to_string(),
-                    }]);
-                } else if let (Some(category), Some(thought)) = (
-                    json.get("category").and_then(|v| v.as_str()),
-                    json.get("thought").and_then(|v| v.as_str()),
-                ) {
-                    // Some Ollama models seem to occasionally emit think payloads as plain assistant JSON content.
-                    // Coerce these into structured tool calls so the loop continues instead of
-                    // being treated as a conversational completion.
-                    log::warn!(
-                        "Model returned text-based think payload, converting to structured tool call"
-                    );
-                    let args = serde_json::json!({
-                        "category": category,
-                        "thought": thought,
-                    });
-                    tool_calls = Some(vec![ToolCall {
-                        id: "call_ollama".to_string(),
-                        name: "think".to_string(),
-                        arguments: args.to_string(),
-                    }]);
-                }
-            }
+    if tool_calls.is_none()
+        && let Some(ref text) = content
+        && let Ok(json) = serde_json::from_str::<serde_json::Value>(text)
+    {
+        if let (Some(name), Some(params)) = (
+            json.get("name").and_then(|v| v.as_str()),
+            json.get("parameters"),
+        ) {
+            log::warn!(
+                "Model returned text-based tool call ({}), converting to structured format",
+                name
+            );
+            tool_calls = Some(vec![ToolCall {
+                id: "call_ollama".to_string(),
+                name: name.to_string(),
+                arguments: params.to_string(),
+            }]);
+        } else if let (Some(category), Some(thought)) = (
+            json.get("category").and_then(|v| v.as_str()),
+            json.get("thought").and_then(|v| v.as_str()),
+        ) {
+            // Some Ollama models seem to occasionally emit think payloads as plain assistant JSON content.
+            // Coerce these into structured tool calls so the loop continues instead of
+            // being treated as a conversational completion.
+            log::warn!(
+                "Model returned text-based think payload, converting to structured tool call"
+            );
+            let args = serde_json::json!({
+                "category": category,
+                "thought": thought,
+            });
+            tool_calls = Some(vec![ToolCall {
+                id: "call_ollama".to_string(),
+                name: "think".to_string(),
+                arguments: args.to_string(),
+            }]);
         }
     }
 

--- a/apps/native/src-tauri/src/evolve/sops.rs
+++ b/apps/native/src-tauri/src/evolve/sops.rs
@@ -63,10 +63,10 @@ fn resolve_sops_config_path(base: &Path) -> PathBuf {
 fn merge_sops_config(existing: &str, public_key: &str) -> Result<String> {
     // Attempt a simple string replacement for the placeholder. This preserves comments
     // and structure for the common case of merging into a template.
-    if existing.contains("AGE_PUBLIC_KEY_PLACEHOLDER") {
-        if let Ok(result) = try_simple_placeholder_replacement(existing, public_key) {
-            return Ok(result);
-        }
+    if existing.contains("AGE_PUBLIC_KEY_PLACEHOLDER")
+        && let Ok(result) = try_simple_placeholder_replacement(existing, public_key)
+    {
+        return Ok(result);
     }
 
     let mut doc = parse_sops_document(existing)?;
@@ -152,12 +152,11 @@ fn ensure_creation_rules_sequence(doc: &mut Value) -> Result<&mut Sequence> {
 fn find_managed_rule_mut(rules: &mut Sequence) -> Option<&mut Mapping> {
     let key = Value::String("path_regex".to_string());
     for rule in rules.iter_mut() {
-        if let Some(map) = rule.as_mapping_mut() {
-            if let Some(path_regex) = map.get(&key).and_then(|v| v.as_str()) {
-                if path_regex == MANAGED_PATH_REGEX {
-                    return Some(map);
-                }
-            }
+        if let Some(map) = rule.as_mapping_mut()
+            && let Some(path_regex) = map.get(&key).and_then(|v| v.as_str())
+            && path_regex == MANAGED_PATH_REGEX
+        {
+            return Some(map);
         }
     }
     None

--- a/apps/native/src-tauri/src/evolve/tools/arg_coercion.rs
+++ b/apps/native/src-tauri/src/evolve/tools/arg_coercion.rs
@@ -65,11 +65,11 @@ fn coerce_value(schema: &Value, root: &Value, value: &mut Value) {
                         }
                     }
                 }
-                if let Some(additional) = branch.get("additionalProperties") {
-                    if additional.is_object() {
-                        for item in map.values_mut() {
-                            coerce_value(additional, root, item);
-                        }
+                if let Some(additional) = branch.get("additionalProperties")
+                    && additional.is_object()
+                {
+                    for item in map.values_mut() {
+                        coerce_value(additional, root, item);
                     }
                 }
             }

--- a/apps/native/src-tauri/src/evolve/tools/list_files.rs
+++ b/apps/native/src-tauri/src/evolve/tools/list_files.rs
@@ -77,16 +77,16 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             continue;
         };
 
-        if let Some(Component::Normal(name)) = rel.components().next() {
-            if ignored_dirs.contains(&name.to_string_lossy().as_ref()) {
-                continue;
-            }
+        if let Some(Component::Normal(name)) = rel.components().next()
+            && ignored_dirs.contains(&name.to_string_lossy().as_ref())
+        {
+            continue;
         }
 
-        if let Some(visible) = &visible {
-            if !visible.contains_file(rel) {
-                continue;
-            }
+        if let Some(visible) = &visible
+            && !visible.contains_file(rel)
+        {
+            continue;
         }
 
         files.push(rel.to_string_lossy().to_string());

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -176,10 +176,10 @@ pub fn extract_build_error_output(app: &AppHandle) -> Option<String> {
 
     let mut last_error: Option<String> = None;
     for message in messages {
-        if let Some(content) = message.get("content").and_then(|v| v.as_str()) {
-            if content.contains("Build check FAILED") || content.contains("Build check failed") {
-                last_error = Some(content.to_string());
-            }
+        if let Some(content) = message.get("content").and_then(|v| v.as_str())
+            && (content.contains("Build check FAILED") || content.contains("Build check failed"))
+        {
+            last_error = Some(content.to_string());
         }
     }
 
@@ -336,17 +336,16 @@ pub fn gather_flake_inputs_snapshot(app: &AppHandle) -> Option<types::FeedbackFl
     };
 
     for name in ["nixpkgs", "nix-darwin", "home-manager"] {
-        if let Some(node) = nodes.get(name) {
-            if let Some(locked) = node.get("locked") {
-                let entry = extract_entry(locked);
-                if entry.rev.is_some() || entry.last_modified.is_some() || entry.nar_hash.is_some()
-                {
-                    match name {
-                        "nixpkgs" => nixpkgs = Some(entry),
-                        "nix-darwin" => nix_darwin = Some(entry),
-                        "home-manager" => home_manager = Some(entry),
-                        _ => {}
-                    }
+        if let Some(node) = nodes.get(name)
+            && let Some(locked) = node.get("locked")
+        {
+            let entry = extract_entry(locked);
+            if entry.rev.is_some() || entry.last_modified.is_some() || entry.nar_hash.is_some() {
+                match name {
+                    "nixpkgs" => nixpkgs = Some(entry),
+                    "nix-darwin" => nix_darwin = Some(entry),
+                    "home-manager" => home_manager = Some(entry),
+                    _ => {}
                 }
             }
         }

--- a/apps/native/src-tauri/src/git/auth.rs
+++ b/apps/native/src-tauri/src/git/auth.rs
@@ -10,10 +10,10 @@ pub fn sanitize_clone_url_for_logs(clone_url: &str) -> String {
         return url.to_string();
     }
 
-    if let Some((_, rest)) = clone_url.split_once('@') {
-        if rest.contains(':') {
-            return format!("***@{}", rest);
-        }
+    if let Some((_, rest)) = clone_url.split_once('@')
+        && rest.contains(':')
+    {
+        return format!("***@{}", rest);
     }
 
     clone_url.to_string()
@@ -69,10 +69,10 @@ pub fn authenticated_fetch_options(token: Option<String>) -> FetchOptions<'stati
             && !credential_helper_attempted
         {
             credential_helper_attempted = true;
-            if let Some(config) = &git_config {
-                if let Ok(credential) = Cred::credential_helper(config, url, username_from_url) {
-                    return Ok(credential);
-                }
+            if let Some(config) = &git_config
+                && let Ok(credential) = Cred::credential_helper(config, url, username_from_url)
+            {
+                return Ok(credential);
             }
         }
 

--- a/apps/native/src-tauri/src/git/auto_update.rs
+++ b/apps/native/src-tauri/src/git/auto_update.rs
@@ -223,7 +223,7 @@ fn fetch_upstream(repo: &Repository, remote_name: &str) -> Result<()> {
     fetch_options.download_tags(AutotagOption::Unspecified);
 
     let mut remote = repo
-        .find_remote(&remote_name)
+        .find_remote(remote_name)
         .with_context(|| format!("failed to find remote {remote_name}"))?;
 
     // Empty refspecs means use the remote's configured fetch refspecs.

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -216,10 +216,10 @@ pub fn commit_file(dir: &str, path: &str, message: &str) -> Result<CommitInfo> {
     index.write().context("git2 write staged index")?;
 
     let tree_id = index.write_tree().context("git2 write commit tree")?;
-    if let Some(parent) = parent.as_ref() {
-        if parent.tree_id() == tree_id {
-            anyhow::bail!("nothing to commit");
-        }
+    if let Some(parent) = parent.as_ref()
+        && parent.tree_id() == tree_id
+    {
+        anyhow::bail!("nothing to commit");
     }
     let tree = repo.find_tree(tree_id).context("git2 find commit tree")?;
 

--- a/apps/native/src-tauri/src/git/query.rs
+++ b/apps/native/src-tauri/src/git/query.rs
@@ -234,10 +234,10 @@ pub fn read_tags(dir: &str, hash: &str) -> Vec<String> {
             continue;
         };
 
-        if resolved.id() == target_obj.id() {
-            if let Ok(name) = reference.shorthand() {
-                tags.push(name.to_string());
-            }
+        if resolved.id() == target_obj.id()
+            && let Ok(name) = reference.shorthand()
+        {
+            tags.push(name.to_string());
         }
     }
 

--- a/apps/native/src-tauri/src/history/get_history.rs
+++ b/apps/native/src-tauri/src/history/get_history.rs
@@ -166,11 +166,11 @@ fn populate_restore_history_items(
     // history is newest-first: restore at index i, origin at index j where j > i.
     let mut undone_indices = HashSet::new();
     for (i, oh) in origin_hashes.iter().enumerate() {
-        if let Some(oh_str) = oh {
-            if let Some(&origin_idx) = hash_to_idx.get(oh_str.as_str()) {
-                for k in (i + 1)..origin_idx {
-                    undone_indices.insert(k);
-                }
+        if let Some(oh_str) = oh
+            && let Some(&origin_idx) = hash_to_idx.get(oh_str.as_str())
+        {
+            for k in (i + 1)..origin_idx {
+                undone_indices.insert(k);
             }
         }
     }

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -990,12 +990,11 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectStat
             // set up watcher with interval based on focus
             let handle_for_focus = handle.clone();
             main_window.on_window_event(move |event| {
-                if let WindowEvent::Focused(focused) = event {
-                    if let Ok(config_dir) = store::get_config_dir(&handle_for_focus) {
+                if let WindowEvent::Focused(focused) = event
+                    && let Ok(config_dir) = store::get_config_dir(&handle_for_focus) {
                         let interval_ms = if *focused { 2500 } else { 15000 };
                         watcher::start_watching(handle_for_focus.clone(), config_dir, interval_ms);
                     }
-                }
             });
 
             // Keep window shadow for visual polish (shadow doesn't cause click issues, Acrylic did)
@@ -1009,11 +1008,10 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectStat
             // Experimental: create the spinning-mascot indicator window when the
             // flag is enabled at launch. Gated here so users who never enable it
             // pay no startup cost; enabling the flag applies on the next launch.
-            if crate::state::ui_prefs::experimental_spinning_mascot(handle) {
-                if let Err(e) = peek::create_evolve_mascot_window(handle) {
+            if crate::state::ui_prefs::experimental_spinning_mascot(handle)
+                && let Err(e) = peek::create_evolve_mascot_window(handle) {
                     log::error!("[peek] failed to create evolve mascot window: {}", e);
                 }
-            }
 
             // Start config watcher - monitors config directory for file changes
             // This emits config:changed events to the frontend when files are modified
@@ -1032,8 +1030,7 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectStat
                 event: WindowEvent::CloseRequested { api, .. },
                 ..
             } = &event
-            {
-                if label == "main" {
+                && label == "main" {
                     // Prevent the window from being destroyed
                     api.prevent_close();
                     if let Some(window) = app_handle.get_webview_window("main") {
@@ -1043,18 +1040,16 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectStat
                         peek::unlock_and_hide();
                     }
                 }
-            }
 
             #[cfg(target_os = "macos")]
             {
                 // Click Nixmac icon to show
-                if let RunEvent::Reopen { .. } = &event {
-                    if let Some(window) = app_handle.get_webview_window("main") {
+                if let RunEvent::Reopen { .. } = &event
+                    && let Some(window) = app_handle.get_webview_window("main") {
                         // fire-and-forget: show/set_focus fail only on destroyed window.
                         let _ = window.show();
                         let _ = window.set_focus();
                     }
-                }
             }
         });
 }

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -150,14 +150,14 @@ fn authorize_request(peer: &PeerIdentity, request: &HelperRequest) -> Result<()>
         );
     }
 
-    if let HelperRequest::ActivateStorePath { request } = request {
-        if peer.uid != request.user_id {
-            bail!(
-                "activation peer uid {} does not match requested uid {}",
-                peer.uid,
-                request.user_id
-            );
-        }
+    if let HelperRequest::ActivateStorePath { request } = request
+        && peer.uid != request.user_id
+    {
+        bail!(
+            "activation peer uid {} does not match requested uid {}",
+            peer.uid,
+            request.user_id
+        );
     }
 
     Ok(())

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -852,56 +852,6 @@ fn activation_failure_left_system_untouched(error_type: &str) -> bool {
     matches!(error_type, "user_cancelled")
 }
 
-#[cfg(test)]
-mod activation_safety_tests {
-    use super::{
-        ActivateResult, activation_failure_left_system_untouched, classify_activate_error,
-    };
-
-    fn failed_activation(stdout: &str, stderr: &str) -> ActivateResult {
-        ActivateResult {
-            success: false,
-            code: 1,
-            stdout: stdout.to_string(),
-            stderr: stderr.to_string(),
-        }
-    }
-
-    #[test]
-    fn app_management_failure_is_classified_from_activation_stdout() {
-        let result = failed_activation(
-            "error: permission denied when trying to update apps, aborting activation\nhome-manager requires permission to update your apps",
-            "",
-        );
-
-        let (error_type, message) = classify_activate_error(&result);
-
-        assert_eq!(error_type, "app_management");
-        assert!(message.contains("App Management"));
-    }
-
-    #[test]
-    fn app_management_failure_takes_precedence_over_generic_not_permitted_text() {
-        let result = failed_activation(
-            "Operation not permitted\nIf you did not get a notification, navigate to System Settings > Privacy & Security > App Management.",
-            "",
-        );
-
-        let (error_type, _) = classify_activate_error(&result);
-
-        assert_eq!(error_type, "app_management");
-    }
-
-    #[test]
-    fn only_explicit_cancellation_is_known_untouched() {
-        assert!(activation_failure_left_system_untouched("user_cancelled"));
-        assert!(!activation_failure_left_system_untouched(
-            "authorization_denied"
-        ));
-        assert!(!activation_failure_left_system_untouched("generic_error"));
-    }
-}
-
 /// Internal function to run darwin-rebuild with proper streaming.
 /// All output is written to ~/Library/Logs/nixmac/darwin-rebuild_<timestamp>.log
 /// Returns Ok(success_payload) on success, Err(error_payload) on failure.
@@ -1232,13 +1182,63 @@ fn run_darwin_rebuild(
         "code": activate_result.code,
         "log_file": log_path.to_string_lossy(),
     });
-    if let Some(et) = error_type {
-        if let Some(obj) = success_payload.as_object_mut() {
-            obj.insert(
-                "error_type".to_string(),
-                serde_json::Value::String(et.to_string()),
-            );
-        }
+    if let Some(et) = error_type
+        && let Some(obj) = success_payload.as_object_mut()
+    {
+        obj.insert(
+            "error_type".to_string(),
+            serde_json::Value::String(et.to_string()),
+        );
     }
     Ok(success_payload)
+}
+
+#[cfg(test)]
+mod activation_safety_tests {
+    use super::{
+        ActivateResult, activation_failure_left_system_untouched, classify_activate_error,
+    };
+
+    fn failed_activation(stdout: &str, stderr: &str) -> ActivateResult {
+        ActivateResult {
+            success: false,
+            code: 1,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    #[test]
+    fn app_management_failure_is_classified_from_activation_stdout() {
+        let result = failed_activation(
+            "error: permission denied when trying to update apps, aborting activation\nhome-manager requires permission to update your apps",
+            "",
+        );
+
+        let (error_type, message) = classify_activate_error(&result);
+
+        assert_eq!(error_type, "app_management");
+        assert!(message.contains("App Management"));
+    }
+
+    #[test]
+    fn app_management_failure_takes_precedence_over_generic_not_permitted_text() {
+        let result = failed_activation(
+            "Operation not permitted\nIf you did not get a notification, navigate to System Settings > Privacy & Security > App Management.",
+            "",
+        );
+
+        let (error_type, _) = classify_activate_error(&result);
+
+        assert_eq!(error_type, "app_management");
+    }
+
+    #[test]
+    fn only_explicit_cancellation_is_known_untouched() {
+        assert!(activation_failure_left_system_untouched("user_cancelled"));
+        assert!(!activation_failure_left_system_untouched(
+            "authorization_denied"
+        ));
+        assert!(!activation_failure_left_system_untouched("generic_error"));
+    }
 }

--- a/apps/native/src-tauri/src/rebuild/finalize_apply.rs
+++ b/apps/native/src-tauri/src/rebuild/finalize_apply.rs
@@ -35,15 +35,15 @@ pub async fn finalize_apply(app: &AppHandle) -> Result<()> {
     build_state::record_build(app, &final_status).context("Failed to record build state")?;
     // Mark onboarding's "first build/evolution" gate as satisfied. Best-effort:
     // a bookkeeping failure must not turn a successful build into a failed apply.
-    if crate::state::onboarding::try_read(app).is_some() {
-        if let Err(error) = crate::state::onboarding::write(app, |state| {
+    if crate::state::onboarding::try_read(app).is_some()
+        && let Err(error) = crate::state::onboarding::write(app, |state| {
             state.last_build_at = Some(crate::utils::unix_now());
             // The applied config is live now: onboarding's ownership of the
             // materialized directory ends, restart must never delete it.
             state.provisional_config_dir = None;
-        }) {
-            log::warn!("Failed to record onboarding build timestamp: {error:#}");
-        }
+        })
+    {
+        log::warn!("Failed to record onboarding build timestamp: {error:#}");
     }
     evolve_state::set_session(app, current_evolve, &final_status.changes)?;
     Ok(())

--- a/apps/native/src-tauri/src/state/build_state.rs
+++ b/apps/native/src-tauri/src/state/build_state.rs
@@ -43,10 +43,10 @@ pub fn read_current_store_path() -> Option<String> {
 /// Load the persisted build state. Returns `BuildState::default()` if absent or corrupt.
 pub fn get<R: Runtime>(app: &AppHandle<R>) -> Result<BuildState> {
     let store = app.store(BUILD_STATE_PATH)?;
-    if let Some(val) = store.get(BUILD_STATE_KEY) {
-        if let Ok(state) = serde_json::from_value::<BuildState>(val.clone()) {
-            return Ok(state);
-        }
+    if let Some(val) = store.get(BUILD_STATE_KEY)
+        && let Ok(state) = serde_json::from_value::<BuildState>(val.clone())
+    {
+        return Ok(state);
     }
     Ok(BuildState::default())
 }

--- a/apps/native/src-tauri/src/state/completion_log.rs
+++ b/apps/native/src-tauri/src/state/completion_log.rs
@@ -35,15 +35,15 @@ pub fn init_recording(prefix: &str, label: &str) -> bool {
     }
 
     let path = log_path_for_today(prefix);
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            error!(
-                "Failed to create completion-recording log directory {}: {}",
-                parent.display(),
-                e
-            );
-            return false;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        error!(
+            "Failed to create completion-recording log directory {}: {}",
+            parent.display(),
+            e
+        );
+        return false;
     }
 
     info!(

--- a/apps/native/src-tauri/src/state/evolve_state.rs
+++ b/apps/native/src-tauri/src/state/evolve_state.rs
@@ -125,10 +125,10 @@ fn write_session<R: Runtime>(app: &AppHandle<R>, session: &EvolveSession) {
         return;
     }
     // Unmanaged (CLI / bare tests): persist directly.
-    if let Ok(persistence) = AppDataJson::for_app(app, EVOLVE_STATE_PATH) {
-        if let Ok(value) = serde_json::to_value(session) {
-            let _ = persistence.flush(&value);
-        }
+    if let Ok(persistence) = AppDataJson::for_app(app, EVOLVE_STATE_PATH)
+        && let Ok(value) = serde_json::to_value(session)
+    {
+        let _ = persistence.flush(&value);
     }
 }
 

--- a/apps/native/src-tauri/src/state/onboarding.rs
+++ b/apps/native/src-tauri/src/state/onboarding.rs
@@ -53,14 +53,13 @@ pub(crate) fn migrate_from_prefs_file(
     };
 
     let mut changed = false;
-    if state.mac_scanned_at.is_none() {
-        if let Some(v) = fields
+    if state.mac_scanned_at.is_none()
+        && let Some(v) = fields
             .get("onboardingMacScannedAt")
             .and_then(|v| v.as_i64())
-        {
-            state.mac_scanned_at = Some(v);
-            changed = true;
-        }
+    {
+        state.mac_scanned_at = Some(v);
+        changed = true;
     }
     if !state.login_decided
         && fields
@@ -71,20 +70,19 @@ pub(crate) fn migrate_from_prefs_file(
         state.login_decided = true;
         changed = true;
     }
-    if state.last_build_at.is_none() {
-        if let Some(v) = fields.get("onboardingLastBuildAt").and_then(|v| v.as_i64()) {
-            state.last_build_at = Some(v);
-            changed = true;
-        }
+    if state.last_build_at.is_none()
+        && let Some(v) = fields.get("onboardingLastBuildAt").and_then(|v| v.as_i64())
+    {
+        state.last_build_at = Some(v);
+        changed = true;
     }
-    if state.provisional_config_dir.is_none() {
-        if let Some(v) = fields
+    if state.provisional_config_dir.is_none()
+        && let Some(v) = fields
             .get("onboardingProvisionalConfigDir")
             .and_then(|v| v.as_str())
-        {
-            state.provisional_config_dir = Some(v.to_string());
-            changed = true;
-        }
+    {
+        state.provisional_config_dir = Some(v.to_string());
+        changed = true;
     }
 
     let mut stripped = false;

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -37,10 +37,11 @@ const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 fn should_check_auto_update(dir: &str, now: Instant) -> bool {
     let mut last_check = LAST_AUTO_UPDATE_CHECK.lock().unwrap();
 
-    if let Some((last_dir, checked_at)) = last_check.as_ref() {
-        if last_dir == dir && now.duration_since(*checked_at) < AUTO_UPDATE_CHECK_INTERVAL {
-            return false;
-        }
+    if let Some((last_dir, checked_at)) = last_check.as_ref()
+        && last_dir == dir
+        && now.duration_since(*checked_at) < AUTO_UPDATE_CHECK_INTERVAL
+    {
+        return false;
     }
 
     *last_check = Some((dir.to_string(), now));
@@ -189,15 +190,15 @@ where
                 // Detect upstream git commits we may want to offer to pull.
                 // This is a fire-and-forget, best-effort check; if it fails,
                 // we just try again on the next scheduled check.
-                if let Some(dir) = current_dir.clone() {
-                    if should_check_auto_update(&dir, Instant::now()) {
-                        // Use a separate thread so we don't block the crazy-fast 100ms loop. The check itself is a git fetch
-                        // which is more like order-of-seconds (usually about 1-2 seconds in practice).
-                        std::thread::spawn(move || {
-                            let decision = git::auto_update::check_auto_update(&dir);
-                            log::debug!("[watcher] git auto-update check result: {:?}", decision);
-                        });
-                    }
+                if let Some(dir) = current_dir.clone()
+                    && should_check_auto_update(&dir, Instant::now())
+                {
+                    // Use a separate thread so we don't block the crazy-fast 100ms loop. The check itself is a git fetch
+                    // which is more like order-of-seconds (usually about 1-2 seconds in practice).
+                    std::thread::spawn(move || {
+                        let decision = git::auto_update::check_auto_update(&dir);
+                        log::debug!("[watcher] git auto-update check result: {:?}", decision);
+                    });
                 }
 
                 std::thread::sleep(Duration::from_millis(100));

--- a/apps/native/src-tauri/src/summarize/group_existing.rs
+++ b/apps/native/src-tauri/src/summarize/group_existing.rs
@@ -29,17 +29,17 @@ pub fn from_change_sets(change_sets: Vec<FoundSetForCurrent>) -> SemanticChangeM
                 Some(true) => continue, // already in a group, nothing better to do
                 Some(false) => {
                     // check for valid group before deduping change currently single
-                    if let Some(gs) = sc.group_summary {
-                        if !is_invalid(&gs) {
-                            singles.retain(|c| c.id != change_id);
-                            let cws = to_change_with_summary(&sc.change, sc.own_summary.as_ref());
-                            groups
-                                .entry(gs.id)
-                                .or_insert_with(|| (gs, vec![]))
-                                .1
-                                .push(cws);
-                            seen.insert(change_id, true);
-                        }
+                    if let Some(gs) = sc.group_summary
+                        && !is_invalid(&gs)
+                    {
+                        singles.retain(|c| c.id != change_id);
+                        let cws = to_change_with_summary(&sc.change, sc.own_summary.as_ref());
+                        groups
+                            .entry(gs.id)
+                            .or_insert_with(|| (gs, vec![]))
+                            .1
+                            .push(cws);
+                        seen.insert(change_id, true);
                     }
                 }
                 None => {

--- a/apps/native/src-tauri/src/sync/github_client.rs
+++ b/apps/native/src-tauri/src/sync/github_client.rs
@@ -340,13 +340,13 @@ fn redact_bootstrap_body(body: &str) -> String {
     let Ok(mut value) = serde_json::from_str::<serde_json::Value>(body) else {
         return truncate_body(body);
     };
-    if let Some(obj) = value.as_object_mut() {
-        if obj.contains_key("apiKey") {
-            obj.insert(
-                "apiKey".to_string(),
-                serde_json::Value::String("[redacted]".to_string()),
-            );
-        }
+    if let Some(obj) = value.as_object_mut()
+        && obj.contains_key("apiKey")
+    {
+        obj.insert(
+            "apiKey".to_string(),
+            serde_json::Value::String("[redacted]".to_string()),
+        );
     }
     truncate_body(&value.to_string())
 }

--- a/apps/native/src-tauri/src/sync/mod.rs
+++ b/apps/native/src-tauri/src/sync/mod.rs
@@ -88,10 +88,10 @@ async fn read_billing_json<T: serde::de::DeserializeOwned>(
     let status = response.status();
     let body = response.text().await.unwrap_or_default();
     if !status.is_success() {
-        if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&body) {
-            if let Some(message) = payload.get("message").and_then(|value| value.as_str()) {
-                return Err(anyhow!("{context} failed ({status}): {message}"));
-            }
+        if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&body)
+            && let Some(message) = payload.get("message").and_then(|value| value.as_str())
+        {
+            return Err(anyhow!("{context} failed ({status}): {message}"));
         }
         return Err(anyhow!("{context} failed ({status}): {body}"));
     }

--- a/apps/native/src-tauri/src/system/nix_ast_lists.rs
+++ b/apps/native/src-tauri/src/system/nix_ast_lists.rs
@@ -135,10 +135,10 @@ fn list_full_attrpath(content: &str, list_start: usize) -> Option<String> {
             }
             '{' if brace_depth == 0 => {
                 let brace_pos = *idx;
-                if let Some(parent_equals) = content.get(..brace_pos).and_then(|s| s.rfind('=')) {
-                    if let Some(parent_lhs) = assignment_lhs_at_equals(content, parent_equals) {
-                        path_segments.insert(0, parent_lhs.to_string());
-                    }
+                if let Some(parent_equals) = content.get(..brace_pos).and_then(|s| s.rfind('='))
+                    && let Some(parent_lhs) = assignment_lhs_at_equals(content, parent_equals)
+                {
+                    path_segments.insert(0, parent_lhs.to_string());
                 }
                 break;
             }

--- a/apps/native/src-tauri/src/system/scanner.rs
+++ b/apps/native/src-tauri/src/system/scanner.rs
@@ -1579,10 +1579,10 @@ pub fn scan_system_defaults(hostname: &str, config_dir: &str) -> SystemDefaultsS
             // Check if this key is currently managed by nix. If it is, we skip it because we don't want to report it as a non-default.
             // Currently we won't compare the value against the factory default because if it's managed by nix it might be intentionally set to a default
             // or non-default value.
-            if let Ok(ref nix_values) = current_nix_managed_values {
-                if nix_values.contains_key(def.defaults_key) {
-                    continue;
-                }
+            if let Ok(ref nix_values) = current_nix_managed_values
+                && nix_values.contains_key(def.defaults_key)
+            {
+                continue;
             }
 
             total_scanned += 1;
@@ -1669,12 +1669,11 @@ pub(crate) fn system_default_current_value_to_json(
             .map(serde_json::Value::Number)
             .unwrap_or_else(|| serde_json::Value::String(value.to_string())),
         Some(ValType::StringFromIntMap) => {
-            if let Ok(n) = value.trim().parse::<i32>() {
-                if let Some(map) = key_def.and_then(|def| def.int_to_string_map) {
-                    if let Some((_, mapped)) = map.iter().find(|(k, _)| *k == n) {
-                        return serde_json::Value::String((*mapped).to_string());
-                    }
-                }
+            if let Ok(n) = value.trim().parse::<i32>()
+                && let Some(map) = key_def.and_then(|def| def.int_to_string_map)
+                && let Some((_, mapped)) = map.iter().find(|(k, _)| *k == n)
+            {
+                return serde_json::Value::String((*mapped).to_string());
             }
             serde_json::Value::String(value.to_string())
         }
@@ -1993,8 +1992,8 @@ mod tests {
             Some("42".to_string())
         );
         assert_eq!(
-            parse_plist_value(plist::Value::Real(3.14)),
-            Some("3.14".to_string())
+            parse_plist_value(plist::Value::Real(2.5)),
+            Some("2.5".to_string())
         );
         assert_eq!(
             parse_plist_value(plist::Value::String("hello".to_string())),

--- a/apps/native/src-tauri/src/system/secret_scanner.rs
+++ b/apps/native/src-tauri/src/system/secret_scanner.rs
@@ -91,11 +91,10 @@ impl SecretScanner {
                 // Startup fast path: skip the original compile attempt when we
                 // know it fails — a failing NFA build takes ~0.3-1s per rule.
                 // Purely advisory: a stale hint falls through to the normal path.
-                if prefers_ascii_rewrite(&rule.id) {
-                    if let Some(Ok(compiled)) = ascii_rewrite(&regex).map(|p| Regex::new(&p)) {
+                if prefers_ascii_rewrite(&rule.id)
+                    && let Some(Ok(compiled)) = ascii_rewrite(&regex).map(|p| Regex::new(&p)) {
                         return Some((rule.id, compiled));
                     }
-                }
 
                 match Regex::new(&regex) {
                     Ok(compiled) => Some((rule.id, compiled)),

--- a/apps/native/src-tauri/src/utils.rs
+++ b/apps/native/src-tauri/src/utils.rs
@@ -153,10 +153,10 @@ mod tests {
         );
 
         // restore (best-effort; ignore failure to restore current dir)
-        if let Some(orig) = orig_cwd {
-            if let Err(e) = std::env::set_current_dir(orig) {
-                eprintln!("restore cwd failed: {}", e);
-            }
+        if let Some(orig) = orig_cwd
+            && let Err(e) = std::env::set_current_dir(orig)
+        {
+            eprintln!("restore cwd failed: {}", e);
         }
     }
 
@@ -185,10 +185,10 @@ mod tests {
         );
 
         // restore (best-effort; ignore failure to restore current dir)
-        if let Some(orig) = orig_cwd {
-            if let Err(e) = std::env::set_current_dir(orig) {
-                eprintln!("restore cwd failed: {}", e);
-            }
+        if let Some(orig) = orig_cwd
+            && let Err(e) = std::env::set_current_dir(orig)
+        {
+            eprintln!("restore cwd failed: {}", e);
         }
     }
 
@@ -204,10 +204,10 @@ mod tests {
         assert!(got.is_absolute(), "should resolve to absolute path");
 
         // restore (best-effort; ignore failure to restore current dir)
-        if let Some(orig) = orig_cwd {
-            if let Err(e) = std::env::set_current_dir(orig) {
-                eprintln!("restore cwd failed: {}", e);
-            }
+        if let Some(orig) = orig_cwd
+            && let Err(e) = std::env::set_current_dir(orig)
+        {
+            eprintln!("restore cwd failed: {}", e);
         }
     }
 
@@ -241,10 +241,10 @@ mod tests {
         );
 
         // restore BEFORE tempdir is dropped so the directory still exists
-        if let Some(orig) = orig_cwd {
-            if let Err(e) = std::env::set_current_dir(orig) {
-                eprintln!("restore cwd failed: {}", e);
-            }
+        if let Some(orig) = orig_cwd
+            && let Err(e) = std::env::set_current_dir(orig)
+        {
+            eprintln!("restore cwd failed: {}", e);
         }
     }
 }

--- a/apps/native/templates/base/modules/darwin/scripts/pkg-search.sh
+++ b/apps/native/templates/base/modules/darwin/scripts/pkg-search.sh
@@ -88,7 +88,7 @@ else
       fi
 
       ((COUNT++))
-      if [ $COUNT -gt $LIMIT ]; then
+      if [ "$COUNT" -gt "$LIMIT" ]; then
         echo -e "\n${YELLOW}Showing first $LIMIT results. Use -n to show more.${NC}"
         break
       fi

--- a/apps/native/templates/minimal/modules/darwin/scripts/pkg-search.sh
+++ b/apps/native/templates/minimal/modules/darwin/scripts/pkg-search.sh
@@ -88,7 +88,7 @@ else
       fi
 
       ((COUNT++))
-      if [ $COUNT -gt $LIMIT ]; then
+      if [ "$COUNT" -gt "$LIMIT" ]; then
         echo -e "\n${YELLOW}Showing first $LIMIT results. Use -n to show more.${NC}"
         break
       fi

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -54,12 +54,10 @@ in
 lib.mkIf (!config.container.isBuilding) {
   # Dev-only packages (excluded from container builds by conditional import).
   packages = [
-    pkgs.rustPackages.rustc
-    pkgs.rustPackages.cargo
-    pkgs.rustPackages.clippy
-    pkgs.rustPackages.rustfmt
-    pkgs.rust-analyzer
-    pkgs.clippy
+    # rustc/cargo/clippy/rustfmt/rust-analyzer come from languages.rust below
+    # as matching-version components. Do not add nixpkgs copies here: mixing
+    # toolchains made cargo compile deps with one rustc while clippy-driver
+    # came from another (E0514 on CI).
     pkgs.cargo-watch
     pkgs.cargo-nextest
     pkgs.flyctl

--- a/tests/e2e/lib/core.sh
+++ b/tests/e2e/lib/core.sh
@@ -247,9 +247,10 @@ print_results() {
     local total=$((_E2E_PASS_COUNT + _E2E_FAIL_COUNT))
     
     for result in "${_E2E_PHASE_RESULTS[@]}"; do
-        local status=$(echo "$result" | cut -d'|' -f1)
-        local num=$(echo "$result" | cut -d'|' -f2)
-        local msg=$(echo "$result" | cut -d'|' -f3-)
+        local status num msg
+        status=$(echo "$result" | cut -d'|' -f1)
+        num=$(echo "$result" | cut -d'|' -f2)
+        msg=$(echo "$result" | cut -d'|' -f3-)
         if [ "$status" = "PASS" ]; then
             echo -e "  ${_GREEN}✅${_NC} Phase $num: $msg" | tee -a "$E2E_LOG_FILE"
         else
@@ -271,9 +272,10 @@ print_results() {
 results_json() {
     local phases="[]"
     for result in "${_E2E_PHASE_RESULTS[@]}"; do
-        local status=$(echo "$result" | cut -d'|' -f1)
-        local num=$(echo "$result" | cut -d'|' -f2)
-        local msg=$(echo "$result" | cut -d'|' -f3-)
+        local status num msg
+        status=$(echo "$result" | cut -d'|' -f1)
+        num=$(echo "$result" | cut -d'|' -f2)
+        msg=$(echo "$result" | cut -d'|' -f3-)
         phases=$(echo "$phases" | jq --arg s "$status" --arg n "$num" --arg m "$msg" \
             '. + [{"phase": ($n | tonumber), "status": $s, "message": $m}]')
     done

--- a/tests/e2e/lib/peekaboo.sh
+++ b/tests/e2e/lib/peekaboo.sh
@@ -500,18 +500,17 @@ screenshot() {
     local name="${1:-screenshot}"
     local app="${2:-}"
     local path
-    local args=""
+    local screenshot_args=()
     local marker=""
     local generated=""
     path="${E2E_SCREENSHOT_DIR}/${name}-$(date +%s).png"
-    [ -n "$app" ] && args="--app $app"
+    [ -n "$app" ] && screenshot_args=(--app "$app")
 
     mkdir -p "$E2E_SCREENSHOT_DIR"
     marker=$(mktemp "${TMPDIR:-/tmp}/e2e-peekaboo-marker.XXXXXX" 2>/dev/null || true)
     [ -n "$marker" ] && touch "$marker"
 
-    # shellcheck disable=SC2086
-    peekaboo_run see $args --annotate --path "$path" 2>/dev/null \
+    peekaboo_run see ${screenshot_args[@]+"${screenshot_args[@]}"} --annotate --path "$path" 2>/dev/null \
         || peekaboo_run image --mode screen --path "$path" 2>/dev/null \
         || true
 

--- a/tests/e2e/lib/peekaboo.test.sh
+++ b/tests/e2e/lib/peekaboo.test.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/peekaboo-lib-test.XXXXXX")"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
-export E2E_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+E2E_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export E2E_ROOT
 export E2E_LIB="$E2E_ROOT/lib"
 export E2E_SCREENSHOT_DIR="$TEST_DIR/screenshots"
 export E2E_PEEKABOO_CAPTURE_DIR="$TEST_DIR/captures"

--- a/tests/e2e/lib/report.sh
+++ b/tests/e2e/lib/report.sh
@@ -106,7 +106,7 @@ e2e_report_write() {
         while IFS= read -r diagnostic; do
             [ -f "$diagnostic" ] || continue
             local rel_path dest rel caption
-            rel_path="${diagnostic#$E2E_DIAGNOSTIC_DIR/}"
+            rel_path="${diagnostic#"$E2E_DIAGNOSTIC_DIR"/}"
             dest="$diagnostics_dest/$rel_path"
             mkdir -p "$(dirname "$dest")"
             cp "$diagnostic" "$dest"

--- a/tests/e2e/lib/runner.sh
+++ b/tests/e2e/lib/runner.sh
@@ -58,7 +58,7 @@ runner_exec() {
     runner_lock
     trap 'runner_cleanup' EXIT
     peekaboo_cleanup_desktop_artifacts 2>/dev/null || true
-    E2E_TERMINAL_CLEANUP_MODE=kill recording_close_terminal_windows 2>/dev/null || true
+    E2E_TERMINAL_CLEANUP_MODE="kill" recording_close_terminal_windows 2>/dev/null || true
     
     # Source scenario first to pick up E2E_ADAPTER/E2E_FIXTURE declarations
     source "$scenario_file"


### PR DESCRIPTION
## Summary

- CI should run git-hooks and check everything passes, otherwise they'll silently break
- same for `cargo clippy`

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
