### PR TITLE
Fix `edit_nix_file` would fail due to double-encoded tool-call arguments

### DIFF
--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -1306,9 +1306,6 @@ pub async fn generate_evolution<R: Runtime>(
                     let args_str = &tool_call.arguments;
                     let args_raw: serde_json::Value =
                         serde_json::from_str(args_str).unwrap_or(serde_json::json!({}));
-                    // Repair double-encoded arguments (nested objects the model
-                    // serialized into strings) before sanitizing and executing.
-                    let args_raw = tools::coerce_stringified_args(&tools, tool_name, args_raw);
                     let args = sanitize_tool_args(tool_name, &args_raw);
 
                     let args_summary = summarize_args(&args);
@@ -1888,9 +1885,14 @@ fn truncate_build_output_for_model(output: &str) -> String {
     truncated
 }
 
-/// Sanitize sensitive tool arguments before logging, telemetry emission, and execution.
+/// Normalize and sanitize tool arguments before logging, telemetry emission,
+/// and execution: repair double-encoded arguments the model serialized into
+/// strings, then redact sensitive fields. `execute_tool` re-applies the
+/// (idempotent) coercion itself so replayed or direct tool calls behave the
+/// same; doing it here as well keeps emitted telemetry consistent with what
+/// actually executes.
 fn sanitize_tool_args(tool_name: &str, args: &serde_json::Value) -> serde_json::Value {
-    let mut sanitized = args.clone();
+    let mut sanitized = tools::coerce_stringified_args(tool_name, args.clone());
 
     if tool_name == "ensure_secret" {
         if let Some(args_obj) = sanitized.as_object_mut() {

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -1306,6 +1306,9 @@ pub async fn generate_evolution<R: Runtime>(
                     let args_str = &tool_call.arguments;
                     let args_raw: serde_json::Value =
                         serde_json::from_str(args_str).unwrap_or(serde_json::json!({}));
+                    // Repair double-encoded arguments (nested objects the model
+                    // serialized into strings) before sanitizing and executing.
+                    let args_raw = tools::coerce_stringified_args(&tools, tool_name, args_raw);
                     let args = sanitize_tool_args(tool_name, &args_raw);
 
                     let args_summary = summarize_args(&args);

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -7,6 +7,7 @@
 //! ([`ToolResult`], [`ToolCtx`]) and helpers live here so every tool module can
 //! reach them via `super::`.
 
+mod arg_coercion;
 mod ask_user;
 mod build_check;
 mod done;
@@ -31,6 +32,8 @@ use crate::shared_types::FileEdit;
 use super::gitignore::GitignoreChecker;
 use anyhow::{Result, anyhow};
 use std::path::{Component, Path};
+
+pub(crate) use arg_coercion::coerce_stringified_args;
 
 // =============================================================================
 // Tool Definitions

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -538,6 +538,60 @@ mod tests {
     }
 
     #[test]
+    fn edit_nix_file_recovers_double_encoded_action_string() {
+        let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
+        fs::write(tmp.path().join("system.nix"), "{ ... }: { }\n").expect("write nix file");
+
+        let result = execute_tool(
+            tmp.path(),
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_nix_file",
+            &json!({
+                "path": "system.nix",
+                "action": "{\"set\": {\"path\": \"system.defaults.NSGlobalDomain._HIHideMenuBar\", \"value\": false}}"
+            }),
+            false,
+            None,
+        )
+        .expect("double-encoded action string should be recovered as the action object");
+
+        assert!(matches!(result, ToolResult::EditSemantic(_)));
+        let content = fs::read_to_string(tmp.path().join("system.nix")).expect("read nix file");
+        assert!(
+            content.contains("_HIHideMenuBar = false"),
+            "unexpected content: {content}"
+        );
+    }
+
+    #[test]
+    fn edit_nix_file_rejects_double_encoded_non_action_string() {
+        let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
+        fs::write(tmp.path().join("system.nix"), "{ ... }: { }\n").expect("write nix file");
+
+        let result = execute_tool(
+            tmp.path(),
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_nix_file",
+            &json!({
+                "path": "system.nix",
+                "action": "\"not-an-action\""
+            }),
+            false,
+            None,
+        );
+
+        let err = result.expect_err("non-object double-encoded action should still error");
+        assert!(
+            err.to_string().contains("unsupported shorthand action"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
     fn edit_nix_file_reports_non_object_action_payload() {
         let tmp = tempdir().expect("tempdir");
         git2::Repository::init(tmp.path()).expect("init git repo");

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -119,11 +119,15 @@ pub fn execute_tool(
     auto_format: bool,
     gitignore_matcher: Option<&GitignoreChecker>,
 ) -> Result<ToolResult> {
+    // Repair double-encoded arguments at the dispatch boundary so every
+    // caller — the live model loop, tests, and replayed tool calls alike —
+    // executes with identically normalized arguments.
+    let args = coerce_stringified_args(name, args.clone());
     let ctx = ToolCtx {
         repo_root,
         config_dir,
         host_attr,
-        args,
+        args: &args,
         auto_format,
         gitignore_matcher,
     };
@@ -564,6 +568,36 @@ mod tests {
         let content = fs::read_to_string(tmp.path().join("system.nix")).expect("read nix file");
         assert!(
             content.contains("_HIHideMenuBar = false"),
+            "unexpected content: {content}"
+        );
+    }
+
+    #[test]
+    fn execute_tool_repairs_stringified_action_payload() {
+        let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
+        fs::write(tmp.path().join("services.nix"), "{ ... }: { }\n").expect("write nix file");
+
+        let result = execute_tool(
+            tmp.path(),
+            tmp.path().to_str().expect("utf-8 path"),
+            "dummy-host",
+            "edit_nix_file",
+            &json!({
+                "path": "services.nix",
+                "action": {
+                    "set": "{\"path\": \"services.tailscale.enable\", \"value\": true}"
+                }
+            }),
+            false,
+            None,
+        )
+        .expect("stringified action payload should be repaired at dispatch");
+
+        assert!(matches!(result, ToolResult::EditSemantic(_)));
+        let content = fs::read_to_string(tmp.path().join("services.nix")).expect("read nix file");
+        assert!(
+            content.contains("services.tailscale.enable = true"),
             "unexpected content: {content}"
         );
     }

--- a/apps/native/src-tauri/src/evolve/tools/arg_coercion.rs
+++ b/apps/native/src-tauri/src/evolve/tools/arg_coercion.rs
@@ -1,0 +1,246 @@
+//! Repair double-encoded tool-call arguments using the tool's parameter schema.
+//!
+//! Some models serialize a nested object or array argument into a JSON string
+//! (for example `"action": "{\"set\": {...}}"` instead of
+//! `"action": {"set": {...}}`), typically when the parameter schema is a union
+//! that also admits strings. [`coerce_stringified_args`] walks the arguments
+//! alongside the tool's JSON schema and replaces a string value with its parsed
+//! JSON form only when the schema rejects that string as-is but accepts the
+//! parsed value, so legitimately string-typed arguments (including strings that
+//! happen to contain JSON) always pass through untouched.
+
+use serde_json::Value;
+
+use crate::evolve::messages::Tool;
+
+/// Guard against pathological `$ref`/`oneOf` cycles when expanding schema
+/// branches. Real tool schemas here are at most a few levels deep.
+const MAX_BRANCH_DEPTH: usize = 8;
+
+/// Coerce double-encoded string arguments for `tool_name` back into structured
+/// values. Arguments for unknown tools pass through unchanged.
+pub(crate) fn coerce_stringified_args(tools: &[Tool], tool_name: &str, mut args: Value) -> Value {
+    if let Some(tool) = tools.iter().find(|tool| tool.name == tool_name) {
+        coerce_value(&tool.parameters, &tool.parameters, &mut args);
+    }
+    args
+}
+
+fn coerce_value(schema: &Value, root: &Value, value: &mut Value) {
+    let Some(schema) = resolve_ref(schema, root) else {
+        return;
+    };
+
+    match value {
+        Value::String(_) => {
+            if schema_accepts(schema, root, value) {
+                return;
+            }
+            let Some(text) = value.as_str() else {
+                return;
+            };
+            let Ok(parsed) = serde_json::from_str::<Value>(text.trim()) else {
+                return;
+            };
+            if !parsed.is_string() && schema_accepts(schema, root, &parsed) {
+                *value = parsed;
+            }
+        }
+        Value::Object(map) => {
+            for branch in schema_branches(schema, root) {
+                if let Some(props) = branch.get("properties").and_then(Value::as_object) {
+                    for (key, item) in map.iter_mut() {
+                        if let Some(prop_schema) = props.get(key) {
+                            coerce_value(prop_schema, root, item);
+                        }
+                    }
+                }
+                if let Some(additional) = branch.get("additionalProperties") {
+                    if additional.is_object() {
+                        for item in map.values_mut() {
+                            coerce_value(additional, root, item);
+                        }
+                    }
+                }
+            }
+        }
+        Value::Array(items) => {
+            for branch in schema_branches(schema, root) {
+                if let Some(item_schema) = branch.get("items") {
+                    for item in items.iter_mut() {
+                        coerce_value(item_schema, root, item);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Resolve a local `$ref` (`#/$defs/...` or `#/definitions/...`) against the
+/// root schema; schemas without `$ref` resolve to themselves.
+fn resolve_ref<'a>(schema: &'a Value, root: &'a Value) -> Option<&'a Value> {
+    let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
+        return Some(schema);
+    };
+    let path = reference.strip_prefix("#/")?;
+    path.split('/')
+        .try_fold(root, |node, segment| node.get(segment))
+}
+
+/// Flatten a schema and its `oneOf`/`anyOf` alternatives (recursively, with
+/// `$ref`s resolved) into the list of branches a value may match.
+fn schema_branches<'a>(schema: &'a Value, root: &'a Value) -> Vec<&'a Value> {
+    let mut branches = Vec::new();
+    collect_branches(schema, root, &mut branches, 0);
+    branches
+}
+
+fn collect_branches<'a>(
+    schema: &'a Value,
+    root: &'a Value,
+    branches: &mut Vec<&'a Value>,
+    depth: usize,
+) {
+    if depth > MAX_BRANCH_DEPTH {
+        return;
+    }
+    branches.push(schema);
+    for key in ["oneOf", "anyOf"] {
+        if let Some(list) = schema.get(key).and_then(Value::as_array) {
+            for branch in list {
+                if let Some(resolved) = resolve_ref(branch, root) {
+                    collect_branches(resolved, root, branches, depth + 1);
+                }
+            }
+        }
+    }
+}
+
+/// Whether any branch of the schema accepts the value, judged by `enum`
+/// membership and the `type` keyword only. Branches that merely wrap
+/// alternatives (they carry `oneOf`/`anyOf` but no own constraints) never
+/// accept directly; a branch with no constraints at all accepts everything.
+fn schema_accepts(schema: &Value, root: &Value, value: &Value) -> bool {
+    schema_branches(schema, root).iter().any(|branch| {
+        if let Some(allowed) = branch.get("enum").and_then(Value::as_array) {
+            return allowed.contains(value);
+        }
+        if let Some(type_spec) = branch.get("type") {
+            return type_spec_matches(type_spec, value);
+        }
+        branch.get("oneOf").is_none() && branch.get("anyOf").is_none()
+    })
+}
+
+fn type_spec_matches(type_spec: &Value, value: &Value) -> bool {
+    match type_spec {
+        Value::String(name) => type_name_matches(name, value),
+        Value::Array(names) => names
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|name| type_name_matches(name, value)),
+        _ => true,
+    }
+}
+
+fn type_name_matches(name: &str, value: &Value) -> bool {
+    match name {
+        "string" => value.is_string(),
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "integer" => value.is_i64() || value.is_u64(),
+        // Unknown type keyword: stay permissive so we never block a
+        // legitimate value on a schema we don't fully understand.
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::super::{edit_file, edit_nix_file};
+    use super::coerce_stringified_args;
+
+    fn tools() -> Vec<crate::evolve::messages::Tool> {
+        vec![edit_file::definition(), edit_nix_file::definition()]
+    }
+
+    #[test]
+    fn coerces_double_encoded_action_into_object() {
+        let args = json!({
+            "path": "system.nix",
+            "action": "{\"set\": {\"path\": \"system.defaults.NSGlobalDomain._HIHideMenuBar\", \"value\": false}}"
+        });
+
+        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args);
+
+        assert_eq!(
+            coerced["action"]["set"]["path"],
+            "system.defaults.NSGlobalDomain._HIHideMenuBar"
+        );
+        assert_eq!(coerced["action"]["set"]["value"], json!(false));
+    }
+
+    #[test]
+    fn keeps_shorthand_action_enum_string() {
+        let args = json!({ "path": "packages.nix", "action": "add", "values": ["bat"] });
+
+        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args);
+
+        assert_eq!(coerced["action"], "add");
+    }
+
+    #[test]
+    fn keeps_json_looking_content_in_string_typed_properties() {
+        let args = json!({
+            "path": "config.json",
+            "search": "",
+            "replace": "{\"set\": {\"key\": \"value\"}}"
+        });
+
+        let coerced = coerce_stringified_args(&tools(), "edit_file", args.clone());
+
+        assert_eq!(coerced, args);
+    }
+
+    #[test]
+    fn keeps_unparseable_action_strings() {
+        let args = json!({ "path": "system.nix", "action": "definitely not json" });
+
+        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args.clone());
+
+        assert_eq!(coerced, args);
+    }
+
+    #[test]
+    fn coerces_stringified_payload_nested_inside_action_object() {
+        let args = json!({
+            "path": "system.nix",
+            "action": {
+                "set": "{\"path\": \"services.tailscale.enable\", \"value\": true}"
+            }
+        });
+
+        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args);
+
+        assert_eq!(
+            coerced["action"]["set"]["path"],
+            "services.tailscale.enable"
+        );
+        assert_eq!(coerced["action"]["set"]["value"], json!(true));
+    }
+
+    #[test]
+    fn passes_unknown_tools_through_unchanged() {
+        let args = json!({ "anything": "{\"looks\": \"like json\"}" });
+
+        let coerced = coerce_stringified_args(&tools(), "no_such_tool", args.clone());
+
+        assert_eq!(coerced, args);
+    }
+}

--- a/apps/native/src-tauri/src/evolve/tools/arg_coercion.rs
+++ b/apps/native/src-tauri/src/evolve/tools/arg_coercion.rs
@@ -9,6 +9,7 @@
 //! parsed value, so legitimately string-typed arguments (including strings that
 //! happen to contain JSON) always pass through untouched.
 
+use once_cell::sync::Lazy;
 use serde_json::Value;
 
 use crate::evolve::messages::Tool;
@@ -17,10 +18,19 @@ use crate::evolve::messages::Tool;
 /// branches. Real tool schemas here are at most a few levels deep.
 const MAX_BRANCH_DEPTH: usize = 8;
 
+/// Full tool registry used to look up parameter schemas. Built without bans:
+/// bans only affect which tools the model is offered, not how the arguments
+/// of a call that did happen are repaired.
+static ALL_TOOL_DEFINITIONS: Lazy<Vec<Tool>> = Lazy::new(|| super::create_tools(&[]));
+
 /// Coerce double-encoded string arguments for `tool_name` back into structured
-/// values. Arguments for unknown tools pass through unchanged.
-pub(crate) fn coerce_stringified_args(tools: &[Tool], tool_name: &str, mut args: Value) -> Value {
-    if let Some(tool) = tools.iter().find(|tool| tool.name == tool_name) {
+/// values. Arguments for unknown tools pass through unchanged. Idempotent:
+/// already-structured arguments are never changed.
+pub(crate) fn coerce_stringified_args(tool_name: &str, mut args: Value) -> Value {
+    if let Some(tool) = ALL_TOOL_DEFINITIONS
+        .iter()
+        .find(|tool| tool.name == tool_name)
+    {
         coerce_value(&tool.parameters, &tool.parameters, &mut args);
     }
     args
@@ -163,12 +173,7 @@ fn type_name_matches(name: &str, value: &Value) -> bool {
 mod tests {
     use serde_json::json;
 
-    use super::super::{edit_file, edit_nix_file};
     use super::coerce_stringified_args;
-
-    fn tools() -> Vec<crate::evolve::messages::Tool> {
-        vec![edit_file::definition(), edit_nix_file::definition()]
-    }
 
     #[test]
     fn coerces_double_encoded_action_into_object() {
@@ -177,7 +182,7 @@ mod tests {
             "action": "{\"set\": {\"path\": \"system.defaults.NSGlobalDomain._HIHideMenuBar\", \"value\": false}}"
         });
 
-        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args);
+        let coerced = coerce_stringified_args("edit_nix_file", args);
 
         assert_eq!(
             coerced["action"]["set"]["path"],
@@ -190,7 +195,7 @@ mod tests {
     fn keeps_shorthand_action_enum_string() {
         let args = json!({ "path": "packages.nix", "action": "add", "values": ["bat"] });
 
-        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args);
+        let coerced = coerce_stringified_args("edit_nix_file", args);
 
         assert_eq!(coerced["action"], "add");
     }
@@ -203,7 +208,7 @@ mod tests {
             "replace": "{\"set\": {\"key\": \"value\"}}"
         });
 
-        let coerced = coerce_stringified_args(&tools(), "edit_file", args.clone());
+        let coerced = coerce_stringified_args("edit_file", args.clone());
 
         assert_eq!(coerced, args);
     }
@@ -212,7 +217,7 @@ mod tests {
     fn keeps_unparseable_action_strings() {
         let args = json!({ "path": "system.nix", "action": "definitely not json" });
 
-        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args.clone());
+        let coerced = coerce_stringified_args("edit_nix_file", args.clone());
 
         assert_eq!(coerced, args);
     }
@@ -226,7 +231,7 @@ mod tests {
             }
         });
 
-        let coerced = coerce_stringified_args(&tools(), "edit_nix_file", args);
+        let coerced = coerce_stringified_args("edit_nix_file", args);
 
         assert_eq!(
             coerced["action"]["set"]["path"],
@@ -239,7 +244,7 @@ mod tests {
     fn passes_unknown_tools_through_unchanged() {
         let args = json!({ "anything": "{\"looks\": \"like json\"}" });
 
-        let coerced = coerce_stringified_args(&tools(), "no_such_tool", args.clone());
+        let coerced = coerce_stringified_args("no_such_tool", args.clone());
 
         assert_eq!(coerced, args);
     }

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -351,6 +351,14 @@ fn shorthand_action_object(
     Ok(serde_json::Value::Object(action))
 }
 
+/// Some models double-encode the action, serializing the whole action object
+/// into the string slot of the schema union (e.g. `"action": "{\"set\": {...}}"`).
+/// Recover the object so the call behaves as if it had been sent unencoded.
+fn parse_stringified_action_object(action_str: &str) -> Option<serde_json::Value> {
+    let value: serde_json::Value = serde_json::from_str(action_str.trim()).ok()?;
+    value.is_object().then_some(value)
+}
+
 pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     let args = ctx.args;
     let path = args["path"]
@@ -362,10 +370,14 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     ensure_nixmac_edit_allowed("edit_nix_file", path)?;
 
     // Prefer an object like { "add": { "path": "a.b", "values": ["v"] } }, but
-    // tolerate shorthand calls like { "action": "add", "path": "file.nix", "values": ["v"] }.
+    // tolerate shorthand calls like { "action": "add", "path": "file.nix", "values": ["v"] }
+    // and double-encoded actions like { "action": "{\"set\": {...}}" }.
     let normalized_action;
-    let action_val = if let Some(action_name) = args["action"].as_str() {
-        normalized_action = shorthand_action_object(ctx, path, action_name, args)?;
+    let action_val = if let Some(action_str) = args["action"].as_str() {
+        normalized_action = match parse_stringified_action_object(action_str) {
+            Some(action) => action,
+            None => shorthand_action_object(ctx, path, action_str, args)?,
+        };
         &normalized_action
     } else if args["action"].is_object() {
         &args["action"]


### PR DESCRIPTION
## Problem

Evolution runs were failing with errors like:

```
Error: edit_nix_file: unsupported shorthand action '{"set": {"path": "system.defaults.NSGlobalDomain._HIHideMenuBar", "value": false}}'; expected add, remove, set, or set_attrs.
```

Some models serialize a nested object argument into a JSON *string* (double encoding), typically provoked by the `action` parameter's `oneOf` union schema, which also admits a shorthand string. The tool then matched the whole serialized object against the shorthand action names and failed — with a perfectly valid payload inside the string.

Ideally the model would not do that, and some don't, but the less smart ones can't help themselves, therefore some defensive mechanisms are needed.

## Fix (three commits)

1. **Local recovery in `edit_nix_file`**: a string `action` that parses as a JSON object is treated as the object form; shorthand names and corrective errors are unchanged.
2. **General, schema-driven coercion** (`evolve/tools/arg_coercion.rs`): walk any tool's arguments alongside its own parameter schema (resolving `$ref`s, expanding `oneOf`/`anyOf`) and replace a string with its parsed JSON form only when the schema rejects the string as-is but accepts the parsed value. Legitimately string-typed arguments — including strings that contain JSON, like `edit_file` payloads — always pass through untouched. This covers the whole class for every tool (e.g. `ensure_secret`'s nested objects), not just `edit_nix_file`.
3. **Consistent placement**: coercion runs inside `execute_tool` at the dispatch boundary, so the live model loop, tests, and replayed/direct tool calls all normalize identically; `sanitize_tool_args` also applies it (idempotent) so emitted telemetry matches what actually executes.

An alternative considered was flattening `edit_nix_file`'s union schema; the coercion layer was preferred because it protects all tools without changing the agent-facing interface. Flattening remains a possible follow-up if weak models mangle the union in other ways.

## Testing

- Unit tests for the coercion (exact failing payload, shorthand enum preserved, JSON-looking strings in string-typed fields untouched, nested stringified payloads, unknown tools).
- End-to-end tests through `execute_tool`, including a nested stringified payload that only passes via the dispatch-boundary coercion.
- Full `evolve::` suite: 198 passed.