### PR TITLE
Eval suite: hermetic isolation, unified CLI, grade-aware stats

### DIFF
--- a/apps/eval/.gitignore
+++ b/apps/eval/.gitignore
@@ -1,5 +1,6 @@
 data/results
 data/results_*
+data/results-*
 data/report
 data/report_*
 ~$*

--- a/apps/eval/README.md
+++ b/apps/eval/README.md
@@ -37,11 +37,16 @@ uv run nixmac-eval run --csv data/test_prompts.csv --vllm-url ... # run cases
 uv run nixmac-eval grade  -i data/results                         # persist grades
 uv run nixmac-eval stats  -i data/results                         # scorecard tables
 uv run nixmac-eval report -i data/results -o data/report          # HTML report
+
+uv run nixmac-eval all --csv data/test_prompts.csv --vllm-url ... # all of the above
 ```
 
-The typical workflow is `run` → `grade` → `stats`/`report`. `stats` also
-works on ungraded results: it grades them in memory (without writing
-back) so its pass/fail always reflects each case's `expected_outcome`.
+The typical workflow is `run` → `grade` → `stats`/`report`; `all` runs
+those four steps in order against a single results directory (it takes
+all of `run`'s flags, plus `--golden-only`, `-s/--summary-only` and
+`-o/--output-dir` for the later stages). `stats` also works on ungraded
+results: it grades them in memory (without writing back) so its
+pass/fail always reflects each case's `expected_outcome`.
 
 The original entry points (`python run_evals.py`, `python calc_stats.py`,
 `python grade.py`, `python generate_report.py`) still work with the same

--- a/apps/eval/README.md
+++ b/apps/eval/README.md
@@ -2,6 +2,24 @@
 
 This directory contains tools for evaluating nixmac's evolution capabilities against a test matrix of user requests.
 
+## Isolation
+
+Every test case runs fully hermetically. The suite creates a fresh temp
+directory per case and passes it to the nixmac binary via the
+`NIXMAC_APP_DATA_DIR` environment variable, which roots **all** of the
+binary's per-device state there: `settings.json`,
+`global-preferences.json`, the sqlite DB, docs cache, and secrets. Eval
+runs therefore never read or mutate your real nixmac preferences, your
+keychain/dev credentials, or your real nix configuration. API keys are
+passed to the child process through the environment
+(`OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `VLLM_API_KEY`), never written
+to disk.
+
+The suite verifies after the first invocation that the binary actually
+honored the override and aborts otherwise, so pointing `--nixmac` at an
+old binary that predates `NIXMAC_APP_DATA_DIR` fails loudly instead of
+silently running against your real state.
+
 ## Setup
 
 Install dependencies with `uv`:
@@ -26,7 +44,7 @@ Options:
 - `--priority <level>` - Filter by priority level
 - `--limit <num>` - Max number of cases to run
 - `--persona <name>` - Filter by persona
-- `--nixmac <path>` - Path to nixmac binary (default: `../../target/debug/nixmac`)
+- `--nixmac <path>` - Path to nixmac binary (default: `../../target/debug/nixmac`, built from this repo with `cargo build`)
 
 Results are saved to `data/results/` as JSON files.
 

--- a/apps/eval/README.md
+++ b/apps/eval/README.md
@@ -28,19 +28,36 @@ Install dependencies with `uv`:
 uv sync
 ```
 
+## The `nixmac-eval` CLI
+
+All tools are available as subcommands of a single CLI:
+
+```bash
+uv run nixmac-eval run --csv data/test_prompts.csv --vllm-url ... # run cases
+uv run nixmac-eval grade  -i data/results                         # persist grades
+uv run nixmac-eval stats  -i data/results                         # scorecard tables
+uv run nixmac-eval report -i data/results -o data/report          # HTML report
+```
+
+The typical workflow is `run` → `grade` → `stats`/`report`. `stats` also
+works on ungraded results: it grades them in memory (without writing
+back) so its pass/fail always reflects each case's `expected_outcome`.
+
+The original entry points (`python run_evals.py`, `python calc_stats.py`,
+`python grade.py`, `python generate_report.py`) still work with the same
+flags.
+
 ## Running Evaluations
 
 Execute the evaluation suite:
 
-### Run with default Excel spreadsheet
-
 ```bash
-uv run python run_evals.py
+uv run nixmac-eval run --csv data/test_prompts.csv --ollama-url http://localhost:11434
 ```
 
 Options:
 
-- `--cases <row_numbers>` - Run specific test cases by row number (comma-separated)
+- `--rows <case_ids>` - Run specific test cases by id (comma-separated)
 - `--priority <level>` - Filter by priority level
 - `--limit <num>` - Max number of cases to run
 - `--persona <name>` - Filter by persona
@@ -53,7 +70,7 @@ Results are saved to `data/results/` as JSON files.
 Calculate statistics from evaluation runs:
 
 ```bash
-uv run python calc_stats.py
+uv run nixmac-eval stats
 ```
 
 Options:
@@ -87,24 +104,25 @@ The script generates two tables:
 ### Example
 
 ```bash
-# Run all evaluations and analyze results
-uv run python run_evals.py
-uv run python calc_stats.py
+# Run all evaluations, grade, and analyze results
+uv run nixmac-eval run --csv data/test_prompts.csv --ollama-url http://localhost:11434
+uv run nixmac-eval grade
+uv run nixmac-eval stats
 
 # Analyze a specific subset of results
-uv run python calc_stats.py -i ./data/results -s
+uv run nixmac-eval stats -i ./data/results -s
 ```
 
 Run specific cases by row number:
 
 ```bash
-uv run python run_evals.py --cases 5,6,8
+uv run nixmac-eval run --csv data/test_prompts.csv --rows 5,6,8
 ```
 
 ### Run with CSV file
 
 ```sh
-python run_evals.py --csv data/test_prompts.csv
+uv run nixmac-eval run --csv data/test_prompts.csv
 ```
 
 The CSV file should have the following columns:
@@ -122,22 +140,26 @@ The CSV file should have the following columns:
 Run specific test cases by row number:
 
 ```sh
-python run_evals.py --csv data/test_prompts.csv --rows 1,5,10
+uv run nixmac-eval run --csv data/test_prompts.csv --rows 1,5,10
 ```
 
 Filter by persona/quality dimension:
 
 ```sh
-python run_evals.py --csv data/test_prompts.csv --persona correctness
+uv run nixmac-eval run --csv data/test_prompts.csv --persona correctness
 ```
 
 ### Configure AI providers
 
+One of `--ollama-url` or `--vllm-url` selects the backend; `--vllm-url`
+works with any OpenAI-compatible endpoint. API keys are forwarded to the
+nixmac binary via environment variables, never written to disk.
+
 ```sh
-python run_evals.py --csv data/test_prompts.csv \
-  --evolve-provider openai \
-  --evolve-model gpt-4 \
-  --openai-key YOUR_API_KEY
+uv run nixmac-eval run --csv data/test_prompts.csv \
+  --vllm-url https://my-endpoint.example.com/v1 \
+  --vllm-api-key YOUR_API_KEY \
+  --evolve-model gpt-oss-120b
 ```
 
 ### Choose the nix-darwin baseline
@@ -149,20 +171,20 @@ behave on different starting points.
 
 ```sh
 # A different bundled template
-python run_evals.py --csv data/test_prompts.csv --base-config minimal
+uv run nixmac-eval run --csv data/test_prompts.csv --base-config minimal
 
 # A local nix-darwin configuration on disk
-python run_evals.py --csv data/test_prompts.csv \
+uv run nixmac-eval run --csv data/test_prompts.csv \
   --base-config ~/.darwin --host my-mac
 
 # A git repo (shallow-cloned for the duration of the run).
 # Refs use Nix flake-URL syntax — drop them in the URL itself.
-python run_evals.py --csv data/test_prompts.csv \
+uv run nixmac-eval run --csv data/test_prompts.csv \
   --base-config github:me/dotfiles/main \
   --host my-mac
 
 # Same thing as a plain git URL with ?ref=
-python run_evals.py --csv data/test_prompts.csv \
+uv run nixmac-eval run --csv data/test_prompts.csv \
   --base-config 'https://github.com/me/dotfiles.git?ref=main' \
   --host my-mac
 ```

--- a/apps/eval/README.md
+++ b/apps/eval/README.md
@@ -167,6 +167,23 @@ uv run nixmac-eval run --csv data/test_prompts.csv \
   --evolve-model gpt-oss-120b
 ```
 
+Provider arguments also fall back to the environment, so with the
+variables exported a plain `nixmac-eval run --csv ...` works:
+
+| Flag | Environment fallback |
+| ----------------- | ------------------------------ |
+| `--vllm-url` | `VLLM_URL` or `VLLM_API_BASE` |
+| `--vllm-api-key` | `VLLM_API_KEY` |
+| `--ollama-url` | `OLLAMA_URL` or `OLLAMA_API_BASE` |
+| `--evolve-model` | `EVOLVE_MODEL` |
+| `--summary-model` | `SUMMARY_MODEL` |
+
+Explicit flags always win. If both a vLLM and an Ollama endpoint are
+set in the environment, the vLLM one is preferred and a warning is
+printed; pass `--ollama-url` to override. (`OPENAI_API_KEY` and
+`OPENROUTER_API_KEY` are picked up by the nixmac binary itself from
+the inherited environment.)
+
 ### Choose the nix-darwin baseline
 
 By default, every test case starts from the bundled

--- a/apps/eval/calc_stats.py
+++ b/apps/eval/calc_stats.py
@@ -1,13 +1,15 @@
 import argparse
 import json
 import statistics
-from collections.abc import Iterable
 from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 import tabulate
+
+import grade as grading
 
 
 @dataclass
@@ -29,6 +31,45 @@ class ResultMetrics:
     state: str = "generated"
     conversational_reply: str | None = None
     model_name: str | None = None
+    expected_outcome: str | None = None
+    graded_pass: bool | None = None
+    failure_class: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        """Graded verdict when available, engine `ok` otherwise.
+
+        The engine's `ok` only means "a result was produced" — it says
+        nothing about whether the behavior matched the case's
+        expected_outcome, which is what the grader checks.
+        """
+        return self.graded_pass if self.graded_pass is not None else self.ok
+
+
+def ensure_grades(results: list[tuple[int, dict[str, Any]]], csv_path: Path, expectations_path: Path) -> int:
+    """Grade any results that lack a persisted `grade` object, in memory.
+
+    Reuses grade.py's deterministic grader so stats always reflect
+    expected_outcome, even when `grade` hasn't been run on the results dir.
+    Nothing is written back to disk. Returns the number graded in memory.
+    """
+    csv_lookup = grading.load_csv_lookup(csv_path)
+    expectations = grading.load_expectations(expectations_path)
+
+    graded = 0
+    for case_num, data in results:
+        if isinstance(data.get("grade"), dict):
+            continue
+        csv_row = csv_lookup.get(case_num)
+        expected = (csv_row or {}).get("expected_outcome", "")
+        if not expected:
+            continue  # not in the CSV — leave ungraded, falls back to `ok`
+        data["_case_id"] = case_num
+        result = grading.grade_case(data, expected, expectations.get(str(case_num)), csv_row)
+        data.pop("_case_id", None)
+        data["grade"] = grading.grade_to_dict(result)
+        graded += 1
+    return graded
 
 
 def extract_metrics(result_path: Path) -> ResultMetrics | None:
@@ -39,7 +80,15 @@ def extract_metrics(result_path: Path) -> ResultMetrics | None:
 
         # Extract case number from filename (e.g., "case_5_result.json" -> 5)
         case_num = int(result_path.stem.split("_")[1])
+        return extract_metrics_from_data(case_num, data)
+    except (json.JSONDecodeError, KeyError, ValueError) as e:
+        print(f"Warning: Failed to parse {result_path}: {e}")
+        return None
 
+
+def extract_metrics_from_data(case_num: int, data: dict[str, Any]) -> ResultMetrics | None:
+    """Extract metrics from an already loaded result JSON object."""
+    try:
         result = data.get("result", {})
 
         def optional_int(d: dict[str, Any], key: str) -> int | None:
@@ -58,7 +107,11 @@ def extract_metrics(result_path: Path) -> ResultMetrics | None:
             or (result.get("summary") or {}).get("commitMessage")
             or ""
         )
-        state = data.get("state") or result.get("state") or "generated"
+        # Prefer the engine state from telemetry (limitReached, conversational,
+        # failed, ...) over the coarser top-level state, which is "generated"
+        # for any run that produced a result.
+        telemetry_state = (result.get("telemetry") or {}).get("state")
+        state = telemetry_state or data.get("state") or result.get("state") or "generated"
         conversational_reply: str | None = None
         if state == "conversational":
             conversational_reply = (result.get("summary") or {}).get("instructions") or None
@@ -88,6 +141,8 @@ def extract_metrics(result_path: Path) -> ResultMetrics | None:
         # newer `branchHasBuiltCommit` key.
         branch_has_built_commit = bool(git_status.get("branchHasBuiltCommit", git_status.get("headIsBuilt", False)))
 
+        grade_obj = data.get("grade") if isinstance(data.get("grade"), dict) else None
+
         return ResultMetrics(
             case_num=case_num,
             prompt=data.get("prompt", ""),
@@ -104,9 +159,12 @@ def extract_metrics(result_path: Path) -> ResultMetrics | None:
             state=state,
             conversational_reply=conversational_reply,
             model_name=model_name,
+            expected_outcome=grade_obj.get("expected_outcome") if grade_obj else None,
+            graded_pass=grade_obj.get("pass") if grade_obj else None,
+            failure_class=grade_obj.get("failure_class") if grade_obj else None,
         )
-    except (json.JSONDecodeError, KeyError, ValueError) as e:
-        print(f"Warning: Failed to parse {result_path}: {e}")
+    except (KeyError, ValueError) as e:
+        print(f"Warning: Failed to parse result for case {case_num}: {e}")
         return None
 
 
@@ -148,8 +206,8 @@ def calculate_stats(metrics_list: list[ResultMetrics]) -> Statistics:
     if not metrics_list:
         raise ValueError("No valid metrics to analyze")
 
-    passed = [m for m in metrics_list if m.ok]
-    failed = [m for m in metrics_list if not m.ok]
+    passed = [m for m in metrics_list if m.passed]
+    failed = [m for m in metrics_list if not m.passed]
 
     durations = [m.duration_ms for m in metrics_list]
     iterations = [m.iterations for m in metrics_list]
@@ -203,8 +261,8 @@ def print_summary_table(stats: Statistics, metrics_list: list[ResultMetrics]) ->
         except Exception:
             return None
 
-    passed_metrics = [m for m in metrics_list if m.ok]
-    failed_metrics = [m for m in metrics_list if not m.ok]
+    passed_metrics = [m for m in metrics_list if m.passed]
+    failed_metrics = [m for m in metrics_list if not m.passed]
     passed_stats = _safe_calc(passed_metrics)
     failed_stats = _safe_calc(failed_metrics)
 
@@ -272,6 +330,24 @@ def print_summary_table(stats: Statistics, metrics_list: list[ResultMetrics]) ->
     for state, cnt in sorted(counts.items()):
         rows.append([f"  {state}", f"{cnt}", f"{passed_counts.get(state, 0)}", f"{failed_counts.get(state, 0)}"])
 
+    # Graded pass rate per expected outcome (succeed / fail_gracefully / refuse)
+    graded = [m for m in metrics_list if m.expected_outcome]
+    if graded:
+        rows.append(["", "", "", ""])
+        rows.append(["Expected Outcome", "Passed/Total", "", ""])
+        for outcome in sorted({m.expected_outcome for m in graded}):
+            subset = [m for m in graded if m.expected_outcome == outcome]
+            n_pass = sum(1 for m in subset if m.passed)
+            rows.append([f"  {outcome}", f"{n_pass}/{len(subset)}", "", ""])
+
+    # Failure-class breakdown for graded failures
+    fail_classes = Counter(m.failure_class or "unclassified" for m in failed_metrics if m.graded_pass is False)
+    if fail_classes:
+        rows.append(["", "", "", ""])
+        rows.append(["Failure Classes", "Count", "", ""])
+        for cls, cnt in fail_classes.most_common():
+            rows.append([f"  {cls}", f"{cnt}", "", ""])
+
     print("\n" + "=" * 95)
     print(f"EVALUATION STATISTICS SUMMARY — {model_title}")
     print("=" * 95)
@@ -285,33 +361,36 @@ def print_cases_table(metrics_list: list[ResultMetrics]) -> None:
 
     cases_data = []
     for m in sorted_metrics:
-        status = "✓ PASS" if m.ok else "✗ FAIL"
+        status = "✓ PASS" if m.passed else "✗ FAIL"
+        if m.graded_pass is None:
+            status += " (ungraded)"
         if m.state == "conversational" and m.conversational_reply:
             raw = m.conversational_reply.replace("\n", " ").strip()
-            commit_msg_display = ("💬 " + raw)[:80]
-            if len("💬 " + raw) > 80:
-                commit_msg_display = commit_msg_display[:77] + "..."
+            commit_msg_display = ("💬 " + raw)[:60]
+            if len("💬 " + raw) > 60:
+                commit_msg_display = commit_msg_display[:57] + "..."
         else:
             commit_msg_display = m.commit_message or ""
-            if len(commit_msg_display) > 80:
-                commit_msg_display = commit_msg_display[:77] + "..."
+            if len(commit_msg_display) > 60:
+                commit_msg_display = commit_msg_display[:57] + "..."
 
         cases_data.append(
             [
                 m.case_num,
                 status,
+                m.expected_outcome or "-",
+                m.state,
+                m.failure_class or "" if m.graded_pass is False else "",
                 m.iterations,
                 m.build_attempts,
                 f"{m.duration_ms // 1000}s",
                 m.total_tokens,
-                m.thinking_count if m.thinking_count is not None else "-",
-                m.tool_calls_count if m.tool_calls_count is not None else "-",
                 m.edits_count,
                 commit_msg_display,
             ]
         )
 
-    headers = ["#", "Status", "Iters", "Blds", "Dur", "Toks", "Think", "Tools", "Edits", "Commit"]
+    headers = ["#", "Status", "Expected", "State", "Class", "Iters", "Blds", "Dur", "Toks", "Edits", "Commit"]
     print("\n" + "=" * 95)
     print("INDIVIDUAL CASE RESULTS")
     print("=" * 95)
@@ -346,6 +425,18 @@ def main() -> None:
         action="store_true",
         help="Print first parsed ResultMetrics for debugging",
     )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=grading.CSV_PATH,
+        help="Path to test_prompts.csv (used to grade ungraded results in memory)",
+    )
+    parser.add_argument(
+        "--expectations",
+        type=Path,
+        default=grading.EXPECTATIONS_PATH,
+        help="Path to golden_set_expectations.json",
+    )
     args = parser.parse_args()
 
     input_dir = args.input_dir
@@ -359,10 +450,30 @@ def main() -> None:
         print(f"No result files found in {input_dir}")
         return
 
-    # Extract metrics from all result files
-    metrics_list: list[ResultMetrics] = []
+    # Load all results, then grade any that lack a persisted grade so
+    # pass/fail always reflects expected_outcome (grades are computed in
+    # memory only; run grade.py to persist them).
+    results: list[tuple[int, dict[str, Any]]] = []
     for result_file in result_files:
-        metrics = extract_metrics(result_file)
+        try:
+            with result_file.open() as f:
+                data = json.load(f)
+            case_num = int(result_file.stem.split("_")[1])
+        except (json.JSONDecodeError, ValueError, OSError) as e:
+            print(f"Warning: Failed to read {result_file}: {e}")
+            continue
+        results.append((case_num, data))
+
+    graded_in_memory = ensure_grades(results, args.csv, args.expectations)
+    if graded_in_memory:
+        print(
+            f"Note: graded {graded_in_memory} result(s) in memory against "
+            f"expected_outcome; run grade.py to persist grades."
+        )
+
+    metrics_list: list[ResultMetrics] = []
+    for case_num, data in results:
+        metrics = extract_metrics_from_data(case_num, data)
         if metrics:
             metrics_list.append(metrics)
 

--- a/apps/eval/calc_stats.py
+++ b/apps/eval/calc_stats.py
@@ -402,17 +402,18 @@ def print_cases_table(metrics_list: list[ResultMetrics]) -> None:
     print("=" * 95 + "\n")
 
 
-def main() -> None:
-    """Main entry point."""
-    parser = argparse.ArgumentParser(
-        description="Calculate statistics from nixmac evaluation result files"
-    )
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    """Add the stats arguments to `parser` (or a fresh one) and return it."""
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            description="Calculate statistics from nixmac evaluation result files"
+        )
     parser.add_argument(
         "-i",
         "--input-dir",
         type=Path,
-        default=Path("./data/results"),
-        help="Directory containing result JSON files (default: ./data/results)",
+        default=grading.DEFAULT_RESULTS_DIR,
+        help="Directory containing result JSON files (default: data/results)",
     )
     parser.add_argument(
         "-s",
@@ -437,8 +438,12 @@ def main() -> None:
         default=grading.EXPECTATIONS_PATH,
         help="Path to golden_set_expectations.json",
     )
-    args = parser.parse_args()
+    parser.set_defaults(func=main)
+    return parser
 
+
+def main(args: argparse.Namespace) -> None:
+    """Compute and print statistics for the results in `args.input_dir`."""
     input_dir = args.input_dir
     if not input_dir.exists():
         print(f"Error: Input directory does not exist: {input_dir}")
@@ -498,4 +503,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(build_parser().parse_args())

--- a/apps/eval/cli.py
+++ b/apps/eval/cli.py
@@ -1,0 +1,66 @@
+"""nixmac-eval: unified CLI for the nixmac evaluation suite.
+
+One tool, four subcommands covering the whole eval workflow:
+
+    nixmac-eval run    --csv data/test_prompts.csv --vllm-url ...   # run cases
+    nixmac-eval grade  -i data/results                              # persist grades
+    nixmac-eval stats  -i data/results                              # scorecard tables
+    nixmac-eval report -i data/results -o data/report               # HTML report
+
+Each subcommand delegates to its module (run_evals, grade, calc_stats,
+generate_report), which all remain runnable standalone via
+`python <module>.py` with identical flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import calc_stats
+import generate_report
+import grade
+import run_evals
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="nixmac-eval",
+        description="Evaluate nixmac's evolution engine: run cases, grade, summarize, report.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_evals.build_parser(
+        sub.add_parser(
+            "run",
+            help="Run evaluation cases against a nixmac binary (hermetic per-case state)",
+        )
+    )
+    grade.build_parser(
+        sub.add_parser(
+            "grade",
+            help="Grade results against expected outcomes and persist grade objects",
+        )
+    )
+    calc_stats.build_parser(
+        sub.add_parser(
+            "stats",
+            help="Print scorecard tables (grades ungraded results in memory)",
+        )
+    )
+    generate_report.build_parser(
+        sub.add_parser(
+            "report",
+            help="Generate an HTML report from (graded) results",
+        )
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args) or 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/eval/cli.py
+++ b/apps/eval/cli.py
@@ -1,26 +1,112 @@
 """nixmac-eval: unified CLI for the nixmac evaluation suite.
 
-One tool, four subcommands covering the whole eval workflow:
+One tool covering the whole eval workflow:
 
     nixmac-eval run    --csv data/test_prompts.csv --vllm-url ...   # run cases
     nixmac-eval grade  -i data/results                              # persist grades
     nixmac-eval stats  -i data/results                              # scorecard tables
     nixmac-eval report -i data/results -o data/report               # HTML report
 
+    nixmac-eval all    --csv data/test_prompts.csv --vllm-url ...   # all of the above
+
 Each subcommand delegates to its module (run_evals, grade, calc_stats,
 generate_report), which all remain runnable standalone via
-`python <module>.py` with identical flags.
+`python <module>.py` with identical flags. `all` chains the four steps
+in order against one results directory.
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
 import calc_stats
 import generate_report
 import grade
 import run_evals
+
+
+def build_all_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """The `all` subcommand: run → grade → stats → report in one go.
+
+    Takes the full set of `run` flags plus the report/stats knobs that
+    make sense for the whole pipeline. `--results-dir` (or the run
+    default, data/results) is the shared handoff directory.
+    """
+    run_evals.build_parser(parser)
+    parser.add_argument(
+        "--expectations",
+        type=Path,
+        default=grade.EXPECTATIONS_PATH,
+        help="Path to golden_set_expectations.json (grade/stats/report)",
+    )
+    parser.add_argument(
+        "--golden-only",
+        action="store_true",
+        help="Only grade/report cases in the golden set",
+    )
+    parser.add_argument(
+        "-s",
+        "--summary-only",
+        action="store_true",
+        help="Show only summary statistics, not individual cases",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        default=generate_report.DEFAULT_OUTPUT,
+        help="Directory to write the HTML report (default: data/report)",
+    )
+    parser.set_defaults(func=main_all)
+    return parser
+
+
+def main_all(args: argparse.Namespace) -> int:
+    """Run the whole pipeline against a single results directory."""
+    results_dir = Path(args.results_dir).expanduser() if args.results_dir else run_evals.RESULTS_DIR
+    csv_path = Path(args.csv) if args.csv else grade.CSV_PATH
+
+    print(f"[1/4] run    → {results_dir}")
+    run_evals.main(args)
+
+    print(f"\n[2/4] grade  → {results_dir}")
+    grade.main(
+        argparse.Namespace(
+            input_dir=results_dir,
+            output_dir=None,
+            golden_only=args.golden_only,
+            csv=csv_path,
+            expectations=args.expectations,
+        )
+    )
+
+    print(f"\n[3/4] stats  → {results_dir}")
+    calc_stats.main(
+        argparse.Namespace(
+            input_dir=results_dir,
+            summary_only=args.summary_only,
+            debug=False,
+            csv=csv_path,
+            expectations=args.expectations,
+        )
+    )
+
+    print(f"\n[4/4] report → {args.output_dir}")
+    return int(
+        generate_report.main(
+            argparse.Namespace(
+                input_dir=results_dir,
+                output_dir=args.output_dir,
+                csv=csv_path,
+                expectations=args.expectations,
+                run_meta=None,
+                golden_only=args.golden_only,
+            )
+        )
+        or 0
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -52,6 +138,12 @@ def build_parser() -> argparse.ArgumentParser:
         sub.add_parser(
             "report",
             help="Generate an HTML report from (graded) results",
+        )
+    )
+    build_all_parser(
+        sub.add_parser(
+            "all",
+            help="Run the whole pipeline: run → grade → stats → report",
         )
     )
     return parser

--- a/apps/eval/generate_report.py
+++ b/apps/eval/generate_report.py
@@ -36,8 +36,9 @@ DEFAULT_CSV = SCRIPT_DIR / "data" / "test_prompts.csv"
 DEFAULT_EXPECTATIONS = SCRIPT_DIR / "data" / "golden_set_expectations.json"
 
 
-def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    """Add the report arguments to `parser` (or a fresh one) and return it."""
+    p = parser if parser is not None else argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("-i", "--input-dir", type=Path, default=DEFAULT_RESULTS,
                    help="Directory of case_*_result.json (default: data/results)")
     p.add_argument("-o", "--output-dir", type=Path, default=DEFAULT_OUTPUT,
@@ -49,11 +50,11 @@ def parse_args() -> argparse.Namespace:
                    help="Path to run_meta.json (default: <input-dir>/run_meta.json)")
     p.add_argument("--golden-only", action="store_true",
                    help="Only include cases in the golden set")
-    return p.parse_args()
+    p.set_defaults(func=main)
+    return p
 
 
-def main() -> int:
-    args = parse_args()
+def main(args: argparse.Namespace) -> int:
     run = loader.load(
         results_dir=args.input_dir,
         csv_path=args.csv,
@@ -73,4 +74,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(build_parser().parse_args()))

--- a/apps/eval/grade.py
+++ b/apps/eval/grade.py
@@ -612,8 +612,12 @@ def grade_to_dict(grade: GradeResult) -> dict[str, Any]:
     }
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Grade nixmac eval results (Phase 1 deterministic)")
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    """Add the grading arguments to `parser` (or a fresh one) and return it."""
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            description="Grade nixmac eval results (Phase 1 deterministic)"
+        )
     parser.add_argument(
         "-i", "--input-dir",
         type=Path,
@@ -643,8 +647,12 @@ def main() -> None:
         default=EXPECTATIONS_PATH,
         help="Path to golden_set_expectations.json",
     )
-    args = parser.parse_args()
+    parser.set_defaults(func=main)
+    return parser
 
+
+def main(args: argparse.Namespace) -> None:
+    """Grade the results in `args.input_dir` and persist grade objects."""
     if not args.input_dir.exists():
         print(f"Error: Input directory does not exist: {args.input_dir}")
         return
@@ -782,4 +790,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(build_parser().parse_args())

--- a/apps/eval/pyproject.toml
+++ b/apps/eval/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nixmac-eval"
 version = "1.0.0"
 description = "AI Evolution Engine Evaluation runner for nixmac"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "openpyxl>=3.0.0",
     "gitpython>=3.1.46",
@@ -14,4 +14,22 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "types-tabulate>=0.9.0.20241207",
+]
+
+[project.scripts]
+nixmac-eval = "cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+# Flat module layout: ship the top-level modules and the report package.
+[tool.hatch.build.targets.wheel]
+include = [
+    "cli.py",
+    "run_evals.py",
+    "calc_stats.py",
+    "grade.py",
+    "generate_report.py",
+    "report/",
 ]

--- a/apps/eval/run_evals.py
+++ b/apps/eval/run_evals.py
@@ -619,13 +619,64 @@ def generate_nixmac_settings(
     print(f"Generated nixmac settings at: {settings_path}")
 
 
+def _env_first(*names: str) -> str:
+    """First non-empty value among the given environment variables, or ""."""
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def resolve_backend_from_env(parsed_args: argparse.Namespace) -> None:
+    """Fill in backend arguments from the environment when flags are absent.
+
+    Precedence: explicit CLI flags always win. When neither --ollama-url
+    nor --vllm-url is given, fall back to the environment — preferring the
+    vLLM/OpenAI-compatible endpoint (VLLM_URL or VLLM_API_BASE) over Ollama
+    (OLLAMA_URL or OLLAMA_API_BASE), since hosted endpoints are usually
+    exported deliberately for a session. If both are present in the
+    environment, warn about the choice and how to override it.
+
+    The vLLM API key similarly falls back to VLLM_API_KEY. (OPENAI_API_KEY
+    and OPENROUTER_API_KEY need no handling here: the nixmac binary already
+    resolves those env-first from the inherited child environment.)
+    """
+    if not parsed_args.ollama_url.strip() and not parsed_args.vllm_url.strip():
+        env_vllm = _env_first("VLLM_URL", "VLLM_API_BASE")
+        env_ollama = _env_first("OLLAMA_URL", "OLLAMA_API_BASE")
+        if env_vllm and env_ollama:
+            print(
+                "Warning: both vLLM (VLLM_URL/VLLM_API_BASE) and Ollama "
+                "(OLLAMA_URL/OLLAMA_API_BASE) endpoints are set in the "
+                "environment; preferring vLLM. Pass --ollama-url explicitly "
+                "to use Ollama."
+            )
+        if env_vllm:
+            parsed_args.vllm_url = env_vllm
+            print(f"Using vLLM endpoint from environment: {env_vllm}")
+        elif env_ollama:
+            parsed_args.ollama_url = env_ollama
+            print(f"Using Ollama endpoint from environment: {env_ollama}")
+
+    if parsed_args.vllm_url.strip() and not parsed_args.vllm_api_key:
+        env_key = _env_first("VLLM_API_KEY")
+        if env_key:
+            parsed_args.vllm_api_key = env_key
+            print("Using vLLM API key from environment (VLLM_API_KEY)")
+
+
 def main(parsed_args: argparse.Namespace) -> None:
+    resolve_backend_from_env(parsed_args)
+
     # Validate that at least one backend is configured: either ollama or vllm
     ollama_set = bool(getattr(parsed_args, "ollama_url", None)) and parsed_args.ollama_url.strip() != ""
     vllm_set = bool(getattr(parsed_args, "vllm_url", None)) and parsed_args.vllm_url.strip() != ""
     if not (ollama_set or vllm_set):
         print(
-            "Error: you must provide either --ollama-url or --vllm-url (and optionally --vllm-api-key)"
+            "Error: no model backend configured. Pass --ollama-url or "
+            "--vllm-url, or export VLLM_URL/VLLM_API_BASE or "
+            "OLLAMA_URL/OLLAMA_API_BASE (plus VLLM_API_KEY if needed)."
         )
         raise SystemExit(2)
 
@@ -786,15 +837,19 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
     parser.add_argument(
         "--nixmac", type=str, default=str(DEFAULT_NIXMAC), help="Path to nixmac binary"
     )
-    # Flags mirroring main nixmac app settings
+    # Flags mirroring main nixmac app settings. Model defaults honor the
+    # same env vars the nixmac binary uses (EVOLVE_MODEL / SUMMARY_MODEL).
     parser.add_argument(
-        "--evolve-model", type=str, default=DEFAULT_EVOLVE_MODEL, help="Evolve model (e.g. gpt-4)"
+        "--evolve-model",
+        type=str,
+        default=os.environ.get("EVOLVE_MODEL") or DEFAULT_EVOLVE_MODEL,
+        help=f"Evolve model (env: EVOLVE_MODEL; default: {DEFAULT_EVOLVE_MODEL})",
     )
     parser.add_argument(
         "--summary-model",
         type=str,
-        default=DEFAULT_SUMMARY_MODEL,
-        help="Summary model (e.g. gpt-4)",
+        default=os.environ.get("SUMMARY_MODEL") or DEFAULT_SUMMARY_MODEL,
+        help=f"Summary model (env: SUMMARY_MODEL; default: {DEFAULT_SUMMARY_MODEL})",
     )
     parser.add_argument(
         "--openai-key", dest="openai_key", type=str, default=None, help="OpenAI API key"
@@ -810,21 +865,24 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
         dest="ollama_url",
         type=str,
         default="",
-        help="Ollama base URL (e.g. http://localhost:11434)",
+        help="Ollama base URL, e.g. http://localhost:11434 (env: OLLAMA_URL or OLLAMA_API_BASE)",
     )
     parser.add_argument(
         "--vllm-url",
         dest="vllm_url",
         type=str,
         default="",
-        help="vLLM base URL (e.g. http://100.111.97.14:8002/v1)",
+        help=(
+            "OpenAI-compatible/vLLM base URL, e.g. https://host/v1 "
+            "(env: VLLM_URL or VLLM_API_BASE; preferred over Ollama when both are set)"
+        ),
     )
     parser.add_argument(
         "--vllm-api-key",
         dest="vllm_api_key",
         type=str,
         default=None,
-        help="vLLM API key (if required)",
+        help="vLLM API key if required (env: VLLM_API_KEY)",
     )
     parser.add_argument("--host", type=str, default=None, help="Host name for your Mac")
 

--- a/apps/eval/run_evals.py
+++ b/apps/eval/run_evals.py
@@ -247,7 +247,12 @@ def _get_eval_hostname() -> str:
         return "localhost"
 
 
-def create_nix_config_git_repo(template_dir: Path, hostname: str | None = None):
+def create_nix_config_git_repo(
+    template_dir: Path,
+    hostname: str | None = None,
+    max_token_budget: int | None = None,
+    max_iterations: int | None = None,
+):
     """
     Create a temporary nix config git repo from `template_dir`, with hostname
     and platform placeholders replaced (where present), ready for nix-darwin
@@ -300,11 +305,20 @@ def create_nix_config_git_repo(template_dir: Path, hostname: str | None = None):
     # a part of dirty changes is noisy and obfuscates the actual changes
     # made by the evolve engine during test runs.
     #
-    # .nixmac/ holds repo-scoped EvolutionLimits (maxTokenBudget,
-    # maxIterations, etc.) the eval writes per-case via
-    # generate_repo_scoped_settings; keep it out of git so it doesn't
-    # show up in the model's view of the working tree.
-    (tmpdir / ".gitignore").write_text("flake.lock\n.nixmac/\n")
+    # .nixmac/ must NOT be gitignored: the template's flake.nix imports
+    # ./.nixmac as a module, and nix flakes only see git-tracked files, so
+    # ignoring it makes every build_check fail before the model has done
+    # anything. It is also where repo-scoped EvolutionLimits live
+    # (mirroring production, where .nixmac/settings.json is tracked so it
+    # follows the repo across machines) — write them before the initial
+    # commit so they are committed and the tree starts clean.
+    (tmpdir / ".gitignore").write_text("flake.lock\n")
+
+    generate_repo_scoped_settings(
+        tmpdir,
+        max_token_budget=max_token_budget,
+        max_iterations=max_iterations,
+    )
 
     # Initialize git repo
     repo = Repo.init(str(tmpdir))
@@ -357,7 +371,15 @@ def run_test_case(
     result_dir: Path | None = None
     app_data_dir: Path | None = None
     try:
-        config_dir = create_nix_config_git_repo(template_dir, hostname=eval_hostname)
+        # Repo-scoped EvolutionLimits (maxTokenBudget, maxIterations) are
+        # written into <config_dir>/.nixmac/settings.json and committed as
+        # part of the fixture's initial state.
+        config_dir = create_nix_config_git_repo(
+            template_dir,
+            hostname=eval_hostname,
+            max_token_budget=max_token_budget,
+            max_iterations=max_iterations,
+        )
         print(f"Created git repo with config at: {config_dir}")
 
         # Fresh hermetic app-data dir per case: the binary roots ALL of its
@@ -366,15 +388,6 @@ def run_test_case(
         # nothing leaks between cases.
         app_data_dir = Path(tempfile.mkdtemp(prefix="nixmac-appdata-"))
         print(f"Created hermetic app-data dir at: {app_data_dir}")
-
-        # Repo-scoped EvolutionLimits (maxTokenBudget, maxIterations) live
-        # under <config_dir>/.nixmac/settings.json. Write after git init
-        # so the file lands in the .gitignored .nixmac/ dir.
-        generate_repo_scoped_settings(
-            config_dir,
-            max_token_budget=max_token_budget,
-            max_iterations=max_iterations,
-        )
 
         # Generate nixmac settings.json pointing to the config dir
         # Use the same eval_hostname for hostAttr so template and build agree

--- a/apps/eval/run_evals.py
+++ b/apps/eval/run_evals.py
@@ -48,11 +48,12 @@ DEFAULT_TEMPLATE_NAME = "nix-darwin-determinate"
 # Default nixmac binary built from this repo (build with `cargo build` at the root).
 DEFAULT_NIXMAC = REPO_ROOT / "target/debug/nixmac"
 
-# Directory containing nixmac config/state files (settings.json, evolve-state.json, etc.)
-NIXMAC_CONFIG_DIR: Path = Path.home() / "Library" / "Application Support" / "com.darkmatter.nixmac"
-
-# System nixmac settings.json (~/Library/Application Support/com.darkmatter.nixmac/settings.json)
-NIXMAC_SETTINGS_PATH: Path = NIXMAC_CONFIG_DIR / "settings.json"
+# Environment variable the nixmac binary honors to root ALL of its per-device
+# state (settings.json, global-preferences.json, nixmac.db, secrets, ...) in a
+# directory of our choosing. Each test case gets a fresh temp dir, so eval runs
+# are fully hermetic: they can never read or mutate the developer's real app
+# state, credentials, or nix config.
+NIXMAC_APP_DATA_DIR_ENV = "NIXMAC_APP_DATA_DIR"
 
 # Populated in __main__ when running as a script
 args: argparse.Namespace | None = None
@@ -336,6 +337,7 @@ def run_test_case(
     openai_key: str | None = None,
     openrouter_key: str | None = None,
     auth_props: dict | None = None,
+    api_key_env: dict | None = None,
     max_iterations: int | None = None,
     max_token_budget: int | None = None,
     host: str | None = None,
@@ -353,9 +355,17 @@ def run_test_case(
     # Create a git repo in a temporary directory from nix-darwin-determinate
     config_dir: Path | None = None
     result_dir: Path | None = None
+    app_data_dir: Path | None = None
     try:
         config_dir = create_nix_config_git_repo(template_dir, hostname=eval_hostname)
         print(f"Created git repo with config at: {config_dir}")
+
+        # Fresh hermetic app-data dir per case: the binary roots ALL of its
+        # per-device state here (via NIXMAC_APP_DATA_DIR), so nothing is
+        # read from or written to the developer's real app state, and
+        # nothing leaks between cases.
+        app_data_dir = Path(tempfile.mkdtemp(prefix="nixmac-appdata-"))
+        print(f"Created hermetic app-data dir at: {app_data_dir}")
 
         # Repo-scoped EvolutionLimits (maxTokenBudget, maxIterations) live
         # under <config_dir>/.nixmac/settings.json. Write after git init
@@ -369,10 +379,9 @@ def run_test_case(
         # Generate nixmac settings.json pointing to the config dir
         # Use the same eval_hostname for hostAttr so template and build agree
         generate_nixmac_settings(
+            app_data_dir,
             evolve_model,
             summary_model,
-            openai_key,
-            openrouter_key,
             auth_props,
             max_iterations,
             max_token_budget,
@@ -390,6 +399,19 @@ def run_test_case(
         # the stop_requested handler until after the child exits.
         # This way we don't have to Ctrl-C O(n) times stop a long-running test suite.
         cmd = [str(nixmac), "evolve", case.request, "--out", str(out_path)]
+
+        # Hermetic state root plus env-first API keys. The keys go through
+        # the environment because that is the binary's highest-precedence
+        # secret source and it keeps them out of on-disk settings.
+        child_env = os.environ.copy()
+        child_env[NIXMAC_APP_DATA_DIR_ENV] = str(app_data_dir)
+        if openai_key:
+            child_env["OPENAI_API_KEY"] = openai_key
+        if openrouter_key:
+            child_env["OPENROUTER_API_KEY"] = openrouter_key
+        for env_key, value in (api_key_env or {}).items():
+            child_env[env_key] = value
+
         timed_out = False
         timeout_seconds = case_timeout if case_timeout and case_timeout > 0 else None
         # Run in a new session so subprocess.run can kill the whole process
@@ -401,6 +423,7 @@ def run_test_case(
                 check=False,
                 timeout=timeout_seconds,
                 start_new_session=True,
+                env=child_env,
             )
         except subprocess.TimeoutExpired:
             timed_out = True
@@ -409,6 +432,10 @@ def run_test_case(
                 f"{timeout_seconds}s; killed nixmac. "
                 f"See apps/eval/wip/evolve_limits-plan.md for the proper fix."
             )
+
+        # Refuse to continue if the binary ignored the hermetic override —
+        # that would mean this case just ran against real user state.
+        assert_hermetic_run(app_data_dir)
 
         # If we timed out, prefer a structured stub so the result is recorded
         # but graders can distinguish a timeout from a successful or
@@ -454,6 +481,10 @@ def run_test_case(
             print(f"Cleaning up temporary evolution result directory: {result_dir}")
             with suppress(Exception):
                 shutil.rmtree(result_dir)
+        if app_data_dir is not None:
+            print(f"Cleaning up hermetic app-data directory: {app_data_dir}")
+            with suppress(Exception):
+                shutil.rmtree(app_data_dir)
 
 
 def update_test_case_status(case_num: Any, result: Any, results_dir: Path = RESULTS_DIR) -> None:
@@ -466,72 +497,23 @@ def update_test_case_status(case_num: Any, result: Any, results_dir: Path = RESU
     print(f"Saved results for case {case_num} to: {result_path}")
 
 
-def backup_nixmac_settings() -> dict:
-    """Back up nixmac config/state files.
+def assert_hermetic_run(app_data_dir: Path) -> None:
+    """Verify the nixmac binary actually honored NIXMAC_APP_DATA_DIR.
 
-    Copies any existing files to a .bak sibling and deletes the originals
-    so each run starts from a known-empty state. Restored from the .bak
-    siblings at the end of main().
-
-    `global-preferences.json` is included because PR #411 on the nixmac
-    side moved GlobalPreferences (configDir, repoRoot, host, model,
-    provider, …) onto a managed Observable persisted there. The legacy
-    settings.json is only consulted via a one-shot migration that
-    *overrides* only fields present in the eval-written settings.json;
-    any field the eval doesn't write (e.g. repoRoot, set by prior GUI
-    use) would otherwise leak through and override the eval's intent.
-    Wiping global-preferences.json forces the observable to start from
-    Default and pick up the eval's values via migration each run.
-    Returns a dict mapping original Path -> backup Path for later
-    restoration.
+    A binary built before the hermetic override existed would silently fall
+    back to the real OS app-data directory — running the evolution against
+    the developer's real nix config with their real credentials. The CLI
+    always creates its sqlite DB in the app-data dir on startup, so its
+    absence in the hermetic dir means the override was ignored. Abort the
+    whole suite in that case rather than keep spawning unsafe runs.
     """
-    backups: dict[Path, Path] = {}
-
-    candidates = [
-        NIXMAC_SETTINGS_PATH,
-        NIXMAC_CONFIG_DIR / "global-preferences.json",
-        NIXMAC_CONFIG_DIR / "evolve-state.json",
-        NIXMAC_CONFIG_DIR / "build-state.json",
-    ]
-
-    for p in candidates:
-        try:
-            if p.exists():
-                backup_path = p.with_suffix(".bak")
-                shutil.copy2(p, backup_path)
-                print(f"Backed up {p.name} to: {backup_path}")
-                # remove the original so tests start from a clean slate
-                p.unlink()
-                print(f"Removed original {p}")
-                backups[p] = backup_path
-        except Exception as exc:
-            print(f"Warning: failed to back up {p}: {exc}")
-
-    if not backups:
-        print("No nixmac files found to back up.")
-
-    return backups
-
-
-def restore_nixmac_settings(backups: dict) -> None:
-    """Restore previously backed up nixmac files from the provided mapping.
-
-    `backups` should be the dict returned from `backup_nixmac_settings`.
-    """
-    if not backups:
-        print("No nixmac backups to restore.")
-        return
-
-    for original_path, backup_path in backups.items():
-        try:
-            if backup_path.exists():
-                shutil.copy2(backup_path, original_path)
-                backup_path.unlink()
-                print(f"Restored {original_path.name} from backup: {backup_path}")
-            else:
-                print(f"Backup not found for {original_path}: {backup_path}")
-        except Exception as exc:
-            print(f"Warning: failed to restore {original_path} from {backup_path}: {exc}")
+    if not (app_data_dir / "nixmac.db").exists():
+        raise RuntimeError(
+            f"nixmac did not write state into {app_data_dir}; the binary "
+            f"appears to ignore {NIXMAC_APP_DATA_DIR_ENV}. Rebuild nixmac "
+            "from this repo (the hermetic override is required for eval "
+            "runs) — refusing to continue against real user state."
+        )
 
 
 def generate_repo_scoped_settings(
@@ -564,37 +546,33 @@ def generate_repo_scoped_settings(
 
 
 def generate_nixmac_settings(
+    app_data_dir: Path,
     evolve_model: str | None = None,
     summary_model: str | None = None,
-    openai_key: str | None = None,
-    openrouter_key: str | None = None,
     auth_props: dict | None = None,
     max_iterations: int | None = None,
     max_token_budget: int | None = None,
     host: str | None = None,
     configDir: str | None = None,
 ) -> None:
-    """Generate a nixmac settings.json file based on provided parameters."""
+    """Write a legacy-format settings.json into the hermetic app-data dir.
+
+    The binary's one-shot legacy migration copies these values into its
+    GlobalPreferences on first load. Because `app_data_dir` is a fresh temp
+    dir per case, there is no stale global-preferences.json to override them
+    and nothing leaks between cases.
+
+    API keys are NOT written here — the binary only reads secrets from the
+    legacy store under the e2e mock-system gate. They are passed via the
+    child environment instead (OPENAI_API_KEY etc.), which the binary's
+    env-first secret resolution picks up.
+    """
     if host is None:
         host = _get_eval_hostname()
-
-    # Wipe the observable's persisted file BETWEEN cases as well, not just
-    # at the start of main(). After any successful case the binary persists
-    # derived state (repoRoot, etc.) back to global-preferences.json; the
-    # legacy-store migration only overrides keys present in the eval-written
-    # settings.json, so fields like repoRoot — which the eval doesn't write
-    # — would otherwise leak from case N into case N+1 and point at a temp
-    # dir that's already been cleaned up.
-    global_prefs_path = NIXMAC_CONFIG_DIR / "global-preferences.json"
-    if global_prefs_path.exists():
-        with suppress(Exception):
-            global_prefs_path.unlink()
 
     settings = {
         "evolveModel": evolve_model,
         "summaryModel": summary_model,
-        "openaiApiKey": openai_key,
-        "openrouterApiKey": openrouter_key,
         "hostAttr": host,
         "configDir": configDir,
     }
@@ -609,32 +587,30 @@ def generate_nixmac_settings(
     if max_token_budget is not None:
         settings["maxTokenBudget"] = max_token_budget
 
-    # Merge any auth_props (e.g., ollamaApiBaseUrl OR vllmApiBaseUrl/vllmApiKey)
-    # Also set provider per auth type.
+    # Merge any auth_props (ollamaApiBaseUrl OR openaiCompatibleApiBaseUrl)
+    # and set the provider per auth type. "openai_compatible" is the current
+    # name for what the eval flags still call vLLM.
     if auth_props is not None:
         for k, v in auth_props.items():
             settings[k] = v
 
-        # Derive provider kind from auth_props after merging: prefer ollama, else vllm
         provider: str | None = None
         if "ollamaApiBaseUrl" in auth_props:
             provider = "ollama"
-        elif "vllmApiBaseUrl" in auth_props:
-            provider = "vllm"
+        elif "openaiCompatibleApiBaseUrl" in auth_props:
+            provider = "openai_compatible"
 
         settings["evolveProvider"] = provider
         settings["summaryProvider"] = provider
 
-    NIXMAC_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    with open(NIXMAC_SETTINGS_PATH, "w") as f:
+    app_data_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = app_data_dir / "settings.json"
+    with open(settings_path, "w") as f:
         json.dump(settings, f, indent=4)
-    print(f"Generated nixmac settings at: {NIXMAC_SETTINGS_PATH}")
+    print(f"Generated nixmac settings at: {settings_path}")
 
 
 def main(parsed_args: argparse.Namespace) -> None:
-    # Back up nixmac files (settings.json, evolve-state.json, build-state.json)
-    # before running any test cases, and restore them at the end
-    backups = backup_nixmac_settings()
     stop_requested = False
 
     def _sigint_handler(signum, frame):
@@ -724,6 +700,7 @@ def main(parsed_args: argparse.Namespace) -> None:
             try:
                 # Build auth_props based on which backend URL is provided (ollama or vllm); validate that both are not provided at the same time
                 auth_props: dict | None = None
+                api_key_env: dict = {}
                 ollama_url = getattr(parsed_args, "ollama_url", "").strip()
                 vllm_url = getattr(parsed_args, "vllm_url", "").strip()
 
@@ -735,10 +712,12 @@ def main(parsed_args: argparse.Namespace) -> None:
                 if ollama_url:
                     auth_props = {"ollamaApiBaseUrl": ollama_url}
                 elif vllm_url:
-                    auth_props = {"vllmApiBaseUrl": vllm_url}
+                    # vLLM is served through the binary's "openai_compatible"
+                    # provider; its key travels via the VLLM_API_KEY env var.
+                    auth_props = {"openaiCompatibleApiBaseUrl": vllm_url}
                     vllm_api_key = getattr(parsed_args, "vllm_api_key", None)
                     if vllm_api_key:
-                        auth_props["vllmApiKey"] = vllm_api_key
+                        api_key_env["VLLM_API_KEY"] = vllm_api_key
 
                 # Run the test case and capture the result
                 result = run_test_case(
@@ -750,6 +729,7 @@ def main(parsed_args: argparse.Namespace) -> None:
                     parsed_args.openai_key,
                     parsed_args.openrouter_key,
                     auth_props,
+                    api_key_env,
                     parsed_args.max_iterations,
                     parsed_args.max_token_budget,
                     parsed_args.host,
@@ -772,8 +752,6 @@ def main(parsed_args: argparse.Namespace) -> None:
             signal.signal(signal.SIGINT, old_handler)
         except Exception:
             pass
-
-        restore_nixmac_settings(backups)
 
         # Clean up the session-level cloned base config, if any.
         if clone_dir is not None:

--- a/apps/eval/run_evals.py
+++ b/apps/eval/run_evals.py
@@ -5,13 +5,13 @@
 
 import argparse
 import csv
+import getpass
 import json
 import os
 import shutil
+import signal
 import subprocess
 import tempfile
-import getpass
-import signal
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -54,10 +54,6 @@ DEFAULT_NIXMAC = REPO_ROOT / "target/debug/nixmac"
 # are fully hermetic: they can never read or mutate the developer's real app
 # state, credentials, or nix config.
 NIXMAC_APP_DATA_DIR_ENV = "NIXMAC_APP_DATA_DIR"
-
-# Populated in __main__ when running as a script
-args: argparse.Namespace | None = None
-
 
 def _looks_like_git_url(value: str) -> bool:
     """Heuristic: is `value` a git URL rather than a local path?"""
@@ -624,6 +620,15 @@ def generate_nixmac_settings(
 
 
 def main(parsed_args: argparse.Namespace) -> None:
+    # Validate that at least one backend is configured: either ollama or vllm
+    ollama_set = bool(getattr(parsed_args, "ollama_url", None)) and parsed_args.ollama_url.strip() != ""
+    vllm_set = bool(getattr(parsed_args, "vllm_url", None)) and parsed_args.vllm_url.strip() != ""
+    if not (ollama_set or vllm_set):
+        print(
+            "Error: you must provide either --ollama-url or --vllm-url (and optionally --vllm-api-key)"
+        )
+        raise SystemExit(2)
+
     stop_requested = False
 
     def _sigint_handler(signum, frame):
@@ -773,8 +778,10 @@ def main(parsed_args: argparse.Namespace) -> None:
                 shutil.rmtree(clone_dir)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Run evaluation test cases.")
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    """Add the run arguments to `parser` (or a fresh one) and return it."""
+    if parser is None:
+        parser = argparse.ArgumentParser(description="Run evaluation test cases.")
 
     parser.add_argument(
         "--nixmac", type=str, default=str(DEFAULT_NIXMAC), help="Path to nixmac binary"
@@ -903,15 +910,9 @@ if __name__ == "__main__":
         "--persona", type=str, help="Filter test cases by persona (e.g., --persona Developer)"
     )
 
-    args = parser.parse_args()
+    parser.set_defaults(func=main)
+    return parser
 
-    # Validate that at least one backend is configured: either ollama or vllm
-    ollama_set = bool(getattr(args, "ollama_url", None)) and args.ollama_url.strip() != ""
-    vllm_set = bool(getattr(args, "vllm_url", None)) and args.vllm_url.strip() != ""
-    if not (ollama_set or vllm_set):
-        print(
-            "Error: you must provide either --ollama-url or --vllm-url (and optionally --vllm-api-key)"
-        )
-        raise SystemExit(2)
 
-    main(args)
+if __name__ == "__main__":
+    main(build_parser().parse_args())

--- a/apps/eval/run_evals.py
+++ b/apps/eval/run_evals.py
@@ -36,14 +36,17 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 # Location where we store JSON evaluation results during test runs
 RESULTS_DIR: Path = SCRIPT_DIR / "data/results"
 
+# Repository root (the eval suite lives in apps/eval of the nixmac repo).
+REPO_ROOT: Path = SCRIPT_DIR.parent.parent
+
 # Directory holding all bundled nix-darwin templates (one subdir per template).
-TEMPLATES_DIR: Path = SCRIPT_DIR.parent.parent / "vendor/nixmac/apps/native/templates"
+TEMPLATES_DIR: Path = REPO_ROOT / "apps/native/templates"
 
 # Template used when no --base-config is supplied.
 DEFAULT_TEMPLATE_NAME = "nix-darwin-determinate"
 
-# Default nixmac binary from the vendored public repo submodule (build with `cargo build` there).
-DEFAULT_NIXMAC = SCRIPT_DIR.parent.parent / "vendor/nixmac/target/debug/nixmac"
+# Default nixmac binary built from this repo (build with `cargo build` at the root).
+DEFAULT_NIXMAC = REPO_ROOT / "target/debug/nixmac"
 
 # Directory containing nixmac config/state files (settings.json, evolve-state.json, etc.)
 NIXMAC_CONFIG_DIR: Path = Path.home() / "Library" / "Application Support" / "com.darkmatter.nixmac"

--- a/apps/eval/uv.lock
+++ b/apps/eval/uv.lock
@@ -1,11 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.8"
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
-]
+requires-python = ">=3.10"
 
 [[package]]
 name = "et-xmlfile"
@@ -34,8 +29,6 @@ version = "3.1.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
 wheels = [
@@ -47,8 +40,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markupsafe", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -57,73 +49,8 @@ wheels = [
 
 [[package]]
 name = "markupsafe"
-version = "2.1.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384, upload-time = "2024-02-02T16:31:22.863Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/54/ad5eb37bf9d51800010a74e4665425831a9db4e7c4e0fde4352e391e808e/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc", size = 18206, upload-time = "2024-02-02T16:30:04.105Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/4a/a4d49415e600bacae038c67f9fecc1d5433b9d3c71a4de6f33537b89654c/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5", size = 14079, upload-time = "2024-02-02T16:30:06.5Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46", size = 26620, upload-time = "2024-02-02T16:30:08.31Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f", size = 25818, upload-time = "2024-02-02T16:30:09.577Z" },
-    { url = "https://files.pythonhosted.org/packages/29/fe/a36ba8c7ca55621620b2d7c585313efd10729e63ef81e4e61f52330da781/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900", size = 25493, upload-time = "2024-02-02T16:30:11.488Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ae/9c60231cdfda003434e8bd27282b1f4e197ad5a710c14bee8bea8a9ca4f0/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff", size = 30630, upload-time = "2024-02-02T16:30:13.144Z" },
-    { url = "https://files.pythonhosted.org/packages/65/dc/1510be4d179869f5dafe071aecb3f1f41b45d37c02329dfba01ff59e5ac5/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad", size = 29745, upload-time = "2024-02-02T16:30:14.222Z" },
-    { url = "https://files.pythonhosted.org/packages/30/39/8d845dd7d0b0613d86e0ef89549bfb5f61ed781f59af45fc96496e897f3a/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd", size = 30021, upload-time = "2024-02-02T16:30:16.032Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5c/356a6f62e4f3c5fbf2602b4771376af22a3b16efa74eb8716fb4e328e01e/MarkupSafe-2.1.5-cp310-cp310-win32.whl", hash = "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4", size = 16659, upload-time = "2024-02-02T16:30:17.079Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/acbf292615c65f0604a0c6fc402ce6d8c991276e16c80c46a8f758fbd30c/MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5", size = 17213, upload-time = "2024-02-02T16:30:18.251Z" },
-    { url = "https://files.pythonhosted.org/packages/11/e7/291e55127bb2ae67c64d66cef01432b5933859dfb7d6949daa721b89d0b3/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f", size = 18219, upload-time = "2024-02-02T16:30:19.988Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2", size = 14098, upload-time = "2024-02-02T16:30:21.063Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/cf/35fe557e53709e93feb65575c93927942087e9b97213eabc3fe9d5b25a55/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced", size = 29014, upload-time = "2024-02-02T16:30:22.926Z" },
-    { url = "https://files.pythonhosted.org/packages/97/18/c30da5e7a0e7f4603abfc6780574131221d9148f323752c2755d48abad30/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5", size = 28220, upload-time = "2024-02-02T16:30:24.76Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/40/2e73e7d532d030b1e41180807a80d564eda53babaf04d65e15c1cf897e40/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c", size = 27756, upload-time = "2024-02-02T16:30:25.877Z" },
-    { url = "https://files.pythonhosted.org/packages/18/46/5dca760547e8c59c5311b332f70605d24c99d1303dd9a6e1fc3ed0d73561/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f", size = 33988, upload-time = "2024-02-02T16:30:26.935Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/c5/27febe918ac36397919cd4a67d5579cbbfa8da027fa1238af6285bb368ea/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a", size = 32718, upload-time = "2024-02-02T16:30:28.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/81/56e567126a2c2bc2684d6391332e357589a96a76cb9f8e5052d85cb0ead8/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f", size = 33317, upload-time = "2024-02-02T16:30:29.214Z" },
-    { url = "https://files.pythonhosted.org/packages/00/0b/23f4b2470accb53285c613a3ab9ec19dc944eaf53592cb6d9e2af8aa24cc/MarkupSafe-2.1.5-cp311-cp311-win32.whl", hash = "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906", size = 16670, upload-time = "2024-02-02T16:30:30.915Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a2/c78a06a9ec6d04b3445a949615c4c7ed86a0b2eb68e44e7541b9d57067cc/MarkupSafe-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617", size = 17224, upload-time = "2024-02-02T16:30:32.09Z" },
-    { url = "https://files.pythonhosted.org/packages/53/bd/583bf3e4c8d6a321938c13f49d44024dbe5ed63e0a7ba127e454a66da974/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1", size = 18215, upload-time = "2024-02-02T16:30:33.081Z" },
-    { url = "https://files.pythonhosted.org/packages/48/d6/e7cd795fc710292c3af3a06d80868ce4b02bfbbf370b7cee11d282815a2a/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4", size = 14069, upload-time = "2024-02-02T16:30:34.148Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b5/5d8ec796e2a08fc814a2c7d2584b55f889a55cf17dd1a90f2beb70744e5c/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee", size = 29452, upload-time = "2024-02-02T16:30:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5", size = 28462, upload-time = "2024-02-02T16:30:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/75/fd6cb2e68780f72d47e6671840ca517bda5ef663d30ada7616b0462ad1e3/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b", size = 27869, upload-time = "2024-02-02T16:30:37.834Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/81/147c477391c2750e8fc7705829f7351cf1cd3be64406edcf900dc633feb2/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a", size = 33906, upload-time = "2024-02-02T16:30:39.366Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ff/9a52b71839d7a256b563e85d11050e307121000dcebc97df120176b3ad93/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f", size = 32296, upload-time = "2024-02-02T16:30:40.413Z" },
-    { url = "https://files.pythonhosted.org/packages/88/07/2dc76aa51b481eb96a4c3198894f38b480490e834479611a4053fbf08623/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169", size = 33038, upload-time = "2024-02-02T16:30:42.243Z" },
-    { url = "https://files.pythonhosted.org/packages/96/0c/620c1fb3661858c0e37eb3cbffd8c6f732a67cd97296f725789679801b31/MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad", size = 16572, upload-time = "2024-02-02T16:30:43.326Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb", size = 17127, upload-time = "2024-02-02T16:30:44.418Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ff/2c942a82c35a49df5de3a630ce0a8456ac2969691b230e530ac12314364c/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a", size = 18192, upload-time = "2024-02-02T16:30:57.715Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/14/6f294b9c4f969d0c801a4615e221c1e084722ea6114ab2114189c5b8cbe0/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46", size = 14072, upload-time = "2024-02-02T16:30:58.844Z" },
-    { url = "https://files.pythonhosted.org/packages/81/d4/fd74714ed30a1dedd0b82427c02fa4deec64f173831ec716da11c51a50aa/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532", size = 26928, upload-time = "2024-02-02T16:30:59.922Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/bd/50319665ce81bb10e90d1cf76f9e1aa269ea6f7fa30ab4521f14d122a3df/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab", size = 26106, upload-time = "2024-02-02T16:31:01.582Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/6f/f2b0f675635b05f6afd5ea03c094557bdb8622fa8e673387444fe8d8e787/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68", size = 25781, upload-time = "2024-02-02T16:31:02.71Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e0/393467cf899b34a9d3678e78961c2c8cdf49fb902a959ba54ece01273fb1/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0", size = 30518, upload-time = "2024-02-02T16:31:04.392Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/02/5437e2ad33047290dafced9df741d9efc3e716b75583bbd73a9984f1b6f7/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4", size = 29669, upload-time = "2024-02-02T16:31:05.53Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/7d/968284145ffd9d726183ed6237c77938c021abacde4e073020f920e060b2/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3", size = 29933, upload-time = "2024-02-02T16:31:06.636Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/f3/ecb00fc8ab02b7beae8699f34db9357ae49d9f21d4d3de6f305f34fa949e/MarkupSafe-2.1.5-cp38-cp38-win32.whl", hash = "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff", size = 16656, upload-time = "2024-02-02T16:31:07.767Z" },
-    { url = "https://files.pythonhosted.org/packages/92/21/357205f03514a49b293e214ac39de01fadd0970a6e05e4bf1ddd0ffd0881/MarkupSafe-2.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029", size = 17206, upload-time = "2024-02-02T16:31:08.843Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/31/780bb297db036ba7b7bbede5e1d7f1e14d704ad4beb3ce53fb495d22bc62/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf", size = 18193, upload-time = "2024-02-02T16:31:10.155Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d77701bbef72892affe060cdacb7a2ed7fd68dae3b477a8642f15ad3b132/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2", size = 14073, upload-time = "2024-02-02T16:31:11.442Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a7/1e558b4f78454c8a3a0199292d96159eb4d091f983bc35ef258314fe7269/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8", size = 26486, upload-time = "2024-02-02T16:31:12.488Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5a/360da85076688755ea0cceb92472923086993e86b5613bbae9fbc14136b0/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3", size = 25685, upload-time = "2024-02-02T16:31:13.726Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/18/ae5a258e3401f9b8312f92b028c54d7026a97ec3ab20bfaddbdfa7d8cce8/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465", size = 25338, upload-time = "2024-02-02T16:31:14.812Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/cc/48206bd61c5b9d0129f4d75243b156929b04c94c09041321456fd06a876d/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e", size = 30439, upload-time = "2024-02-02T16:31:15.946Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/06/a41c112ab9ffdeeb5f77bc3e331fdadf97fa65e52e44ba31880f4e7f983c/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea", size = 29531, upload-time = "2024-02-02T16:31:17.13Z" },
-    { url = "https://files.pythonhosted.org/packages/02/8c/ab9a463301a50dab04d5472e998acbd4080597abc048166ded5c7aa768c8/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6", size = 29823, upload-time = "2024-02-02T16:31:18.247Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/29/9bc18da763496b055d8e98ce476c8e718dcfd78157e17f555ce6dd7d0895/MarkupSafe-2.1.5-cp39-cp39-win32.whl", hash = "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf", size = 16658, upload-time = "2024-02-02T16:31:19.583Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f8/4da07de16f10551ca1f640c92b5f316f9394088b183c6a57183df6de5ae4/MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5", size = 17211, upload-time = "2024-02-02T16:31:20.96Z" },
-]
-
-[[package]]
-name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
@@ -203,37 +130,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-    { url = "https://files.pythonhosted.org/packages/56/23/0d8c13a44bde9154821586520840643467aee574d8ce79a17da539ee7fed/markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26", size = 11623, upload-time = "2025-09-27T18:37:29.296Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/23/07a2cb9a8045d5f3f0890a8c3bc0859d7a47bfd9a560b563899bec7b72ed/markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc", size = 12049, upload-time = "2025-09-27T18:37:30.234Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e4/6be85eb81503f8e11b61c0b6369b6e077dcf0a74adbd9ebf6b349937b4e9/markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c", size = 21923, upload-time = "2025-09-27T18:37:31.177Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/bc/4dc914ead3fe6ddaef035341fee0fc956949bbd27335b611829292b89ee2/markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42", size = 20543, upload-time = "2025-09-27T18:37:32.168Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/5fe81fbcfba4aef4093d5f856e5c774ec2057946052d18d168219b7bd9f9/markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b", size = 20585, upload-time = "2025-09-27T18:37:33.166Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f6/e0e5a3d3ae9c4020f696cd055f940ef86b64fe88de26f3a0308b9d3d048c/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758", size = 21387, upload-time = "2025-09-27T18:37:34.185Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/25/651753ef4dea08ea790f4fbb65146a9a44a014986996ca40102e237aa49a/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2", size = 20133, upload-time = "2025-09-27T18:37:35.138Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/0a/c3cf2b4fef5f0426e8a6d7fce3cb966a17817c568ce59d76b92a233fdbec/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d", size = 20588, upload-time = "2025-09-27T18:37:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/1b/a7782984844bd519ad4ffdbebbba2671ec5d0ebbeac34736c15fb86399e8/markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7", size = 14566, upload-time = "2025-09-27T18:37:37.09Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1f/8d9c20e1c9440e215a44be5ab64359e207fcb4f675543f1cf9a2a7f648d0/markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e", size = 15053, upload-time = "2025-09-27T18:37:38.054Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d3/fe08482b5cd995033556d45041a4f4e76e7f0521112a9c9991d40d39825f/markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8", size = 13928, upload-time = "2025-09-27T18:37:39.037Z" },
 ]
 
 [[package]]
 name = "nixmac-eval"
 version = "1.0.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
     { name = "jinja2" },
     { name = "openpyxl" },
-    { name = "pygments", version = "2.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pygments", version = "2.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "tabulate", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "tabulate", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments" },
+    { name = "tabulate" },
 ]
 
 [package.optional-dependencies]
 dev = [
-    { name = "types-tabulate", version = "0.9.0.20241207", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "types-tabulate", version = "0.10.0.20260308", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "types-tabulate" },
 ]
 
 [package.metadata]
@@ -261,24 +174,8 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
-]
-
-[[package]]
-name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
@@ -295,24 +192,8 @@ wheels = [
 
 [[package]]
 name = "tabulate"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
-]
-
-[[package]]
-name = "tabulate"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
@@ -320,49 +201,9 @@ wheels = [
 
 [[package]]
 name = "types-tabulate"
-version = "0.9.0.20241207"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/43/16030404a327e4ff8c692f2273854019ed36718667b2993609dc37d14dd4/types_tabulate-0.9.0.20241207.tar.gz", hash = "sha256:ac1ac174750c0a385dfd248edc6279fa328aaf4ea317915ab879a2ec47833230", size = 8195, upload-time = "2024-12-07T02:54:42.554Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/86/a9ebfd509cbe74471106dffed320e208c72537f9aeb0a55eaa6b1b5e4d17/types_tabulate-0.9.0.20241207-py3-none-any.whl", hash = "sha256:b8dad1343c2a8ba5861c5441370c3e35908edd234ff036d4298708a1d4cf8a85", size = 8307, upload-time = "2024-12-07T02:54:41.031Z" },
-]
-
-[[package]]
-name = "types-tabulate"
 version = "0.10.0.20260308"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/44/d9e94f06010dde47b89892b2b133e3e54da729d8280ead4165dfdfa484ea/types_tabulate-0.10.0.20260308.tar.gz", hash = "sha256:724dcb1330ffba5f46d3cf6e29f45089fccb8e85801e6e7ac9efb1195bf7bea1", size = 8364, upload-time = "2026-03-08T03:59:59.472Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/74/3097387a6efcaef5ae92c7707a1a3e34a3881457d9ef1443a33681a77e08/types_tabulate-0.10.0.20260308-py3-none-any.whl", hash = "sha256:94a9795965bc6290f844d61e8680a1270040664b88fd12014624090fd847e13c", size = 8139, upload-time = "2026-03-08T03:59:58.678Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.13.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]

--- a/apps/eval/wip/evolve-loop-convergence-followups.md
+++ b/apps/eval/wip/evolve-loop-convergence-followups.md
@@ -1,0 +1,95 @@
+# Evolve-loop convergence follow-ups
+
+Findings from the first hermetic Critical-priority baseline run
+(2026-07-18, 28 cases, `gpt-oss-120b` via an OpenAI-compatible endpoint,
+results in `data/results-critical-baseline/`). These are **product-side
+issues in the nixmac evolve engine**, observed through eval traces — they
+are not eval-suite bugs. Recorded here so eval work can stay focused;
+each item should become its own fix/PR against `apps/native`.
+
+Baseline context: 16/28 cases generated cleanly, 7 ended
+conversationally (5 of them correctly), 5 hit `limitReached`. Every
+`limitReached` case traces back to one or more of the mechanisms below.
+
+## 1. Build-error truncation drops the root cause
+
+`truncate_build_output_for_model`
+(`apps/native/src-tauri/src/evolve/mod.rs:1854`) slices the build output
+from the last `error:` line, but when that section still exceeds
+`BUILD_OUTPUT_MAX_CHARS` (6,000) it truncates the **tail**. Nix puts the
+causal message at the *end* of the `… while evaluating …` chain, so for
+long errors the model sees the trace preamble and loses the actual
+failing line, then debugs by guessing (observed: model invented a
+".nixmac git tracking" explanation from an unrelated dirty-tree
+warning).
+
+Also: first builds flood stderr with lockfile-creation noise
+(`creating lock file …`, `Added input 'nixpkgs' …`) that eats the
+6,000-char budget before any error text.
+
+**Fix direction:** keep the tail (root cause) rather than the head when
+over budget; strip lockfile/warning noise before budgeting.
+
+## 2. `done`-rejection hint references a parameter that doesn't exist
+
+When `done` arrives with unverified edits the engine replies
+`"Run build_check with host='<host>' to validate, then call done again"`
+(`apps/native/src-tauri/src/evolve/mod.rs:2186`) — but the `build_check`
+tool only accepts `show_trace`, not `host`
+(`apps/native/src-tauri/src/evolve/tools/build_check.rs`). gpt-oss-120b
+takes the hint literally, concludes the tool is broken
+("Cannot run build_check with host parameter"), and starts re-calling
+`done` with near-identical summaries. The rejection text is identical on
+every repeat, so nothing breaks the cycle; one case spent iterations
+11–25 in this loop.
+
+**Fix direction:** drop the phantom `host` argument from the message;
+escalate/vary the message after the first repeated rejection (e.g. name
+the last build error inline).
+
+## 3. Nothing terminates a doomed session early
+
+`build_attempts` is capped (5) but reaching the cap does not end the
+evolution, and repeated rejected `done` calls don't count toward any
+limit. The only exit is `maxIterations` → `limitReached`, so a session
+that cannot fix its build always burns the full iteration and token
+budget (cases 39, 44, 60: 25 iterations, 265–425k tokens each).
+
+**Fix direction:** end with a graceful structured failure when the
+build-attempt cap is hit, or after N identical rejected `done` calls,
+instead of grinding to `limitReached`.
+
+## 4. Exploration thrash: repeated tool calls, no dead-end detection
+
+Case 50 ("configure git with name/email") spent all 18 iterations on
+`list_files`/`search_code`/`read_file` — including literally repeated
+calls (`list_files pattern="**/modules/**"` twice, overlapping regex
+searches) — and made zero edits, hunting for a home-manager-style
+`programs.git` location the template doesn't obviously have.
+
+Related: case 65 (intentionally ambiguous "make my mac look cool")
+ground through 25 iterations / 453k tokens instead of using the
+conversational-response path that 7 other cases used successfully.
+
+**Fix direction:** detect repeated identical tool calls and nudge the
+model to commit to a decision; strengthen system-prompt guidance on
+when to answer conversationally / ask for clarification instead of
+continuing to explore.
+
+## How to re-measure
+
+Re-run the baseline after each fix and diff the scorecards:
+
+```sh
+cd apps/eval
+uv run python run_evals.py --csv data/test_prompts.csv \
+  --priority Critical --results-dir data/results-critical-<tag> \
+  --vllm-url "$VLLM_URL" --vllm-api-key "$VLLM_API_KEY"
+uv run python calc_stats.py -i data/results-critical-<tag>
+```
+
+Watch: `limitReached` count (baseline: 5/28), iterations and
+`totalTokens` on cases 39, 44, 50, 60, 65, and that the 16 clean
+`generated` cases stay clean. Note `calc_stats.py` currently counts any
+produced result as PASS — it does not compare against
+`expected_outcome` (separate eval-suite follow-up).

--- a/apps/native/src-tauri/src/db/mod.rs
+++ b/apps/native/src-tauri/src/db/mod.rs
@@ -29,8 +29,7 @@ pub fn get_db_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf> {
         return Ok(path.clone());
     }
 
-    let app_data = app.path().app_data_dir()?;
-    std::fs::create_dir_all(&app_data)?;
+    let app_data = crate::env::app_data_dir(app)?;
     let path = app_data.join("nixmac.db");
     // fire-and-forget: OnceLock::set returns Err if already initialised (race on first call).
     // The first writer wins; the value is the same path, so ignoring the Err is correct.

--- a/apps/native/src-tauri/src/docs/generated_docs.rs
+++ b/apps/native/src-tauri/src/docs/generated_docs.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use serde_json::{Value, json};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Runtime};
 use walkdir::WalkDir;
 
 use crate::commands::debug::TimerGuard;
@@ -125,8 +125,7 @@ impl GeneratedDocsIndexLoader {
 
     /// Resolve the app-data directory and create a loader for generated docs.
     pub fn for_app<R: Runtime>(app: &AppHandle<R>) -> Result<Self> {
-        let docs_dir = app.path().app_data_dir()?;
-        std::fs::create_dir_all(&docs_dir)?;
+        let docs_dir = crate::env::app_data_dir(app)?;
         Ok(Self::new(docs_dir))
     }
 

--- a/apps/native/src-tauri/src/env/mod.rs
+++ b/apps/native/src-tauri/src/env/mod.rs
@@ -68,6 +68,42 @@ pub fn submitted_feedback_dsn() -> Option<String> {
     non_empty(settings(None).submitted_feedback_dsn)
 }
 
+/// Hermetic state override: when `NIXMAC_APP_DATA_DIR` is set, all per-device
+/// state (global preferences, legacy `settings.json` store, sqlite DB, docs
+/// cache, feedback queue, secret cache) is rooted there instead of the OS
+/// app-data directory.
+///
+/// This is the isolation mechanism for automated harnesses (the eval suite,
+/// scripted runs) that must never read or mutate the developer's real app
+/// state. It is deliberately available in all build profiles: a debug-only
+/// gate would silently fall back to the real app-data directory when pointed
+/// at a release binary, which is exactly the failure mode this exists to
+/// prevent. Read directly from the process environment (not via
+/// `NixmacEnvSettings`) because settings resolution itself depends on state
+/// loaded from this directory.
+pub fn app_data_dir_override() -> Option<std::path::PathBuf> {
+    std::env::var(keys::NIXMAC_APP_DATA_DIR)
+        .ok()
+        .and_then(non_empty)
+        .map(std::path::PathBuf::from)
+}
+
+/// The directory holding per-device state: the `NIXMAC_APP_DATA_DIR` override
+/// when set, otherwise Tauri's app-data directory. Created if missing.
+pub fn app_data_dir<R: Runtime>(app: &AppHandle<R>) -> Result<std::path::PathBuf> {
+    use tauri::Manager;
+    let dir = match app_data_dir_override() {
+        Some(dir) => dir,
+        None => app
+            .path()
+            .app_data_dir()
+            .context("failed to resolve app data directory")?,
+    };
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("failed to create app data directory {}", dir.display()))?;
+    Ok(dir)
+}
+
 /// Debug-only E2E mock-system gate shared across store and scanners.
 pub fn e2e_mock_system_enabled() -> bool {
     cfg!(debug_assertions) && crate::e2e_runtime::enabled(keys::NIXMAC_E2E_MOCK_SYSTEM)

--- a/apps/native/src-tauri/src/env_keys.rs
+++ b/apps/native/src-tauri/src/env_keys.rs
@@ -42,6 +42,8 @@ pub mod names {
     pub const NIXMAC_E2E_CONFIG_DIR: &str = "NIXMAC_E2E_CONFIG_DIR";
     pub const NIXMAC_E2E_HOST_ATTR: &str = "NIXMAC_E2E_HOST_ATTR";
 
+    pub const NIXMAC_APP_DATA_DIR: &str = "NIXMAC_APP_DATA_DIR";
+
     pub const NIXMAC_RECORD_COMPLETIONS: &str = "NIXMAC_RECORD_COMPLETIONS";
     pub const NIXMAC_COMPLETION_LOG_DIR: &str = "NIXMAC_COMPLETION_LOG_DIR";
     pub const NIXMAC_LOGFILE: &str = "NIXMAC_LOGFILE";

--- a/apps/native/src-tauri/src/feedback.rs
+++ b/apps/native/src-tauri/src/feedback.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 // Number of lines to include when attaching app logs
 const APP_LOG_LAST_LINES: usize = 200;
@@ -510,11 +510,7 @@ fn redact_metadata_with_scanner(
 
 /// Get the path to the pending feedback report file
 fn get_report_path(app: &AppHandle) -> Result<PathBuf> {
-    let app_data = app
-        .path()
-        .app_data_dir()
-        .context("Failed to get app data directory")?;
-    fs::create_dir_all(&app_data)?;
+    let app_data = crate::env::app_data_dir(app)?;
     Ok(app_data.join("report.json"))
 }
 

--- a/apps/native/src-tauri/src/observable/persistence.rs
+++ b/apps/native/src-tauri/src/observable/persistence.rs
@@ -5,10 +5,10 @@
 //! Subscribers attach a backend to an [`Observable<T>`] via
 //! [`Observable::persist_to`](super::Observable::persist_to).
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
-use tauri::{Manager, Runtime};
+use tauri::Runtime;
 
 use super::json_io::{read_json_file, write_json_file};
 
@@ -41,16 +41,14 @@ impl AppDataJson {
         Self { path: path.into() }
     }
 
-    /// Resolve a file under Tauri's app data directory.
+    /// Resolve a file under the app data directory (honors the hermetic
+    /// `NIXMAC_APP_DATA_DIR` override).
     #[allow(dead_code)]
     pub fn for_app<R: Runtime>(
         app: &tauri::AppHandle<R>,
         file_name: impl AsRef<Path>,
     ) -> Result<Self> {
-        let app_data = app
-            .path()
-            .app_data_dir()
-            .context("failed to resolve app data directory")?;
+        let app_data = crate::env::app_data_dir(app)?;
         Ok(Self::new(app_data.join(file_name)))
     }
 }

--- a/apps/native/src-tauri/src/state/completion_log.rs
+++ b/apps/native/src-tauri/src/state/completion_log.rs
@@ -10,12 +10,14 @@ use tokio::task::spawn_blocking;
 ///
 /// Uses `NIXMAC_COMPLETION_LOG_DIR` (resolved through `crate::env`, which
 /// checks process env, the build-time profile, and the e2e runtime file)
-/// when set, otherwise defaults to
+/// when set, then the hermetic `NIXMAC_APP_DATA_DIR` override (so hermetic
+/// runs never write recordings outside their state root), otherwise
 /// `~/Library/Application Support/nixmac/logs/{prefix}_YYYY-MM-DD.jsonl` on macOS.
 fn log_path_for_today(prefix: &str) -> PathBuf {
     let date = Local::now().format("%Y-%m-%d");
     crate::env::completion_log_dir()
         .map(PathBuf::from)
+        .or_else(crate::env::app_data_dir_override)
         .unwrap_or_else(|| {
             dirs::data_local_dir()
                 .unwrap_or_else(|| PathBuf::from("."))

--- a/apps/native/src-tauri/src/storage/legacy_kv.rs
+++ b/apps/native/src-tauri/src/storage/legacy_kv.rs
@@ -9,6 +9,12 @@ use tauri_plugin_store::{Store, StoreExt};
 const STORE_PATH: &str = "settings.json";
 
 pub fn get_store<R: Runtime>(app: &AppHandle<R>) -> Result<Arc<Store<R>>> {
+    // tauri-plugin-store resolves relative paths against the OS app-data
+    // directory, so the hermetic NIXMAC_APP_DATA_DIR override must be applied
+    // here as an absolute path.
+    if let Some(dir) = crate::env::app_data_dir_override() {
+        return Ok(app.store(dir.join(STORE_PATH))?);
+    }
     Ok(app.store(STORE_PATH)?)
 }
 

--- a/apps/native/src-tauri/src/storage/secrets.rs
+++ b/apps/native/src-tauri/src/storage/secrets.rs
@@ -1,14 +1,12 @@
 //! Keychain-backed secrets with env-first resolution for dev/CI.
 
 use crate::storage::credential_store::CredentialStore;
-#[cfg(debug_assertions)]
 use crate::storage::credential_store::FileStore;
 #[cfg(not(debug_assertions))]
 use crate::storage::credential_store::KeychainStore;
 use crate::storage::legacy_kv::{delete_legacy_key, get_legacy_string, set_legacy_string};
 
 use anyhow::Result;
-#[cfg(debug_assertions)]
 use std::path::PathBuf;
 use tauri::{AppHandle, Runtime};
 
@@ -47,7 +45,6 @@ fn keychain_store_for<R: Runtime>(app: &AppHandle<R>, key: &str) -> KeychainStor
     KeychainStore::new(app.clone(), KEYCHAIN_SERVICE, key)
 }
 
-#[cfg(debug_assertions)]
 fn sanitize_dev_cache_segment(value: &str) -> String {
     let sanitized: String = value
         .chars()
@@ -132,7 +129,23 @@ fn delete_persistent_secret_pref<R: Runtime>(app: &AppHandle<R>, key: &'static s
         .map_err(anyhow::Error::from)
 }
 
+/// Hermetic secret storage: when `NIXMAC_APP_DATA_DIR` is set, secrets live
+/// in plain files under `<dir>/secrets/` in every build profile, so a
+/// hermetic run can neither read nor write the real keychain or the shared
+/// dev secret cache.
+fn hermetic_secret_store(key: &str) -> Option<FileStore> {
+    crate::env::app_data_dir_override()
+        .map(|dir| FileStore::new(dir.join("secrets").join(sanitize_dev_cache_segment(key))))
+}
+
 fn get_secret_pref<R: Runtime>(app: &AppHandle<R>, key: &'static str) -> Result<Option<String>> {
+    if let Some(store) = hermetic_secret_store(key) {
+        return store
+            .get()
+            .map(normalize_secret)
+            .map_err(anyhow::Error::from);
+    }
+
     if crate::env::e2e_mock_system_enabled() {
         return Ok(normalize_secret(get_legacy_string(app, key)?));
     }
@@ -145,6 +158,10 @@ fn set_secret_pref<R: Runtime>(app: &AppHandle<R>, key: &'static str, value: &st
         return delete_secret_pref(app, key);
     };
 
+    if let Some(store) = hermetic_secret_store(key) {
+        return store.set(&value).map_err(anyhow::Error::from);
+    }
+
     if crate::env::e2e_mock_system_enabled() {
         return set_legacy_string(app, key, &value);
     }
@@ -153,6 +170,10 @@ fn set_secret_pref<R: Runtime>(app: &AppHandle<R>, key: &'static str, value: &st
 }
 
 fn delete_secret_pref<R: Runtime>(app: &AppHandle<R>, key: &'static str) -> Result<()> {
+    if let Some(store) = hermetic_secret_store(key) {
+        return store.delete().map_err(anyhow::Error::from);
+    }
+
     if crate::env::e2e_mock_system_enabled() {
         return delete_legacy_key(app, key);
     }

--- a/apps/native/src-tauri/src/storage/secrets.rs
+++ b/apps/native/src-tauri/src/storage/secrets.rs
@@ -7,6 +7,7 @@ use crate::storage::credential_store::KeychainStore;
 use crate::storage::legacy_kv::{delete_legacy_key, get_legacy_string, set_legacy_string};
 
 use anyhow::Result;
+#[cfg(debug_assertions)]
 use std::path::PathBuf;
 use tauri::{AppHandle, Runtime};
 

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -245,6 +245,15 @@ lib.mkIf (!config.container.isBuilding) {
     exec = "bun run check";
   };
 
+  # Eval suite CLI, callable from anywhere in the repo without cd'ing into
+  # apps/eval. `uv run --project` resolves (and auto-syncs) that project's
+  # venv; the tools' own path defaults are script-relative, so the caller's
+  # cwd doesn't matter.
+  scripts.nixmac-eval = {
+    description = "nixmac evaluation suite (run | grade | stats | report | all)";
+    exec = ''exec ${pkgs.uv}/bin/uv run --project "${config.git.root}/apps/eval" nixmac-eval "$@"'';
+  };
+
   # Formatting
   treefmt.enable = true;
   treefmt.config = {


### PR DESCRIPTION
## Summary

Makes the freshly imported `apps/eval` suite safe and usable in this repo.

The main change is **hermetic isolation**: eval runs previously guessed the binary's app-data path and got it wrong for dev-identifier builds (`com.darkmatter.nixmac.dev`), so a run would silently pick up the developer's real preferences — and actually ran an AI evolution against my real dotfiles with my real OpenRouter credentials before being killed by a timeout.

### Isolation (native + eval)

- **`NIXMAC_APP_DATA_DIR`**: new env override in the binary that roots *all* per-device state in a given directory — global preferences, legacy `settings.json` store, sqlite DB, docs cache, feedback queue, secrets (file-backed under `<dir>/secrets` in every build profile, so hermetic runs can never touch the real keychain or the shared dev secret cache), and completion recordings. 

- The eval suite gives each case a fresh temp app-data dir, passes API keys via the child environment only, and **aborts loudly** if the binary didn't honor the override (old binary → refuse to run against real state).

- Fixture fix: the suite gitignored `.nixmac/`, but the template imports `./.nixmac` as a flake module and flakes only see tracked files — every case started with a broken build and models were graded on working around it. Case 1 went from 25 iterations / `limitReached` / 298k tokens to 11 iterations / clean done / 102k tokens after the fix.

### Correctness of reporting

- **`calc_stats` is now grade-aware**: it reuses `grade.py`'s deterministic grader (persisted grades when present, in-memory otherwise), so pass/fail reflects each case's `expected_outcome` instead of "a result file exists". The Critical baseline reports an honest **64.3% (18/28)** instead of 100%, with per-outcome ratios and failure-class breakdowns.

### Ergonomics

- **Unified `nixmac-eval` CLI** (`run` / `grade` / `stats` / `report` + `all` to chain the pipeline), installed via `[project.scripts]`; the standalone `python <script>.py` entry points keep working.

- Exposed in the devenv shell (wraps `uv run --project apps/eval`), so it works from any cwd without `uv sync`.

- Provider args fall back to the environment (`VLLM_URL`/`VLLM_API_BASE`, `VLLM_API_KEY`, `OLLAMA_URL`/`OLLAMA_API_BASE`, `EVOLVE_MODEL`, `SUMMARY_MODEL`). Explicit flags win; if both backends are in the env, vLLM is preferred with a warning. With the env exported, a full evaluation is:

```sh
nixmac-eval all --csv apps/eval/data/test_prompts.csv
```

### Follow-ups (documented, not fixed here)

`apps/eval/wip/evolve-loop-convergence-followups.md` records engine-side issues found via the baseline traces: build-error truncation keeps the head instead of the tail (root cause lost), the done-rejection hint names a `host` parameter `build_check` doesn't have (models loop on it), no early termination for doomed sessions, and exploration thrash. Grader policy soft spots (passes `limitReached`-with-edits and conversational-on-`succeed`) are also candidates.

## Test plan

- `cargo test -p nixmac`: 682 passed.
- Hermetic verification: mtime snapshots of both real app-data dirs and `~/dotfiles` unchanged across runs; hermetic guard tested against a non-compliant binary (aborts).
- Live end-to-end: 28-case Critical baseline via an OpenAI-compatible endpoint; `nixmac-eval all` (run→grade→stats→report) verified with live cases; env-fallback matrix (env-only, both-set warning, flag-beats-env, nothing-set error) exercised.