### PR TITLE
fix(evolve): break the rejected-done loop and stop doomed sessions early

### DIFF
--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -2034,6 +2034,12 @@ struct DoneGate {
     /// Set by a passing build_check; cleared by any subsequent edit or a
     /// failing build.
     build_verified: bool,
+    /// Consecutive `done` calls rejected for lacking a verified build.
+    /// Reset whenever the model actually runs build_check.
+    rejected_dones: usize,
+    /// Model-facing output of the last failed build_check, inlined into
+    /// repeated rejections so the loop has fresh signal to break on.
+    last_build_error: Option<String>,
 }
 
 fn process_tool_result(
@@ -2190,9 +2196,14 @@ fn process_tool_result(
                 (None, None) => "(no build output captured)".to_string(),
             };
 
+            // Running build_check is exactly what a done-rejection asks for,
+            // so any attempt (pass or fail) resets the rejection streak.
+            done_gate.rejected_dones = 0;
+
             if *success {
                 info!("✅ BUILD CHECK PASSED");
                 done_gate.build_verified = true;
+                done_gate.last_build_error = None;
 
                 let msg = Message::Tool {
                     tool_call_id: tool_call_id.to_string(),
@@ -2206,6 +2217,7 @@ fn process_tool_result(
                 // A failing build invalidates any earlier successful verification,
                 // otherwise `done` could still accept the (now broken) config.
                 done_gate.build_verified = false;
+                done_gate.last_build_error = Some(model_output.clone());
                 warn!(
                     "❌ BUILD CHECK FAILED (attempt {}/{})",
                     build_attempts, max_build_attempts
@@ -2247,13 +2259,36 @@ fn process_tool_result(
                 };
                 (msg, Some(true))
             } else if evolution.has_edits() {
-                info!("⚠️ Agent called done without build verification");
+                done_gate.rejected_dones += 1;
+                info!(
+                    "⚠️ Agent called done without build verification (rejection #{})",
+                    done_gate.rejected_dones
+                );
+                // Vary the message on repeats: an identical rejection gives a
+                // looping model nothing new to react to, so escalate with the
+                // concrete blocker (the last build error) when we have one.
+                let content = if done_gate.rejected_dones <= 1 {
+                    "Before completing, you must verify your changes compile. \
+                     Call the build_check tool (it takes no required arguments) \
+                     to validate, then call done again."
+                        .to_string()
+                } else if let Some(last_error) = &done_gate.last_build_error {
+                    format!(
+                        "done rejected again: the build is still not verified. Do not \
+                         call done again until build_check passes. The last build_check \
+                         failed with:\n\n{}\n\nFix that error, run build_check, and only \
+                         call done once it passes.",
+                        last_error
+                    )
+                } else {
+                    "done rejected again: you have made edits but have not run \
+                     build_check even once. Call the build_check tool now (it takes \
+                     no required arguments); call done only after it passes."
+                        .to_string()
+                };
                 let msg = Message::Tool {
                     tool_call_id: tool_call_id.to_string(),
-                    content: "Before completing, you must verify your changes compile. \
-                              Call the build_check tool (it takes no required arguments) \
-                              to validate, then call done again."
-                        .to_string(),
+                    content,
                 };
                 (msg, None) // Break inner loop, continue outer
             } else {
@@ -2421,6 +2456,73 @@ mod tests {
         assert!(
             !content.contains("host="),
             "hint must not reference a parameter build_check does not accept: {content}"
+        );
+    }
+
+    fn done_rejection_content(evolution: &mut Evolution, done_gate: &mut DoneGate) -> String {
+        let mut build_attempts = 0usize;
+        let (msg, _) = process_tool_result(
+            "tool-call-id",
+            &ToolResult::Done("done".to_string()),
+            evolution,
+            done_gate,
+            &mut build_attempts,
+            5,
+            0,
+            0,
+        )
+        .expect("done rejection should not error");
+        match msg {
+            Message::Tool { content, .. } => content,
+            _ => panic!("done rejection should produce a tool message"),
+        }
+    }
+
+    // Repeated rejections must not be byte-identical: the repeat names the
+    // last build failure so the model has something new to react to.
+    #[test]
+    fn repeated_done_rejections_escalate_with_the_last_build_error() {
+        let mut evolution = Evolution::new("prompt");
+        evolution.edits.push(FileEdit {
+            path: "configuration.nix".to_string(),
+            search: "a".to_string(),
+            replace: "b".to_string(),
+        });
+        let mut done_gate = DoneGate::default();
+
+        run_tool_result(&build_result(false), &mut evolution, &mut done_gate);
+
+        let first = done_rejection_content(&mut evolution, &mut done_gate);
+        let second = done_rejection_content(&mut evolution, &mut done_gate);
+
+        assert_ne!(
+            first, second,
+            "a repeated rejection must vary so the model can break the loop"
+        );
+        assert!(
+            second.contains("boom"),
+            "repeat rejection should inline the last build error: {second}"
+        );
+    }
+
+    #[test]
+    fn running_build_check_resets_the_rejected_done_streak() {
+        let mut evolution = Evolution::new("prompt");
+        evolution.edits.push(FileEdit {
+            path: "configuration.nix".to_string(),
+            search: "a".to_string(),
+            replace: "b".to_string(),
+        });
+        let mut done_gate = DoneGate::default();
+
+        done_rejection_content(&mut evolution, &mut done_gate);
+        done_rejection_content(&mut evolution, &mut done_gate);
+        assert_eq!(done_gate.rejected_dones, 2);
+
+        run_tool_result(&build_result(false), &mut evolution, &mut done_gate);
+        assert_eq!(
+            done_gate.rejected_dones, 0,
+            "any build_check attempt should reset the rejection streak"
         );
     }
 

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -328,6 +328,10 @@ const MAX_ITERATIONS_BEFORE_EDIT_PERCENT: usize = 75;
 const BUILD_OUTPUT_MAX_CHARS: usize = 6_000;
 const BUILD_OUTPUT_TAIL_LINES: usize = 80;
 
+// Consecutive rejected `done` calls after which the evolution stops gracefully
+// (limit prompt / LimitReached) instead of grinding to the iteration limit.
+const MAX_REJECTED_DONE_CALLS: usize = 3;
+
 const SYSTEM_PROMPT: &str = include_str!("../../prompts/system.md");
 
 fn configured_model(
@@ -562,6 +566,7 @@ enum EvolutionLimitKind {
     MaxIterations,
     BuildAttempts,
     TokenBudget,
+    DoneRejections,
 }
 
 fn format_token_count(tokens: usize) -> String {
@@ -587,6 +592,7 @@ impl EvolutionLimitKind {
             Self::BuildAttempts => format!("{} build attempts", attempts),
             Self::NoProgress | Self::MaxIterations => format!("{} attempts", attempts),
             Self::TokenBudget => format!("{} tokens", format_token_count(attempts)),
+            Self::DoneRejections => format!("{} unverified attempts to finish", attempts),
         }
     }
 
@@ -619,6 +625,10 @@ impl EvolutionLimitKind {
             ),
             Self::TokenBudget => format!(
                 "Evolution stopped after consuming {}. You can review the current changes or continue with a follow-up prompt.",
+                self.attempts_label(attempts)
+            ),
+            Self::DoneRejections => format!(
+                "Evolution stopped after {} — the changes never passed a build check. You can review the current changes or continue with a follow-up prompt.",
                 self.attempts_label(attempts)
             ),
         }
@@ -1782,6 +1792,51 @@ Do not invent tool names and do not place tool invocations in assistant content.
                         iteration,
                         EvolutionLimitKind::BuildAttempts,
                         build_attempts,
+                    );
+                    break;
+                }
+                LimitDecision::Cancelled => {
+                    evolution.state = EvolutionState::Failed;
+                    return Err(EvolutionRunError::from_state(
+                        session_control::EVOLUTION_CANCELLED_MSG,
+                        &evolution,
+                        iteration,
+                        build_attempts,
+                        total_tokens,
+                    )
+                    .into());
+                }
+            }
+        }
+
+        // Safety limits -- Repeated rejected `done` calls
+        if done_gate.rejected_dones >= MAX_REJECTED_DONE_CALLS {
+            warn!(
+                "⚠️ Model tried to finish {} times without a verified build - asking whether to continue",
+                done_gate.rejected_dones
+            );
+            match ask_to_continue_after_limit(
+                app,
+                start_time,
+                iteration,
+                EvolutionLimitKind::DoneRejections,
+                done_gate.rejected_dones,
+                interactive_limit_prompt,
+            )
+            .await
+            {
+                LimitDecision::Continue => {
+                    done_gate.rejected_dones = 0;
+                    info!("Resetting rejected-done streak at user request");
+                }
+                LimitDecision::Stop => {
+                    finish_after_limit_stop(
+                        app,
+                        &mut evolution,
+                        start_time,
+                        iteration,
+                        EvolutionLimitKind::DoneRejections,
+                        done_gate.rejected_dones,
                     );
                     break;
                 }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -994,7 +994,7 @@ pub async fn generate_evolution<R: Runtime>(
     let mut evolution = Evolution::new(prompt);
     let mut iteration: usize = 0;
     let mut build_attempts: usize = 0;
-    let mut build_verified = false;
+    let mut done_gate = DoneGate::default();
     let mut total_tokens: u32 = 0;
     let chat_memory_store = session_chat_memory_store();
 
@@ -1533,7 +1533,7 @@ pub async fn generate_evolution<R: Runtime>(
                                 &tool_call.id,
                                 res,
                                 &mut evolution,
-                                &mut build_verified,
+                                &mut done_gate,
                                 &mut build_attempts,
                                 max_build_attempts,
                                 start_time,
@@ -2024,11 +2024,23 @@ fn summarize_result(result: &ToolResult) -> (String, bool) {
 /// Returns `Ok(Some(true))` if the loop should break, `Ok(Some(false))` to continue,
 /// or `Ok(None)` to break the inner tool loop but continue the outer loop.
 #[allow(clippy::too_many_arguments)]
+/// Gate deciding whether `done` may complete the evolution.
+///
+/// Kept as a struct (rather than a bare bool) so the completion rules —
+/// verification state and, later, repeated-rejection tracking — travel
+/// together through the tool-result pipeline.
+#[derive(Default)]
+struct DoneGate {
+    /// Set by a passing build_check; cleared by any subsequent edit or a
+    /// failing build.
+    build_verified: bool,
+}
+
 fn process_tool_result(
     tool_call_id: &str,
     result: &ToolResult,
     evolution: &mut Evolution,
-    build_verified: &mut bool,
+    done_gate: &mut DoneGate,
     build_attempts: &mut usize,
     max_build_attempts: usize,
     start_time: i64,
@@ -2092,7 +2104,7 @@ fn process_tool_result(
             // A new edit invalidates any prior successful build: the verified
             // state no longer matches the files, so `done` must require a fresh
             // build_check.
-            *build_verified = false;
+            done_gate.build_verified = false;
             let msg = Message::Tool {
                 tool_call_id: tool_call_id.to_string(),
                 content:
@@ -2115,7 +2127,7 @@ fn process_tool_result(
                 replace: format!("semantic:{:?}", edit.action),
             });
             // A new edit invalidates any prior successful build verification.
-            *build_verified = false;
+            done_gate.build_verified = false;
 
             let msg = Message::Tool {
                 tool_call_id: tool_call_id.to_string(),
@@ -2134,7 +2146,7 @@ fn process_tool_result(
                 replace: format!("ensure_secret:{}", result.name),
             });
             // A new edit invalidates any prior successful build verification.
-            *build_verified = false;
+            done_gate.build_verified = false;
             let content = serde_json::to_string(result)
                 .unwrap_or_else(|_| format!("{{\"name\":\"{}\"}}", result.name));
             let msg = Message::Tool {
@@ -2180,7 +2192,7 @@ fn process_tool_result(
 
             if *success {
                 info!("✅ BUILD CHECK PASSED");
-                *build_verified = true;
+                done_gate.build_verified = true;
 
                 let msg = Message::Tool {
                     tool_call_id: tool_call_id.to_string(),
@@ -2193,7 +2205,7 @@ fn process_tool_result(
             } else {
                 // A failing build invalidates any earlier successful verification,
                 // otherwise `done` could still accept the (now broken) config.
-                *build_verified = false;
+                done_gate.build_verified = false;
                 warn!(
                     "❌ BUILD CHECK FAILED (attempt {}/{})",
                     build_attempts, max_build_attempts
@@ -2224,7 +2236,7 @@ fn process_tool_result(
         }
 
         ToolResult::Done(summary) => {
-            if *build_verified {
+            if done_gate.build_verified {
                 info!("✅ EVOLUTION COMPLETE (build verified)");
                 info!("Summary: {}", summary);
                 evolution.summary = Some(summary.clone());
@@ -2270,10 +2282,10 @@ fn process_tool_result(
 #[cfg(test)]
 mod tests {
     use super::{
-        BUILD_OUTPUT_MAX_CHARS, Evolution, EvolutionMessage, EvolutionState, FileEdit, Message,
-        Retention, ToolResult, filter_evolution_messages, normalize_openai_max_output_tokens,
-        process_tool_result, read_file_dedup_key, store_tool_result,
-        truncate_build_output_for_model,
+        BUILD_OUTPUT_MAX_CHARS, DoneGate, Evolution, EvolutionMessage, EvolutionState, FileEdit,
+        Message, Retention, ToolResult, filter_evolution_messages,
+        normalize_openai_max_output_tokens, process_tool_result, read_file_dedup_key,
+        store_tool_result, truncate_build_output_for_model,
     };
 
     fn build_result(success: bool) -> ToolResult {
@@ -2289,13 +2301,13 @@ mod tests {
         }
     }
 
-    fn run_tool_result(result: &ToolResult, evolution: &mut Evolution, build_verified: &mut bool) {
+    fn run_tool_result(result: &ToolResult, evolution: &mut Evolution, done_gate: &mut DoneGate) {
         let mut build_attempts = 0usize;
         process_tool_result(
             "tool-call-id",
             result,
             evolution,
-            build_verified,
+            done_gate,
             &mut build_attempts,
             5,
             0,
@@ -2336,17 +2348,17 @@ mod tests {
     #[test]
     fn failing_build_check_clears_prior_verification() {
         let mut evolution = Evolution::new("prompt");
-        let mut build_verified = false;
+        let mut done_gate = DoneGate::default();
 
-        run_tool_result(&build_result(true), &mut evolution, &mut build_verified);
+        run_tool_result(&build_result(true), &mut evolution, &mut done_gate);
         assert!(
-            build_verified,
+            done_gate.build_verified,
             "a passing build_check should set build_verified"
         );
 
-        run_tool_result(&build_result(false), &mut evolution, &mut build_verified);
+        run_tool_result(&build_result(false), &mut evolution, &mut done_gate);
         assert!(
-            !build_verified,
+            !done_gate.build_verified,
             "a failing build_check must clear the prior verification"
         );
     }
@@ -2361,14 +2373,14 @@ mod tests {
             search: "a".to_string(),
             replace: "b".to_string(),
         });
-        let mut build_verified = false;
+        let mut done_gate = DoneGate::default();
 
-        run_tool_result(&build_result(true), &mut evolution, &mut build_verified);
-        run_tool_result(&build_result(false), &mut evolution, &mut build_verified);
+        run_tool_result(&build_result(true), &mut evolution, &mut done_gate);
+        run_tool_result(&build_result(false), &mut evolution, &mut done_gate);
         run_tool_result(
             &ToolResult::Done("done".to_string()),
             &mut evolution,
-            &mut build_verified,
+            &mut done_gate,
         );
 
         assert!(
@@ -2387,14 +2399,14 @@ mod tests {
             search: "a".to_string(),
             replace: "b".to_string(),
         });
-        let mut build_verified = false;
+        let mut done_gate = DoneGate::default();
         let mut build_attempts = 0usize;
 
         let (msg, _) = process_tool_result(
             "tool-call-id",
             &ToolResult::Done("done".to_string()),
             &mut evolution,
-            &mut build_verified,
+            &mut done_gate,
             &mut build_attempts,
             5,
             0,
@@ -2417,11 +2429,11 @@ mod tests {
     #[test]
     fn edit_after_passing_build_clears_verification() {
         let mut evolution = Evolution::new("prompt");
-        let mut build_verified = false;
+        let mut done_gate = DoneGate::default();
 
-        run_tool_result(&build_result(true), &mut evolution, &mut build_verified);
+        run_tool_result(&build_result(true), &mut evolution, &mut done_gate);
         assert!(
-            build_verified,
+            done_gate.build_verified,
             "a passing build_check should set build_verified"
         );
 
@@ -2432,10 +2444,10 @@ mod tests {
                 replace: "b".to_string(),
             }),
             &mut evolution,
-            &mut build_verified,
+            &mut done_gate,
         );
         assert!(
-            !build_verified,
+            !done_gate.build_verified,
             "an edit after a passing build must clear the prior verification"
         );
     }

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -1536,7 +1536,6 @@ pub async fn generate_evolution<R: Runtime>(
                                 &mut build_verified,
                                 &mut build_attempts,
                                 max_build_attempts,
-                                &host_attr,
                                 start_time,
                                 iteration,
                             ) {
@@ -2032,7 +2031,6 @@ fn process_tool_result(
     build_verified: &mut bool,
     build_attempts: &mut usize,
     max_build_attempts: usize,
-    host_attr: &str,
     start_time: i64,
     iteration: usize,
 ) -> Result<(Message, Option<bool>)> {
@@ -2240,11 +2238,10 @@ fn process_tool_result(
                 info!("⚠️ Agent called done without build verification");
                 let msg = Message::Tool {
                     tool_call_id: tool_call_id.to_string(),
-                    content: format!(
-                        "Before completing, you must verify your changes compile. \
-                         Run build_check with host='{}' to validate, then call done again.",
-                        host_attr
-                    ),
+                    content: "Before completing, you must verify your changes compile. \
+                              Call the build_check tool (it takes no required arguments) \
+                              to validate, then call done again."
+                        .to_string(),
                 };
                 (msg, None) // Break inner loop, continue outer
             } else {
@@ -2301,7 +2298,6 @@ mod tests {
             build_verified,
             &mut build_attempts,
             5,
-            "host",
             0,
             0,
         )
@@ -2378,6 +2374,41 @@ mod tests {
         assert!(
             !matches!(evolution.state, EvolutionState::Generated),
             "done must not complete an evolution whose last build_check failed"
+        );
+    }
+
+    // The rejection hint must only reference parameters build_check actually
+    // accepts; a phantom host= argument sent gpt-oss-120b into a retry loop.
+    #[test]
+    fn done_rejection_hint_references_only_real_build_check_parameters() {
+        let mut evolution = Evolution::new("prompt");
+        evolution.edits.push(FileEdit {
+            path: "configuration.nix".to_string(),
+            search: "a".to_string(),
+            replace: "b".to_string(),
+        });
+        let mut build_verified = false;
+        let mut build_attempts = 0usize;
+
+        let (msg, _) = process_tool_result(
+            "tool-call-id",
+            &ToolResult::Done("done".to_string()),
+            &mut evolution,
+            &mut build_verified,
+            &mut build_attempts,
+            5,
+            0,
+            0,
+        )
+        .expect("done rejection should not error");
+
+        let Message::Tool { content, .. } = msg else {
+            panic!("done rejection should produce a tool message");
+        };
+        assert!(content.contains("build_check"));
+        assert!(
+            !content.contains("host="),
+            "hint must not reference a parameter build_check does not accept: {content}"
         );
     }
 


### PR DESCRIPTION
In #550 we bring the Eval suite back in shape. This is one of a series of PR's addressing some initial findings running it.

This addresses 2 + 3 of the evolve-loop convergence follow-ups (`apps/eval/wip/eval-suite-findings.md` on `jp/eval-fixes`). Companion to #551.

## Problems

1. When `done` arrives with unverified edits, the engine replied "Run build_check with host='<host>'" — but `build_check` accepts no `host` parameter. gpt-oss-120b takes the hint literally, concludes the tool is broken, and re-calls `done` with near-identical summaries; the rejection text was byte-identical on every repeat, so nothing broke the cycle (baseline case spent iterations 11–25 in this loop).
2. Repeated rejected `done` calls counted toward no limit, so a session stuck in this loop only exits via `maxIterations`, burning the full iteration/token budget (baseline cases 39/44/60: 25 iterations, 265–425k tokens each).

## Changes (4 commits, each green)

- **Drop the phantom `host` argument** from the rejection hint (and the now-unused `host_attr` parameter of `process_tool_result`).
- **Refactor:** `build_verified` moves into a `DoneGate` struct so completion-gate state travels together.
- **Escalate repeats:** consecutive rejections are tracked; from the second one the message changes and inlines the last `build_check` failure (or points out `build_check` was never run). Any `build_check` attempt resets the streak.
- **Stop gracefully:** after 3 consecutive rejections the standard limit flow runs — interactive sessions ask the user, non-interactive runs stop with a `LimitReached` summary saying the changes never passed a build check — instead of grinding to `maxIterations`.

## Testing

- 4 new unit tests: hint references only real parameters; repeat rejections differ and inline the last build error; `build_check` resets the streak; plus existing done/build-verification tests still pass.
- Full `cargo test` green except the 2 pre-existing sandbox-only `prepare_import_target_*` failures (pass when run normally).
- Eval spot-check (cases 39/44/60, PR1+PR2 binary): no regressions attributable to this change; in this stochastic sample none of the three cases entered the done-rejection loop (they failed via exploration thrash, item 4), so the new paths are exercised by the unit tests rather than this run. Full 28-case sweep is the real re-measure.
