### PR TITLE
fix(evolve): stop edit_nix_file 'set' from corrupting flakes on nested paths

### DIFF
--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -906,7 +906,34 @@ fn remove(content: &str, attrpath: &str, values: &[String]) -> Result<String> {
     Ok(content.to_string())
 }
 
+/// Reject string values that are Nix source in disguise. A value like
+/// `"{ url = …; }"` would be spliced as a *quoted string literal* — observed
+/// with gpt-oss-120b setting `inputs.home-manager` to a stringified attrset,
+/// which produced `inputs.home-manager = "{ … }";` and a broken flake. Only
+/// strings that actually parse as Nix attrset/list syntax are rejected, so
+/// ordinary string values (including ones containing braces) pass through.
+fn reject_nix_source_string(value: &serde_json::Value) -> Result<()> {
+    let Some(text) = value.as_str() else {
+        return Ok(());
+    };
+    let trimmed = text.trim();
+    let looks_structural = (trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'));
+    if !looks_structural {
+        return Ok(());
+    }
+    if Root::parse(trimmed).errors().is_empty() {
+        return Err(anyhow::anyhow!(
+            "The value is Nix source serialized as a string; inserting it would produce a \
+             quoted string literal, not the expression you intend. Pass structured JSON \
+             instead: objects become attrsets and arrays become lists."
+        ));
+    }
+    Ok(())
+}
+
 fn set_value(content: &str, attrpath: &str, value: &serde_json::Value) -> Result<String> {
+    reject_nix_source_string(value)?;
     let rendered_value = render_nix_value(value)?;
 
     if let Some(value_range) = find_assignment_value_range(content, attrpath) {
@@ -1591,6 +1618,38 @@ environment.systemPackages = with pkgs; [
         assert!(
             Root::parse(&edited).errors().is_empty(),
             "edited content must stay valid Nix:\n{edited}"
+        );
+    }
+
+    #[test]
+    fn set_rejects_stringified_nix_attrset_value() {
+        let err = set_value(
+            FLAKE_WITH_INPUTS,
+            "inputs.home-manager",
+            &serde_json::Value::String(
+                "{\n  url = \"github:nix-community/home-manager\";\n}".to_string(),
+            ),
+        )
+        .expect_err("set should refuse Nix source disguised as a string");
+
+        assert!(
+            err.to_string().contains("structured JSON"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn set_keeps_braced_prose_strings_as_strings() {
+        let edited = set_value(
+            WITH_PKGS_EMPTY,
+            "system.defaults.loginwindow.LoginwindowText",
+            &serde_json::Value::String("{ welcome to this mac }".to_string()),
+        )
+        .expect("prose in braces is still a string value");
+
+        assert!(
+            edited.contains("LoginwindowText = \"{ welcome to this mac }\";"),
+            "expected the prose string to stay quoted:\n{edited}"
         );
     }
 

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -923,7 +923,33 @@ fn set_value(content: &str, attrpath: &str, value: &serde_json::Value) -> Result
     let root: Root = parsed
         .ok()
         .context("Failed to parse Nix content when setting value")?;
-    let insert_pos = find_top_level_attrset_end(&root.syntax().clone())
+    let root_node = root.syntax().clone();
+
+    // The flat matcher above only sees `a.b.c = …` written literally. A leaf
+    // that lives inside an attrset literal (`a = { b.c = …; }`) must be
+    // replaced in place — inserting a fresh assignment would define the same
+    // attribute twice.
+    if let Some(value_node) = find_attrpath_value_node(&root_node, attrpath) {
+        let byte_range = text_range_to_usize_range(value_node.text_range());
+        info!(
+            "Replacing nested value for {} at {:?} with {}",
+            attrpath, byte_range, rendered_value
+        );
+        let mut patched = content.to_string();
+        patched.replace_range(byte_range, &rendered_value);
+        return Ok(patched);
+    }
+
+    // Nix forbids `inputs = { … }` and `inputs.home-manager = …` side by
+    // side ("attribute 'inputs' already defined"), so when a prefix of the
+    // attrpath is already bound, the new attribute must go inside it.
+    if let Some(patched) =
+        insert_into_prefix_attrset(content, &root_node, attrpath, &rendered_value)?
+    {
+        return Ok(patched);
+    }
+
+    let insert_pos = find_top_level_attrset_end(&root_node)
         .context("Cannot find top-level attribute set to insert scalar attr")?;
     let addition = format!("\n  {} = {};", attrpath, rendered_value);
     info!(
@@ -933,6 +959,70 @@ fn set_value(content: &str, attrpath: &str, value: &serde_json::Value) -> Result
     let mut patched = content.to_string();
     patched.insert_str(insert_pos, &addition);
     Ok(patched)
+}
+
+/// If a strict prefix of `attrpath` is already bound, insert the remainder
+/// inside that binding's attrset literal (before its closing brace). Errors
+/// when the prefix is bound to something that is not an attrset literal —
+/// inserting a sibling dotted assignment would be invalid Nix, and silently
+/// rewriting a non-literal value (e.g. `inputs = import ./x.nix`) is not our
+/// call to make.
+fn insert_into_prefix_attrset(
+    content: &str,
+    root: &SyntaxNode,
+    attrpath: &str,
+    rendered_value: &str,
+) -> Result<Option<String>> {
+    let segments: Vec<&str> = attrpath.split('.').collect();
+    for split in (1..segments.len()).rev() {
+        let prefix = segments[..split].join(".");
+        let Some(prefix_value) = find_attrpath_value_node(root, &prefix) else {
+            continue;
+        };
+        let remainder = segments[split..].join(".");
+
+        if AttrSet::cast(prefix_value.clone()).is_none() {
+            return Err(anyhow::anyhow!(
+                "Cannot set '{}': '{}' is already defined and is not an attrset literal. \
+                 Edit the value of '{}' directly instead.",
+                attrpath,
+                prefix,
+                prefix
+            ));
+        }
+
+        let byte_range = text_range_to_usize_range(prefix_value.text_range());
+        let attrset_text = content
+            .get(byte_range.clone())
+            .context("Attrset text range was out of bounds")?;
+        let close_offset = attrset_text
+            .rfind('}')
+            .context("Existing attrset literal had no closing '}' token")?;
+
+        let insertion = if attrset_text.contains('\n') {
+            // Multiline: the closing line's indentation already precedes the
+            // insertion point, so emit one extra level, then restore the
+            // closing line's own indent after the newline.
+            let before_close = &attrset_text[..close_offset];
+            let close_line_start = before_close.rfind('\n').map_or(0, |idx| idx + 1);
+            let close_indent: String = attrset_text[close_line_start..close_offset]
+                .chars()
+                .take_while(|ch| ch.is_whitespace())
+                .collect();
+            format!("  {} = {};\n{}", remainder, rendered_value, close_indent)
+        } else {
+            format!("{} = {}; ", remainder, rendered_value)
+        };
+
+        info!(
+            "Inserting '{} = {}' inside existing attrset '{}'",
+            remainder, rendered_value, prefix
+        );
+        let mut patched = content.to_string();
+        patched.insert_str(byte_range.start + close_offset, &insertion);
+        return Ok(Some(patched));
+    }
+    Ok(None)
 }
 
 /// Find the end of the top-level attribute set to insert new attributes
@@ -1437,6 +1527,86 @@ environment.systemPackages = with pkgs; [
         assert!(
             edited.contains("networking.hostName = \"my-mac\";"),
             "expected set to quote string values as Nix strings"
+        );
+    }
+
+    const FLAKE_WITH_INPUTS: &str = r#"{
+  description = "test";
+
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, ... }: { };
+}
+"#;
+
+    // The case-44 failure shape: setting `inputs.home-manager` while
+    // `inputs = { … }` exists must merge into that block — a sibling
+    // top-level assignment is invalid Nix ("attribute 'inputs' already
+    // defined").
+    #[test]
+    fn set_merges_new_attribute_into_existing_prefix_attrset() {
+        let edited = set_value(
+            FLAKE_WITH_INPUTS,
+            "inputs.home-manager",
+            &serde_json::json!({"url": "github:nix-community/home-manager"}),
+        )
+        .expect("set should succeed");
+
+        assert_eq!(
+            edited.matches("inputs =").count(),
+            1,
+            "must not add a second `inputs` binding:\n{edited}"
+        );
+        assert!(
+            edited.contains("home-manager = { url = \"github:nix-community/home-manager\"; };"),
+            "expected home-manager inside the inputs block:\n{edited}"
+        );
+        assert!(
+            Root::parse(&edited).errors().is_empty(),
+            "edited content must stay valid Nix:\n{edited}"
+        );
+    }
+
+    #[test]
+    fn set_replaces_leaf_nested_inside_attrset_literal() {
+        let edited = set_value(
+            FLAKE_WITH_INPUTS,
+            "inputs.nixpkgs.url",
+            &serde_json::Value::String("github:NixOS/nixpkgs/nixos-24.05".to_string()),
+        )
+        .expect("set should succeed");
+
+        assert!(
+            edited.contains("url = \"github:NixOS/nixpkgs/nixos-24.05\";"),
+            "expected nested url to be replaced in place:\n{edited}"
+        );
+        assert!(
+            !edited.contains("inputs.nixpkgs.url ="),
+            "must not insert a duplicate flat assignment:\n{edited}"
+        );
+        assert!(
+            Root::parse(&edited).errors().is_empty(),
+            "edited content must stay valid Nix:\n{edited}"
+        );
+    }
+
+    #[test]
+    fn set_rejects_prefix_bound_to_non_attrset() {
+        let content = "{\n  inputs = import ./inputs.nix;\n}\n";
+        let err = set_value(
+            content,
+            "inputs.home-manager",
+            &serde_json::json!({"url": "github:nix-community/home-manager"}),
+        )
+        .expect_err("set should refuse to shadow a non-attrset binding");
+
+        assert!(
+            err.to_string().contains("not an attrset literal"),
+            "unexpected error: {err:#}"
         );
     }
 


### PR DESCRIPTION
In #550 we bring the Eval suite back in shape. This is one of a series of PR's addressing some initial findings running it.

This addresses item 5 of the evolve-loop convergence follow-ups (`apps/eval/wip/eval-suite-findings.md` on `jp/eval-fixes`). Companion to #551–#554.

## Problem

Observed in eval case 44: the model called `edit_nix_file action=set path=inputs.home-manager` with an attrset value while `inputs = { … }` already existed. `set_value` only matched a *flat* dotted LHS, so it fell back to inserting a top-level `inputs.home-manager = "…"` — which (a) conflicts with the existing `inputs` binding (`error: attribute 'inputs' already defined`; Nix forbids mixing `inputs = {…}` and `inputs.x = …` at one level) and (b) rendered the attrset value, passed as a string, as a quoted string literal. The model then burned its remaining iterations repairing the damage and hit `limitReached` anyway.

## Changes (2 commits)

1. **AST-aware `set`** (reusing the resolver `add()` already has):
   - a leaf nested inside an attrset literal (`inputs = { nixpkgs = { url = …; }; }` + set `inputs.nixpkgs.url`) is replaced in place;
   - a new dotted path whose prefix is already bound to an attrset literal is merged *inside* that block (multiline indentation preserved);
   - a prefix bound to a non-attrset value (`inputs = import ./x.nix`) is refused with a clear error instead of silently corrupting.
2. **String-value guard:** a string value that parses as Nix attrset/list syntax is rejected with guidance to pass structured JSON. Ordinary strings — including braced prose that isn't valid Nix — pass through unchanged.

## Testing

6 new unit tests replicating the exact case-44 file shape (merge without duplicate `inputs`, in-place nested replace, non-attrset prefix refusal, stringified-attrset rejection, braced-prose passthrough), plus the existing 31 editor tests all green. Full `cargo test` green except the 2 pre-existing sandbox-only failures. End-to-end effect will show in the next full 28-case sweep.
