### PR TITLE
fix(evolve): tell the model which tool edits .nixmac data.json

### DIFF
--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -212,8 +212,21 @@ pub(crate) fn ensure_nixmac_edit_allowed(tool: &str, path: &str) -> Result<()> {
         return Ok(());
     }
 
+    // A data.json path rejected only because of the tool choice needs a
+    // different message: telling the model "you may edit only
+    // .nixmac/<module>/data.json" while it is doing exactly that reads as a
+    // contradiction (observed: gpt-oss-120b gave up and never edited again).
+    if is_module_data_json {
+        return Err(anyhow!(
+            "{}: .nixmac/<module>/data.json is JSON, not Nix — edit it with the \
+             edit_file tool instead",
+            tool
+        ));
+    }
+
     Err(anyhow!(
-        "{}: .nixmac is reserved for Nixmac official modules; agents may edit only .nixmac/<module>/data.json",
+        "{}: .nixmac is reserved for Nixmac official modules; agents may edit only \
+         .nixmac/<module>/data.json (via edit_file)",
         tool
     ))
 }
@@ -1042,5 +1055,22 @@ mod tests {
                 banned
             );
         }
+    }
+
+    #[test]
+    fn nixmac_guard_points_wrong_tool_at_edit_file_for_data_json() {
+        let err = super::ensure_nixmac_edit_allowed("edit_nix_file", ".nixmac/homebrew/data.json")
+            .expect_err("edit_nix_file must not edit module data.json");
+        assert!(
+            err.to_string().contains("edit_file"),
+            "error must name the tool that CAN do this edit: {err:#}"
+        );
+
+        let err = super::ensure_nixmac_edit_allowed("edit_file", ".nixmac/homebrew/default.nix")
+            .expect_err("non-data.json .nixmac files stay reserved");
+        assert!(err.to_string().contains("reserved"), "unexpected: {err:#}");
+
+        super::ensure_nixmac_edit_allowed("edit_file", ".nixmac/homebrew/data.json")
+            .expect("edit_file on module data.json is allowed");
     }
 }

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -212,18 +212,6 @@ pub(crate) fn ensure_nixmac_edit_allowed(tool: &str, path: &str) -> Result<()> {
         return Ok(());
     }
 
-    // A data.json path rejected only because of the tool choice needs a
-    // different message: telling the model "you may edit only
-    // .nixmac/<module>/data.json" while it is doing exactly that reads as a
-    // contradiction (observed: gpt-oss-120b gave up and never edited again).
-    if is_module_data_json {
-        return Err(anyhow!(
-            "{}: .nixmac/<module>/data.json is JSON, not Nix — edit it with the \
-             edit_file tool instead",
-            tool
-        ));
-    }
-
     Err(anyhow!(
         "{}: .nixmac is reserved for Nixmac official modules; agents may edit only \
          .nixmac/<module>/data.json (via edit_file)",
@@ -1058,9 +1046,9 @@ mod tests {
     }
 
     #[test]
-    fn nixmac_guard_points_wrong_tool_at_edit_file_for_data_json() {
-        let err = super::ensure_nixmac_edit_allowed("edit_nix_file", ".nixmac/homebrew/data.json")
-            .expect_err("edit_nix_file must not edit module data.json");
+    fn nixmac_guard_names_edit_file_for_module_data_json() {
+        let err = super::ensure_nixmac_edit_allowed("ensure_secret", ".nixmac/homebrew/data.json")
+            .expect_err("only edit_file may edit module data.json");
         assert!(
             err.to_string().contains("edit_file"),
             "error must name the tool that CAN do this edit: {err:#}"
@@ -1072,5 +1060,40 @@ mod tests {
 
         super::ensure_nixmac_edit_allowed("edit_file", ".nixmac/homebrew/data.json")
             .expect("edit_file on module data.json is allowed");
+    }
+
+    #[test]
+    fn edit_nix_file_rejects_non_nix_files_and_names_edit_file() {
+        let tmp = tempdir().expect("tempdir");
+
+        for path in [".nixmac/homebrew/data.json", "config/settings.json"] {
+            let result = execute_tool(
+                tmp.path(),
+                tmp.path().to_str().expect("utf-8 path"),
+                "dummy-host",
+                "edit_nix_file",
+                &json!({
+                    "path": path,
+                    "action": {
+                        "set": {
+                            "path": "homebrew.enable",
+                            "value": true
+                        }
+                    }
+                }),
+                false,
+                None,
+            );
+
+            let err = result.expect_err("edit_nix_file must reject non-.nix files");
+            assert!(
+                err.to_string().contains("not a .nix file"),
+                "'{path}' must be rejected by the extension gate: {err:#}"
+            );
+            assert!(
+                err.to_string().contains("edit_file"),
+                "error must name the tool that CAN edit '{path}': {err:#}"
+            );
+        }
     }
 }

--- a/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/edit_nix_file.rs
@@ -17,6 +17,7 @@ pub(crate) fn definition() -> Tool {
         description: r#"Edit a Nix file with semantic operations using attribute-path Add/Remove/Set/SetAttrs actions.
 Use this tool whenever you need the agent to make structured edits to Nix config. `add` and `remove` operate on list-valued attributes such as `home.packages` or `environment.systemPackages`. For Homebrew list attributes (`homebrew.brews`, `homebrew.casks`, and `homebrew.taps`), pass raw package/token strings such as `"bat"`; the tool writes them as Nix string literals. `set` assigns a scalar value such as a boolean, string, number, or `null` to an attribute path like `services.tailscale.enable`. `set_attrs` creates or updates a Nix attribute set (object) at a given path and sets key-value pairs inside it, including nested JSON objects/arrays that map to nested Nix attrsets/lists. Use this for options like `system.defaults.dock` that take an attrset value. The tool understands Nix syntax and will modify existing assignments when possible, or insert a new assignment into the module body if missing.
 Prefer: provide an `action` object with exactly one of `add`, `remove`, `set`, or `set_attrs`. A shorthand string action such as `"add"` is also accepted with sibling payload fields (for example `values`) and, when possible, the tool infers the only list attribute path in the target file. After calling this tool, run `build_check` to verify changes.
+IMPORTANT: This tool edits .nix files only; use edit_file for JSON and other file types.
 IMPORTANT: Do not use this tool for files under .nixmac. Nix implementation files there are reserved for Nixmac; only exact .nixmac/<module>/data.json files may be edited with edit_file.
 IMPORTANT: The generated Nix code is syntax-validated before writing. Edits with syntax errors (unmatched braces/brackets, unclosed strings, etc) will be rejected. Ensure all generated code is syntactically complete and correct."#.to_string(),            parameters: serde_json::json!({
             "type": "object",
@@ -366,6 +367,18 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
         .ok_or_else(|| anyhow!("edit_nix_file: missing path"))?;
     if looks_like_attr_path(path) {
         return Err(explain_attr_path_used_as_file_path(args, path));
+    }
+    // Reject non-Nix files before the .nixmac guard: a data.json path must get
+    // a "wrong tool" error, not a reservation error telling the model it may
+    // edit only the very path it passed (observed: gpt-oss-120b read that as a
+    // contradiction and gave up).
+    if !path.ends_with(".nix") {
+        return Err(anyhow!(
+            "edit_nix_file: '{}' is not a .nix file — this tool makes semantic edits \
+             to Nix code only. Use edit_file for JSON and other file types \
+             (e.g. .nixmac/<module>/data.json).",
+            path
+        ));
     }
     ensure_nixmac_edit_allowed("edit_nix_file", path)?;
 


### PR DESCRIPTION
In #550 we bring the Eval suite back in shape. This is one of a series of PR's addressing some initial findings running it.

This addresses item 7 of the evolve-loop convergence follow-ups (new finding from the full 28-case sweep; doc on `jp/eval-fixes`). Companion to #551–#555.

In sweep case 69, the model called `edit_nix_file` on `.nixmac/homebrew/data.json` and was told *"agents may edit only .nixmac/<module>/data.json"* — the exact path it had just passed. The actual rule is that module data.json is editable only via `edit_file` (it's JSON, not Nix), but the message never said so; the model read it as a contradiction, gave up on editing entirely, and died at the no-progress limit.

The guard now returns a tool-specific message ("…is JSON, not Nix — edit it with the edit_file tool instead") for data.json paths, and the generic reserved message names `edit_file` too. One unit test covering the three cases (wrong tool on data.json, reserved non-data.json path, allowed edit_file on data.json).