### PR TITLE
fix: persist inference setup form draft in onboarding store to survive remounts

### DIFF
--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { InferenceSetup } from "@/components/widget/onboarding/inference/inference-setup";
 import type { AccountBilling, BillingProductInfo } from "@/lib/orpc";
+import { onboardingActions } from "@nixmac/state";
 
 type AuthStatus = {
   signedIn: boolean;
@@ -134,6 +135,7 @@ function renderSetup(onConfigured = vi.fn<(config: unknown) => void>()): void {
 describe("InferenceSetup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    onboardingActions.reset();
     mocks.status.mockResolvedValue({
       signedIn: false,
       account: null,
@@ -240,6 +242,34 @@ describe("InferenceSetup", () => {
         }),
       ),
     );
+  });
+
+  it("preserves BYOK entries when the setup component remounts", async () => {
+    const { unmount } = render(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+          })
+        }
+      >
+        <InferenceSetup onConfigured={vi.fn<(config: unknown) => void>()} />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /bring your own key/i }));
+    fireEvent.change(screen.getByLabelText("API key"), {
+      target: { value: "sk-or-v1-test-key-with-enough-length" },
+    });
+
+    unmount();
+    renderSetup();
+
+    expect(screen.getByRole("tab", { name: /bring your own key/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByLabelText("API key")).toHaveValue("sk-or-v1-test-key-with-enough-length");
   });
 
   it("resumes at payment when a web account is already persisted", async () => {

--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.tsx
@@ -33,6 +33,7 @@ import type { AccountBilling, BillingProductInfo } from "@/lib/orpc";
 import { client, orpc } from "@/lib/orpc";
 import { getTelemetry } from "@/lib/telemetry/instance";
 import { cn } from "@/lib/utils";
+import { onboardingActions, useOnboarding } from "@nixmac/state";
 import NixmacIcon from "@nixmac/ui/components/icon";
 import { useQuery } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-shell";
@@ -53,7 +54,9 @@ interface InferenceSetupProps {
 }
 
 export function InferenceSetup({ onConfigured }: InferenceSetupProps) {
-  const [mode, setMode] = useState<InferenceMode>("hosted");
+  const mode = useOnboarding((s) => s.inferenceSetupDraft.mode);
+  const setMode = (nextMode: InferenceMode) =>
+    onboardingActions.setInferenceSetupDraft({ mode: nextMode });
 
   return (
     <div className="flex flex-col gap-5">
@@ -260,10 +263,10 @@ function activeBillingLabel(billing: AccountBilling | null | undefined): string 
 
 function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) => void }) {
   const [stage, setStage] = useState<HostedStage>("account");
-  const [email, setEmail] = useState("");
-  const [otp, setOtp] = useState("");
-  const [otpSent, setOtpSent] = useState(false);
-  const [selectedPlan, setSelectedPlan] = useState<CheckoutProduct>("credits");
+  const { email, otp, otpSent, selectedPlan } = useOnboarding(
+    (s) => s.inferenceSetupDraft.hosted,
+  );
+  const setHostedDraft = onboardingActions.setHostedInferenceDraft;
   const [checkoutStarted, setCheckoutStarted] = useState(false);
   const [planChooserExpanded, setPlanChooserExpanded] = useState(false);
   const [working, setWorking] = useState(false);
@@ -294,7 +297,7 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
   const showPlanChooser = !activePlanLabel || planChooserExpanded;
 
   function selectPlan(plan: CheckoutProduct) {
-    setSelectedPlan(plan);
+    setHostedDraft({ selectedPlan: plan });
     setCheckoutStarted(false);
     setError(null);
   }
@@ -320,16 +323,14 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
       .status()
       .then((status) => {
         if (cancelled || !status.webAccount) return;
-        setEmail(status.webAccount.email);
-        setOtp("");
-        setOtpSent(false);
+        setHostedDraft({ email: status.webAccount.email, otp: "", otpSent: false });
         setStage("payment");
       })
       .catch(() => { });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [setHostedDraft]);
 
   async function sendSignInCode() {
     if (!emailValid) return;
@@ -338,8 +339,7 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
     try {
       // deprecated(orpc): replace with client/orpc from @/lib/orpc
       await tauriAPI.account.sendOtp(normalizedEmail);
-      setOtp("");
-      setOtpSent(true);
+      setHostedDraft({ otp: "", otpSent: true });
     } catch (e: unknown) {
       setError(errorMessage(e));
     } finally {
@@ -348,8 +348,7 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
   }
 
   function changeEmail() {
-    setOtp("");
-    setOtpSent(false);
+    setHostedDraft({ otp: "", otpSent: false });
     setError(null);
   }
 
@@ -364,8 +363,7 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
         otp.trim(),
         accountNameFromEmail(normalizedEmail),
       );
-      setEmail(normalizedEmail);
-      setOtp("");
+      setHostedDraft({ email: normalizedEmail, otp: "" });
       posthog.identify(normalizedEmail, { email: normalizedEmail });
       getTelemetry().captureEvent({ name: "account_signed_in" });
       setStage("payment");
@@ -443,7 +441,7 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
             id="inf-email"
             type="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => setHostedDraft({ email: e.target.value })}
             placeholder="you@example.com"
             autoComplete="email"
             disabled={otpSent || working}
@@ -462,7 +460,7 @@ function HostedFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) 
                 type="text"
                 inputMode="numeric"
                 value={otp}
-                onChange={(e) => setOtp(e.target.value)}
+                onChange={(e) => setHostedDraft({ otp: e.target.value })}
                 placeholder="Enter the code from your email"
                 autoComplete="one-time-code"
                 className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -693,13 +691,9 @@ function PlanCard({
 type KeyState = "idle" | "checking" | "invalid" | "valid";
 
 function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) => void }) {
-  const initialProvider = getAiModelProvider("openrouter");
-  const [providerId, setProviderId] = useState(initialProvider.id);
+  const { providerId, model, key, baseUrl } = useOnboarding((s) => s.inferenceSetupDraft.byok);
+  const setByokDraft = onboardingActions.setByokInferenceDraft;
   const provider = useMemo(() => getAiModelProvider(providerId), [providerId]);
-  // Empty model tracks the provider default at runtime.
-  const [model, setModel] = useState("");
-  const [key, setKey] = useState("");
-  const [baseUrl, setBaseUrl] = useState("");
   const [keyState, setKeyState] = useState<KeyState>("idle");
   const [serverError, setServerError] = useState("");
   const cliProvidersVisible = useCliProvidersVisible();
@@ -724,10 +718,14 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
   async function changeProvider(id: string) {
     const next = getAiModelProvider(id);
     await tauriAPI.models.clearCached(next.id);
-    setProviderId(next.id);
-    setModel(prefillModel(next.id, "evolve"));
-    setKey("");
-    setBaseUrl("");
+    setByokDraft({
+      providerId: next.id,
+      // Empty model tracks the provider default at runtime unless provider choice
+      // carries an explicit onboarding prefill.
+      model: prefillModel(next.id, "evolve"),
+      key: "",
+      baseUrl: "",
+    });
     setKeyState("idle");
     setServerError("");
   }
@@ -809,7 +807,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
             <input
               type="text"
               value={model}
-              onChange={(e) => setModel(e.target.value)}
+              onChange={(e) => setByokDraft({ model: e.target.value })}
               placeholder="Leave empty for CLI default"
               className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
             />
@@ -820,7 +818,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
               }
               defaultModel={getAiModelProvider(provider.id).defaultEvolveModel}
               value={model}
-              onChange={setModel}
+              onChange={(nextModel) => setByokDraft({ model: nextModel })}
               placeholder={modelPlaceholder(provider.id, "evolve")}
             />
           )}
@@ -848,7 +846,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
               type="password"
               value={key}
               onChange={(e) => {
-                setKey(e.target.value);
+                setByokDraft({ key: e.target.value });
                 setKeyState("idle");
                 setServerError("");
               }}
@@ -903,7 +901,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
               type="url"
               value={baseUrl}
               onChange={(e) => {
-                setBaseUrl(e.target.value);
+                setByokDraft({ baseUrl: e.target.value });
                 setKeyState("idle");
                 setServerError("");
               }}
@@ -926,7 +924,7 @@ function ByokFlow({ onConfigured }: { onConfigured: (config: InferenceConfig) =>
                   type="password"
                   value={key}
                   onChange={(e) => {
-                    setKey(e.target.value);
+                    setByokDraft({ key: e.target.value });
                     setKeyState("idle");
                     setServerError("");
                   }}

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -74,6 +74,6 @@ export {
 	useOnboarding,
 	type OnboardingSelector,
 } from "./onboarding";
-export type { TrackedCustomizationSource } from "./onboarding";
+export type { InferenceSetupDraft, TrackedCustomizationSource } from "./onboarding";
 
 export type { InferenceConfig, InferenceMode } from "./onboarding-types";

--- a/packages/state/src/onboarding/index.ts
+++ b/packages/state/src/onboarding/index.ts
@@ -13,4 +13,4 @@ export {
 	useOnboarding,
 	type OnboardingSelector,
 } from "./selectors";
-export type { TrackedCustomizationSource } from "./types";
+export type { InferenceSetupDraft, TrackedCustomizationSource } from "./types";

--- a/packages/state/src/onboarding/store.ts
+++ b/packages/state/src/onboarding/store.ts
@@ -7,11 +7,28 @@
  */
 
 import { create } from "zustand";
-import type { OnboardingStateValues, OnboardingStepId } from "./types";
+import type { InferenceSetupDraft, OnboardingStateValues, OnboardingStepId } from "./types";
+
+export const initialInferenceSetupDraft: InferenceSetupDraft = {
+	mode: "hosted",
+	hosted: {
+		email: "",
+		otp: "",
+		otpSent: false,
+		selectedPlan: "credits",
+	},
+	byok: {
+		providerId: "openrouter",
+		model: "",
+		key: "",
+		baseUrl: "",
+	},
+};
 
 export const initialOnboardingState: OnboardingStateValues = {
 	trackedCustomizations: [],
 	trackedCustomizationSources: {},
+	inferenceSetupDraft: initialInferenceSetupDraft,
 	inferenceDeferred: false,
 	celebrating: false,
 	viewingStep: null,
@@ -24,6 +41,11 @@ export type OnboardingActions = {
 		trackedCustomizations: string[],
 		trackedCustomizationSources: OnboardingStateValues["trackedCustomizationSources"],
 	) => void;
+	setInferenceSetupDraft: (draft: Partial<InferenceSetupDraft>) => void;
+	setHostedInferenceDraft: (
+		draft: Partial<InferenceSetupDraft["hosted"]>,
+	) => void;
+	setByokInferenceDraft: (draft: Partial<InferenceSetupDraft["byok"]>) => void;
 	/** Defer inference to the build step (inline setup runs alongside the build). */
 	deferInference: () => void;
 	/** Keep the success celebration mounted after the build gate is satisfied. */
@@ -41,6 +63,33 @@ export const onboardingStore = create<OnboardingStore>()((set) => ({
 		trackedCustomizations,
 		trackedCustomizationSources,
 	) => set({ trackedCustomizations, trackedCustomizationSources }),
+	setInferenceSetupDraft: (draft) =>
+		set((state) => ({
+			inferenceSetupDraft: {
+				...state.inferenceSetupDraft,
+				...draft,
+			},
+		})),
+	setHostedInferenceDraft: (draft) =>
+		set((state) => ({
+			inferenceSetupDraft: {
+				...state.inferenceSetupDraft,
+				hosted: {
+					...state.inferenceSetupDraft.hosted,
+					...draft,
+				},
+			},
+		})),
+	setByokInferenceDraft: (draft) =>
+		set((state) => ({
+			inferenceSetupDraft: {
+				...state.inferenceSetupDraft,
+				byok: {
+					...state.inferenceSetupDraft.byok,
+					...draft,
+				},
+			},
+		})),
 	deferInference: () => set({ inferenceDeferred: true, viewingStep: null }),
 	setCelebrating: (celebrating) => set({ celebrating }),
 	setViewingStep: (viewingStep) => set({ viewingStep }),
@@ -56,6 +105,9 @@ export const onboardingStore = create<OnboardingStore>()((set) => ({
 const {
 	reset,
 	setTrackedCustomizations,
+	setInferenceSetupDraft,
+	setHostedInferenceDraft,
+	setByokInferenceDraft,
 	deferInference,
 	setCelebrating,
 	setViewingStep,
@@ -71,6 +123,9 @@ export const onboardingActions: OnboardingActions & {
 	subscribe: onboardingStore.subscribe,
 	reset,
 	setTrackedCustomizations,
+	setInferenceSetupDraft,
+	setHostedInferenceDraft,
+	setByokInferenceDraft,
 	deferInference,
 	setCelebrating,
 	setViewingStep,

--- a/packages/state/src/onboarding/types.ts
+++ b/packages/state/src/onboarding/types.ts
@@ -14,6 +14,22 @@ export type TrackedCustomizationSource =
   | { type: "launchd"; item: LaunchdItem }
   | { type: "system-default"; item: SystemDefault };
 
+export type InferenceSetupDraft = {
+  mode: "hosted" | "byok";
+  hosted: {
+    email: string;
+    otp: string;
+    otpSent: boolean;
+    selectedPlan: "credits" | "pro";
+  };
+  byok: {
+    providerId: string;
+    model: string;
+    key: string;
+    baseUrl: string;
+  };
+};
+
 /**
  * Transient, session-only onboarding UI state. Completion and per-step progress
  * are NOT stored here — they are derived from durable facts (permissions, nix,
@@ -25,6 +41,8 @@ export type OnboardingStateValues = {
   trackedCustomizations: string[];
   /** Original scanner payload for each tracked customization, keyed by customization ID. */
   trackedCustomizationSources: Record<string, TrackedCustomizationSource>;
+  /** In-progress inference form values, kept in memory while the wizard remounts steps. */
+  inferenceSetupDraft: InferenceSetupDraft;
   /** User chose to defer inference setup until the first build runs. */
   inferenceDeferred: boolean;
   /** Keep the success celebration mounted after the build gate is satisfied. */


### PR DESCRIPTION
## Summary

See Linear issue #597 -- if you do your inference setup i the Onboarding wizard then bounce away to a different step and come back, all your entries are lost, which is annoying. This PR adds in-memory state that survives react remounts.

<!-- What does this PR do? Why? -->

## Test Plan

Updated unit tests, and tested manually.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed