### PR TITLE
fix(native): allow window drag while settings open

### DIFF
--- a/apps/native/.storybook/main.ts
+++ b/apps/native/.storybook/main.ts
@@ -3,7 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mergeConfig } from "vite";
-import { nixmacBuildDefines } from "../nixmac-profile";
+import { nixmacBuildDefines } from "../nixmac-profile.ts";
 
 const storybookDir = fileURLToPath(new URL(".", import.meta.url));
 const appRoot = path.resolve(storybookDir, "..");
@@ -13,7 +13,6 @@ const statePackageRoot = path.resolve(repoRoot, "packages/state/src");
 
 const config: StorybookConfig = {
   stories: [
-    "../src/**/*.mdx",
     "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../../../packages/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],

--- a/apps/native/src/components/widget/settings/settings-dialog.test.tsx
+++ b/apps/native/src/components/widget/settings/settings-dialog.test.tsx
@@ -1,0 +1,65 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RouterProvider, nav, router } from "@/router";
+
+// The root layout mounts DarwinWidget alongside the settings overlay; its
+// side-effect hooks are irrelevant to this test.
+vi.mock("@/components/widget/widget", () => ({
+  DarwinWidget: () => null,
+}));
+
+// Tab contents are exercised by their own tests — stub them all so switching
+// module-level imports don't drag in the IPC layer.
+vi.mock("@/components/widget/settings/account-tab", () => ({ AccountTab: () => null }));
+vi.mock("@/components/widget/settings/ai-models-tab", () => ({ AiModelsTab: () => null }));
+vi.mock("@/components/widget/settings/api-keys-tab", () => ({ ApiKeysTab: () => null }));
+vi.mock("@/components/widget/settings/developer-tab", () => ({ DeveloperTab: () => null }));
+vi.mock("@/components/widget/settings/general-tab", () => ({ GeneralTab: () => null }));
+vi.mock("@/components/widget/settings/permissions-tab", () => ({ PermissionsTab: () => null }));
+vi.mock("@/components/widget/settings/preferences-tab", () => ({ PreferencesTab: () => null }));
+vi.mock("@/components/widget/settings/tuning-tab", () => ({ TuningTab: () => null }));
+
+vi.mock("@/hooks/use-darwin-config", () => ({
+  useDarwinConfig: () => ({ saveHost: vi.fn() }),
+}));
+
+vi.mock("@/viewmodel/preferences", () => ({
+  refreshHostsSnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    ui: {
+      getPrefs: vi.fn().mockResolvedValue(null),
+      setPrefs: vi.fn().mockResolvedValue(undefined),
+    },
+    models: {
+      clearCached: vi.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+
+describe("SettingsDialog", () => {
+  // Regression: the settings overlay used to cover the app-level drag strip,
+  // making the window undraggable while settings was open. The dialog must
+  // provide its own strip, painted above the click-to-close backdrop.
+  it("keeps a window drag strip above the backdrop", async () => {
+    render(<RouterProvider router={router} />);
+    await act(async () => {
+      await nav.openSettings();
+    });
+
+    const backdrop = await screen.findByRole("button", { name: "Close settings" });
+    const strip = document.querySelector("[data-tauri-drag-region]");
+    expect(strip).not.toBeNull();
+
+    // Tauri 2.9's drag handler keys off `e.target` only, so the strip must be
+    // a childless leaf — any child under the cursor breaks dragging.
+    expect(strip?.childElementCount).toBe(0);
+
+    // Same stacking context as the backdrop, later in the DOM → paints above
+    // it, so the strip (not the backdrop) receives the mouse-down.
+    expect(strip?.parentElement).toBe(backdrop.parentElement);
+    expect(backdrop.compareDocumentPosition(strip as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/apps/native/src/components/widget/settings/settings-dialog.tsx
+++ b/apps/native/src/components/widget/settings/settings-dialog.tsx
@@ -197,12 +197,22 @@ export function SettingsDialog() {
 
   return (
     <Suspense fallback={<div>loading...</div>}>
-      <div className="fixed inset-0 z-40 flex items-center justify-center" data-tauri-no-drag>
+      <div className="fixed inset-0 z-40 flex items-center justify-center">
         <button
           aria-label="Close settings"
           className="absolute inset-0 bg-black/40"
           onClick={() => nav.closeSettings()}
           type="button"
+        />
+        {/*
+         * The overlay covers the app-level drag strip (App.tsx), and Tauri's
+         * drag handler only fires on the exact element under the cursor — so
+         * the strip must be re-created above the backdrop, same geometry.
+         */}
+        <div
+          data-tauri-drag-region
+          className="absolute top-0 left-20 right-44 h-7"
+          aria-hidden="true"
         />
         <div className="relative z-10 flex h-[460px] w-[620px] max-w-[90vw] overflow-hidden rounded-xl border border-border bg-card/95 shadow-2xl backdrop-blur-xl">
           {/* Sidebar */}

--- a/apps/native/vitest.setup.ts
+++ b/apps/native/vitest.setup.ts
@@ -14,3 +14,7 @@ afterEach(() => {
 if (!document.queryCommandSupported) {
   document.queryCommandSupported = () => false;
 }
+
+// jsdom's scrollTo throws "Not implemented"; TanStack Router calls it on
+// navigation.
+window.scrollTo = () => {};


### PR DESCRIPTION
## Summary

- the window was impossible to drag while settings are open

## Test Plan

- [x] Manual test

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
