### PR TITLE
fix: remaining clippy errors and the overall environment clippy configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.allTargets": true,
+  "rust-analyzer.check.extraArgs": ["--workspace"]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ resolver = "2"
 unused = { level = "deny", priority = -1 }
 unexpected_cfgs = { level = "allow" }
 
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/apps/native/src-tauri/src/evolve/providers/ollama.rs
+++ b/apps/native/src-tauri/src/evolve/providers/ollama.rs
@@ -423,10 +423,10 @@ impl AiProvider for OllamaProvider {
                     }
                 }
             }
-            if stream_result.is_ok() {
-                if let Some(record) = ndjson.finish() {
-                    stream_result = handle_line(&record, &mut assembled, &mut done_chunk);
-                }
+            if stream_result.is_ok()
+                && let Some(record) = ndjson.finish()
+            {
+                stream_result = handle_line(&record, &mut assembled, &mut done_chunk);
             }
 
             if let Err(e) = stream_result {

--- a/apps/native/src-tauri/src/evolve/providers/openai.rs
+++ b/apps/native/src-tauri/src/evolve/providers/openai.rs
@@ -318,11 +318,11 @@ impl AiProvider for OpenAIProvider {
             let Some(choice) = chunk.choices.first() else {
                 continue;
             };
-            if let Some(text) = &choice.delta.content {
-                if !text.is_empty() {
-                    content.push_str(text);
-                    on_delta(StreamEvent::Delta(text));
-                }
+            if let Some(text) = &choice.delta.content
+                && !text.is_empty()
+            {
+                content.push_str(text);
+                on_delta(StreamEvent::Delta(text));
             }
             if let Some(chunks) = &choice.delta.tool_calls {
                 for tool_chunk in chunks {
@@ -333,16 +333,15 @@ impl AiProvider for OpenAIProvider {
                     if tool_chunk.id.is_some() && !name.is_empty() {
                         super::announce_tool_call(on_delta, name);
                     }
-                    if name == "think" {
-                        if let Some(fragment) = tool_chunk
+                    if name == "think"
+                        && let Some(fragment) = tool_chunk
                             .function
                             .as_ref()
                             .and_then(|f| f.arguments.as_deref())
-                        {
-                            let text = thought_extractors.entry(index).or_default().push(fragment);
-                            if !text.is_empty() {
-                                on_delta(StreamEvent::Delta(&text));
-                            }
+                    {
+                        let text = thought_extractors.entry(index).or_default().push(fragment);
+                        if !text.is_empty() {
+                            on_delta(StreamEvent::Delta(&text));
                         }
                     }
                 }

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -1112,6 +1112,7 @@ mod tests {
                 }),
                 false,
                 None,
+                None,
             );
 
             let err = result.expect_err("edit_nix_file must reject non-.nix files");

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10


### PR DESCRIPTION
## Summary

The environmental clippy configuration doesn't match what's in CI so depending on how you use your local tools and IDE you may get errors in GHA that didn't show up for you earlier. There were also latent clippy issues to fix, and what looks to be a compile error in a specific test. And I relaxed the default rule for # of function args.

<!-- What does this PR do? Why? -->

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed