### PR TITLE
feat: wire up `pullFromUpstream` command and "Update" button in upstream-update banner

### DIFF
--- a/apps/native/src-tauri/src/commands/git.rs
+++ b/apps/native/src-tauri/src/commands/git.rs
@@ -152,6 +152,61 @@ pub async fn discard_single_file(
     Ok(shared_types::OkResult { ok: true })
 }
 
+/// Pull from the upstream remote and update the local repo.
+/// Currently, the only pull we support must be a fast-forward.
+/// If a fast-forward is possible, this will succeed and return Ok.
+/// If the local repo has diverged from the upstream, this will return
+/// an error with a message to display to the user.
+/// In either case, the git state is refreshed and cached for later comparison.
+pub async fn pull_from_upstream(app: AppHandle) -> Result<shared_types::OkResult, String> {
+    let dir = store::ensure_git_repo_folder(&app)
+        .map_err(|e| capture_err("git_pull_from_upstream", e))?;
+
+    log::info!("[git_pull_from_upstream] Pulling from upstream in {}", dir);
+    let decision = git::auto_update::pull_from_upstream(&dir)
+        .map_err(|e| capture_err("git_pull_from_upstream", e))?;
+
+    match decision {
+        git::auto_update::AutoUpdateDecision::UpdateAndRebuild { .. } => {
+            // Fast-forward succeeded; immediately hide the stale banner.
+            crate::state::git_state::set_upstream_update_available(&app, false);
+        }
+        git::auto_update::AutoUpdateDecision::Noop(message)
+        | git::auto_update::AutoUpdateDecision::WarnAndSkip(message) => {
+            // The pre-click banner can become stale (local edits, upstream moved, etc.).
+            // Clear it now rather than waiting for the next background check.
+            crate::state::git_state::set_upstream_update_available(&app, false);
+            return Err(message);
+        }
+    }
+
+    match git::query::status_and_cache(&dir, &app) {
+        Ok(status) => {
+            // Moving HEAD invalidates any persisted evolution/rollback base
+            // anchored at the old commit. Clear that stale session before
+            // rebuilding the change map, otherwise the pulled commit range is
+            // presented as manual drift, which is super-annoying particularly
+            // since the manual drift UI makes that situation non-actionable
+            // (no rollback possible even though it suggests otherwise, plus
+            // bogus diff rows between the previous commit and the HEAD would
+            // be presented).
+            // TODO: Update the "Review" screen to handle this new use case properly.
+            evolve_state::refresh(&app, &status.changes);
+            if status.clean_head {
+                crate::state::change_map::clear(&app);
+            } else {
+                crate::summarize::refresh_change_map(&app);
+            }
+        }
+        Err(e) => log::warn!(
+            "[git_pull_from_upstream] Failed to refresh git state: {}",
+            e
+        ),
+    }
+
+    Ok(shared_types::OkResult { ok: true })
+}
+
 /// Returns original (HEAD) and modified (working-tree) content for each requested file.
 #[tauri::command]
 pub async fn git_file_diff_contents(

--- a/apps/native/src-tauri/src/commands/git.rs
+++ b/apps/native/src-tauri/src/commands/git.rs
@@ -155,9 +155,9 @@ pub async fn discard_single_file(
 /// Pull from the upstream remote and update the local repo.
 /// Currently, the only pull we support must be a fast-forward.
 /// If a fast-forward is possible, this will succeed and return Ok.
-/// If the local repo has diverged from the upstream, this will return
-/// an error with a message to display to the user.
-/// In either case, the git state is refreshed and cached for later comparison.
+/// If the local repo is already up to date, this will also return Ok (the banner was stale).
+/// If the local repo has diverged from the upstream and the update no longer looks safe,
+/// this will return an error with a message to display to the user.
 pub async fn pull_from_upstream(app: AppHandle) -> Result<shared_types::OkResult, String> {
     let dir = store::ensure_git_repo_folder(&app)
         .map_err(|e| capture_err("git_pull_from_upstream", e))?;
@@ -171,10 +171,14 @@ pub async fn pull_from_upstream(app: AppHandle) -> Result<shared_types::OkResult
             // Fast-forward succeeded; immediately hide the stale banner.
             crate::state::git_state::set_upstream_update_available(&app, false);
         }
-        git::auto_update::AutoUpdateDecision::Noop(message)
-        | git::auto_update::AutoUpdateDecision::WarnAndSkip(message) => {
-            // The pre-click banner can become stale (local edits, upstream moved, etc.).
-            // Clear it now rather than waiting for the next background check.
+        git::auto_update::AutoUpdateDecision::Noop(_) => {
+            // The banner was stale: nothing needed updating. Clear it and
+            // continue through the normal state refresh below.
+            crate::state::git_state::set_upstream_update_available(&app, false);
+        }
+        git::auto_update::AutoUpdateDecision::WarnAndSkip(message) => {
+            // The update is no longer safe (local edits, divergence, etc.).
+            // Clear the stale banner and surface the reason to the user.
             crate::state::git_state::set_upstream_update_available(&app, false);
             return Err(message);
         }

--- a/apps/native/src-tauri/src/git/auto_update.rs
+++ b/apps/native/src-tauri/src/git/auto_update.rs
@@ -67,7 +67,7 @@ pub fn fast_forward_to_upstream(repo: &Repository, upstream_oid: git2::Oid) -> R
         .to_string_lossy();
 
     // Fetching can take long enough for the worktree to change after the
-    // initial safety check. Recheck immediately before the forced checkout.
+    // initial safety check. Recheck immediately before the checkout.
     if !is_worktree_clean_for_auto_update(&workdir)? {
         anyhow::bail!("worktree changed while preparing the upstream update");
     }
@@ -107,7 +107,7 @@ pub fn fast_forward_to_upstream(repo: &Repository, upstream_oid: git2::Oid) -> R
     let mut checkout_builder = git2::build::CheckoutBuilder::new();
 
     checkout_builder
-        .force()
+        .safe()
         .recreate_missing(true)
         .remove_untracked(false);
 
@@ -358,7 +358,11 @@ pub fn check_auto_update(config_dir: &str) -> Result<AutoUpdateDecision> {
 
 /// Pull from upstream only if it's safe from a fast-forward perspective.
 ///
-/// Returns the fresh auto-update decision so the caller can react immediately as appropriate (e.g., hide the stale banner, show a warning, etc.).
+/// Returns the pre-pull decision:
+///   - if a fast-forward is performed, returns `UpdateAndRebuild` to indicate
+///     a rebuild may be needed.
+///   - otherwise the result can be used to determine if the caller needs
+///     to update UI since the previous state it was using may have been stale.
 pub fn pull_from_upstream(config_dir: &str) -> Result<AutoUpdateDecision> {
     require_repo(config_dir)?;
     let repo = Repository::discover(config_dir)?;

--- a/apps/native/src-tauri/src/git/auto_update.rs
+++ b/apps/native/src-tauri/src/git/auto_update.rs
@@ -67,7 +67,7 @@ pub fn fast_forward_to_upstream(repo: &Repository, upstream_oid: git2::Oid) -> R
         .to_string_lossy();
 
     // Fetching can take long enough for the worktree to change after the
-    // initial safety check. Recheck immediately before the checkout.
+    // initial safety check. Recheck immediately before updating the tip.
     if !is_worktree_clean_for_auto_update(&workdir)? {
         anyhow::bail!("worktree changed while preparing the upstream update");
     }
@@ -104,12 +104,15 @@ pub fn fast_forward_to_upstream(repo: &Repository, upstream_oid: git2::Oid) -> R
     repo.set_head(&refname)
         .with_context(|| format!("failed to set HEAD to {refname}"))?;
 
+    // Force checkout after moving the tip so the index and worktree match the
+    // new HEAD. Safe because we just confirmed a clean worktree and a
+    // fast-forward-only relationship.
     let mut checkout_builder = git2::build::CheckoutBuilder::new();
-
     checkout_builder
-        .safe()
+        .force()
         .recreate_missing(true)
-        .remove_untracked(false);
+        .remove_untracked(false)
+        .remove_ignored(false);
 
     repo.checkout_head(Some(&mut checkout_builder))
         .context("failed to check out updated HEAD")?;

--- a/apps/native/src-tauri/src/git/auto_update.rs
+++ b/apps/native/src-tauri/src/git/auto_update.rs
@@ -59,12 +59,18 @@ pub struct AutoUpdateConfig {
 }
 
 /// Fast-forwards the current local branch to an already-fetched upstream commit.
-///
-/// TODO: This is not hooked up yet but will be the next step in implementing the actual update
-/// after the check decision is made.
-#[allow(dead_code)]
 pub fn fast_forward_to_upstream(repo: &Repository, upstream_oid: git2::Oid) -> Result<()> {
     let branch_name = current_branch(repo).context("repository is in detached HEAD state")?;
+    let workdir = repo
+        .workdir()
+        .context("cannot fast-forward a bare repository")?
+        .to_string_lossy();
+
+    // Fetching can take long enough for the worktree to change after the
+    // initial safety check. Recheck immediately before the forced checkout.
+    if !is_worktree_clean_for_auto_update(&workdir)? {
+        anyhow::bail!("worktree changed while preparing the upstream update");
+    }
 
     let annotated = repo
         .find_annotated_commit(upstream_oid)
@@ -101,7 +107,7 @@ pub fn fast_forward_to_upstream(repo: &Repository, upstream_oid: git2::Oid) -> R
     let mut checkout_builder = git2::build::CheckoutBuilder::new();
 
     checkout_builder
-        .safe()
+        .force()
         .recreate_missing(true)
         .remove_untracked(false);
 
@@ -350,6 +356,37 @@ pub fn check_auto_update(config_dir: &str) -> Result<AutoUpdateDecision> {
     Ok(decide_auto_update(&status))
 }
 
+/// Pull from upstream only if it's safe from a fast-forward perspective.
+///
+/// Returns the fresh auto-update decision so the caller can react immediately as appropriate (e.g., hide the stale banner, show a warning, etc.).
+pub fn pull_from_upstream(config_dir: &str) -> Result<AutoUpdateDecision> {
+    require_repo(config_dir)?;
+    let repo = Repository::discover(config_dir)?;
+
+    let decision = check_auto_update(config_dir)?;
+
+    if let AutoUpdateDecision::UpdateAndRebuild {
+        local_oid,
+        upstream_oid,
+        upstream_name,
+    } = decision
+    {
+        fast_forward_to_upstream(&repo, upstream_oid).with_context(|| {
+            format!(
+                "failed to fast-forward branch from {local_oid} to {upstream_oid} ({upstream_name})"
+            )
+        })?;
+
+        return Ok(AutoUpdateDecision::UpdateAndRebuild {
+            local_oid,
+            upstream_oid,
+            upstream_name,
+        });
+    }
+
+    Ok(decision)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::git::init::init_repo;
@@ -423,6 +460,28 @@ mod tests {
         let branch_name = current_branch(repo).unwrap();
         let mut branch = repo.find_branch(&branch_name, BranchType::Local).unwrap();
         branch.set_upstream(Some("origin/main")).unwrap();
+    }
+
+    fn setup_remote_and_local_clone() -> (TempDir, Repository, std::path::PathBuf, Repository) {
+        let temp_dir = TempDir::new().unwrap();
+        let remote_dir = temp_dir.path().join("remote");
+        let local_dir = temp_dir.path().join("local");
+
+        let remote_repo = Repository::init(&remote_dir).unwrap();
+        create_commit(
+            &remote_repo,
+            &remote_dir,
+            "flake.nix",
+            "{ remote = 1; }\n",
+            "initial",
+            None,
+            Some("HEAD"),
+        );
+
+        let remote_url = remote_dir.to_string_lossy().to_string();
+        let local_repo = Repository::clone(&remote_url, &local_dir).unwrap();
+
+        (temp_dir, remote_repo, local_dir, local_repo)
     }
 
     #[test]
@@ -582,5 +641,95 @@ mod tests {
         fs::write(&file_path, "content").unwrap();
 
         assert!(!is_worktree_clean_for_auto_update(&repo_dir_str).unwrap());
+    }
+
+    #[test]
+    fn pull_from_upstream_fast_forwards_when_still_safe() {
+        let (_temp_dir, remote_repo, local_dir, local_repo) = setup_remote_and_local_clone();
+        let local_before = head_oid(&local_repo).unwrap();
+
+        let remote_before = head_oid(&remote_repo).unwrap();
+        let remote_after = create_commit(
+            &remote_repo,
+            local_dir.parent().unwrap().join("remote").as_path(),
+            "flake.nix",
+            "{ remote = 2; }\n",
+            "upstream",
+            Some(remote_before),
+            Some("HEAD"),
+        );
+
+        let local_dir_str = local_dir.to_string_lossy().to_string();
+        let decision = pull_from_upstream(&local_dir_str).unwrap();
+
+        let AutoUpdateDecision::UpdateAndRebuild {
+            local_oid,
+            upstream_oid,
+            ..
+        } = decision
+        else {
+            panic!("expected UpdateAndRebuild decision")
+        };
+
+        assert_eq!(local_oid, local_before);
+        assert_eq!(upstream_oid, remote_after);
+
+        let local_after = head_oid(&Repository::discover(&local_dir).unwrap()).unwrap();
+        assert_eq!(local_after, remote_after);
+        assert_eq!(
+            fs::read_to_string(local_dir.join("flake.nix")).unwrap(),
+            "{ remote = 2; }\n"
+        );
+        assert!(
+            crate::git::status(local_dir_str.as_str())
+                .unwrap()
+                .clean_head
+        );
+    }
+
+    #[test]
+    fn pull_from_upstream_returns_noop_when_no_update_is_needed() {
+        let (_temp_dir, _remote_repo, local_dir, local_repo) = setup_remote_and_local_clone();
+        let local_before = head_oid(&local_repo).unwrap();
+
+        let local_dir_str = local_dir.to_string_lossy().to_string();
+        let decision = pull_from_upstream(&local_dir_str).unwrap();
+
+        let AutoUpdateDecision::Noop(message) = decision else {
+            panic!("expected Noop decision")
+        };
+
+        assert!(message.contains("already up to date"));
+
+        let local_after = head_oid(&Repository::discover(&local_dir).unwrap()).unwrap();
+        assert_eq!(local_after, local_before);
+    }
+
+    #[test]
+    fn pull_from_upstream_returns_warn_and_skip_when_local_is_ahead() {
+        let (_temp_dir, _remote_repo, local_dir, local_repo) = setup_remote_and_local_clone();
+        let local_before = head_oid(&local_repo).unwrap();
+
+        let local_after_commit = create_commit(
+            &local_repo,
+            &local_dir,
+            "flake.nix",
+            "{ local = 2; }\n",
+            "local",
+            Some(local_before),
+            Some("HEAD"),
+        );
+
+        let local_dir_str = local_dir.to_string_lossy().to_string();
+        let decision = pull_from_upstream(&local_dir_str).unwrap();
+
+        let AutoUpdateDecision::WarnAndSkip(message) = decision else {
+            panic!("expected WarnAndSkip decision")
+        };
+
+        assert!(message.contains("ahead of"));
+
+        let local_after = head_oid(&Repository::discover(&local_dir).unwrap()).unwrap();
+        assert_eq!(local_after, local_after_commit);
     }
 }

--- a/apps/native/src-tauri/src/orpc/git.rs
+++ b/apps/native/src-tauri/src/orpc/git.rs
@@ -78,6 +78,12 @@ async fn status_and_cache(ctx: OrpcCtx, _input: ()) -> Result<GitStatus, ORPCErr
         .map_err(|error| internal_err("git.statusAndCache", error))
 }
 
+async fn pull_from_upstream(ctx: OrpcCtx, _input: ()) -> Result<OkResult, ORPCError> {
+    git::pull_from_upstream(ctx.app)
+        .await
+        .map_err(|error| internal_err("git.pullFromUpstream", error))
+}
+
 pub fn routes() -> Router<OrpcCtx> {
     router! {
         "commit" => os::<OrpcCtx>()
@@ -105,5 +111,8 @@ pub fn routes() -> Router<OrpcCtx> {
         "statusAndCache" => os::<OrpcCtx>()
             .output(orpc_specta::specta::<GitStatus>())
             .handler(status_and_cache),
+        "pullFromUpstream" => os::<OrpcCtx>()
+            .output(orpc_specta::specta::<OkResult>())
+            .handler(pull_from_upstream),
     }
 }

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -184,15 +184,23 @@ where
                         let status_changed = current.git_status.as_ref() != Some(&status);
 
                         if status_changed || external_build_detected {
-                            let pool = app_handle.state::<db::DbPool>();
-                            let change_map =
+                            // HEAD may have moved since an evolution session was
+                            // persisted. Invalidate that session before choosing
+                            // the summary base ref, so a stale rollback branch
+                            // cannot turn committed changes into manual drift.
+                            evolve_state::refresh(&app_handle, &status.changes);
+                            let change_map = if status.clean_head {
+                                // A clean worktree has no manual drift. Never
+                                // carry a historical/session-derived diff into
+                                // the live drift cell.
+                                Default::default()
+                            } else {
+                                let pool = app_handle.state::<db::DbPool>();
                                 summarize::find_existing::for_current_state(&pool, dir)
                                     .ok()
                                     .map(summarize::group_existing::from_change_sets)
-                                    .unwrap_or_default();
-                            // Refresh the derived evolve projection from the new git/build
-                            // state; the projection cell emits `evolve_state_changed`.
-                            evolve_state::refresh(&app_handle, &status.changes);
+                                    .unwrap_or_default()
+                            };
                             // Native drift notification (config drift / external build).
                             drift_notifications::maybe_notify(
                                 Some(&status),

--- a/apps/native/src/components/widget/notifications/upstream-update-available.tsx
+++ b/apps/native/src/components/widget/notifications/upstream-update-available.tsx
@@ -1,20 +1,56 @@
 "use client";
 
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { client } from "@/lib/orpc";
 import { GitPullRequestArrow } from "lucide-react";
-import { useViewModel } from "@nixmac/state";
+import { uiActions, useViewModel } from "@nixmac/state";
 
 export function UpstreamUpdateAvailable() {
   const available = useViewModel((s) => s.build.upstreamUpdateAvailable);
+  const [isUpdating, setIsUpdating] = useState(false);
 
   if (!available) return null;
 
+  const handleUpdate = async () => {
+    setIsUpdating(true);
+    try {
+      await client.git.pullFromUpstream();
+    } catch (error: unknown) {
+      const message = (error as Error)?.message ?? String(error);
+      uiActions.setError(message);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
   return (
-    <div className="flex w-full shrink-0 items-center gap-2 border-amber-400/25 border-b bg-amber-500/5 px-3 py-2 text-xs">
-      <GitPullRequestArrow className="h-3.5 w-3.5 shrink-0 text-amber-400" aria-hidden="true" />
-      <span>
-        <span className="font-medium text-foreground">Your Git repository is behind the upstream.</span>{" "}
-        <span className="text-muted-foreground">Update it before making more changes.</span>
+    <div className="flex w-full shrink-0 items-center justify-between gap-2 border-amber-400/25 border-b bg-amber-500/5 px-3 py-2 text-xs">
+      <span className="flex items-center gap-2">
+        <GitPullRequestArrow className="h-3.5 w-3.5 shrink-0 text-amber-400" aria-hidden="true" />
+        <span>
+          <span className="font-medium text-foreground">Your Git repository is behind the upstream.</span>{" "}
+          <span className="text-muted-foreground">Update it before making more changes.</span>
+        </span>
       </span>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={isUpdating}
+        onClick={() => void handleUpdate()}
+        className="h-7 border-amber-300/40 bg-transparent px-2 text-xs text-amber-200 hover:border-amber-200 hover:text-amber-100"
+      >
+        {isUpdating ? (
+          <>
+            <Spinner className="h-3 w-3" />
+            Updating...
+          </>
+        ) : (
+          "Update"
+        )}
+      </Button>
     </div>
   );
 }

--- a/apps/native/src/ipc/api.ts
+++ b/apps/native/src/ipc/api.ts
@@ -102,6 +102,8 @@ export const tauriAPI = {
     commit: (message: string) => client.git.commit({ message }),
     /** @deprecated Use `client.git.fileDiffContents()` or `orpc.git.fileDiffContents` from `@/lib/orpc`. */
     fileDiffContents: (filenames: string[]) => client.git.fileDiffContents({ filenames }),
+    /** @deprecated Use `client.git.pullFromUpstream()` or `orpc.git.pullFromUpstream` from `@/lib/orpc`. */
+    pullFromUpstream: () => client.git.pullFromUpstream(),
   },
   darwin: {
     /** @deprecated Use `client.darwin.evolve()` or `orpc.darwin.evolve` from `@/lib/orpc`. */

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -1978,6 +1978,7 @@ export type Procedures = {
     commitFile: Client<Record<never, never>, GitCommitFileInput, CommitResult, Error>
     discardFile: Client<Record<never, never>, GitDiscardFileInput, OkResult, Error>
     fileDiffContents: Client<Record<never, never>, GitFileDiffContentsInput, Partial<{ [key in string]: FileDiffContents }>, Error>
+    pullFromUpstream: Client<Record<never, never>, void, OkResult, Error>
     state: Client<Record<never, never>, void, GitState, Error>
     status: Client<Record<never, never>, void, GitStatus, Error>
     statusAndCache: Client<Record<never, never>, void, GitStatus, Error>


### PR DESCRIPTION
## Summary

This is the next incremental change the for git auto-update and rebuild feature. The scope is simply to add the "Update" button to the banner and do the fast-forward if it's still possible. As expected, implementing the pull itself was very easy since the fast-forward method was done in a prior PR. What was less easy was convincing nixmac that this pull was NOT "manual drift", which is the code in watcher.rs.

I called the button **"Update"** instead of (say) "Pull" for a less-developer-friendly target audience. But we can change that if we want.

**NOTE** that this change does _not_ result in any truly new state of the application, since it's actually the same behavior (fixed, now, vis a vis the aforementioned bogus "manual drift") as you'd see if you did a git CLI "git pull" and picked up new changes to your config repo that way.

Next planned change is to detect that you're in this state where you have pulled unbuilt changes and take you to the Review step and offer to "Build and Test".

![Screenshot 2026-07-21 at 10.58.04 AM.png](https://app.graphite.com/user-attachments/assets/51dd3880-a130-46fd-8cce-837395a2a610.png)

<!-- What does this PR do? Why? -->

## Test Plan

Some new unit tests where they made sense, plus a lot of manual testing with my private nix config repo.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed