### PR TITLE
feat(ci): before/after screenshots + stale-acceptance guard for snapshot flow

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -258,7 +258,7 @@ jobs:
 
       # ---- Failed-story screenshots (PR only, only when snapshots drifted) ----
       # Resolve the failed stories (recorded by the runner) into Storybook IDs +
-      # deep links, and emit the Creevey skip regex used to scope capture.
+      # deep links, then capture PR-head "after" and merge-base "before" images.
       - name: Resolve failed stories
         id: resolve_failures
         if: steps.snapshot_tests.outcome == 'failure' && github.event_name == 'pull_request' && steps.deploy.outputs.deployment-url != ''
@@ -287,9 +287,50 @@ jobs:
             curl -sf http://localhost:6100/index.json >/dev/null && break
             sleep 1
           done
+          rm -rf test-results/creevey test-results/shots
           CREEVEY_STORYBOOK_URL="http://localhost:6100" bunx creevey test --no-docker || true
-          node scripts/harvest-creevey-shots.mjs
+          SHOT_KIND=after node scripts/harvest-creevey-shots.mjs
 
+      - name: Capture before failed-story screenshots (Creevey)
+        if: ${{ steps.resolve_failures.outcome == 'success' && steps.resolve_failures.outputs.count != '0' }}
+        continue-on-error: true
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          APP_DIR="$GITHUB_WORKSPACE/apps/native"
+          SKIP_REGEX="$(cat "$APP_DIR/test-results/creevey-skip-regex.txt")"
+          BASE_COMMIT="$(git merge-base HEAD "$BASE_REF")"
+          BASE_PARENT="$(mktemp -d)"
+          BASE_WORKTREE="$BASE_PARENT/base"
+          git worktree add --detach "$BASE_WORKTREE" "$BASE_COMMIT"
+          BASE_PID=""
+          cleanup() {
+            if [ -n "$BASE_PID" ]; then
+              kill "$BASE_PID" 2>/dev/null || true
+            fi
+            git worktree remove --force "$BASE_WORKTREE" 2>/dev/null || true
+            rm -rf "$BASE_PARENT"
+          }
+          trap cleanup EXIT
+          if [ -d "$GITHUB_WORKSPACE/node_modules" ] && [ ! -e "$BASE_WORKTREE/node_modules" ]; then
+            ln -s "$GITHUB_WORKSPACE/node_modules" "$BASE_WORKTREE/node_modules"
+          fi
+          if [ -d "$APP_DIR/node_modules" ] && [ ! -e "$BASE_WORKTREE/apps/native/node_modules" ]; then
+            ln -s "$APP_DIR/node_modules" "$BASE_WORKTREE/apps/native/node_modules"
+          fi
+          cd "$BASE_WORKTREE/apps/native"
+          VITE_CREEVEY_SKIP_REGEX="$SKIP_REGEX" bun run build-storybook
+          python3 -m http.server 6101 --directory storybook-static >/tmp/creevey-storybook-before.log 2>&1 &
+          BASE_PID=$!
+          for _ in $(seq 1 30); do
+            curl -sf http://localhost:6101/index.json >/dev/null && break
+            sleep 1
+          done
+          cd "$APP_DIR"
+          rm -rf test-results/creevey
+          CREEVEY_STORYBOOK_URL="http://localhost:6101" bunx creevey test --no-docker || true
+          SHOT_KIND=before node scripts/harvest-creevey-shots.mjs
       # Host the screenshots on Cloudflare Pages so the PR comment can embed them.
       - name: Deploy failed-story screenshots
         id: deploy_shots

--- a/.github/workflows/update-snapshots.yaml
+++ b/.github/workflows/update-snapshots.yaml
@@ -70,11 +70,38 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "Resolved PR #${PR_NUMBER} head: ${head_ref} (${head_sha})"
 
+      - name: Validate Storybook comment is current
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          CURRENT_SHA: ${{ steps.ref.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # UI edits (checkbox flips) can rewrite the body with CRLF endings;
+          # strip \r so the anchored sed match below still works.
+          body=$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" --jq '.body' | tr -d '\r')
+          rendered_sha=$(printf '%s\n' "$body" | sed -n 's/^<!-- nixmac-storybook-sha:\([0-9a-f]\{40\}\) -->$/\1/p' | head -n1 || true)
+          if [ -z "$rendered_sha" ]; then
+            gh api --method POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+              -f content='confused' >/dev/null
+            echo "::error::Storybook comment does not include a rendered commit SHA; wait for the latest Storybook run to refresh the comment."
+            exit 1
+          fi
+          if [ "$rendered_sha" != "$CURRENT_SHA" ]; then
+            gh api --method POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+              -f content='-1' >/dev/null
+            gh pr comment "${{ steps.ref.outputs.pr_number }}" --repo "${REPO}" --body "Storybook snapshot acceptance is stale: the checked gallery was rendered for ${rendered_sha}, but the PR head is ${CURRENT_SHA}. Wait for the latest Storybook run to update the comment, then accept again."
+            echo "::error::Storybook snapshot acceptance is stale: rendered ${rendered_sha}, current ${CURRENT_SHA}."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ steps.ref.outputs.ref || github.ref }}
+          ref: ${{ steps.ref.outputs.sha || github.ref }}
           token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup Nix and caches

--- a/apps/native/scripts/build-failed-comment.mjs
+++ b/apps/native/scripts/build-failed-comment.mjs
@@ -23,6 +23,11 @@ const deployUrl = process.env.DEPLOY_URL ?? "";
 const commitSha = process.env.COMMIT_SHA ?? "";
 const shotsBaseUrl = (process.env.SHOTS_BASE_URL ?? "").replace(/\/+$/, "");
 
+function shotUrl(file) {
+  const url = `${shotsBaseUrl}/${file}`;
+  return commitSha ? `${url}?sha=${commitSha}` : url;
+}
+
 async function readManifest() {
   try {
     return JSON.parse(await readFile(manifestFile, "utf8"));
@@ -42,7 +47,11 @@ async function readDigest() {
 const manifest = await readManifest();
 const digest = await readDigest();
 
-const lines = [marker, "### 🎨 Storybook preview", ""];
+const lines = [marker];
+if (commitSha) {
+  lines.push(`<!-- nixmac-storybook-sha:${commitSha} -->`);
+}
+lines.push("### 🎨 Storybook preview", "");
 if (deployUrl) {
   lines.push(`[Open Storybook preview](${deployUrl})`, "");
 }
@@ -66,8 +75,19 @@ if (manifest.length > 0) {
     const label = `${story.title} › ${story.name}`;
     const heading = story.storyUrl ? `[${label}](${story.storyUrl})` : label;
     lines.push(`#### ${heading}`, "");
-    if (shotsBaseUrl) {
-      lines.push(`![${label}](${shotsBaseUrl}/${story.file})`, "");
+    if (shotsBaseUrl && story.afterFile) {
+      lines.push(`![${label}](${shotUrl(story.afterFile)})`, "");
+    }
+    if (shotsBaseUrl && story.beforeFile) {
+      lines.push(
+        "<details>",
+        "<summary>Before</summary>",
+        "",
+        `![${label} before](${shotUrl(story.beforeFile)})`,
+        "",
+        "</details>",
+        "",
+      );
     }
   }
   lines.push(

--- a/apps/native/scripts/harvest-creevey-shots.mjs
+++ b/apps/native/scripts/harvest-creevey-shots.mjs
@@ -10,9 +10,11 @@
 // Inputs:
 //   - test-results/failed-stories-resolved.json
 //   - test-results/creevey/report/**            (from `creevey test`)
+//   - env SHOT_KIND=after|before                (default: after)
 // Output:
-//   - test-results/shots/<id>.png
-//   - test-results/shots/manifest.json   Array<{ id, name, title, file, storyUrl? }>
+//   - test-results/shots/<id>-<kind>.png
+//   - test-results/shots/manifest.json
+//     Array<{ id, name, title, afterFile?, beforeFile?, storyUrl? }>
 
 import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -21,6 +23,9 @@ const appRoot = path.resolve(import.meta.dirname, "..");
 const resolvedFile = path.join(appRoot, "test-results", "failed-stories-resolved.json");
 const reportDir = path.join(appRoot, "test-results", "creevey", "report");
 const shotsDir = path.join(appRoot, "test-results", "shots");
+
+const shotKind = process.env.SHOT_KIND === "before" ? "before" : "after";
+const fileField = shotKind === "before" ? "beforeFile" : "afterFile";
 
 async function readJsonOrDefault(file, fallback) {
   try {
@@ -45,9 +50,10 @@ async function findActualPng(dir) {
 }
 
 const resolved = await readJsonOrDefault(resolvedFile, []);
+const existingManifest = await readJsonOrDefault(path.join(shotsDir, "manifest.json"), []);
+const manifestById = new Map(existingManifest.map((entry) => [entry.id, entry]));
 await mkdir(shotsDir, { recursive: true });
-
-const manifest = [];
+let harvestedCount = 0;
 for (const story of resolved) {
   const storyDir = path.join(reportDir, ...story.title.split("/"), story.name);
   const png = await findActualPng(storyDir);
@@ -55,18 +61,21 @@ for (const story of resolved) {
     console.warn(`::warning::No screenshot captured for ${story.title} › ${story.name}`);
     continue;
   }
-  const destName = `${story.id}.png`;
+  const destName = `${story.id}-${shotKind}.png`;
   await copyFile(png, path.join(shotsDir, destName));
-  manifest.push({
+  harvestedCount += 1;
+  manifestById.set(story.id, {
+    ...(manifestById.get(story.id) ?? {}),
     id: story.id,
     name: story.name,
     title: story.title,
-    file: destName,
+    [fileField]: destName,
     ...(story.storyUrl ? { storyUrl: story.storyUrl } : {}),
   });
 }
 
+const manifest = [...manifestById.values()];
 await writeFile(path.join(shotsDir, "manifest.json"), JSON.stringify(manifest, null, 2));
 console.log(
-  `Harvested ${manifest.length} screenshot${manifest.length === 1 ? "" : "s"} to ${path.relative(appRoot, shotsDir)}.`,
+  `Harvested ${harvestedCount} ${shotKind} screenshot${harvestedCount === 1 ? "" : "s"} to ${path.relative(appRoot, shotsDir)}.`,
 );

--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -1112,6 +1112,7 @@ mod tests {
                 }),
                 false,
                 None,
+                None,
             );
 
             let err = result.expect_err("edit_nix_file must reject non-.nix files");


### PR DESCRIPTION
Follow-ups to #519 (autoupdate PR screenshots):

## What changed

- **Before/after screenshots**: the Storybook workflow now also builds the merge-base commit in a throwaway git worktree and captures "before" screenshots of the failed stories. The PR comment shows the "after" image inline with the "before" collapsed in a `<details>` block.
- **Stale-acceptance guard**: `build-failed-comment.mjs` embeds a hidden `<!-- nixmac-storybook-sha:... -->` marker in the sticky comment. When someone checks the accept box, `update-snapshots.yaml` verifies the rendered SHA matches the current PR head; if the gallery is stale it reacts 👎, posts an explanation, and fails instead of committing baselines for code nobody reviewed.
- **Race fix**: the update-snapshots checkout now pins the resolved head **SHA** (not the ref) so validation and checkout can't disagree.
- **Cache-busting**: screenshot URLs get `?sha=<commit>` so GitHub's camo cache doesn't serve images from a previous run at the same Pages URL.

## Verification

- Both scripts smoke-tested locally: harvest merges after+before entries into one manifest keyed by story id; comment builder renders the SHA marker, inline after image, and collapsed before section.
- `actionlint` on both workflows: no new issues (only pre-existing style notes and the custom `arc` runner label).
- Verified the `sed` SHA extraction against a sample comment body (with CRLF stripping for UI-edited bodies).