### PR TITLE
fix(build): missing an argument in execute_tool

### DIFF
--- a/apps/native/src-tauri/src/evolve/tools.rs
+++ b/apps/native/src-tauri/src/evolve/tools.rs
@@ -1112,6 +1112,7 @@ mod tests {
                 }),
                 false,
                 None,
+                None,
             );
 
             let err = result.expect_err("edit_nix_file must reject non-.nix files");


### PR DESCRIPTION
## Summary

- Fixes a missing argument that this merged PR https://github.com/darkmatter/nixmac/pull/561 somehow missed

## Test Plan

- [x] Unit tests

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
