### PR TITLE
fix(ui): show change paths relative to config dir

### DIFF
--- a/apps/native/src/components/widget/drift/drift-file-row.tsx
+++ b/apps/native/src/components/widget/drift/drift-file-row.tsx
@@ -9,11 +9,13 @@ import { ChevronRight, MoveRight } from "lucide-react";
 import { useState } from "react";
 import { DriftActionsMenu } from "./drift-actions-menu";
 import { DriftDiffPreview } from "./drift-diff-preview";
+import { useDisplayPath } from "@/hooks/use-display-path";
 import { CHANGE_TYPE_GLYPH, type DriftFileRowData } from "./drift-utils";
 
 function FilePath({ path, role }: { path: string; role?: "old" | "new" }) {
-  const dir = getDirectory(path);
-  const name = getShortFilename(path);
+  const displayPath = useDisplayPath()(path);
+  const dir = getDirectory(displayPath);
+  const name = getShortFilename(displayPath);
   return (
     <span className="min-w-0 truncate font-mono text-[13px]">
       {dir && (

--- a/apps/native/src/components/widget/drift/drift-plain-row.tsx
+++ b/apps/native/src/components/widget/drift/drift-plain-row.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { ChangeType } from "@/ipc/types";
 import { File } from "lucide-react";
+import { useDisplayPath } from "@/hooks/use-display-path";
 import { DriftActionsMenu } from "./drift-actions-menu";
 
 // The change type is conveyed by the filename's color (git-diff convention):
@@ -26,17 +27,18 @@ const NAME_COLOR: Record<ChangeType, string> = {
  */
 export function DriftPlainRow({ file }: { file: ChangeFileSummary }) {
   const { changeType, filename } = file;
-  const dir = getDirectory(filename);
+  const displayPath = useDisplayPath()(filename);
+  const dir = getDirectory(displayPath);
   // Directory as a muted path prefix so the whole entry fits on one line.
-  const prefix = dir ? `/${dir}/` : "/";
+  const prefix = dir ? `${dir}/` : "";
 
   return (
     <li className="group flex items-center gap-3 py-2.5">
       <File className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <p className="min-w-0 flex-1 truncate font-mono text-[13px]">
-        <span className="text-muted-foreground">{prefix}</span>
+        {prefix && <span className="text-muted-foreground">{prefix}</span>}
         <span className={cn("font-medium", NAME_COLOR[changeType])}>
-          {getShortFilename(filename)}
+          {getShortFilename(displayPath)}
         </span>
       </p>
       <DriftActionsMenu filename={filename} />

--- a/apps/native/src/components/widget/summaries/collapsible-diff.tsx
+++ b/apps/native/src/components/widget/summaries/collapsible-diff.tsx
@@ -5,6 +5,7 @@ import {
   getShortFilename,
   type ChangeWithRichType,
 } from "@/components/widget/utils";
+import { useDisplayPath } from "@/hooks/use-display-path";
 import { ChevronRight } from "lucide-react";
 
 interface CollapsibleDiffProps {
@@ -27,8 +28,11 @@ export function CollapsibleDiff({
   children,
 }: CollapsibleDiffProps) {
   const { icon: Icon, iconColor } = CHANGE_TYPE_STYLES[change.changeType];
-  const dir = getDirectory(change.filename);
-  const name = getShortFilename(change.filename);
+  // Display-only: the data-testid below must keep the repo-relative filename
+  // (e2e selectors key off it).
+  const displayPath = useDisplayPath()(change.filename);
+  const dir = getDirectory(displayPath);
+  const name = getShortFilename(displayPath);
 
   return (
     <Collapsible

--- a/apps/native/src/components/widget/summaries/unsummarized-change.tsx
+++ b/apps/native/src/components/widget/summaries/unsummarized-change.tsx
@@ -3,13 +3,15 @@
 import { Button } from "@/components/ui/button";
 import type { ChangeFileSummary } from "@/components/widget/utils";
 import { CHANGE_TYPE_STYLES, getDirectory, getShortFilename } from "@/components/widget/utils";
+import { useDisplayPath } from "@/hooks/use-display-path";
 import { cn } from "@/lib/utils";
 import { EllipsisVerticalIcon, MoveRight, Undo } from "lucide-react";
 import { useState } from "react";
 
 function FilePath({ path, role }: { path: string; role?: "old" | "new" }) {
-  const dir = getDirectory(path);
-  const name = getShortFilename(path);
+  const displayPath = useDisplayPath()(path);
+  const dir = getDirectory(displayPath);
+  const name = getShortFilename(displayPath);
   return (
     <span className="min-w-0 font-mono text-[11px]">
       {dir && (

--- a/apps/native/src/components/widget/utils.test.ts
+++ b/apps/native/src/components/widget/utils.test.ts
@@ -2,6 +2,7 @@ import type { ChangeWithRichType } from "@/components/widget/utils";
 import {
   categorizeRenamed,
   computeCurrentStep,
+  configRelativePath,
   getModStartLine,
   inferChangeType,
   newFileContentFromDiffs,
@@ -283,5 +284,55 @@ describe("computeCurrentStep — diff gating", () => {
         ),
       ).toBe("manualEvolve");
     });
+  });
+});
+
+describe("configRelativePath", () => {
+  const root = "/Users/alex/repos/nixos";
+  const config = "/Users/alex/repos/nixos/apple-slicer";
+
+  it("passes through when the config dir is the repo root", () => {
+    expect(configRelativePath("configuration.nix", root, root)).toBe("configuration.nix");
+  });
+
+  it("strips the config-dir prefix for files inside it", () => {
+    expect(configRelativePath("apple-slicer/configuration.nix", config, root)).toBe(
+      "configuration.nix",
+    );
+  });
+
+  it("marks files outside the config dir with ../", () => {
+    expect(configRelativePath("alex-laptop/configuration.nix", config, root)).toBe(
+      "../alex-laptop/configuration.nix",
+    );
+  });
+
+  it("does not strip a sibling dir that merely shares the prefix string", () => {
+    expect(configRelativePath("apple-slicer-old/configuration.nix", config, root)).toBe(
+      "../apple-slicer-old/configuration.nix",
+    );
+  });
+
+  it("walks up one level per nesting segment", () => {
+    expect(configRelativePath("other.nix", `${root}/hosts/mac`, root)).toBe("../../other.nix");
+  });
+
+  it("keeps shared parent segments instead of backing out to the root", () => {
+    expect(configRelativePath("hosts/other.nix", `${root}/hosts/mac`, root)).toBe("../other.nix");
+  });
+
+  it("tolerates trailing slashes on both dirs", () => {
+    expect(configRelativePath("apple-slicer/configuration.nix", `${config}/`, `${root}/`)).toBe(
+      "configuration.nix",
+    );
+  });
+
+  it("passes through when either path is unknown", () => {
+    expect(configRelativePath("a/b.nix", null, root)).toBe("a/b.nix");
+    expect(configRelativePath("a/b.nix", config, null)).toBe("a/b.nix");
+  });
+
+  it("passes through when the config dir is not under the repo root", () => {
+    expect(configRelativePath("a/b.nix", "/etc/nix-darwin", root)).toBe("a/b.nix");
   });
 });

--- a/apps/native/src/components/widget/utils.ts
+++ b/apps/native/src/components/widget/utils.ts
@@ -102,6 +102,31 @@ export function getDirectory(path: string): string {
   return parts.slice(0, -1).join("/");
 }
 
+/**
+ * Re-express a repo-root-relative path (how git reports changes) relative to
+ * the config dir for display: files inside it lose the config-dir prefix, and
+ * files elsewhere in the repo gain `../` so their location is honest. Backend
+ * calls must keep the repo-relative path — this is display-only.
+ *
+ * Falls back to the input when the config dir *is* the repo root (the common
+ * case, where the two forms are identical) or when either path is unknown.
+ */
+export function configRelativePath(
+  filename: string,
+  configDir: string | null | undefined,
+  repoRoot: string | null | undefined,
+): string {
+  if (!configDir || !repoRoot) return filename;
+  const root = repoRoot.replace(/\/+$/, "");
+  const config = configDir.replace(/\/+$/, "");
+  if (config === root || !config.startsWith(`${root}/`)) return filename;
+  const prefix = config.slice(root.length + 1).split("/");
+  const parts = filename.split("/");
+  let common = 0;
+  while (common < prefix.length && parts[common] === prefix[common]) common += 1;
+  return "../".repeat(prefix.length - common) + parts.slice(common).join("/");
+}
+
 // =============================================================================
 // SUMMARY CATEGORY COLORS
 // =============================================================================

--- a/apps/native/src/hooks/use-display-path.ts
+++ b/apps/native/src/hooks/use-display-path.ts
@@ -1,0 +1,13 @@
+import { configRelativePath } from "@/components/widget/utils";
+import { useViewModel } from "@nixmac/state";
+
+/**
+ * Returns a mapper from git's repo-root-relative filenames to the
+ * config-dir-relative form shown in the UI. Display-only: anything sent back
+ * to the backend (discard, diff) must keep the repo-relative filename.
+ */
+export function useDisplayPath(): (filename: string) => string {
+  const configDir = useViewModel((s) => s.preferences?.configDir ?? null);
+  const repoRoot = useViewModel((s) => s.preferences?.repoRoot ?? null);
+  return (filename) => configRelativePath(filename, configDir, repoRoot);
+}


### PR DESCRIPTION
## Summary

- Displayed paths should be relative to the user selected directory, not git-root

<img width="762" height="373" alt="no fix" src="https://github.com/user-attachments/assets/3e3270dd-c428-4ce6-b31b-d77d50e147ee" />

<img width="762" height="373" alt="with fix" src="https://github.com/user-attachments/assets/8383a51e-1b28-44fd-8612-dd80bb41b2b1" />


## Test Plan

- [x] Visual test

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
