### PR TITLE
feat: add `rebuild_needed` projection to detect when repo config is ahead of the running system, offer up UI

### DIFF
--- a/apps/native/src-tauri/src/commands/git.rs
+++ b/apps/native/src-tauri/src/commands/git.rs
@@ -240,6 +240,7 @@ pub async fn get_git_state(app: AppHandle) -> Result<shared_types::GitState, Str
             git_status: Some(status),
             external_build_detected: false,
             upstream_update_available: state.upstream_update_available,
+            rebuild_needed: state.rebuild_needed,
         });
     }
     Ok(crate::state::git_state::get(&app))

--- a/apps/native/src-tauri/src/commands/onboarding.rs
+++ b/apps/native/src-tauri/src/commands/onboarding.rs
@@ -88,6 +88,7 @@ pub async fn onboarding_reset(app: AppHandle) -> Result<shared_types::OkResult, 
             git_status: None,
             external_build_detected: false,
             upstream_update_available: false,
+            rebuild_needed: false,
         },
     );
     if let Err(e) = evolve_state::clear(&app) {

--- a/apps/native/src-tauri/src/rebuild/finalize_apply.rs
+++ b/apps/native/src-tauri/src/rebuild/finalize_apply.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use tauri::AppHandle;
 
-use crate::state::{build_state, evolve_state};
+use crate::state::{build_state, evolve_state, git_state};
 use crate::storage::store;
 use crate::{git, shared_types};
 
@@ -33,6 +33,10 @@ pub async fn finalize_apply(app: &AppHandle) -> Result<()> {
     }
 
     build_state::record_build(app, &final_status).context("Failed to record build state")?;
+    // `prepare` refreshed the git status before the build record existed. Now
+    // that activation and bookkeeping both succeeded, immediately clear the
+    // rebuild-needed projection instead of waiting for the watcher interval.
+    git_state::mark_build_applied(app);
     // Mark onboarding's "first build/evolution" gate as satisfied. Best-effort:
     // a bookkeeping failure must not turn a successful build into a failed apply.
     if crate::state::onboarding::try_read(app).is_some()

--- a/apps/native/src-tauri/src/rebuild/finalize_apply.rs
+++ b/apps/native/src-tauri/src/rebuild/finalize_apply.rs
@@ -36,7 +36,7 @@ pub async fn finalize_apply(app: &AppHandle) -> Result<()> {
     // `prepare` refreshed the git status before the build record existed. Now
     // that activation and bookkeeping both succeeded, immediately clear the
     // rebuild-needed projection instead of waiting for the watcher interval.
-    git_state::mark_build_applied(app);
+    git_state::invalidate_rebuild_needed(app);
     // Mark onboarding's "first build/evolution" gate as satisfied. Best-effort:
     // a bookkeeping failure must not turn a successful build into a failed apply.
     if crate::state::onboarding::try_read(app).is_some()

--- a/apps/native/src-tauri/src/rebuild/rollback.rs
+++ b/apps/native/src-tauri/src/rebuild/rollback.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use log::warn;
 use tauri::{AppHandle, Runtime};
 
-use crate::state::evolve_state;
+use crate::state::{evolve_state, git_state};
 use crate::storage::store;
 use crate::{
     git,
@@ -55,6 +55,9 @@ pub fn rollback_erase<R: Runtime>(app: &AppHandle<R>) -> Result<RollbackResult> 
     restore_worktree(&repo_root, &current_evolve)?;
 
     let final_status = git::status(&repo_root).context("Failed to get final git status")?;
+    // Any rebuild-needed evaluation started before the restore describes the
+    // discarded tree. Clear it and reject late results from that tree.
+    git_state::invalidate_rebuild_needed(app);
     // Record the post-rollback status; the cell write emits `git_state_changed`.
     crate::state::git_state::update_status(app, final_status.clone());
     evolve_state::set_session(app, EvolveSession::default(), &final_status.changes)

--- a/apps/native/src-tauri/src/shared_types/git.rs
+++ b/apps/native/src-tauri/src/shared_types/git.rs
@@ -69,6 +69,8 @@ pub struct GitState {
     pub external_build_detected: bool,
     /// True when the configured upstream contains a fast-forward update.
     pub upstream_update_available: bool,
+    /// True when a rebuild is needed to bring the system up to date with the current working tree.
+    pub rebuild_needed: bool,
 }
 
 /// Result of a successful `git_commit` command. State mirrors (git, evolve,

--- a/apps/native/src-tauri/src/state/git_state.rs
+++ b/apps/native/src-tauri/src/state/git_state.rs
@@ -71,10 +71,10 @@ pub fn set_rebuild_needed_from_check<R: Runtime>(
     true
 }
 
-/// Record that a successful activation brought the running system up to date.
-/// Invalidates older asynchronous checks and emits `git_state_changed` when
-/// the rebuild-needed flag changes.
-pub fn mark_build_applied<R: Runtime>(app: &AppHandle<R>) {
+/// Clear the cached rebuild-needed result. Useful to call after the configuration used by an
+/// in-flight check has been replaced or discarded. Invalidates older checks
+/// so they cannot publish a result derived from the previous working tree.
+pub fn invalidate_rebuild_needed<R: Runtime>(app: &AppHandle<R>) {
     let mut revision = REBUILD_NEEDED_REVISION.lock().unwrap();
     *revision = revision.wrapping_add(1);
     set_rebuild_needed(app, false);

--- a/apps/native/src-tauri/src/state/git_state.rs
+++ b/apps/native/src-tauri/src/state/git_state.rs
@@ -5,6 +5,7 @@
 //! record the status they just produced. Everything else reads the cell via
 //! [`get`] or subscribes to [`GIT_STATE_CHANGED_EVENT`].
 
+use std::sync::Mutex;
 use tauri::{AppHandle, Manager, Runtime};
 
 use crate::observable::Observable;
@@ -12,11 +13,17 @@ use crate::shared_types::{GitState, GitStatus};
 
 pub const GIT_STATE_CHANGED_EVENT: &str = "git_state_changed";
 
+/// Coordinates asynchronous rebuild-needed checks with successful builds.
+/// A mutex makes validating a check revision and writing its result atomic
+/// with invalidating checks after activation.
+static REBUILD_NEEDED_REVISION: Mutex<u64> = Mutex::new(0);
+
 pub fn load_observable<R: Runtime>(app: &AppHandle<R>) -> Observable<GitState> {
     Observable::new(GitState {
         git_status: None,
         external_build_detected: false,
         upstream_update_available: false,
+        rebuild_needed: false,
     })
     .emit_to(app, GIT_STATE_CHANGED_EVENT)
 }
@@ -36,6 +43,41 @@ pub fn update<R: Runtime>(app: &AppHandle<R>, next: GitState) -> bool {
 pub fn set_upstream_update_available<R: Runtime>(app: &AppHandle<R>, available: bool) -> bool {
     app.state::<Observable<GitState>>()
         .update_if_changed(|state| state.upstream_update_available = available)
+}
+
+/// Atomically update only the result of the asynchronous rebuild-needed check.
+pub fn set_rebuild_needed<R: Runtime>(app: &AppHandle<R>, needed: bool) -> bool {
+    app.state::<Observable<GitState>>()
+        .update_if_changed(|state| state.rebuild_needed = needed)
+}
+
+/// Capture the revision an asynchronous rebuild-needed check belongs to.
+pub fn rebuild_needed_check_revision() -> u64 {
+    *REBUILD_NEEDED_REVISION.lock().unwrap()
+}
+
+/// Apply an asynchronous rebuild-needed result only if no successful build
+/// has invalidated it since the check began. Returns whether it was accepted.
+pub fn set_rebuild_needed_from_check<R: Runtime>(
+    app: &AppHandle<R>,
+    revision: u64,
+    needed: bool,
+) -> bool {
+    let current_revision = REBUILD_NEEDED_REVISION.lock().unwrap();
+    if *current_revision != revision {
+        return false;
+    }
+    set_rebuild_needed(app, needed);
+    true
+}
+
+/// Record that a successful activation brought the running system up to date.
+/// Invalidates older asynchronous checks and emits `git_state_changed` when
+/// the rebuild-needed flag changes.
+pub fn mark_build_applied<R: Runtime>(app: &AppHandle<R>) {
+    let mut revision = REBUILD_NEEDED_REVISION.lock().unwrap();
+    *revision = revision.wrapping_add(1);
+    set_rebuild_needed(app, false);
 }
 
 /// Record a fresh status snapshot, clearing the external-build flag.

--- a/apps/native/src-tauri/src/state/git_state.rs
+++ b/apps/native/src-tauri/src/state/git_state.rs
@@ -63,8 +63,11 @@ pub fn set_rebuild_needed_from_check<R: Runtime>(
     revision: u64,
     needed: bool,
 ) -> bool {
-    let current_revision = REBUILD_NEEDED_REVISION.lock().unwrap();
-    if *current_revision != revision {
+    let should_apply = {
+        let current_revision = REBUILD_NEEDED_REVISION.lock().unwrap();
+        *current_revision == revision
+    };
+    if !should_apply {
         return false;
     }
     set_rebuild_needed(app, needed);
@@ -75,8 +78,11 @@ pub fn set_rebuild_needed_from_check<R: Runtime>(
 /// in-flight check has been replaced or discarded. Invalidates older checks
 /// so they cannot publish a result derived from the previous working tree.
 pub fn invalidate_rebuild_needed<R: Runtime>(app: &AppHandle<R>) {
-    let mut revision = REBUILD_NEEDED_REVISION.lock().unwrap();
-    *revision = revision.wrapping_add(1);
+    {
+        let mut revision = REBUILD_NEEDED_REVISION.lock().unwrap();
+        *revision = revision.wrapping_add(1);
+    }
+
     set_rebuild_needed(app, false);
 }
 

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -9,6 +9,7 @@ use crate::shared_types::GitState;
 use crate::state::{
     build_state, change_map as change_map_state, drift_notifications, evolve_state, git_state,
 };
+use crate::system::nix;
 use crate::{db, git, summarize};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -33,9 +34,16 @@ static WATCHER_THREAD: Mutex<Option<std::thread::JoinHandle<()>>> = Mutex::new(N
 /// restarts do not reset the five-minute throttle.
 static LAST_AUTO_UPDATE_CHECK: Mutex<Option<(String, Instant)>> = Mutex::new(None);
 
+/// Last rebuild-needed check by watched directory.
+static LAST_REBUILD_NEEDED_CHECK: Mutex<Option<(String, Instant)>> = Mutex::new(None);
+
 /// Check the upstream git repo for new commits that we might be able to pull
 /// every 5 minutes.
 const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Check if we need to suggest a darwin-rebuild switch to the user (if the current working tree is newer than the last build)
+/// every 1 minute.
+const REBUILD_NEEDED_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Git auto-update mode preference values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,6 +85,171 @@ fn should_check_auto_update(dir: &str, now: Instant) -> bool {
 
     *last_check = Some((dir.to_string(), now));
     true
+}
+
+fn should_check_rebuild_needed(dir: &str, now: Instant) -> bool {
+    let mut last_check = LAST_REBUILD_NEEDED_CHECK.lock().unwrap();
+
+    if let Some((last_dir, checked_at)) = last_check.as_ref()
+        && last_dir == dir
+        && now.duration_since(*checked_at) < REBUILD_NEEDED_CHECK_INTERVAL
+    {
+        return false;
+    }
+
+    *last_check = Some((dir.to_string(), now));
+    true
+}
+
+fn check_for_external_build<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    last_known_store_path: &mut Option<String>,
+) -> bool {
+    let live_store_path = build_state::read_current_store_path();
+    if live_store_path == *last_known_store_path {
+        return false;
+    }
+
+    *last_known_store_path = live_store_path.clone();
+    if let Ok(mut build_state) = build_state::get(app_handle) {
+        build_state.current_nix_store_path = live_store_path.clone();
+        let _ = build_state::set(app_handle, build_state);
+    }
+
+    let nixmac_built = build_state::get(app_handle)
+        .ok()
+        .and_then(|state| state.nixmac_built_store_path);
+    live_store_path.is_some() && live_store_path != nixmac_built
+}
+
+fn check_git_status<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    dir: &str,
+    external_build_detected: bool,
+) {
+    let status = match git::status(dir) {
+        Ok(status) => status,
+        Err(error) => {
+            let _ = app_handle.emit("git_state_error", error.to_string());
+            return;
+        }
+    };
+
+    let current = git_state::get(app_handle);
+    let status_changed = current.git_status.as_ref() != Some(&status);
+    if !status_changed && !external_build_detected {
+        return;
+    }
+
+    evolve_state::refresh(app_handle, &status.changes);
+    let change_map = if status.clean_head {
+        Default::default()
+    } else {
+        let pool = app_handle.state::<db::DbPool>();
+        summarize::find_existing::for_current_state(&pool, dir)
+            .ok()
+            .map(summarize::group_existing::from_change_sets)
+            .unwrap_or_default()
+    };
+    drift_notifications::maybe_notify(Some(&status), external_build_detected);
+    app_handle
+        .state::<crate::observable::Observable<GitState>>()
+        .update_if_changed(move |state| {
+            let live_status_changed = state.git_status.as_ref() != Some(&status);
+            let flag =
+                external_build_detected || (state.external_build_detected && !live_status_changed);
+            state.git_status = Some(status);
+            state.external_build_detected = flag;
+        });
+    change_map_state::update(app_handle, change_map);
+}
+
+fn check_upstream<R: Runtime + 'static>(app_handle: &AppHandle<R>, dir: &str, generation: u64) {
+    if GitAutoUpdateMode::from_env() == GitAutoUpdateMode::Off
+        || !should_check_auto_update(dir, Instant::now())
+    {
+        return;
+    }
+
+    let check_app_handle = app_handle.clone();
+    let dir = dir.to_string();
+    std::thread::spawn(move || {
+        let decision = git::auto_update::check_auto_update(&dir);
+        log::debug!("[watcher] git auto-update check result: {:?}", decision);
+        if let Ok(decision) = decision {
+            let available = matches!(
+                decision,
+                git::auto_update::AutoUpdateDecision::UpdateAndRebuild { .. }
+            );
+            let watch_dir = WATCH_DIR.lock().unwrap();
+            if WATCHER_GENERATION.load(Ordering::SeqCst) == generation
+                && watch_dir.as_deref() == Some(dir.as_str())
+            {
+                git_state::set_upstream_update_available(&check_app_handle, available);
+            } else {
+                log::debug!("[watcher] discarding stale git auto-update result for {dir}");
+            }
+        }
+    });
+}
+
+fn check_rebuild_needed<R: Runtime + 'static>(
+    app_handle: &AppHandle<R>,
+    dir: &str,
+    generation: u64,
+) {
+    if !should_check_rebuild_needed(dir, Instant::now()) {
+        return;
+    }
+    let Some(hostname) = nix::determine_host_attr(app_handle) else {
+        return;
+    };
+
+    let check_app_handle = app_handle.clone();
+    let dir = dir.to_string();
+    let rebuild_check_revision = git_state::rebuild_needed_check_revision();
+    std::thread::spawn(move || match nix::is_rebuild_needed(&hostname, &dir) {
+        Ok(needed) => {
+            log::debug!(
+                "[watcher] rebuild-needed check result for {dir} on {hostname}: {}",
+                if needed { "needed" } else { "not needed" }
+            );
+            let watch_dir = WATCH_DIR.lock().unwrap();
+            if WATCHER_GENERATION.load(Ordering::SeqCst) == generation
+                && watch_dir.as_deref() == Some(dir.as_str())
+                && nix::determine_host_attr(&check_app_handle).as_deref() == Some(&hostname)
+            {
+                if !git_state::set_rebuild_needed_from_check(
+                    &check_app_handle,
+                    rebuild_check_revision,
+                    needed,
+                ) {
+                    log::debug!(
+                        "[watcher] discarding rebuild-needed result invalidated by a successful build"
+                    );
+                }
+            } else {
+                log::debug!("[watcher] discarding stale rebuild-needed result for {dir}");
+            }
+        }
+        Err(error) => log::warn!("[watcher] rebuild-needed check failed: {error:#}"),
+    });
+}
+
+fn wait_for_next_poll<R: Runtime + 'static>(
+    app_handle: &AppHandle<R>,
+    dir: Option<&str>,
+    interval_ms: u64,
+    generation: u64,
+) {
+    let sleep_until = Instant::now() + Duration::from_millis(interval_ms);
+    while Instant::now() < sleep_until && WATCHER_ACTIVE.load(Ordering::SeqCst) {
+        if let Some(dir) = dir {
+            check_upstream(app_handle, dir, generation);
+            check_rebuild_needed(app_handle, dir, generation);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
 }
 
 /// Stops the git status watcher, if one is running, and waits for it to exit.
@@ -130,6 +303,7 @@ where
     // If the repository changed, reset the upstream update available flag so the next check can re-evaluate it.
     if repository_changed {
         git_state::set_upstream_update_available(&app_handle, false);
+        git_state::set_rebuild_needed(&app_handle, false);
     }
 
     // Step 3: Signal that a watcher is now active and spawn the new thread.
@@ -153,131 +327,14 @@ where
                 watch_dir.clone()
             };
 
-            // Detect external builds
-            let mut external_build_detected = false;
-            let live_store_path = build_state::read_current_store_path();
-            if live_store_path != last_known_store_path {
-                last_known_store_path = live_store_path.clone();
-                // Persist so the next app start initialises correctly.
-                if let Ok(mut bs) = build_state::get(&app_handle) {
-                    bs.current_nix_store_path = live_store_path.clone();
-                    // fire-and-forget: persisting the updated store path to cache.
-                    // The in-memory value is already updated above; a write failure
-                    // means the next app start will re-detect the path from the filesystem.
-                    let _ = build_state::set(&app_handle, bs);
-                }
-                // If the new path differs from what nixmac built, it's an external build.
-                let nixmac_built = build_state::get(&app_handle)
-                    .ok()
-                    .and_then(|bs| bs.nixmac_built_store_path);
-                if live_store_path.is_some() && live_store_path != nixmac_built {
-                    external_build_detected = true;
-                }
-            }
+            let external_build_detected =
+                check_for_external_build(&app_handle, &mut last_known_store_path);
 
             if let Some(ref dir) = current_dir {
-                match git::status(dir) {
-                    Ok(status) => {
-                        // Compare against the in-memory cell (last-known state).
-                        // Both this watcher and the mutating commands write it.
-                        let current = git_state::get(&app_handle);
-                        let status_changed = current.git_status.as_ref() != Some(&status);
-
-                        if status_changed || external_build_detected {
-                            // HEAD may have moved since an evolution session was
-                            // persisted. Invalidate that session before choosing
-                            // the summary base ref, so a stale rollback branch
-                            // cannot turn committed changes into manual drift.
-                            evolve_state::refresh(&app_handle, &status.changes);
-                            let change_map = if status.clean_head {
-                                // A clean worktree has no manual drift. Never
-                                // carry a historical/session-derived diff into
-                                // the live drift cell.
-                                Default::default()
-                            } else {
-                                let pool = app_handle.state::<db::DbPool>();
-                                summarize::find_existing::for_current_state(&pool, dir)
-                                    .ok()
-                                    .map(summarize::group_existing::from_change_sets)
-                                    .unwrap_or_default()
-                            };
-                            // Native drift notification (config drift / external build).
-                            drift_notifications::maybe_notify(
-                                Some(&status),
-                                external_build_detected,
-                            );
-                            // The cell write emits `git_state_changed`; one emit per
-                            // slice — frontend listens on its dedicated channel. Derive
-                            // the sticky external-build flag from the live cell while its
-                            // write lock is held so another writer cannot be clobbered.
-                            app_handle
-                                .state::<crate::observable::Observable<GitState>>()
-                                .update_if_changed(move |state| {
-                                    let live_status_changed =
-                                        state.git_status.as_ref() != Some(&status);
-                                    let flag = external_build_detected
-                                        || (state.external_build_detected && !live_status_changed);
-                                    state.git_status = Some(status);
-                                    state.external_build_detected = flag;
-                                });
-                            // The cell write emits `change_map_changed`.
-                            change_map_state::update(&app_handle, change_map);
-                        }
-                    }
-                    Err(e) => {
-                        // fire-and-forget: error event delivery to frontend.
-                        let _ = app_handle.emit("git_state_error", e.to_string());
-                    }
-                }
+                check_git_status(&app_handle, dir, external_build_detected);
             }
 
-            // Check periodically (100ms) to break if restart / stop was requested
-            let sleep_until = std::time::Instant::now() + Duration::from_millis(interval_ms);
-            let auto_update_mode = GitAutoUpdateMode::from_env();
-            while std::time::Instant::now() < sleep_until {
-                if !WATCHER_ACTIVE.load(Ordering::SeqCst) {
-                    break;
-                }
-
-                // Detect upstream git commits we may want to offer to pull.
-                // This is a fire-and-forget, best-effort check; if it fails,
-                // we just try again on the next scheduled check.
-                if auto_update_mode != GitAutoUpdateMode::Off
-                    && let Some(dir) = current_dir.clone()
-                    && should_check_auto_update(&dir, Instant::now())
-                {
-                    // Use a separate thread so we don't block the crazy-fast 100ms loop. The check itself is a git fetch
-                    // which is more like order-of-seconds (usually about 1-2 seconds in practice).
-                    let check_app_handle = app_handle.clone();
-                    std::thread::spawn(move || {
-                        let decision = git::auto_update::check_auto_update(&dir);
-                        log::debug!("[watcher] git auto-update check result: {:?}", decision);
-                        if let Ok(decision) = decision {
-                            let available = matches!(
-                                decision,
-                                git::auto_update::AutoUpdateDecision::UpdateAndRebuild { .. }
-                            );
-                            // Hold WATCH_DIR through the state write so a repository
-                            // switch cannot race the validation below.
-                            let watch_dir = WATCH_DIR.lock().unwrap();
-                            if WATCHER_GENERATION.load(Ordering::SeqCst) == generation
-                                && watch_dir.as_deref() == Some(dir.as_str())
-                            {
-                                git_state::set_upstream_update_available(
-                                    &check_app_handle,
-                                    available,
-                                );
-                            } else {
-                                log::debug!(
-                                    "[watcher] discarding stale git auto-update result for {dir}"
-                                );
-                            }
-                        }
-                    });
-                }
-
-                std::thread::sleep(Duration::from_millis(100));
-            }
+            wait_for_next_poll(&app_handle, current_dir.as_deref(), interval_ms, generation);
         }
     });
 

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -157,6 +157,26 @@ pub fn is_rebuild_needed(hostname: &str, config_dir: &str) -> Result<bool> {
     /* General approach:
         expected=$(nix eval --raw ".#darwinConfigurations.${host}.system")
         active=$(readlink /run/current-system)
+
+        Helper bash function to test:
+
+        ```sh
+        config="your-host-name"
+
+        check_state() {
+        expected=$(nix eval --raw ".#darwinConfigurations.${config}.system") || return
+        active=$(realpath /run/current-system)
+
+        printf 'expected: %s\n' "$expected"
+        printf 'active:   %s\n' "$active"
+
+        if [ "$expected" = "$active" ]; then
+            echo "STATUS: even"
+        else
+            echo "STATUS: rebuild needed"
+        fi
+        }
+        ```
     */
     let host_attr = serde_json::to_string(hostname)?;
     let flake_attr = format!(".#darwinConfigurations.{}.system", host_attr);

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -156,7 +156,7 @@ fn nix_eval_value_to_string(value: serde_json::Value) -> String {
 pub fn is_rebuild_needed(hostname: &str, config_dir: &str) -> Result<bool> {
     /* General approach:
         expected=$(nix eval --raw ".#darwinConfigurations.${host}.system")
-        active=$(readlink /run/current-system)
+        active=$(realpath /run/current-system)
 
         Helper bash function to test:
 
@@ -197,7 +197,7 @@ pub fn is_rebuild_needed(hostname: &str, config_dir: &str) -> Result<bool> {
         .trim()
         .to_string();
 
-    let actual_system_output = Command::new("readlink")
+    let actual_system_output = Command::new("realpath")
         .arg("/run/current-system")
         .output()?;
     if !actual_system_output.status.success() {

--- a/apps/native/src-tauri/src/system/nix.rs
+++ b/apps/native/src-tauri/src/system/nix.rs
@@ -151,6 +151,47 @@ fn nix_eval_value_to_string(value: serde_json::Value) -> String {
     }
 }
 
+/// Check to see if a rebuild is needed for the given host and config dir.
+/// This can happen when (for example) the user pulled git changes from the upstream.
+pub fn is_rebuild_needed(hostname: &str, config_dir: &str) -> Result<bool> {
+    /* General approach:
+        expected=$(nix eval --raw ".#darwinConfigurations.${host}.system")
+        active=$(readlink /run/current-system)
+    */
+    let host_attr = serde_json::to_string(hostname)?;
+    let flake_attr = format!(".#darwinConfigurations.{}.system", host_attr);
+
+    let expected_output = nix_command(config_dir)
+        .args(["eval", "--raw", &flake_attr])
+        .output()?;
+
+    if !expected_output.status.success() {
+        anyhow::bail!(
+            "Failed to evaluate expected system for host {}: {}",
+            hostname,
+            String::from_utf8_lossy(&expected_output.stderr)
+        );
+    }
+
+    let expected_system = String::from_utf8(expected_output.stdout)?
+        .trim()
+        .to_string();
+
+    let actual_system_output = Command::new("readlink")
+        .arg("/run/current-system")
+        .output()?;
+    if !actual_system_output.status.success() {
+        anyhow::bail!(
+            "Failed to read current system symlink: {}",
+            String::from_utf8_lossy(&actual_system_output.stderr)
+        );
+    }
+    let actual_system = String::from_utf8(actual_system_output.stdout)?
+        .trim()
+        .to_string();
+    Ok(expected_system != actual_system)
+}
+
 /// Gets the `system.primaryUser` for the given host by running `nix eval` if it's
 /// defined. This is required for (for example) setting system.defaults.
 pub fn get_system_primary_user(hostname: &str, config_dir: &str) -> Option<String> {
@@ -1079,6 +1120,24 @@ mod tests {
                 eprintln!("Error evaluating nix launchd items: {}", err);
             }
         }
+    }
+
+    #[test]
+    #[ignore = "Runs against the local system; enable explicitly when debugging the nix rebuild check."]
+    #[cfg(target_os = "macos")]
+    fn test_is_rebuild_needed() -> Result<()> {
+        use crate::bootstrap::default_config::detect_hostname;
+
+        let this_host_name = detect_hostname().expect("failed to get hostname");
+        const CONFIG_DIR: &str = "~/.darwin";
+
+        let rebuild_needed = is_rebuild_needed(&this_host_name, CONFIG_DIR)?;
+        println!(
+            "Rebuild needed for host {}: {}",
+            this_host_name, rebuild_needed
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/apps/native/src/components/widget/drift/drift-review.stories.tsx
+++ b/apps/native/src/components/widget/drift/drift-review.stories.tsx
@@ -133,11 +133,13 @@ function setup({
   changeMap,
   configDir = "/Users/user/darwin",
   evolve = null,
+  rebuildNeeded = false,
 }: {
   changes: Change[];
   changeMap: SemanticChangeMap;
   configDir?: string;
   evolve?: unknown;
+  rebuildNeeded?: boolean;
 }) {
   useEffect(() => {
     viewModelActions.setState({
@@ -146,6 +148,11 @@ function setup({
       preferences: makeGlobalPreferences({ configDir }),
       rebuildStatus: null,
       evolve: evolve as never,
+      build: {
+        externalBuildDetected: false,
+        upstreamUpdateAvailable: false,
+        rebuildNeeded,
+      },
     });
   }, []);
 
@@ -190,6 +197,15 @@ export const Grouped = meta.story({
 export const AiSession = meta.story({
   render: () =>
     setup({ changes: driftChanges, changeMap: summarizedChangeMap, evolve: aiSession }),
+});
+
+/**
+ * Saved configuration is newer than the running system, while the working
+ * tree itself is clean. Only the explanation and applicable build action show.
+ */
+export const SavedUpdatesReady = meta.story({
+  render: () =>
+    setup({ changes: [], changeMap: emptyChangeMap, rebuildNeeded: true }),
 });
 
 /**

--- a/apps/native/src/components/widget/drift/drift-review.tsx
+++ b/apps/native/src/components/widget/drift/drift-review.tsx
@@ -26,6 +26,7 @@ import {
   Sparkles,
   Trash2,
   Wrench,
+  CircleCheckBig,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { DriftBanner } from "./drift-banner";
@@ -50,6 +51,7 @@ export function DriftReview() {
   const evolveState = useViewModel((s) => s.evolve);
   const isApplyBusy = useUiState((s) => s.isProcessing && s.processingAction === "apply");
   const rebuildRunning = useViewModel((s) => s.rebuildStatus?.isRunning ?? false);
+  const rebuildNeeded = useViewModel((s) => s.build.rebuildNeeded);
 
   // No active evolution → the changes are manual drift, not AI-generated.
   const isManualDrift = (evolveState?.evolutionId ?? null) === null;
@@ -66,6 +68,7 @@ export function DriftReview() {
   const changes = gitStatus?.changes;
   const files = useMemo(() => deriveDriftFiles(changes ?? []), [changes]);
   const counts = useMemo(() => summarizeDriftCounts(files), [files]);
+  const isSavedBuildPending = rebuildNeeded && files.length === 0;
 
   // Re-run the dry build check whenever the set of changes changes.
   const changeFingerprint = useMemo(
@@ -77,7 +80,7 @@ export function DriftReview() {
     // AI-generated changes were already built during evolution, so there's no
     // dry-run gate — the build button is ready immediately (matching the prior
     // evolve step). Manual drift hasn't been built, so dry-run check it first.
-    if (!isManualDrift) {
+    if (!isManualDrift || isSavedBuildPending) {
       setBuildStatus("passed");
       return;
     }
@@ -96,13 +99,52 @@ export function DriftReview() {
     return () => {
       cancelled = true;
     };
-  }, [buildCheck, changeFingerprint, isManualDrift]);
+  }, [buildCheck, changeFingerprint, isManualDrift, isSavedBuildPending]);
 
-  if (!gitStatus || files.length === 0) return null;
+  if (!gitStatus) return null;
+
+  const buildReady = buildStatus === "passed" && !isApplyBusy && !rebuildRunning;
+
+  if (isSavedBuildPending) {
+    return (
+      <div className="flex flex-col gap-5 rounded-xl border border-border/70 bg-card/50 p-5">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 rounded-full bg-teal-500/10 p-2 text-teal-500">
+            <CircleCheckBig className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="space-y-1">
+            <h2 className="font-semibold text-foreground">New configuration updates are available</h2>
+            <p className="max-w-xl text-muted-foreground text-sm leading-relaxed">
+              This Mac isn’t using the latest configuration yet. Apply the updates to bring it up to date.
+            </p>
+          </div>
+        </div>
+
+        <footer className="flex justify-end border-border/60 border-t pt-4">
+          <ConfirmButton
+            size="sm"
+            disabled={!buildReady}
+            confirmPrefKey="confirmBuild"
+            onConfirm={handleApply}
+            message="Build and apply your saved configuration?"
+            color="teal"
+          >
+            {rebuildRunning ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <Wrench className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            {rebuildRunning ? "Building…" : "Build & Test"}
+          </ConfirmButton>
+        </footer>
+      </div>
+    );
+  }
+
+  if (files.length === 0) return null;
 
   const total = files.length;
   const buildChecking = isManualDrift && buildStatus === "checking";
-  const buildReady = buildStatus === "passed" && !isApplyBusy && !rebuildRunning;
 
   return (
     <div className="flex flex-col gap-4">

--- a/apps/native/src/components/widget/layout/header.tsx
+++ b/apps/native/src/components/widget/layout/header.tsx
@@ -33,6 +33,7 @@ export function Header() {
         isBootstrapping: state.isBootstrapping,
         activeStepOverride: state.activeStepOverride,
         hasChanges: (viewModel.git?.changes.length ?? 0) > 0,
+        rebuildNeeded: viewModel.build.rebuildNeeded,
       });
       if (step !== "setup" && state.error && state.error !== prevState.error) {
         setIsPulsing(true);

--- a/apps/native/src/components/widget/layout/stepper.test.tsx
+++ b/apps/native/src/components/widget/layout/stepper.test.tsx
@@ -101,6 +101,26 @@ describe("Stepper", () => {
     expect(screen.getByRole("button", { name: "Go to Review step" })).toBeDisabled();
   });
 
+  it("shows Review as the active destination when saved updates need a build", () => {
+    viewModelActions.setState({
+      evolve: makeEvolveState({ step: "begin" }),
+      git: { ...gitWithChanges(), changes: [], cleanHead: true },
+      build: {
+        externalBuildDetected: false,
+        upstreamUpdateAvailable: false,
+        rebuildNeeded: true,
+      },
+    });
+
+    render(<Stepper />);
+
+    expect(screen.getByRole("list", { name: /step 2 of 3, Review/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to Review step" })).toHaveAttribute(
+      "aria-current",
+      "step",
+    );
+  });
+
   it("stays visible while generating, with navigation locked", () => {
     viewModelActions.setState({
       evolve: makeEvolveState({ step: "commit" }),

--- a/apps/native/src/components/widget/layout/stepper.tsx
+++ b/apps/native/src/components/widget/layout/stepper.tsx
@@ -30,12 +30,17 @@ export function Stepper() {
   const isGenerating = useUiState((s) => s.isGenerating);
   const rawBackendStep = useViewModel((s) => s.evolve?.step ?? "begin");
   const hasChanges = useViewModel((s) => (s.git?.changes.length ?? 0) > 0);
+  const rebuildNeeded = useViewModel((s) => s.build.rebuildNeeded);
   const isRebuilding = useViewModel((s) => s.rebuildStatus?.isRunning ?? false);
 
   // Review/Save are only real destinations when there's a diff. Without changes
   // the user belongs at the prompt step, so progress collapses to "begin" and
   // the later steps stay locked — matching computeCurrentStep.
-  const backendStep = hasChanges ? rawBackendStep : "begin";
+  const backendStep = rebuildNeeded && !hasChanges
+    ? "manualEvolve"
+    : hasChanges
+      ? rawBackendStep
+      : "begin";
 
   if (
     step === "setup" ||

--- a/apps/native/src/components/widget/promptinput/prompt-input.test.tsx
+++ b/apps/native/src/components/widget/promptinput/prompt-input.test.tsx
@@ -88,7 +88,11 @@ function resetStore() {
   viewModelActions.setState({
     git: null,
     evolve: null,
-    build: { externalBuildDetected: false, upstreamUpdateAvailable: false },
+    build: {
+      externalBuildDetected: false,
+      upstreamUpdateAvailable: false,
+      rebuildNeeded: false,
+    },
     preferences: makeGlobalPreferences(),
   });
   uiActions.setProcessing(false);

--- a/apps/native/src/components/widget/utils.test.ts
+++ b/apps/native/src/components/widget/utils.test.ts
@@ -213,6 +213,7 @@ describe("computeCurrentStep — diff gating", () => {
       evolveState: null as EvolveState | null,
       activeStepOverride: null as EvolveStep | null,
       hasChanges: false,
+      rebuildNeeded: false,
       ...overrides,
     };
   }
@@ -223,6 +224,10 @@ describe("computeCurrentStep — diff gating", () => {
     expect(computeCurrentStep(readyState({ evolveState: evolveAt("evolve") }))).toBe("begin");
     expect(computeCurrentStep(readyState({ evolveState: evolveAt("commit") }))).toBe("begin");
     expect(computeCurrentStep(readyState({ evolveState: evolveAt("manualEvolve") }))).toBe("begin");
+  });
+
+  it("routes a clean working tree with unapplied settings to review", () => {
+    expect(computeCurrentStep(readyState({ rebuildNeeded: true }))).toBe("manualEvolve");
   });
 
   it("honors the backend step once there is a diff to act on", () => {

--- a/apps/native/src/components/widget/utils.ts
+++ b/apps/native/src/components/widget/utils.ts
@@ -18,6 +18,8 @@ type CurrentStepState = {
   activeStepOverride: EvolveStep | null;
   /** Whether the working tree currently has any tracked changes (a diff). */
   hasChanges: boolean;
+  /** Whether saved configuration is newer than the currently running system. */
+  rebuildNeeded: boolean;
 };
 
 const orderByStep: { [key in EvolveStep]: number } = {
@@ -68,11 +70,14 @@ export function computeCurrentStep(state: CurrentStepState): WidgetStep {
     return "filesystem";
   }
 
-  // The review/commit steps only make sense when there's an actual diff to act
-  // on. Without changes there is nothing to review, build, or save, so route to
-  // the prompt step even if an evolve session is still active (e.g. all changes
-  // were discarded, or a session persisted across restart). The prompt step
-  // still surfaces any conversational response, so nothing is lost.
+  // A clean working tree can still need a build after pulling or committing
+  // configuration changes. Route that state to Review so the user can bring
+  // the running system up to date without inventing a diff to review.
+  if (state.rebuildNeeded && !state.hasChanges) {
+    return "manualEvolve";
+  }
+
+  // Otherwise Review/Save only make sense when there's an actual diff.
   if (!state.hasChanges) {
     return "begin";
   }

--- a/apps/native/src/hooks/use-current-step.ts
+++ b/apps/native/src/hooks/use-current-step.ts
@@ -25,6 +25,7 @@ export function useCurrentStep(): WidgetStep {
   const isBootstrapping = useUiState((state) => state.isBootstrapping);
   const activeStepOverride = useUiState((state) => state.activeStepOverride);
   const hasChanges = useViewModel((state) => (state.git?.changes.length ?? 0) > 0);
+  const rebuildNeeded = useViewModel((state) => state.build.rebuildNeeded);
   return computeCurrentStep({
     nixInstalled,
     darwinRebuildAvailable,
@@ -39,5 +40,6 @@ export function useCurrentStep(): WidgetStep {
     isBootstrapping,
     activeStepOverride,
     hasChanges,
+    rebuildNeeded,
   });
 }

--- a/apps/native/src/hooks/use-evolve.test.ts
+++ b/apps/native/src/hooks/use-evolve.test.ts
@@ -45,7 +45,11 @@ describe("useEvolve", () => {
       changeMap: null,
       git: null,
       evolve: null,
-      build: { externalBuildDetected: false, upstreamUpdateAvailable: false },
+      build: {
+        externalBuildDetected: false,
+        upstreamUpdateAvailable: false,
+        rebuildNeeded: false,
+      },
     });
   });
 

--- a/apps/native/src/hooks/use-rollback.test.ts
+++ b/apps/native/src/hooks/use-rollback.test.ts
@@ -67,7 +67,11 @@ describe("useRollback", () => {
     viewModelActions.setState({
       evolve: committableEvolveState,
       git: cleanGitStatus,
-      build: { externalBuildDetected: false, upstreamUpdateAvailable: false },
+      build: {
+        externalBuildDetected: false,
+        upstreamUpdateAvailable: false,
+        rebuildNeeded: false,
+      },
     });
   });
 

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -925,7 +925,11 @@ externalBuildDetected: boolean;
 /**
  * True when the configured upstream contains a fast-forward update.
  */
-upstreamUpdateAvailable: boolean }
+upstreamUpdateAvailable: boolean;
+/**
+ * True when a rebuild is needed to bring the system up to date with the current working tree.
+ */
+rebuildNeeded: boolean }
 
 /**
  * Comprehensive git repository status.

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1156,7 +1156,11 @@ externalBuildDetected: boolean;
 /**
  * True when the configured upstream contains a fast-forward update.
  */
-upstreamUpdateAvailable: boolean }
+upstreamUpdateAvailable: boolean;
+/**
+ * True when a rebuild is needed to bring the system up to date with the current working tree.
+ */
+rebuildNeeded: boolean }
 
 /**
  * Comprehensive git repository status.
@@ -2484,4 +2488,3 @@ version: string;
  * Release notes from the channel manifest, when available.
  */
 notes: string | null }
-

--- a/apps/native/src/viewmodel/git.ts
+++ b/apps/native/src/viewmodel/git.ts
@@ -8,6 +8,7 @@ function mirrorGitState(
   git: GitStatus | null,
   externalBuildDetected = false,
   upstreamUpdateAvailable = false,
+  rebuildNeeded = false,
 ): void {
   viewModelActions.setState((state) => ({
     git,
@@ -15,6 +16,7 @@ function mirrorGitState(
       ...state.build,
       externalBuildDetected,
       upstreamUpdateAvailable,
+      rebuildNeeded,
     },
   }));
 }
@@ -36,8 +38,13 @@ export async function startGitSync(): Promise<() => void> {
       // deprecated(orpc): replace with client/orpc from @/lib/orpc
       hydrate: () => tauriAPI.git.state(),
       event: "git_state_changed",
-      mirror: ({ gitStatus, externalBuildDetected, upstreamUpdateAvailable }) =>
-        mirrorGitState(gitStatus, externalBuildDetected, upstreamUpdateAvailable),
+      mirror: ({ gitStatus, externalBuildDetected, upstreamUpdateAvailable, rebuildNeeded }) =>
+        mirrorGitState(
+          gitStatus,
+          externalBuildDetected,
+          upstreamUpdateAvailable,
+          rebuildNeeded,
+        ),
       onEvent: () => invalidateHistory(),
     }),
     ipcRenderer.on<string>("git_state_error", (event) => {

--- a/apps/native/src/viewmodel/viewmodel.test.ts
+++ b/apps/native/src/viewmodel/viewmodel.test.ts
@@ -126,6 +126,7 @@ describe("view model sync", () => {
       gitStatus: { hasChanges: false, files: [] } as unknown as GitStatus,
       externalBuildDetected: false,
       upstreamUpdateAvailable: false,
+      rebuildNeeded: false,
     };
     apiMocks.changeMap = { groups: [], singles: [] } as unknown as SemanticChangeMap;
     apiMocks.preferences = makeGlobalPreferences();
@@ -143,7 +144,11 @@ describe("view model sync", () => {
     viewModelActions.setState({
       evolve: null,
       git: null,
-      build: { externalBuildDetected: false, upstreamUpdateAvailable: false },
+      build: {
+        externalBuildDetected: false,
+        upstreamUpdateAvailable: false,
+        rebuildNeeded: false,
+      },
       changeMap: null,
       preferences: null,
       hosts: [],
@@ -183,6 +188,7 @@ describe("view model sync", () => {
       gitStatus,
       externalBuildDetected: true,
       upstreamUpdateAvailable: true,
+      rebuildNeeded: true,
     };
 
     apiMocks.listeners.get("git_state_changed")?.({ payload: event });
@@ -190,6 +196,7 @@ describe("view model sync", () => {
     expect(viewModelActions.getState().git).toBe(gitStatus);
     expect(viewModelActions.getState().build.externalBuildDetected).toBe(true);
     expect(viewModelActions.getState().build.upstreamUpdateAvailable).toBe(true);
+    expect(viewModelActions.getState().build.rebuildNeeded).toBe(true);
 
     stop();
     expect(apiMocks.unlisten).toHaveBeenCalledTimes(2);

--- a/packages/state/src/viewmodel/store.ts
+++ b/packages/state/src/viewmodel/store.ts
@@ -21,6 +21,7 @@ export const initialViewModelState: ViewModelState = {
   build: {
     externalBuildDetected: false,
     upstreamUpdateAvailable: false,
+    rebuildNeeded: false,
   },
   changeMap: null,
   preferences: null,

--- a/packages/state/src/viewmodel/types.ts
+++ b/packages/state/src/viewmodel/types.ts
@@ -14,6 +14,7 @@ import type { RebuildLine, RebuildNotice } from "@nixmac/native/types/rebuild";
 type BuildView = {
   externalBuildDetected: boolean;
   upstreamUpdateAvailable: boolean;
+  rebuildNeeded: boolean;
 };
 
 export type RebuildLog = {


### PR DESCRIPTION
## Summary

This aims to detect if the current (clean working tree) git repo is ahead of the build nix config and if so present the "Review" screen with a prompt to "Build & Test" -- similar workflow (but simpler UI) to how we handle drift from manual changes.

The key things to look at are:

- The approach for how we detect this situation (in nix.rs)
- When we set as well as invalidate the status (which is refreshed every minute by the watcher) -- this one I'm particularly interested in reviewers' thoughts because while developing and testing I found a couple of states in the app where we needed to proactively invalidate and there may be others I missed or didn't think of.
- I refactored the watcher kernel since it was turning into a huge mess of spaghetti code.
- Will do a follow-up to trigger a refresh of the check immediately when we use the new UI to invoke a git-pull as for now it can take up to a minute to reflect in the UI.

<img width="790" height="442" alt="Screenshot 2026-07-22 at 9 37 30 AM" src="https://github.com/user-attachments/assets/a14b4381-80a8-429e-b51d-902f4a47c424" />

<!-- What does this PR do? Why? -->

## Test Plan

I worked through a bunch of scenarios involving pulling new git changes from the upstream, creating/undoing manual drift, and building and rolling back with `darwin-rebuild switch`. I should say there are no doubt some I missed, though, as we have a ton of different possible states in the app these days.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed