### PR TITLE
Cli evolve: take the result envelope state from telemetry.state

### DIFF
--- a/apps/native/src-tauri/src/cli.rs
+++ b/apps/native/src-tauri/src/cli.rs
@@ -337,12 +337,7 @@ pub async fn handle_evolve_command(app: &AppHandle, cfg: EvolveConfig) -> Result
     };
 
     if let Some(out_path) = out {
-        // Hoist `state` to the envelope so test suites can branch on it without
-        // digging into result.telemetry.state.
-        let state_str = output_value
-            .get("state")
-            .and_then(|v| v.as_str())
-            .unwrap_or(if ok { "generated" } else { "failed" });
+        let state_str = evolution_result_state(&output_value, ok);
 
         let combined = json!({
             "ok": ok,
@@ -373,6 +368,19 @@ pub async fn handle_evolve_command(app: &AppHandle, cfg: EvolveConfig) -> Result
     Ok(())
 }
 
+/// The evolution's lifecycle state as reported in the result envelope, so
+/// consumers can branch on it without digging into result.telemetry.state.
+/// Both `EvolutionResult` and `EvolutionFailureResult` carry it at
+/// `telemetry.state`; the fallback only covers outputs that failed to
+/// serialize into that shape.
+fn evolution_result_state(output_value: &serde_json::Value, ok: bool) -> &str {
+    output_value
+        .get("telemetry")
+        .and_then(|telemetry| telemetry.get("state"))
+        .and_then(|state| state.as_str())
+        .unwrap_or(if ok { "generated" } else { "failed" })
+}
+
 /// Check if CLI mode should be activated based on arguments
 pub fn should_run_cli() -> bool {
     let args: Vec<String> = std::env::args().collect();
@@ -388,4 +396,56 @@ pub fn should_run_cli() -> bool {
 /// Parse args
 pub fn parse_cli() -> Result<Cli, String> {
     Cli::try_parse().map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared_types::{EvolutionState, EvolutionTelemetry};
+
+    fn output_with_state(state: EvolutionState) -> serde_json::Value {
+        let telemetry = EvolutionTelemetry {
+            state,
+            iterations: 18,
+            build_attempts: 0,
+            total_tokens: 222_976,
+            edits_count: 0,
+            thinking_count: 0,
+            tool_calls_count: 42,
+            duration_ms: 1_000,
+        };
+        json!({
+            "telemetry": serde_json::to_value(&telemetry).unwrap(),
+        })
+    }
+
+    #[test]
+    fn evolution_result_state_should_report_limit_reached_from_telemetry() {
+        let output = output_with_state(EvolutionState::LimitReached);
+        assert_eq!(evolution_result_state(&output, true), "limitReached");
+    }
+
+    #[test]
+    fn evolution_result_state_should_report_conversational_from_telemetry() {
+        let output = output_with_state(EvolutionState::Conversational);
+        assert_eq!(evolution_result_state(&output, true), "conversational");
+    }
+
+    #[test]
+    fn evolution_result_state_should_report_failed_from_failure_telemetry() {
+        let output = output_with_state(EvolutionState::Failed);
+        assert_eq!(evolution_result_state(&output, false), "failed");
+    }
+
+    #[test]
+    fn evolution_result_state_should_fall_back_to_generated_when_telemetry_missing() {
+        let output = json!({ "raw": "unserializable output" });
+        assert_eq!(evolution_result_state(&output, true), "generated");
+    }
+
+    #[test]
+    fn evolution_result_state_should_fall_back_to_failed_when_telemetry_missing() {
+        let output = json!({ "error": "boom" });
+        assert_eq!(evolution_result_state(&output, false), "failed");
+    }
 }


### PR DESCRIPTION
## Summary

PR-1 of the eval-driven improvement plan (`apps/eval/wip/agent-improvements-combined-plan.md` on #578, issue C2). Supersedes #575 (closed before review; its head commit no longer exists after a rename + rebase).

`nixmac evolve --out` wraps the evolution output in an envelope with a top-level `state` field so consumers can branch on the outcome without digging into the payload. That field was computed by reading `output_value.get("state")` — but the serialized `EvolutionResult`/`EvolutionFailureResult` has no top-level `state`; the lifecycle state lives at `telemetry.state`. The lookup therefore missed **every time** and fell back to `"generated"`/`"failed"` based on `ok` alone.

## Impact

In the 2026-07-20 `glm-5.2` eval run, the envelope `state` disagreed with `telemetry.state` in **111 of 232** results: every `conversational` reply and every `limitReached` cut-off was stamped `generated` (failures happened to be labeled correctly only because the fallback coincides). Anything branching on the envelope inherited the error — in the eval grader this made correct conversational no-ops grade as non-conversational (case 72), let `limitReached` runs pass the build-success proxy, and turned the grader's `state == "conversational"` fallback into dead code.

## Relationship to #578

The grader on #578 already prefers `telemetry.state` when grading, which makes *recorded* artifacts judgeable despite this bug. This PR fixes *future* artifacts at the source, so the envelope is self-consistent for every other consumer (scripts, `jq`, `run_evals.py`).

Out of scope, tracked in the plan: why `limitReached` happens (convergence, N11) and the fact that `Generated` is reachable without a verified build (DoneGate bypass, plan PR-4) — this PR only makes the envelope report those states truthfully.

## Test plan

- `cargo test --bin nixmac cli::tests` — 5 tests, green on the rebased branch (`origin/main` @ 0126bca4).