### PR TITLE
feat: add `GitAutoUpdate` preference and wire up git auto-update setting in UI

### DIFF
--- a/apps/native/src-tauri/examples/specta_gen_ts.rs
+++ b/apps/native/src-tauri/examples/specta_gen_ts.rs
@@ -87,6 +87,7 @@ fn main() {
         .register::<shared_types::RollbackResult>()
         .register::<shared_types::SetDirResult>()
         .register::<shared_types::UpdateChannel>()
+        .register::<shared_types::GitAutoUpdate>()
         .register::<shared_types::UpdateInfo>()
         .register::<shared_types::GlobalPreferences>()
         .register::<shared_types::OnboardingState>()

--- a/apps/native/src-tauri/src/shared_types/prefs.rs
+++ b/apps/native/src-tauri/src/shared_types/prefs.rs
@@ -11,6 +11,16 @@ pub enum UpdateChannel {
     Develop,
 }
 
+/// How nixmac handles updates available from the configuration Git repository.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum GitAutoUpdate {
+    #[default]
+    Off,
+    Confirm,
+    Automatic,
+}
+
 /// User interface preferences (synced to settings.json via tauri-plugin-store).
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
@@ -71,6 +81,8 @@ pub struct UiPrefs {
     pub pinned_version: Option<String>,
     /// Auto-update channel used when no explicit version pin is active.
     pub update_channel: UpdateChannel,
+    /// How updates from the configuration Git repository are handled.
+    pub git_auto_update: GitAutoUpdate,
     /// Developer-only feature flag overrides (flag key → variant string).
     /// `None` or missing key = use PostHog default.
     pub feature_flag_overrides: Option<BTreeMap<String, String>>,
@@ -140,6 +152,8 @@ pub struct UiPrefsUpdate {
     pub pinned_version: Option<Option<String>>,
     /// Auto-update channel preference update.
     pub update_channel: Option<UpdateChannel>,
+    /// Git repository auto-update preference update.
+    pub git_auto_update: Option<GitAutoUpdate>,
     /// `None` -> field not sent; `Some(None)` -> clear all overrides;
     /// `Some(Some(map))` -> replace overrides with `map`.
     #[serde(
@@ -199,6 +213,7 @@ pub struct GlobalPreferences {
     pub developer_mode: bool,
     pub pinned_version: Option<String>,
     pub update_channel: UpdateChannel,
+    pub git_auto_update: GitAutoUpdate,
     pub feature_flag_overrides: Option<BTreeMap<String, String>>,
     /// Root of an import clone parked on the "which flake dir?" choice
     /// (`NeedsFlakeDirChoice`). Recorded so an abandoned choice can be
@@ -240,6 +255,7 @@ impl Default for GlobalPreferences {
             developer_mode: false,
             pinned_version: None,
             update_channel: UpdateChannel::default(),
+            git_auto_update: GitAutoUpdate::default(),
             feature_flag_overrides: None,
             pending_import_dir: None,
             auto_format_nix_files: false,
@@ -310,6 +326,9 @@ impl GlobalPreferences {
         }
         if let Some(v) = update.update_channel {
             self.update_channel = v;
+        }
+        if let Some(v) = update.git_auto_update {
+            self.git_auto_update = v;
         }
         if let Some(v) = &update.feature_flag_overrides {
             self.feature_flag_overrides = v.clone();
@@ -390,6 +409,7 @@ impl GlobalPreferences {
             developer_mode: self.developer_mode,
             pinned_version: self.pinned_version.clone(),
             update_channel: self.update_channel,
+            git_auto_update: self.git_auto_update,
             feature_flag_overrides: self.feature_flag_overrides.clone(),
             auto_format_nix_files: self.auto_format_nix_files,
         }

--- a/apps/native/src-tauri/src/state/watcher.rs
+++ b/apps/native/src-tauri/src/state/watcher.rs
@@ -5,9 +5,10 @@
 //! compares against the in-memory git-state cell, which is kept in sync by
 //! both this watcher and the mutating command paths.
 
-use crate::shared_types::GitState;
+use crate::shared_types::{GitAutoUpdate, GitState};
 use crate::state::{
     build_state, change_map as change_map_state, drift_notifications, evolve_state, git_state,
+    preferences,
 };
 use crate::system::nix;
 use crate::{db, git, summarize};
@@ -45,7 +46,6 @@ const AUTO_UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 /// every 1 minute.
 const REBUILD_NEEDED_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Git auto-update mode preference values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GitAutoUpdateMode {
     Off,
@@ -53,24 +53,36 @@ enum GitAutoUpdateMode {
     Automatic,
 }
 
-/// Git auto-update mode preference implementation.
-/// TODO: Move to real system preference when ready to hook up to UI.
 impl GitAutoUpdateMode {
-    fn from_env() -> Self {
-        Self::from_value(std::env::var("NIXMAC_GIT_AUTO_UPDATE_MODE").ok().as_deref())
+    fn resolve(override_value: Option<&str>, preference: GitAutoUpdate) -> Self {
+        override_value
+            .map(Self::from_override)
+            .unwrap_or(match preference {
+                GitAutoUpdate::Off => Self::Off,
+                GitAutoUpdate::Confirm => Self::Confirm,
+                GitAutoUpdate::Automatic => Self::Automatic,
+            })
     }
 
-    fn from_value(value: Option<&str>) -> Self {
+    fn from_override(value: &str) -> Self {
         match value {
-            Some("confirm") => Self::Confirm,
-            Some("automatic") => Self::Automatic,
-            Some(value) if !value.is_empty() && value != "off" => {
+            "confirm" => Self::Confirm,
+            "automatic" => Self::Automatic,
+            value if !value.is_empty() && value != "off" => {
                 log::warn!("[watcher] ignoring invalid NIXMAC_GIT_AUTO_UPDATE_MODE value: {value}");
                 Self::Off
             }
             _ => Self::Off,
         }
     }
+}
+
+fn git_auto_update_mode<R: Runtime>(app_handle: &AppHandle<R>) -> GitAutoUpdateMode {
+    let override_value = std::env::var("NIXMAC_GIT_AUTO_UPDATE_MODE").ok();
+    let preference = preferences::try_read(app_handle)
+        .map(|prefs| prefs.git_auto_update)
+        .unwrap_or_default();
+    GitAutoUpdateMode::resolve(override_value.as_deref(), preference)
 }
 
 fn should_check_auto_update(dir: &str, now: Instant) -> bool {
@@ -165,7 +177,7 @@ fn check_git_status<R: Runtime>(
 }
 
 fn check_upstream<R: Runtime + 'static>(app_handle: &AppHandle<R>, dir: &str, generation: u64) {
-    if GitAutoUpdateMode::from_env() == GitAutoUpdateMode::Off
+    if git_auto_update_mode(app_handle) == GitAutoUpdateMode::Off
         || !should_check_auto_update(dir, Instant::now())
     {
         return;
@@ -345,28 +357,45 @@ where
 #[cfg(test)]
 mod tests {
     use super::GitAutoUpdateMode;
+    use crate::shared_types::GitAutoUpdate;
 
     #[test]
-    fn parses_auto_update_mode() {
-        assert_eq!(GitAutoUpdateMode::from_value(None), GitAutoUpdateMode::Off);
+    fn stored_auto_update_mode_is_used_without_an_environment_override() {
         assert_eq!(
-            GitAutoUpdateMode::from_value(Some("")),
-            GitAutoUpdateMode::Off
-        );
-        assert_eq!(
-            GitAutoUpdateMode::from_value(Some("off")),
-            GitAutoUpdateMode::Off
-        );
-        assert_eq!(
-            GitAutoUpdateMode::from_value(Some("confirm")),
+            GitAutoUpdateMode::resolve(None, GitAutoUpdate::Confirm),
             GitAutoUpdateMode::Confirm
         );
+    }
+
+    #[test]
+    fn environment_auto_update_mode_overrides_the_stored_preference() {
         assert_eq!(
-            GitAutoUpdateMode::from_value(Some("automatic")),
+            GitAutoUpdateMode::resolve(Some("automatic"), GitAutoUpdate::Off),
             GitAutoUpdateMode::Automatic
         );
         assert_eq!(
-            GitAutoUpdateMode::from_value(Some("invalid")),
+            GitAutoUpdateMode::resolve(Some("off"), GitAutoUpdate::Confirm),
+            GitAutoUpdateMode::Off
+        );
+    }
+
+    #[test]
+    fn parses_auto_update_mode() {
+        assert_eq!(GitAutoUpdateMode::from_override(""), GitAutoUpdateMode::Off);
+        assert_eq!(
+            GitAutoUpdateMode::from_override("off"),
+            GitAutoUpdateMode::Off
+        );
+        assert_eq!(
+            GitAutoUpdateMode::from_override("confirm"),
+            GitAutoUpdateMode::Confirm
+        );
+        assert_eq!(
+            GitAutoUpdateMode::from_override("automatic"),
+            GitAutoUpdateMode::Automatic
+        );
+        assert_eq!(
+            GitAutoUpdateMode::from_override("invalid"),
             GitAutoUpdateMode::Off
         );
     }

--- a/apps/native/src/components/widget/settings/general-tab.test.tsx
+++ b/apps/native/src/components/widget/settings/general-tab.test.tsx
@@ -48,6 +48,7 @@ describe("GeneralTab", () => {
     );
 
     await screen.findByText("0.0.0-test");
+    expect(screen.getByRole("combobox", { name: "Git auto-update" })).toBeInTheDocument();
     expect(screen.getByText("Support Nixmac")).toBeInTheDocument();
     expect(screen.getByText("Help fund continued development.")).toBeInTheDocument();
 

--- a/apps/native/src/components/widget/settings/general-tab.tsx
+++ b/apps/native/src/components/widget/settings/general-tab.tsx
@@ -13,6 +13,7 @@ import { RestartSetupConfirmation } from "@/components/widget/onboarding/restart
 import { getWebSiteUrl } from "@/lib/env";
 import { useViewModel } from "@nixmac/state";
 import { tauriAPI } from "@/ipc/api";
+import type { GitAutoUpdate } from "@/ipc/types";
 import { useTelemetry } from "@/lib/telemetry/context";
 import { getVersion } from "@tauri-apps/api/app";
 import { open } from "@tauri-apps/plugin-shell";
@@ -58,6 +59,7 @@ export function GeneralTab({
   sendDiagnosticsField,
 }: GeneralTabProps) {
   const telemetry = useTelemetry();
+  const gitAutoUpdate = useViewModel((s) => s.preferences?.gitAutoUpdate ?? "off");
   const [confirmingRestart, setConfirmingRestart] = useState(false);
   return (
     <div className="space-y-6">
@@ -111,6 +113,35 @@ export function GeneralTab({
               <BootstrapConfig label="Configuration" onSuccess={() => setSettingsOpen(false)} />
             )
           )}
+
+          {/* Git auto-update */}
+          <label className="font-medium text-sm" htmlFor="git-auto-update">
+            Git auto-update
+          </label>
+          <div className="flex items-center gap-2">
+            <Select
+              value={gitAutoUpdate}
+              onValueChange={async (value) => {
+                await tauriAPI.ui.setPrefs({ gitAutoUpdate: value as GitAutoUpdate });
+                telemetry.captureEvent({
+                  name: "settings_changed",
+                  props: { setting: "git_auto_update" },
+                });
+              }}
+            >
+              <SelectTrigger id="git-auto-update" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="off">Off</SelectItem>
+                <SelectItem value="confirm">Confirm</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="text-muted-foreground text-xs">
+            Check your configuration repository for upstream commits. Confirm offers available
+            updates for review before applying them.
+          </div>
 
           {/* Diagnostics */}
           <div className="flex items-center justify-between rounded-lg border border-border p-3">

--- a/apps/native/src/components/widget/settings/general-tab.tsx
+++ b/apps/native/src/components/widget/settings/general-tab.tsx
@@ -122,11 +122,15 @@ export function GeneralTab({
             <Select
               value={gitAutoUpdate}
               onValueChange={async (value) => {
-                await tauriAPI.ui.setPrefs({ gitAutoUpdate: value as GitAutoUpdate });
-                telemetry.captureEvent({
-                  name: "settings_changed",
-                  props: { setting: "git_auto_update" },
-                });
+                try {
+                  await tauriAPI.ui.setPrefs({ gitAutoUpdate: value as GitAutoUpdate });
+                  telemetry.captureEvent({
+                    name: "settings_changed",
+                    props: { setting: "git_auto_update" },
+                  });
+                } catch (error) {
+                  console.error("Failed to update git auto-update setting:", error);
+                }
               }}
             >
               <SelectTrigger id="git-auto-update" className="w-full">

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -889,6 +889,11 @@ limit: number | null;
  */
 offset: number | null }
 
+/**
+ * How nixmac handles updates available from the configuration Git repository.
+ */
+export type GitAutoUpdate = "off" | "confirm" | "automatic"
+
 export type GitCommitFileInput = { filename: string; message: string }
 
 export type GitCommitInput = { message: string }
@@ -921,11 +926,11 @@ gitStatus: GitStatus | null;
 /**
  * True when a build outside nixmac was detected.
  */
-externalBuildDetected: boolean;
+externalBuildDetected: boolean; 
 /**
  * True when the configured upstream contains a fast-forward update.
  */
-upstreamUpdateAvailable: boolean;
+upstreamUpdateAvailable: boolean; 
 /**
  * True when a rebuild is needed to bring the system up to date with the current working tree.
  */
@@ -1138,7 +1143,7 @@ summaryModel: string | null;
  * Remembered summary model per provider; a missing entry means the
  * provider default is used. Never stores `""`.
  */
-summaryModels: Partial<{ [key in string]: string }>; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; experimentalStreamingEvolve: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
+summaryModels: Partial<{ [key in string]: string }>; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; experimentalStreamingEvolve: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; gitAutoUpdate: GitAutoUpdate; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
 /**
  * Root of an import clone parked on the "which flake dir?" choice
  * (`NeedsFlakeDirChoice`). Recorded so an abandoned choice can be

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1129,6 +1129,11 @@ export type FileEditAction =
 { setAttrs: { path: string; attrs: Partial<{ [key in string]: JsonValue }> } }
 
 /**
+ * How nixmac handles updates available from the configuration Git repository.
+ */
+export type GitAutoUpdate = "off" | "confirm" | "automatic"
+
+/**
  * Individual file status parsed from diff headers.
  */
 export type GitFileStatus = { 
@@ -1156,7 +1161,7 @@ externalBuildDetected: boolean;
 /**
  * True when the configured upstream contains a fast-forward update.
  */
-upstreamUpdateAvailable: boolean;
+upstreamUpdateAvailable: boolean; 
 /**
  * True when a rebuild is needed to bring the system up to date with the current working tree.
  */
@@ -1365,7 +1370,7 @@ summaryModel: string | null;
  * Remembered summary model per provider; a missing entry means the
  * provider default is used. Never stores `""`.
  */
-summaryModels: Partial<{ [key in string]: string }>; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; experimentalStreamingEvolve: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
+summaryModels: Partial<{ [key in string]: string }>; ollamaApiBaseUrl: string | null; openaiCompatibleApiBaseUrl: string | null; confirmBuild: boolean; confirmClear: boolean; confirmRollback: boolean; autoSummarizeOnFocus: boolean; scanHomebrewOnStartup: boolean; defaultToDiffTab: boolean; experimentalSpinningMascot: boolean; experimentalStreamingEvolve: boolean; developerMode: boolean; pinnedVersion: string | null; updateChannel: UpdateChannel; gitAutoUpdate: GitAutoUpdate; featureFlagOverrides: Partial<{ [key in string]: string }> | null; 
 /**
  * Root of an import clone parked on the "which flake dir?" choice
  * (`NeedsFlakeDirChoice`). Recorded so an abandoned choice can be
@@ -2331,6 +2336,10 @@ pinnedVersion: string | null;
  */
 updateChannel: UpdateChannel; 
 /**
+ * How updates from the configuration Git repository are handled.
+ */
+gitAutoUpdate: GitAutoUpdate; 
+/**
  * Developer-only feature flag overrides (flag key → variant string).
  * `None` or missing key = use PostHog default.
  */
@@ -2450,6 +2459,10 @@ pinnedVersion?: string | null;
  */
 updateChannel: UpdateChannel | null; 
 /**
+ * Git repository auto-update preference update.
+ */
+gitAutoUpdate: GitAutoUpdate | null; 
+/**
  * `None` -> field not sent; `Some(None)` -> clear all overrides;
  * `Some(Some(map))` -> replace overrides with `map`.
  */
@@ -2488,3 +2501,4 @@ version: string;
  * Release notes from the channel manifest, when available.
  */
 notes: string | null }
+

--- a/apps/native/src/lib/providers/ai-provider-migration.test.ts
+++ b/apps/native/src/lib/providers/ai-provider-migration.test.ts
@@ -32,6 +32,7 @@ const PREFS: UiPrefs = {
 	experimentalStreamingEvolve: false,
 	pinnedVersion: null,
 	updateChannel: "stable",
+	gitAutoUpdate: "off",
 	featureFlagOverrides: null,
 	autoFormatNixFiles: false,
 };

--- a/apps/native/src/utils/test-fixtures.ts
+++ b/apps/native/src/utils/test-fixtures.ts
@@ -39,6 +39,7 @@ export function makeGlobalPreferences(
 		developerMode: false,
 		pinnedVersion: null,
 		updateChannel: "stable",
+		gitAutoUpdate: "off",
 		featureFlagOverrides: null,
 		pendingImportDir: null,
 		autoFormatNixFiles: false,


### PR DESCRIPTION
## Summary

Add the git auto-update preference to storage and UI. It's on the General tab since that doesn't seem like a Developer-only feature. Don't expose "automatic" since auto-rebuilds aren't implemented yet. But keep the env var around so development on that feature can proceed.

<!-- What does this PR do? Why? -->

## ![Screenshot 2026-07-23 at 11.25.18 AM.png](https://app.graphite.com/user-attachments/assets/508629fb-9afb-45b9-bb41-294c7816036d.png)

## Test Plan

Manual and unit tests updated.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed