### PR TITLE
feat(helper)!: drop /etc/nix-darwin link maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,6 +3587,7 @@ dependencies = [
  "libc",
  "libsqlite3-sys",
  "log",
+ "nix",
  "objc",
  "once_cell",
  "opentelemetry",

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -130,6 +130,9 @@ cocoa = "0.26"
 objc = "0.2"
 window-vibrancy = "0.6"
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", features = ["user"] }
+
 [dependencies.tera]
 version = "1"
 

--- a/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
+++ b/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
@@ -91,8 +91,11 @@ fn run_once() -> anyhow::Result<()> {
         return Err(anyhow::anyhow!(
             "activation failed ({}): {}",
             response.code,
-            response.error.unwrap_or(response.stderr)
+            response.failure_detail()
         ));
+    }
+    for warning in response.warnings() {
+        eprintln!("nixmac-sync-agent: {warning}");
     }
 
     // Activation set the durable system-profile GC root, so the out-link is
@@ -113,7 +116,7 @@ fn verify_helper_ready() {
         Ok(response) => {
             eprintln!(
                 "nixmac-sync-agent: helper unhealthy: {}",
-                response.error.unwrap_or(response.stderr)
+                response.failure_detail()
             );
             std::process::exit(2);
         }

--- a/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
+++ b/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
@@ -83,11 +83,7 @@ fn run_once() -> anyhow::Result<()> {
     }
 
     let activate_path = store_path.join("activate");
-    // No canonical-link maintenance here: this agent re-applies the same
-    // config dir it was registered with, so the /etc/nix-darwin link set by
-    // the interactive apply that registered it is still correct.
-    let request =
-        privileged_helper::protocol::current_user_activation_request(&activate_path, None)?;
+    let request = privileged_helper::protocol::current_user_activation_request(&activate_path)?;
     let response = privileged_helper::client::activate_store_path(request)?;
     if !response.ok {
         // Leave the out-link in place: it keeps the built closure GC-rooted

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -226,6 +226,19 @@ const E2E_CAPTURE_DARK_BACKGROUND_SCRIPT: &str = r#"
 "#;
 
 fn main() {
+    // Root re-entry for the interactive activation fallback: `osascript ...
+    // with administrator privileges` re-executes this binary with this
+    // argument so the privileged step runs fixed Rust code instead of a
+    // generated shell script. Dispatched before anything else — the elevated
+    // process must never boot the GUI.
+    if std::env::args().nth(1).as_deref()
+        == Some(privileged_helper::root_activation::ROOT_ACTIVATE_ARG)
+    {
+        std::process::exit(privileged_helper::root_activation::run(
+            std::env::args().skip(2),
+        ));
+    }
+
     #[cfg(feature = "codegen")]
     if std::env::args().nth(1).as_deref() == Some("gen-schemas") {
         if let Err(error) = schema_gen::write_default_config_schemas() {

--- a/apps/native/src-tauri/src/privileged_helper/client.rs
+++ b/apps/native/src-tauri/src/privileged_helper/client.rs
@@ -8,6 +8,9 @@ use std::time::Duration;
 
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 const ACTIVATION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+/// Status probes back the permissions UI; a wedged helper must not stall a
+/// permissions refresh, so they get a short leash instead of CLIENT_TIMEOUT.
+const STATUS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub fn socket_available() -> bool {
     std::path::Path::new(HELPER_SOCKET_PATH).exists()
@@ -33,13 +36,8 @@ fn request_with_timeout(request: &HelperRequest, timeout: Duration) -> Result<He
     Ok(serde_json::from_str(&line)?)
 }
 
-pub fn request(request: &HelperRequest) -> Result<HelperResponse> {
-    request_with_timeout(request, CLIENT_TIMEOUT)
-}
-
-#[allow(dead_code)]
 pub fn status() -> Result<HelperResponse> {
-    request(&HelperRequest::Status)
+    request_with_timeout(&HelperRequest::Status, STATUS_PROBE_TIMEOUT)
 }
 
 pub fn activate_store_path(request_body: ActivateStorePathRequest) -> Result<HelperResponse> {

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -1,6 +1,6 @@
 use crate::privileged_helper::protocol::{
     ActivateStorePathRequest, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HelperRequest, HelperResponse,
-    canonical_link_shell_snippet, validate_canonical_activate_path, validate_canonical_link_target,
+    validate_canonical_activate_path,
 };
 use anyhow::{Context, Result, bail};
 use std::fs;
@@ -99,13 +99,6 @@ fn activate_store_path(request: &ActivateStorePathRequest) -> Result<HelperRespo
 
 pub fn validate_activation_request(request: &ActivateStorePathRequest) -> Result<()> {
     validate_canonical_activate_path(&request.activate_path)?;
-    if let Some(target) = &request.canonical_link_target {
-        validate_canonical_link_target(target)?;
-        // Checked here, as root: the link must point at a real directory.
-        if !Path::new(target).is_dir() {
-            bail!("canonical link target is not a directory: {target}");
-        }
-    }
     if request.user_name.trim().is_empty() {
         bail!("activation user is required");
     }
@@ -268,15 +261,6 @@ pub fn root_activation_script(request: &ActivateStorePathRequest) -> Result<Stri
     validate_canonical_activate_path(&request.activate_path)?;
     let sudoers_path = "/etc/sudoers.d/nixmac-activate-helper";
     let ssh_sock = request.ssh_auth_sock.as_deref().unwrap_or("");
-    // The canonical-link lines run after activation succeeded (`set -e`) and
-    // are best-effort themselves — a link failure must not fail the apply.
-    let canonical_link = match &request.canonical_link_target {
-        Some(target) => {
-            validate_canonical_link_target(target)?;
-            format!("{}\n", canonical_link_shell_snippet(target))
-        }
-        None => String::new(),
-    };
     Ok(format!(
         "set -e\n\
          ACTIVATE='{activate}'\n\
@@ -291,8 +275,7 @@ pub fn root_activation_script(request: &ActivateStorePathRequest) -> Result<Stri
          export SSH_AUTH_SOCK='{sock}'\n\
          launchctl asuser \"$USER_ID\" sudo -E -n \"$ACTIVATE\" 2>&1\n\
          SYSTEM_PATH=$(dirname \"$ACTIVATE\")\n\
-         nix-env -p /nix/var/nix/profiles/system --set \"$SYSTEM_PATH\" || true\n\
-         {canonical_link}",
+         nix-env -p /nix/var/nix/profiles/system --set \"$SYSTEM_PATH\" || true\n",
         activate = shell_single_quote(&request.activate_path),
         user_id = request.user_id,
         user_name = shell_single_quote(&request.user_name),
@@ -318,7 +301,6 @@ mod tests {
             home: "/Users/alice".to_string(),
             ssh_auth_sock: Some("/tmp/ssh.sock".to_string()),
             nix_path: "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin".to_string(),
-            canonical_link_target: None,
         }
     }
 
@@ -337,38 +319,6 @@ mod tests {
     #[test]
     fn root_activation_script_rejects_non_store_path() {
         assert!(root_activation_script(&request("/tmp/activate")).is_err());
-    }
-
-    #[test]
-    fn root_activation_script_appends_canonical_link_after_activation() {
-        let mut with_link = request("/nix/store/abc123-darwin-system-25.05.20260629/activate");
-        with_link.canonical_link_target = Some("/Users/alice/.darwin".to_string());
-
-        let script = root_activation_script(&with_link).expect("build script");
-
-        let activate_pos = script.find("launchctl asuser").expect("activation line");
-        let link_pos = script
-            .find("ln -sfn '/Users/alice/.darwin' '/etc/nix-darwin' || true")
-            .expect("link line");
-        assert!(link_pos > activate_pos, "link must run after activation");
-    }
-
-    #[test]
-    fn root_activation_script_omits_link_lines_without_target() {
-        let script = root_activation_script(&request(
-            "/nix/store/abc123-darwin-system-25.05.20260629/activate",
-        ))
-        .expect("build script");
-
-        assert!(!script.contains("ln -sfn"));
-    }
-
-    #[test]
-    fn root_activation_script_rejects_relative_link_target() {
-        let mut with_link = request("/nix/store/abc123-darwin-system-25.05.20260629/activate");
-        with_link.canonical_link_target = Some("relative/dir".to_string());
-
-        assert!(root_activation_script(&with_link).is_err());
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -1,6 +1,6 @@
 use crate::privileged_helper::protocol::{
-    ActivateStorePathRequest, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HelperRequest, HelperResponse,
-    validate_canonical_activate_path,
+    ActivateStorePathRequest, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HELPER_WARNING_PREFIX,
+    HelperRequest, HelperResponse, validate_canonical_activate_path,
 };
 use anyhow::{Context, Result, bail};
 use std::fs;
@@ -12,7 +12,30 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::process::Command;
 
+/// Fixed PATH for the privileged activation: root-owned system and Nix
+/// profile directories only. The requester's `nix_path` never reaches root
+/// command lookup.
+const ACTIVATION_PATH_ENV: &str =
+    "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
+const NIX_ENV_CANDIDATES: [&str; 2] = [
+    "/nix/var/nix/profiles/default/bin/nix-env",
+    "/run/current-system/sw/bin/nix-env",
+];
+/// Sudoers rule older helpers created (and could leave behind on forced
+/// termination). No longer written; removed on startup if present.
+const LEGACY_SUDOERS_PATH: &str = "/etc/sudoers.d/nixmac-activate-helper";
+
 pub fn run_daemon() -> Result<()> {
+    if let Err(error) = fs::remove_file(LEGACY_SUDOERS_PATH)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        // Keep serving — failing startup would not remove the rule either —
+        // but a stale NOPASSWD grant must never go unnoticed.
+        eprintln!(
+            "nixmac-helper: SECURITY: failed to remove legacy sudoers rule {LEGACY_SUDOERS_PATH}: {error}"
+        );
+    }
     fs::create_dir_all(HELPER_SOCKET_DIR)?;
     let socket_path = Path::new(HELPER_SOCKET_PATH);
     if socket_path.exists() {
@@ -58,9 +81,11 @@ fn handle_stream(mut stream: UnixStream) -> Result<()> {
     let mut line = String::new();
     BufReader::new(stream.try_clone()?).read_line(&mut line)?;
     let request: HelperRequest = serde_json::from_str(&line)?;
-    let response = match peer_identity(&stream).and_then(|peer| authorize_request(&peer, &request))
-    {
-        Ok(()) => handle_request(request),
+    let response = match peer_identity(&stream) {
+        Ok(peer) => match authorize_request(&peer, &request) {
+            Ok(()) => handle_request(&peer, request),
+            Err(error) => HelperResponse::error(-1, error.to_string()),
+        },
         Err(error) => HelperResponse::error(-1, error.to_string()),
     };
     serde_json::to_writer(&mut stream, &response)?;
@@ -69,66 +94,134 @@ fn handle_stream(mut stream: UnixStream) -> Result<()> {
     Ok(())
 }
 
-pub fn handle_request(request: HelperRequest) -> HelperResponse {
+pub fn handle_request(peer: &PeerIdentity, request: HelperRequest) -> HelperResponse {
     match request {
         HelperRequest::Status => HelperResponse::ok("nixmac helper ready"),
-        HelperRequest::ActivateStorePath { request } => match activate_store_path(&request) {
+        HelperRequest::ActivateStorePath { request } => match activate_store_path(peer, &request) {
             Ok(response) => response,
             Err(error) => HelperResponse::error(-1, error.to_string()),
         },
     }
 }
 
-fn activate_store_path(request: &ActivateStorePathRequest) -> Result<HelperResponse> {
-    validate_activation_request(request)?;
-    let script = root_activation_script(request)?;
-    let output = Command::new("/bin/sh")
-        .arg("-c")
-        .arg(script)
-        .output()
-        .context("failed to execute activation shell")?;
+fn activate_store_path(
+    peer: &PeerIdentity,
+    request: &ActivateStorePathRequest,
+) -> Result<HelperResponse> {
+    validate_canonical_activate_path(&request.activate_path)?;
+    // Account values are derived from the socket peer credentials; the
+    // request's `user_name`/`user_id`/`home` are never trusted here.
+    let account = user_account(peer.uid)?;
+    let argv = activation_argv(
+        peer.uid,
+        &account,
+        &request.activate_path,
+        request.ssh_auth_sock.as_deref(),
+    );
+    let (status, mut stdout) = run_activation_command(&argv)?;
+
+    // Profile maintenance runs only after a successful activation and is
+    // best-effort: the system switch already happened, so its failures
+    // surface as warnings instead of failing the apply.
+    if status.success() {
+        for warning in post_activation_maintenance(&request.activate_path) {
+            stdout.push_str(&format!("\n{HELPER_WARNING_PREFIX} {warning}"));
+        }
+    }
 
     Ok(HelperResponse {
-        ok: output.status.success(),
-        code: output.status.code().unwrap_or(-1),
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        ok: status.success(),
+        code: status.code().unwrap_or(-1),
+        stdout,
+        stderr: String::new(),
         error: None,
     })
 }
 
-pub fn validate_activation_request(request: &ActivateStorePathRequest) -> Result<()> {
-    validate_canonical_activate_path(&request.activate_path)?;
-    if request.user_name.trim().is_empty() {
-        bail!("activation user is required");
-    }
-    if request.home.trim().is_empty() {
-        bail!("activation home is required");
-    }
-    if request.nix_path.trim().is_empty() {
-        bail!("activation PATH is required");
-    }
+/// Runs a prepared activation argv with stderr merged into stdout (the old
+/// script's `2>&1`): consumers stream, log, and summarize a single output
+/// stream, and the activate script writes most of its output to stderr.
+/// Shared by the helper daemon and the interactive fallback's root re-entry
+/// (`privileged_helper::root_activation`).
+pub(crate) fn run_activation_command(
+    argv: &[String],
+) -> Result<(std::process::ExitStatus, String)> {
+    let (mut reader, writer) = std::io::pipe().context("failed to create activation pipe")?;
+    let mut command = Command::new(&argv[0]);
+    command
+        .args(&argv[1..])
+        .stdout(
+            writer
+                .try_clone()
+                .context("failed to clone activation pipe")?,
+        )
+        .stderr(writer);
+    let mut child = command.spawn().context("failed to execute activation")?;
+    // The command still holds write ends of the pipe; drop them so the read
+    // below ends when the child (and its descendants) exit.
+    drop(command);
+    let mut output = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut output)
+        .context("failed to read activation output")?;
+    let status = child.wait().context("failed to wait for activation")?;
+    Ok((status, String::from_utf8_lossy(&output).to_string()))
+}
 
-    let id_output = Command::new("/usr/bin/id")
-        .args(["-u", &request.user_name])
-        .output()
-        .with_context(|| format!("failed to look up user {}", request.user_name))?;
-    if !id_output.status.success() {
-        bail!("activation user {} does not exist", request.user_name);
+/// Direct-exec activation command: no shell, absolute programs only, a fixed
+/// root-owned PATH, and an otherwise empty environment (`env -i`).
+pub(crate) fn activation_argv(
+    uid: u32,
+    account: &UserAccount,
+    activate_path: &str,
+    ssh_auth_sock: Option<&str>,
+) -> Vec<String> {
+    let mut argv = vec![
+        "/bin/launchctl".to_string(),
+        "asuser".to_string(),
+        uid.to_string(),
+        "/usr/bin/env".to_string(),
+        "-i".to_string(),
+        format!("PATH={ACTIVATION_PATH_ENV}"),
+        format!("HOME={}", account.home),
+        format!("USER={}", account.name),
+        format!("LOGNAME={}", account.name),
+    ];
+    if let Some(sock) = ssh_auth_sock.filter(|sock| !sock.is_empty()) {
+        argv.push(format!("SSH_AUTH_SOCK={sock}"));
     }
-    let actual_uid = String::from_utf8_lossy(&id_output.stdout)
-        .trim()
-        .parse::<u32>()
-        .context("failed to parse user id")?;
-    if actual_uid != request.user_id {
+    argv.push(activate_path.to_string());
+    argv
+}
+
+pub(crate) fn post_activation_maintenance(activate_path: &str) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if let Err(error) = set_system_profile(activate_path) {
+        warnings.push(format!("failed to update system profile: {error:#}"));
+    }
+    warnings
+}
+
+fn set_system_profile(activate_path: &str) -> Result<()> {
+    let system_path = Path::new(activate_path)
+        .parent()
+        .context("activation path has no parent")?;
+    let nix_env = NIX_ENV_CANDIDATES
+        .iter()
+        .find(|candidate| Path::new(candidate).exists())
+        .context("nix-env not found in root-owned profile directories")?;
+    let output = Command::new(nix_env)
+        .args(["-p", SYSTEM_PROFILE, "--set"])
+        .arg(system_path)
+        .env_clear()
+        .env("PATH", ACTIVATION_PATH_ENV)
+        .output()
+        .context("failed to execute nix-env")?;
+    if !output.status.success() {
         bail!(
-            "activation user id mismatch for {}: expected {}, got {}",
-            request.user_name,
-            request.user_id,
-            actual_uid
+            "nix-env --set failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
         );
     }
-
     Ok(())
 }
 
@@ -157,9 +250,35 @@ fn authorize_request(peer: &PeerIdentity, request: &HelperRequest) -> Result<()>
 }
 
 #[derive(Debug, Clone)]
-struct PeerIdentity {
-    uid: u32,
-    executable: Option<String>,
+pub struct PeerIdentity {
+    pub uid: u32,
+    pub executable: Option<String>,
+}
+
+pub(crate) struct UserAccount {
+    name: String,
+    home: String,
+}
+
+/// Resolves the account name and home directory for `uid` from the user
+/// database, so privileged activation never trusts requester-supplied
+/// account values.
+#[cfg(target_os = "macos")]
+pub(crate) fn user_account(uid: u32) -> Result<UserAccount> {
+    let user = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+        .context("failed to look up peer account")?
+        .with_context(|| format!("no account found for peer uid {uid}"))?;
+    let name = user.name;
+    let home = user.dir.to_string_lossy().into_owned();
+    if name.is_empty() || home.is_empty() {
+        bail!("peer uid {uid} resolves to an account without a name or home");
+    }
+    Ok(UserAccount { name, home })
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn user_account(_uid: u32) -> Result<UserAccount> {
+    bail!("peer account lookup is only implemented on macOS")
 }
 
 #[cfg(target_os = "macos")]
@@ -257,38 +376,6 @@ fn console_user() -> Option<String> {
     }
 }
 
-pub fn root_activation_script(request: &ActivateStorePathRequest) -> Result<String> {
-    validate_canonical_activate_path(&request.activate_path)?;
-    let sudoers_path = "/etc/sudoers.d/nixmac-activate-helper";
-    let ssh_sock = request.ssh_auth_sock.as_deref().unwrap_or("");
-    Ok(format!(
-        "set -e\n\
-         ACTIVATE='{activate}'\n\
-         USER_ID='{user_id}'\n\
-         USER_NAME='{user_name}'\n\
-         trap 'rm -f {sudoers_path}' EXIT\n\
-         printf '%s ALL=(ALL) NOPASSWD: %s\\n' \"$USER_NAME\" \"$ACTIVATE\" > {sudoers_path}\n\
-         chmod 440 {sudoers_path}\n\
-         visudo -cf {sudoers_path} >/dev/null\n\
-         export PATH='{path}'\n\
-         export HOME='{home}'\n\
-         export SSH_AUTH_SOCK='{sock}'\n\
-         launchctl asuser \"$USER_ID\" sudo -E -n \"$ACTIVATE\" 2>&1\n\
-         SYSTEM_PATH=$(dirname \"$ACTIVATE\")\n\
-         nix-env -p /nix/var/nix/profiles/system --set \"$SYSTEM_PATH\" || true\n",
-        activate = shell_single_quote(&request.activate_path),
-        user_id = request.user_id,
-        user_name = shell_single_quote(&request.user_name),
-        path = shell_single_quote(&request.nix_path),
-        home = shell_single_quote(&request.home),
-        sock = shell_single_quote(ssh_sock),
-    ))
-}
-
-fn shell_single_quote(value: &str) -> String {
-    value.replace('\'', "'\\''")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,30 +387,76 @@ mod tests {
             user_id: 501,
             home: "/Users/alice".to_string(),
             ssh_auth_sock: Some("/tmp/ssh.sock".to_string()),
-            nix_path: "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin".to_string(),
+            nix_path: "/tmp/attacker-bin:/usr/bin".to_string(),
+        }
+    }
+
+    fn account() -> UserAccount {
+        UserAccount {
+            name: "peer-alice".to_string(),
+            home: "/Users/peer-alice".to_string(),
         }
     }
 
     #[test]
-    fn root_activation_script_contains_exact_activate_path() {
-        let script = root_activation_script(&request(
+    fn activation_argv_execs_directly_with_fixed_path_and_derived_account() {
+        let argv = activation_argv(
+            501,
+            &account(),
             "/nix/store/abc123-darwin-system-25.05.20260629/activate",
-        ))
-        .expect("build script");
+            Some("/tmp/ssh.sock"),
+        );
 
-        assert!(script.contains("/nix/store/abc123-darwin-system-25.05.20260629/activate"));
-        assert!(script.contains("launchctl asuser"));
-        assert!(script.contains("NOPASSWD"));
+        assert_eq!(argv[0], "/bin/launchctl");
+        assert_eq!(&argv[1..3], ["asuser", "501"]);
+        assert_eq!(&argv[3..5], ["/usr/bin/env", "-i"]);
+        assert!(argv.contains(&format!("PATH={ACTIVATION_PATH_ENV}")));
+        // Account values come from the peer lookup, not the request.
+        assert!(argv.contains(&"HOME=/Users/peer-alice".to_string()));
+        assert!(argv.contains(&"USER=peer-alice".to_string()));
+        assert!(!argv.iter().any(|arg| arg.contains("/tmp/attacker-bin")));
+        assert!(!argv.iter().any(|arg| arg.contains("/Users/alice")));
+        assert_eq!(
+            argv.last().map(String::as_str),
+            Some("/nix/store/abc123-darwin-system-25.05.20260629/activate")
+        );
     }
 
     #[test]
-    fn root_activation_script_rejects_non_store_path() {
-        assert!(root_activation_script(&request("/tmp/activate")).is_err());
+    fn activation_argv_never_builds_shell_or_sudoers() {
+        let argv = activation_argv(
+            501,
+            &account(),
+            "/nix/store/abc123-darwin-system-25.05.20260629/activate",
+            Some("/tmp/ssh.sock"),
+        );
+
+        assert!(!argv.iter().any(|arg| arg.contains("/bin/sh")));
+        assert!(!argv.iter().any(|arg| arg.contains("sudo")));
+        assert!(!argv.iter().any(|arg| arg.contains("sudoers")));
+    }
+
+    #[test]
+    fn activation_argv_omits_ssh_sock_when_absent_or_empty() {
+        for sock in [None, Some("")] {
+            let argv = activation_argv(
+                501,
+                &account(),
+                "/nix/store/abc123-darwin-system-25.05.20260629/activate",
+                sock,
+            );
+
+            assert!(!argv.iter().any(|arg| arg.starts_with("SSH_AUTH_SOCK=")));
+        }
     }
 
     #[test]
     fn helper_status_request_returns_ready_response() {
-        let response = handle_request(HelperRequest::Status);
+        let peer = PeerIdentity {
+            uid: 501,
+            executable: None,
+        };
+        let response = handle_request(&peer, HelperRequest::Status);
 
         assert!(response.ok);
         assert_eq!(response.code, 0);

--- a/apps/native/src-tauri/src/privileged_helper/mod.rs
+++ b/apps/native/src-tauri/src/privileged_helper/mod.rs
@@ -8,5 +8,6 @@ pub mod client;
 #[allow(dead_code)]
 pub mod helper_runtime;
 pub mod protocol;
+pub mod root_activation;
 pub mod service;
 pub mod sync_agent;

--- a/apps/native/src-tauri/src/privileged_helper/protocol.rs
+++ b/apps/native/src-tauri/src/privileged_helper/protocol.rs
@@ -76,7 +76,41 @@ pub struct HelperResponse {
     pub error: Option<String>,
 }
 
+/// Prefix the helper puts on post-activation maintenance warnings appended to
+/// the (merged) stdout, so consumers can surface them.
+pub const HELPER_WARNING_PREFIX: &str = "nixmac-helper: warning:";
+
 impl HelperResponse {
+    /// Human-readable failure detail: the explicit error when present, else
+    /// stderr, else the tail of stdout — the helper merges the activation's
+    /// stderr into stdout (`2>&1`), so on a plain nonzero exit the detail
+    /// lives there. Used by the sync-agent binary (this file is `include!`d
+    /// there), hence dead code in targets that report through other paths.
+    #[allow(dead_code)]
+    pub fn failure_detail(&self) -> String {
+        if let Some(error) = self.error.as_deref().filter(|error| !error.is_empty()) {
+            return error.to_string();
+        }
+        if !self.stderr.is_empty() {
+            return self.stderr.clone();
+        }
+        let lines: Vec<&str> = self
+            .stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .collect();
+        lines[lines.len().saturating_sub(20)..].join("\n")
+    }
+
+    /// Post-activation maintenance warnings embedded in stdout.
+    #[allow(dead_code)]
+    pub fn warnings(&self) -> Vec<&str> {
+        self.stdout
+            .lines()
+            .filter(|line| line.starts_with(HELPER_WARNING_PREFIX))
+            .collect()
+    }
+
     pub fn ok(stdout: impl Into<String>) -> Self {
         Self {
             ok: true,
@@ -322,6 +356,60 @@ mod tests {
         let json = r#"{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","sshAuthSock":null,"nixPath":"/bin","canonicalLinkTarget":"/Users/alice/.darwin"}"#;
         let request: ActivateStorePathRequest = serde_json::from_str(json).expect("deserializes");
         assert_eq!(request.user_id, 501);
+    }
+
+    fn response(stdout: &str, stderr: &str, error: Option<&str>) -> HelperResponse {
+        HelperResponse {
+            ok: false,
+            code: 1,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            error: error.map(String::from),
+        }
+    }
+
+    #[test]
+    fn failure_detail_prefers_error_then_stderr_then_stdout_tail() {
+        assert_eq!(
+            response("out", "err", Some("boom")).failure_detail(),
+            "boom"
+        );
+        assert_eq!(response("out", "err", None).failure_detail(), "err");
+        // The helper merges activation stderr into stdout, so a plain nonzero
+        // exit must still produce a detail.
+        assert_eq!(
+            response("activation exploded\n", "", None).failure_detail(),
+            "activation exploded"
+        );
+    }
+
+    #[test]
+    fn failure_detail_returns_stdout_tail_only() {
+        let lines: Vec<String> = (1..=30).map(|n| format!("line {n}")).collect();
+        let detail = response(&lines.join("\n"), "", None).failure_detail();
+
+        assert!(detail.starts_with("line 11"));
+        assert!(detail.ends_with("line 30"));
+    }
+
+    #[test]
+    fn warnings_extracts_prefixed_stdout_lines() {
+        let stdout = format!(
+            "activated\n{HELPER_WARNING_PREFIX} failed to update system profile\nplain line"
+        );
+        let with_warning = response(&stdout, "", None);
+
+        assert_eq!(
+            with_warning.warnings(),
+            vec![format!(
+                "{HELPER_WARNING_PREFIX} failed to update system profile"
+            )]
+        );
+        assert!(
+            response("no warnings here\n", "", None)
+                .warnings()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/protocol.rs
+++ b/apps/native/src-tauri/src/privileged_helper/protocol.rs
@@ -12,11 +12,6 @@ pub const SYNC_AGENT_PLIST_NAME: &str = "com.darkmatter.nixmac.sync-agent.plist"
 pub const HELPER_SOCKET_PATH: &str = "/var/run/nixmac/helper.sock";
 #[allow(dead_code)]
 pub const HELPER_SOCKET_DIR: &str = "/var/run/nixmac";
-/// Canonical nix-darwin configuration path. Lives here (rather than in
-/// `storage::canonical_config`, which re-exports it) because this file is
-/// `include!`d into the helper binary, which maintains the link during
-/// privileged activation.
-pub const CANONICAL_CONFIG_DIR: &str = "/etc/nix-darwin";
 const DEFAULT_SYNC_AGENT_INTERVAL_SECONDS: u32 = 900;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
@@ -52,14 +47,6 @@ pub struct ActivateStorePathRequest {
     pub home: String,
     pub ssh_auth_sock: Option<String>,
     pub nix_path: String,
-    /// When set, activation also re-points `/etc/nix-darwin` at this config
-    /// directory — the convention that makes a bare `darwin-rebuild switch`
-    /// on the CLI rebuild the nixmac-managed config. Maintained here, during
-    /// an already-privileged step, so selecting a directory in preferences
-    /// never has to prompt for a password on its own. `default` keeps the
-    /// wire format compatible with helpers/apps from before the field.
-    #[serde(default)]
-    pub canonical_link_target: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Type, PartialEq, Eq)]
@@ -147,47 +134,8 @@ pub fn canonicalize_activate_path(path: impl AsRef<Path>) -> Result<PathBuf> {
     validate_canonical_activate_path(&canonical)
 }
 
-/// Validates a `canonical_link_target`: an absolute path with no relative
-/// components. Existence is checked at execution time by the privileged side
-/// (the requesting user may not even be able to stat it).
-pub fn validate_canonical_link_target(path: impl AsRef<Path>) -> Result<PathBuf> {
-    let path = path.as_ref();
-    if !path.is_absolute() {
-        bail!("canonical link target must be absolute");
-    }
-    if path
-        .components()
-        .any(|component| !matches!(component, Component::RootDir | Component::Normal(_)))
-    {
-        bail!("canonical link target must not contain relative components");
-    }
-    Ok(path.to_path_buf())
-}
-
-/// Shell lines that re-point `/etc/nix-darwin` at `target`, appended to both
-/// privileged activation scripts (helper daemon and osascript fallback).
-/// Best-effort by design: the system switch already succeeded by the time
-/// these run, so a link failure must not turn the apply into an error.
-/// `target` must have passed [`validate_canonical_link_target`]; the caller
-/// decides *whether* an update is needed (see
-/// `storage::canonical_config::canonical_link_pending`).
-pub fn canonical_link_shell_snippet(target: &str) -> String {
-    let target = target.replace('\'', "'\\''");
-    format!(
-        "if [ -e '{link}' ] && [ ! -L '{link}' ]; then rm -rf '{link}' || true; fi\n\
-         ln -sfn '{target}' '{link}' || true",
-        link = CANONICAL_CONFIG_DIR,
-    )
-}
-
-pub fn current_user_activation_request(
-    activate_path: &Path,
-    canonical_link_target: Option<String>,
-) -> Result<ActivateStorePathRequest> {
+pub fn current_user_activation_request(activate_path: &Path) -> Result<ActivateStorePathRequest> {
     let canonical = canonicalize_activate_path(activate_path)?;
-    if let Some(target) = &canonical_link_target {
-        validate_canonical_link_target(target)?;
-    }
     let user_name = whoami::username().unwrap_or_else(|_| "root".to_string());
     let user_id = current_user_id();
     let home = std::env::var("HOME").unwrap_or_default();
@@ -203,7 +151,6 @@ pub fn current_user_activation_request(
         home,
         ssh_auth_sock,
         nix_path,
-        canonical_link_target,
     })
 }
 
@@ -369,34 +316,12 @@ mod tests {
     }
 
     #[test]
-    fn link_target_accepts_absolute_paths_only() {
-        assert!(validate_canonical_link_target("/Users/alice/.darwin").is_ok());
-        assert!(validate_canonical_link_target("relative/dir").is_err());
-        assert!(validate_canonical_link_target("/Users/alice/../root").is_err());
-    }
-
-    #[test]
-    fn link_snippet_targets_the_canonical_path_and_never_fails() {
-        let snippet = canonical_link_shell_snippet("/Users/alice/.darwin");
-
-        assert!(snippet.contains("ln -sfn '/Users/alice/.darwin' '/etc/nix-darwin' || true"));
-        assert!(snippet.contains("rm -rf '/etc/nix-darwin' || true"));
-    }
-
-    #[test]
-    fn link_snippet_escapes_single_quotes() {
-        let snippet = canonical_link_shell_snippet("/Users/al'ice/.darwin");
-
-        assert!(snippet.contains("'/Users/al'\\''ice/.darwin'"));
-    }
-
-    #[test]
-    fn activation_request_json_roundtrips_without_link_field() {
-        // Wire compat with pre-link helpers/apps: the field is optional in
-        // both directions.
-        let json = r#"{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","sshAuthSock":null,"nixPath":"/bin"}"#;
+    fn activation_request_json_ignores_removed_link_field() {
+        // Wire compat with apps that still send canonicalLinkTarget: unknown
+        // fields are ignored on deserialization.
+        let json = r#"{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","sshAuthSock":null,"nixPath":"/bin","canonicalLinkTarget":"/Users/alice/.darwin"}"#;
         let request: ActivateStorePathRequest = serde_json::from_str(json).expect("deserializes");
-        assert_eq!(request.canonical_link_target, None);
+        assert_eq!(request.user_id, 501);
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/root_activation.rs
+++ b/apps/native/src-tauri/src/privileged_helper/root_activation.rs
@@ -1,0 +1,301 @@
+//! Root re-entry point for the interactive activation fallback.
+//!
+//! When the privileged helper is unavailable, the app elevates through one
+//! native admin prompt (`osascript ... with administrator privileges`). The
+//! privileged step used to be a generated shell script that wrote a temporary
+//! NOPASSWD rule to `/etc/sudoers.d/nixmac-activate-temp` and cleaned it up
+//! with an EXIT trap. That mechanism is gone: the unprivileged app now
+//! re-executes its own binary with [`ROOT_ACTIVATE_ARG`], and this mode
+//! applies the same hardening rules as the helper daemon — direct exec with
+//! absolute programs, a fixed root-owned PATH and otherwise empty environment
+//! (`env -i`), and account values derived from the target uid (no sudoers,
+//! no shell logic as root).
+
+use crate::privileged_helper::helper_runtime;
+use crate::privileged_helper::protocol::validate_canonical_activate_path;
+use anyhow::{Context, Result, bail};
+
+/// First argv element that switches the app binary into root-activation mode.
+/// Deliberately not a user-facing CLI subcommand: it exists only for the
+/// osascript elevation and is dispatched before any other argument parsing.
+pub const ROOT_ACTIVATE_ARG: &str = "__nixmac-root-activate";
+
+/// Sudoers rule older app versions wrote for the osascript fallback (and
+/// could leave behind if the elevated shell died before its EXIT trap ran).
+/// No longer written; removed on every root activation if present.
+const LEGACY_SUDOERS_PATH: &str = "/etc/sudoers.d/nixmac-activate-temp";
+
+/// Prefix on post-activation maintenance warnings, so they read as warnings
+/// (not activation output) in the streamed apply log.
+const WARNING_PREFIX: &str = "nixmac: warning:";
+
+/// Validated inputs of a root activation. Built by the unprivileged side
+/// (which knows its own uid and environment) and re-validated after the
+/// privilege boundary by [`parse_args`].
+#[derive(Debug)]
+pub struct RootActivationArgs {
+    pub uid: u32,
+    pub activate_path: String,
+    pub ssh_auth_sock: Option<String>,
+}
+
+/// The exact command line handed to `osascript ... with administrator
+/// privileges`: this binary re-executed in root-activation mode. Every
+/// element is an absolute path, a fixed literal, or a single-quoted value,
+/// and the leading `exec` makes the elevated shell replace itself with this
+/// argv instead of staying alive as its parent.
+pub fn shell_command(exe: &str, args: &RootActivationArgs) -> String {
+    let mut argv = vec![
+        exe.to_string(),
+        ROOT_ACTIVATE_ARG.to_string(),
+        "--uid".to_string(),
+        args.uid.to_string(),
+        "--activate".to_string(),
+        args.activate_path.clone(),
+    ];
+    if let Some(sock) = args
+        .ssh_auth_sock
+        .as_deref()
+        .filter(|sock| !sock.is_empty())
+    {
+        argv.push("--ssh-auth-sock".to_string());
+        argv.push(sock.to_string());
+    }
+    let quoted = argv
+        .iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("exec {quoted}")
+}
+
+/// Single-quotes `value` for /bin/sh: the only character that needs escaping
+/// inside single quotes is the single quote itself.
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// Parses and validates the argv after [`ROOT_ACTIVATE_ARG`]. Validation
+/// runs on the privileged side of the boundary: the activate path must be a
+/// canonical /nix/store activation script, exactly as the helper daemon
+/// requires.
+pub fn parse_args(args: impl IntoIterator<Item = String>) -> Result<RootActivationArgs> {
+    let mut uid = None;
+    let mut activate_path = None;
+    let mut ssh_auth_sock = None;
+
+    let mut args = args.into_iter();
+    while let Some(flag) = args.next() {
+        let value = args
+            .next()
+            .with_context(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--uid" => {
+                uid = Some(value.parse::<u32>().context("--uid must be an integer")?);
+            }
+            "--activate" => activate_path = Some(value),
+            "--ssh-auth-sock" => ssh_auth_sock = Some(value),
+            other => bail!("unknown root-activation argument: {other}"),
+        }
+    }
+
+    let uid = uid.context("--uid is required")?;
+    if uid == 0 {
+        bail!("root activation must target a non-root user");
+    }
+    let activate_path = activate_path.context("--activate is required")?;
+    validate_canonical_activate_path(&activate_path)?;
+
+    Ok(RootActivationArgs {
+        uid,
+        activate_path,
+        ssh_auth_sock,
+    })
+}
+
+/// Entry point for the root-activation dispatch in `main()`. Returns the
+/// process exit code: the activation's own code, or 1 when the mode itself
+/// fails before activation runs.
+pub fn run(args: impl IntoIterator<Item = String>) -> i32 {
+    match run_root_activation(args) {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("nixmac root activation failed: {error:#}");
+            1
+        }
+    }
+}
+
+fn run_root_activation(args: impl IntoIterator<Item = String>) -> Result<i32> {
+    let args = parse_args(args)?;
+    if !nix::unistd::Uid::effective().is_root() {
+        bail!(
+            "root-activation mode must run as root (it is only ever invoked via the admin prompt)"
+        );
+    }
+    let legacy_sudoers_warning = remove_legacy_sudoers();
+    // stderr is what `do shell script` surfaces on any failure — a nonzero
+    // activation or any early `?` return below — so emit the warning there
+    // eagerly; no failure path can lose it. A successful run discards stderr
+    // and returns stdout, so the success branch repeats it there.
+    if let Some(warning) = &legacy_sudoers_warning {
+        eprintln!("{WARNING_PREFIX} {warning}");
+    }
+
+    // Mirror the helper daemon: account values come from the uid lookup, and
+    // the activation is a direct exec of absolute programs with a fixed
+    // environment — the caller's environment never reaches root.
+    let account = helper_runtime::user_account(args.uid)?;
+    let argv = helper_runtime::activation_argv(
+        args.uid,
+        &account,
+        &args.activate_path,
+        args.ssh_auth_sock.as_deref(),
+    );
+    let (status, output) = helper_runtime::run_activation_command(&argv)?;
+
+    if status.success() {
+        // `do shell script` returns the elevated command's stdout as its
+        // result, which the app surfaces in the apply stream. stderr is
+        // discarded on success, so warnings must ride stdout.
+        print!("{output}");
+        // Warnings must start their own line even when the activation's
+        // last output line has no trailing newline.
+        if !output.is_empty() && !output.ends_with('\n') {
+            println!();
+        }
+        if let Some(warning) = &legacy_sudoers_warning {
+            println!("{WARNING_PREFIX} {warning}");
+        }
+        // Best-effort, same as the helper: the system switch already
+        // happened, so maintenance failures are warnings, not errors.
+        for warning in helper_runtime::post_activation_maintenance(&args.activate_path) {
+            println!("{WARNING_PREFIX} {warning}");
+        }
+    } else {
+        // A failed `do shell script` discards stdout and surfaces stderr
+        // through the AppleScript error, so route diagnostics there.
+        eprint!("{output}");
+    }
+    Ok(status.code().unwrap_or(-1))
+}
+
+/// Removes the legacy fallback sudoers rule, best-effort. Returns a warning
+/// when a stale NOPASSWD grant could not be removed: it must never go
+/// unnoticed, but must not block the activation either (blocking would not
+/// remove it any better). The caller routes it through whichever stream
+/// `do shell script` actually surfaces for the run's outcome.
+fn remove_legacy_sudoers() -> Option<String> {
+    match std::fs::remove_file(LEGACY_SUDOERS_PATH) {
+        Ok(()) => None,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => Some(format!(
+            "SECURITY: failed to remove legacy sudoers rule {LEGACY_SUDOERS_PATH}: {error}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACTIVATE: &str = "/nix/store/abc123-darwin-system-25.05.20260629/activate";
+
+    fn args(flags: &[&str]) -> Result<RootActivationArgs> {
+        parse_args(flags.iter().map(|flag| flag.to_string()))
+    }
+
+    #[test]
+    fn parse_accepts_full_argument_set() {
+        let parsed = args(&[
+            "--uid",
+            "501",
+            "--activate",
+            ACTIVATE,
+            "--ssh-auth-sock",
+            "/tmp/ssh.sock",
+        ])
+        .expect("valid args");
+
+        assert_eq!(parsed.uid, 501);
+        assert_eq!(parsed.activate_path, ACTIVATE);
+        assert_eq!(parsed.ssh_auth_sock.as_deref(), Some("/tmp/ssh.sock"));
+    }
+
+    #[test]
+    fn parse_rejects_root_uid() {
+        let error = args(&["--uid", "0", "--activate", ACTIVATE]).expect_err("uid 0 must fail");
+
+        assert!(error.to_string().contains("non-root user"));
+    }
+
+    #[test]
+    fn parse_rejects_missing_uid_and_missing_activate() {
+        assert!(args(&["--activate", ACTIVATE]).is_err());
+        assert!(args(&["--uid", "501"]).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_non_store_activate_path() {
+        assert!(args(&["--uid", "501", "--activate", "/tmp/activate"]).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_arguments() {
+        let error = args(&["--uid", "501", "--activate", ACTIVATE, "--shell", "/bin/sh"])
+            .expect_err("unknown flag must fail");
+
+        assert!(error.to_string().contains("unknown root-activation"));
+    }
+
+    fn full_args() -> RootActivationArgs {
+        RootActivationArgs {
+            uid: 501,
+            activate_path: ACTIVATE.to_string(),
+            ssh_auth_sock: Some("/tmp/ssh.sock".to_string()),
+        }
+    }
+
+    #[test]
+    fn shell_command_re_execs_the_app_binary_with_quoted_arguments() {
+        let command = shell_command(
+            "/Applications/nix mac.app/Contents/MacOS/nixmac",
+            &full_args(),
+        );
+
+        assert!(command.starts_with("exec '/Applications/nix mac.app/Contents/MacOS/nixmac'"));
+        assert!(command.contains(&format!("'{ROOT_ACTIVATE_ARG}'")));
+        assert!(command.contains("'--uid' '501'"));
+        assert!(command.contains(&format!("'--activate' '{ACTIVATE}'")));
+    }
+
+    #[test]
+    fn shell_command_never_builds_sudoers_traps_or_redirections() {
+        let command = shell_command(
+            "/Applications/nixmac.app/Contents/MacOS/nixmac",
+            &full_args(),
+        );
+
+        for forbidden in ["sudo", "sudoers", "trap", "rm ", "visudo", ">", "$", ";"] {
+            assert!(
+                !command.contains(forbidden),
+                "shell command must not contain {forbidden:?}: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_command_omits_empty_ssh_sock() {
+        let mut args = full_args();
+        args.ssh_auth_sock = Some(String::new());
+
+        let command = shell_command("/Applications/nixmac.app/Contents/MacOS/nixmac", &args);
+
+        assert!(!command.contains("--ssh-auth-sock"));
+    }
+
+    #[test]
+    fn shell_quote_escapes_single_quotes() {
+        assert_eq!(shell_quote("/Users/al'ice"), "'/Users/al'\\''ice'");
+    }
+}

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -627,23 +627,15 @@ fn run_build_step(
 fn run_activate_step(
     system_store_path: &Path,
     allow_helper: bool,
-    canonical_link_target: Option<String>,
 ) -> Result<ActivateResult, anyhow::Error> {
     let activate_path = system_store_path.join("activate");
-    run_activate_with_path(
-        &activate_path.to_string_lossy(),
-        allow_helper,
-        canonical_link_target,
-    )
+    run_activate_with_path(&activate_path.to_string_lossy(), allow_helper)
 }
 
 /// Activate a specific nix store path directly
 fn activate_store_path(store_path: &str) -> Result<ActivateResult, anyhow::Error> {
     let activate_path = format!("{}/activate", store_path);
-    // Rollback-style activation: the source config dir did not change, so the
-    // canonical link is left alone (a stale link must not be "fixed" to point
-    // at a directory whose config was never applied).
-    run_activate_with_path(&activate_path, true, None)
+    run_activate_with_path(&activate_path, true)
 }
 
 /// Classify an activation failure into (error_type, error_message).
@@ -767,7 +759,6 @@ pub fn activate_store_path_stream(
 fn run_activate_with_path(
     activate_path: &str,
     allow_helper: bool,
-    canonical_link_target: Option<String>,
 ) -> Result<ActivateResult, anyhow::Error> {
     let nix_path = crate::system::nix::get_nix_path();
     let home = std::env::var("HOME").unwrap_or_default();
@@ -781,9 +772,7 @@ fn run_activate_with_path(
         .unwrap_or_else(|_| activate_path.to_owned());
 
     if allow_helper {
-        if let Some(result) =
-            try_activate_with_helper(&real_activate, canonical_link_target.clone())
-        {
+        if let Some(result) = try_activate_with_helper(&real_activate) {
             return result;
         }
     } else {
@@ -800,15 +789,6 @@ fn run_activate_with_path(
     //      domain before calling sudo, so the activation script sees
     //      `launchctl managername == "Aqua"`.
     //   3. Removes the temp sudoers file via a trap on exit.
-    // Same best-effort canonical-link maintenance as the helper path: runs
-    // only after activation succeeded (`set -e`), never fails the apply.
-    let canonical_link = match &canonical_link_target {
-        Some(target) => format!(
-            "\n{}",
-            crate::privileged_helper::protocol::canonical_link_shell_snippet(target)
-        ),
-        None => String::new(),
-    };
     let shell_script = format!(
         "set -e\n\
          ACTIVATE='{activate}'\n\
@@ -826,7 +806,7 @@ fn run_activate_with_path(
          export SSH_AUTH_SOCK='{sock}'\n\
          launchctl asuser \"$USER_ID\" sudo -E -n \"$ACTIVATE\" 2>&1\n\
          SYSTEM_PATH=$(dirname \"$ACTIVATE\")\n\
-         nix-env -p /nix/var/nix/profiles/system --set \"$SYSTEM_PATH\" || true{canonical_link}",
+         nix-env -p /nix/var/nix/profiles/system --set \"$SYSTEM_PATH\" || true",
         activate = sq(&real_activate),
         user = sq(&user),
         path = sq(&nix_path),
@@ -868,19 +848,13 @@ fn run_activate_with_path(
     })
 }
 
-fn try_activate_with_helper(
-    activate_path: &str,
-    canonical_link_target: Option<String>,
-) -> Option<Result<ActivateResult, anyhow::Error>> {
+fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult, anyhow::Error>> {
     let status = helper_service::status();
     if !status.authorized || !status.socket_available {
         return None;
     }
 
-    let request = match helper_protocol::current_user_activation_request(
-        Path::new(activate_path),
-        canonical_link_target,
-    ) {
+    let request = match helper_protocol::current_user_activation_request(Path::new(activate_path)) {
         Ok(request) => request,
         Err(error) => {
             return Some(Err(
@@ -1187,24 +1161,6 @@ fn run_darwin_rebuild(
     // =========================================================================
     log_and_emit!("Requesting admin privileges for activation...");
 
-    // Piggyback the /etc/nix-darwin convention link on the already-privileged
-    // activation: the link then always names the configuration that was last
-    // applied, and selecting a directory in preferences never prompts. When
-    // the canonical path is occupied by something nixmac must not delete,
-    // say so in the apply stream — the frontend surfaces it as a notice.
-    use crate::storage::canonical_config::CanonicalLinkPlan;
-    let canonical_link_target =
-        match crate::storage::canonical_config::canonical_link_plan(Path::new(config_dir)) {
-            CanonicalLinkPlan::Update(target) => Some(target),
-            CanonicalLinkPlan::UpToDate => None,
-            CanonicalLinkPlan::Blocked(reason) => {
-                log_and_emit!(format!(
-                    "warning: /etc/nix-darwin was not updated: {reason}"
-                ));
-                None
-            }
-        };
-
     // The build succeeded, so the resolved store path is present.
     let Some(system_store_path) = build_result.store_path.as_deref() else {
         return Err(serde_json::json!({
@@ -1217,21 +1173,17 @@ fn run_darwin_rebuild(
         }));
     };
 
-    let activate_result = run_activate_step(
-        system_store_path,
-        allow_activation_helper,
-        canonical_link_target,
-    )
-    .map_err(|e| {
-        serde_json::json!({
-            "ok": false,
-            "code": -1,
-            "log_file": log_path.to_string_lossy(),
-            "error_type": "generic_error",
-            "system_untouched": true,
-            "error": format!("Activation step failed to execute: {}", e),
-        })
-    })?;
+    let activate_result =
+        run_activate_step(system_store_path, allow_activation_helper).map_err(|e| {
+            serde_json::json!({
+                "ok": false,
+                "code": -1,
+                "log_file": log_path.to_string_lossy(),
+                "error_type": "generic_error",
+                "system_untouched": true,
+                "error": format!("Activation step failed to execute: {}", e),
+            })
+        })?;
 
     if !activate_result.success {
         summarizer.complete(false);

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -4,7 +4,8 @@
 
 use crate::ai::log_summarizer;
 use crate::privileged_helper::{
-    client as helper_client, protocol as helper_protocol, service as helper_service,
+    client as helper_client, protocol as helper_protocol, root_activation,
+    service as helper_service,
 };
 use chrono::Local;
 use log::{error, info};
@@ -615,15 +616,17 @@ fn run_build_step(
 ///   calls `launchctl managername` and aborts with the "over SSH" error
 ///   whenever the result is not "Aqua" — even when called from a GUI app.
 ///
-/// Fix: from within the root osascript shell, use `launchctl asuser <uid>`
-///   to re-enter the user's Aqua bootstrap domain before invoking sudo.
+/// Fix: the elevated step uses `launchctl asuser <uid>` to re-enter the
+///   user's Aqua bootstrap domain before exec'ing the activation script.
 ///   fork()/exec() inherits the bootstrap port, so the activation script
 ///   sees `launchctl managername == "Aqua"` and the App Management check
 ///   proceeds correctly.
 ///
-///   A temporary NOPASSWD sudoers rule is created for the exact, content-
-///   addressed, immutable nix store activate path and is removed via a shell
-///   trap — no persistent system configuration is required.
+///   The elevated command is this binary re-executed in root-activation
+///   mode (`privileged_helper::root_activation`): fixed Rust code with the
+///   same hardening rules as the helper daemon — no shell script, no
+///   sudoers rules, no EXIT traps, absolute programs, and a fixed root-owned
+///   environment.
 fn run_activate_step(
     system_store_path: &Path,
     allow_helper: bool,
@@ -760,13 +763,8 @@ fn run_activate_with_path(
     activate_path: &str,
     allow_helper: bool,
 ) -> Result<ActivateResult, anyhow::Error> {
-    let nix_path = crate::system::nix::get_nix_path();
-    let home = std::env::var("HOME").unwrap_or_default();
-    let ssh_sock = std::env::var("SSH_AUTH_SOCK").unwrap_or_default();
-    let user = whoami::username().unwrap_or_else(|_| "root".to_string());
-
-    // Resolve the symlink to the real nix store path.
-    // sudo / visudo match against the canonical path, not the symlink.
+    // Resolve the symlink to the real nix store path: the privileged step
+    // only ever accepts canonical /nix/store activation paths.
     let real_activate = std::fs::canonicalize(activate_path)
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| activate_path.to_owned());
@@ -779,53 +777,35 @@ fn run_activate_with_path(
         info!("[darwin] Skipping privileged helper for App Management-sensitive activation");
     }
 
-    // Escape a value for safe embedding inside a shell single-quoted string.
-    let sq = |s: &str| s.replace('\'', "'\\''");
+    // Interactive fallback: one native admin prompt (Touch ID capable), then
+    // re-execute this binary in root-activation mode. The privileged step is
+    // fixed Rust code mirroring the helper daemon — direct exec of absolute
+    // programs with a fixed root-owned environment. No sudoers rules, EXIT
+    // traps, or requester-controlled PATH/HOME reach root.
+    let root_args = root_activation::RootActivationArgs {
+        // SAFETY: `getuid` is thread-safe, has no preconditions, and cannot fail.
+        uid: unsafe { libc::getuid() },
+        activate_path: real_activate,
+        ssh_auth_sock: std::env::var("SSH_AUTH_SOCK")
+            .ok()
+            .filter(|sock| !sock.is_empty()),
+    };
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("Failed to resolve current executable: {}", e))?;
+    let shell_command = root_activation::shell_command(&exe.to_string_lossy(), &root_args);
 
-    // Build the privileged shell script that runs as root via osascript.
-    // It:
-    //   1. Creates a temp NOPASSWD sudoers rule for this exact nix store path.
-    //   2. Uses `launchctl asuser` to switch into the user's Aqua bootstrap
-    //      domain before calling sudo, so the activation script sees
-    //      `launchctl managername == "Aqua"`.
-    //   3. Removes the temp sudoers file via a trap on exit.
-    let shell_script = format!(
-        "set -e\n\
-         ACTIVATE='{activate}'\n\
-         USER_ID=$(id -u '{user}')\n\
-         \n\
-         trap 'rm -f /etc/sudoers.d/nixmac-activate-temp' EXIT\n\
-         \n\
-         printf '%s ALL=(ALL) NOPASSWD: %s\\n' '{user}' \"$ACTIVATE\" \
-             > /etc/sudoers.d/nixmac-activate-temp\n\
-         chmod 440 /etc/sudoers.d/nixmac-activate-temp\n\
-         visudo -cf /etc/sudoers.d/nixmac-activate-temp >/dev/null\n\
-         \n\
-         export PATH='{path}'\n\
-         export HOME='{home}'\n\
-         export SSH_AUTH_SOCK='{sock}'\n\
-         launchctl asuser \"$USER_ID\" sudo -E -n \"$ACTIVATE\" 2>&1\n\
-         SYSTEM_PATH=$(dirname \"$ACTIVATE\")\n\
-         nix-env -p /nix/var/nix/profiles/system --set \"$SYSTEM_PATH\" || true",
-        activate = sq(&real_activate),
-        user = sq(&user),
-        path = sq(&nix_path),
-        home = sq(&home),
-        sock = sq(&ssh_sock),
-    );
-
-    // Escape the shell script for embedding in an AppleScript string literal:
+    // Escape the command for embedding in an AppleScript string literal:
     //   \ → \\ and " → \"
-    let escaped_script = shell_script.replace('\\', "\\\\").replace('"', "\\\"");
+    let escaped_command = shell_command.replace('\\', "\\\\").replace('"', "\\\"");
 
     let osascript_cmd = format!(
         "do shell script \"{}\" with administrator privileges",
-        escaped_script
+        escaped_command
     );
 
-    info!("[darwin] Running activation with launchctl asuser (Aqua bootstrap domain)");
+    info!("[darwin] Running interactive activation via root re-exec of the app binary");
 
-    let output = Command::new("osascript")
+    let output = Command::new("/usr/bin/osascript")
         .args(["-e", &osascript_cmd])
         .output()
         .map_err(|e| anyhow::anyhow!("Failed to run osascript: {}", e))?;
@@ -1187,7 +1167,8 @@ fn run_darwin_rebuild(
 
     if !activate_result.success {
         summarizer.complete(false);
-        // Write and emit activation output (osascript uses `2>&1`, so useful details are often in stdout)
+        // Write and emit activation output (the privileged step merges stderr
+        // into stdout, so useful details are often in stdout)
         let mut stdout_lines: Vec<String> = Vec::new();
         for line in activate_result.stdout.lines() {
             if !line.is_empty() {

--- a/apps/native/src-tauri/src/storage/canonical_config.rs
+++ b/apps/native/src-tauri/src/storage/canonical_config.rs
@@ -1,18 +1,15 @@
 //! Canonical nix-darwin configuration path at `/etc/nix-darwin`.
 //!
-//! `darwin-rebuild` invoked without `--flake` looks for the system flake at
-//! this location, so when the user stores their configuration elsewhere a
-//! symlink from `/etc/nix-darwin` keeps the bare-CLI convention working.
-//! Updating the link needs root, so it is maintained during the privileged
-//! activation step of the next apply ([`canonical_link_pending`] decides,
-//! the activation scripts execute) rather than eagerly on directory
-//! selection — nixmac itself always passes `--flake` and never needs the
-//! link for its own operation.
+//! Supports configurations stored at the canonical path itself: the
+//! directory is created and re-owned (with admin approval) when needed.
+//! nixmac does not maintain an `/etc/nix-darwin` symlink for configs stored
+//! elsewhere — it always passes `--flake` and never needs the bare-CLI
+//! convention for its own operation.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-pub use crate::privileged_helper::protocol::CANONICAL_CONFIG_DIR;
+pub const CANONICAL_CONFIG_DIR: &str = "/etc/nix-darwin";
 
 /// Returns true when `path` resolves to the canonical nix-darwin directory.
 pub fn is_canonical_config_path(path: &Path) -> bool {
@@ -32,65 +29,6 @@ pub fn ensure_canonical_dir_ready() -> Result<(), String> {
     ensure_canonical_directory_owned()
 }
 
-/// What the next privileged activation should do about the `/etc/nix-darwin`
-/// convention link. See [`canonical_link_plan`].
-pub enum CanonicalLinkPlan {
-    /// Nothing to do: link already current, config lives at the canonical
-    /// path itself, or an e2e override is active.
-    UpToDate,
-    /// Re-point the link at this canonicalized config directory.
-    Update(String),
-    /// The canonical path is occupied by something nixmac must not delete;
-    /// the link stays untouched. Carries a user-facing reason so the apply
-    /// stream can surface it as a notice.
-    Blocked(String),
-}
-
-/// Decides whether the next privileged activation should re-point
-/// `/etc/nix-darwin` at `repo_dir`.
-///
-/// The link is maintained during apply — an already-privileged step — so
-/// changing the configuration directory in preferences never has to prompt
-/// for a password on its own, and the link always names the configuration
-/// that was last *applied* (the one a bare `darwin-rebuild switch` should
-/// rebuild), not one merely selected.
-pub fn canonical_link_plan(repo_dir: &Path) -> CanonicalLinkPlan {
-    if crate::env::e2e_override(crate::env::keys::NIXMAC_E2E_CONFIG_DIR).is_some() {
-        return CanonicalLinkPlan::UpToDate;
-    }
-
-    let repo = repo_dir
-        .canonicalize()
-        .unwrap_or_else(|_| repo_dir.to_path_buf());
-
-    if is_canonical_config_path(&repo) {
-        return CanonicalLinkPlan::UpToDate;
-    }
-
-    match symlink_blocked_reason(&repo) {
-        Ok(None) => {}
-        Ok(Some(reason)) | Err(reason) => {
-            log::warn!("[canonical-config] leaving {CANONICAL_CONFIG_DIR} alone: {reason}");
-            return CanonicalLinkPlan::Blocked(reason);
-        }
-    }
-
-    match canonical_symlink_is_current(&repo) {
-        Ok(true) => CanonicalLinkPlan::UpToDate,
-        Ok(false) => match repo.to_str() {
-            Some(target) => CanonicalLinkPlan::Update(target.to_string()),
-            None => {
-                log::warn!("[canonical-config] config dir path is not valid UTF-8");
-                CanonicalLinkPlan::UpToDate
-            }
-        },
-        Err(error) => {
-            log::warn!("[canonical-config] cannot read {CANONICAL_CONFIG_DIR}: {error}");
-            CanonicalLinkPlan::UpToDate
-        }
-    }
-}
-
 fn paths_equivalent(left: &Path, right: &Path) -> bool {
     let left = left.canonicalize().unwrap_or_else(|_| left.to_path_buf());
     let right = right.canonicalize().unwrap_or_else(|_| right.to_path_buf());
@@ -99,36 +37,6 @@ fn paths_equivalent(left: &Path, right: &Path) -> bool {
 
 fn canonical_path() -> PathBuf {
     PathBuf::from(CANONICAL_CONFIG_DIR)
-}
-
-fn symlink_blocked_reason(target: &Path) -> Result<Option<String>, String> {
-    let link = canonical_path();
-    if !link.exists() {
-        return Ok(None);
-    }
-
-    if link.is_symlink() {
-        return Ok(None);
-    }
-
-    if !link.is_dir() {
-        return Err(format!(
-            "{} exists but is not a directory or symlink",
-            CANONICAL_CONFIG_DIR
-        ));
-    }
-
-    if paths_equivalent(&link, target) {
-        return Ok(None);
-    }
-
-    if directory_has_entries(&link)? {
-        return Ok(Some(format!(
-            "{CANONICAL_CONFIG_DIR} already contains a configuration that nixmac will not delete. Move or remove it to let nixmac maintain the link."
-        )));
-    }
-
-    Ok(None)
 }
 
 /// Returns true when `/etc/nix-darwin` already exists and the current user can
@@ -148,31 +56,6 @@ fn canonical_directory_is_ready() -> bool {
 #[cfg(not(unix))]
 fn canonical_directory_is_ready() -> bool {
     canonical_path().is_dir()
-}
-
-fn canonical_symlink_is_current(target: &Path) -> Result<bool, String> {
-    symlink_points_to(&canonical_path(), target)
-}
-
-fn symlink_points_to(link: &Path, target: &Path) -> Result<bool, String> {
-    if !link.is_symlink() {
-        return Ok(false);
-    }
-
-    let link_target = std::fs::read_link(link)
-        .map_err(|e| format!("Failed to read symlink {}: {e}", link.display()))?;
-
-    Ok(paths_equivalent(&link_target, target))
-}
-
-fn directory_has_entries(path: &Path) -> Result<bool, String> {
-    let entries: Vec<_> = std::fs::read_dir(path)
-        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.file_name().to_str() != Some(".DS_Store"))
-        .collect();
-
-    Ok(!entries.is_empty())
 }
 
 fn ensure_canonical_directory_owned() -> Result<(), String> {
@@ -225,31 +108,10 @@ fn run_privileged_shell(script: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
 
     #[test]
     fn is_canonical_config_path_matches_etc_nix_darwin() {
         assert!(is_canonical_config_path(Path::new("/etc/nix-darwin")));
-    }
-
-    #[test]
-    fn directory_has_entries_ignores_ds_store() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        fs::write(temp.path().join(".DS_Store"), "").expect("write metadata");
-
-        assert!(!directory_has_entries(temp.path()).expect("check directory"));
-    }
-
-    #[test]
-    fn symlink_points_to_matches_equivalent_target() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let target = temp.path().join("config");
-        fs::create_dir_all(&target).expect("create target");
-
-        let link = temp.path().join("nix-darwin");
-        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
-
-        assert!(symlink_points_to(&link, &target).expect("check symlink"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/storage/store.rs
+++ b/apps/native/src-tauri/src/storage/store.rs
@@ -93,9 +93,7 @@ pub fn ensure_config_dir_exists<R: Runtime>(app: &AppHandle<R>) -> Result<String
 
     if canonical_config::is_canonical_config_path(path) {
         // Creating /etc/nix-darwin itself needs root — a one-time privileged
-        // step when the user keeps the config at the canonical path. The
-        // convention *link* (config elsewhere) is maintained during apply
-        // instead; see canonical_config::canonical_link_pending.
+        // step when the user keeps the config at the canonical path.
         canonical_config::ensure_canonical_dir_ready().map_err(anyhow::Error::msg)?;
     } else {
         std::fs::create_dir_all(path)?;

--- a/apps/native/src-tauri/src/system/permissions.rs
+++ b/apps/native/src-tauri/src/system/permissions.rs
@@ -114,6 +114,12 @@ fn granted_permissions_state() -> PermissionsState {
     let mut permissions = get_default_permissions();
     for perm in &mut permissions {
         perm.status = PermissionStatus::Granted;
+        // Granted here is a debug-build fiction, not a probe result; say so
+        // instead of letting the row imply the real thing was verified.
+        perm.instructions = Some(
+            "Check skipped: this build has VITE_NIXMAC_SKIP_PERMISSIONS enabled, so the real status was not probed."
+                .to_string(),
+        );
     }
     PermissionsState {
         permissions,
@@ -341,7 +347,15 @@ pub fn check_all_permissions() -> PermissionsState {
             "admin" => check_admin_privileges(),
             "full-disk" => check_full_disk_access(),
             "app-management" => check_app_management(),
-            "privileged-helper" => check_privileged_helper(),
+            "privileged-helper" => {
+                let (status, detail) = check_privileged_helper();
+                // Keep the default instructions when healthy; surface what is
+                // actually wrong otherwise.
+                if let Some(detail) = detail {
+                    perm.instructions = Some(detail);
+                }
+                status
+            }
             _ => PermissionStatus::Unknown,
         };
 
@@ -528,46 +542,121 @@ pub fn request_permission(permission_id: &str) -> Result<Permission> {
                 .bundle_path
                 .is_some();
 
+            const APPROVE_INSTRUCTIONS: &str = "Approve nixmac in System Settings → General → Login Items & Extensions if macOS asks for background item approval.";
+
             let (status, instructions) = if !bundle_present {
                 warn!(
                     "privileged helper registration skipped: nixmac is not running from a .app bundle"
                 );
                 (
                     PermissionStatus::Pending,
-                    "Build a signed .app with `bun run desktop:build:local`, drag it into /Applications, and launch it from there to install the unattended sync helper. It cannot be installed from a dev build.",
+                    "Build a signed .app with `bun run desktop:build:local`, drag it into /Applications, and launch it from there to install the unattended sync helper. It cannot be installed from a dev build."
+                        .to_string(),
                 )
             } else {
-                let status = match crate::privileged_helper::service::register() {
-                    Ok(status) if status.authorized => PermissionStatus::Granted,
+                match crate::privileged_helper::service::register() {
+                    // Registration alone is not a working helper: wait briefly
+                    // for the freshly launched daemon to answer a status
+                    // round-trip before reporting Granted.
+                    Ok(status) if status.authorized => match await_helper_ready() {
+                        Ok(()) => (PermissionStatus::Granted, APPROVE_INSTRUCTIONS.to_string()),
+                        Err(error) => (
+                            PermissionStatus::Pending,
+                            format!(
+                                "The helper is registered but did not answer a status probe: {error:#}."
+                            ),
+                        ),
+                    },
                     Ok(_) => {
                         crate::privileged_helper::service::open_login_items_settings();
-                        PermissionStatus::Pending
+                        (PermissionStatus::Pending, APPROVE_INSTRUCTIONS.to_string())
                     }
                     Err(error) => {
                         warn!("privileged helper registration failed: {error:#}");
                         crate::privileged_helper::service::open_login_items_settings();
-                        PermissionStatus::Pending
+                        (PermissionStatus::Pending, APPROVE_INSTRUCTIONS.to_string())
                     }
-                };
-                (
-                    status,
-                    "Approve nixmac in System Settings → General → Login Items & Extensions if macOS asks for background item approval.",
-                )
+                }
             };
-            Ok(privileged_helper_permission(status, instructions))
+            Ok(privileged_helper_permission(status, &instructions))
         }
         _ => Err(anyhow::anyhow!("Unknown permission: {}", permission_id)),
     }
 }
 
-fn check_privileged_helper() -> PermissionStatus {
+/// Wait for a freshly registered helper daemon to come up and answer a
+/// status round-trip. launchd starts it asynchronously after approval, so the
+/// socket appears a moment after `register()` returns.
+fn await_helper_ready() -> Result<()> {
+    const ATTEMPTS: u32 = 10;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
+
+    let mut last_error = anyhow::anyhow!("helper socket never appeared");
+    for attempt in 0..ATTEMPTS {
+        if attempt > 0 {
+            std::thread::sleep(RETRY_DELAY);
+        }
+        if !crate::privileged_helper::client::socket_available() {
+            continue;
+        }
+        match crate::privileged_helper::client::status() {
+            Ok(response) if response.ok => return Ok(()),
+            Ok(response) => {
+                last_error = anyhow::anyhow!(
+                    response
+                        .error
+                        .unwrap_or_else(|| "helper returned an error".to_string())
+                );
+            }
+            Err(error) => last_error = error,
+        }
+    }
+    Err(last_error)
+}
+
+/// Status of the unattended sync helper, with a detail message when it is
+/// not fully working.
+///
+/// `SMAppService` registration alone is not proof of a working helper: the
+/// approval persists in the BackgroundTaskManagement database even after the
+/// helper binary is gone or replaced. Granted therefore additionally requires
+/// a live status round-trip through the socket, which also exercises both
+/// code-signature checks (client validates the daemon, daemon validates this
+/// client).
+fn check_privileged_helper() -> (PermissionStatus, Option<String>) {
     let status = crate::privileged_helper::service::status();
-    if status.authorized {
-        PermissionStatus::Granted
-    } else if status.available {
-        PermissionStatus::Pending
-    } else {
-        PermissionStatus::Unknown
+    if !status.available {
+        return (PermissionStatus::Unknown, status.detail);
+    }
+    if !status.authorized {
+        return (PermissionStatus::Pending, None);
+    }
+    if !status.socket_available {
+        return (
+            PermissionStatus::Pending,
+            Some(
+                "The helper is approved in Login Items, but its daemon is not running (no socket). Use Grant to re-register it, or toggle nixmac off and on in System Settings → General → Login Items & Extensions."
+                    .to_string(),
+            ),
+        );
+    }
+    match crate::privileged_helper::client::status() {
+        Ok(response) if response.ok => (PermissionStatus::Granted, None),
+        Ok(response) => (
+            PermissionStatus::Pending,
+            Some(format!(
+                "The helper is running but refused this app: {}. Unattended sync will fall back to password prompts until a matching signed build talks to it.",
+                response
+                    .error
+                    .unwrap_or_else(|| "unknown error".to_string())
+            )),
+        ),
+        Err(error) => (
+            PermissionStatus::Pending,
+            Some(format!(
+                "The helper is registered but did not answer a status probe: {error:#}."
+            )),
+        ),
     }
 }
 

--- a/apps/native/src/viewmodel/log-triggers.test.ts
+++ b/apps/native/src/viewmodel/log-triggers.test.ts
@@ -19,21 +19,6 @@ describe("build log triggers", () => {
     });
   });
 
-  it("emits canonical-link guidance when /etc/nix-darwin could not be updated", () => {
-    const notices = noticesForBuildLogLines(
-      [
-        "warning: /etc/nix-darwin was not updated: /etc/nix-darwin already contains a configuration that nixmac will not delete. Move or remove it to let nixmac maintain the link.",
-      ],
-      [],
-    );
-
-    expect(notices).toHaveLength(1);
-    expect(notices[0]).toMatchObject({
-      id: "canonical-link-blocked",
-      title: "/etc/nix-darwin was not updated",
-    });
-  });
-
   it("deduplicates notices that already fired for a rebuild", () => {
     const [existingNotice] = noticesForBuildLogLines(
       ["error: permission denied when trying to update apps, aborting activation"],

--- a/apps/native/src/viewmodel/log-triggers.ts
+++ b/apps/native/src/viewmodel/log-triggers.ts
@@ -13,12 +13,6 @@ const appManagementNotice: RebuildNotice = {
   actionLabel: "Open App Management",
 };
 
-const canonicalLinkBlockedNotice: RebuildNotice = {
-  id: "canonical-link-blocked",
-  title: "/etc/nix-darwin was not updated",
-  body: "Your configuration was applied, but /etc/nix-darwin already contains another configuration, which nixmac won't delete. Running darwin-rebuild from a terminal without --flake will keep using whatever is there. Move or remove /etc/nix-darwin and rebuild to let nixmac maintain the link.",
-};
-
 const buildLogTriggers: BuildLogTrigger[] = [
   {
     matches: (line) => {
@@ -30,12 +24,6 @@ const buildLogTriggers: BuildLogTrigger[] = [
       );
     },
     notice: appManagementNotice,
-  },
-  {
-    // Emitted by the backend when the canonical-link maintenance during
-    // activation found /etc/nix-darwin occupied by a foreign directory.
-    matches: (line) => line.toLowerCase().includes("/etc/nix-darwin was not updated"),
-    notice: canonicalLinkBlockedNotice,
   },
 ];
 


### PR DESCRIPTION
## Summary

This stops maintaining the symlink at /etc/nix-darwin. Main reason: reduce the root-level code exposure.

If ever this feature needs to be brought back, there are better ways:
- `environment.etc."nix-darwin".source`
- an activation script, `system.activationScripts.extraActivation.text`

## Test Plan

- [x] Manual test

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
