### PR TITLE
fix(rebuild): re-exec app binary for root activation, no shell

### DIFF
--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -129,6 +129,8 @@ url = "2"
 cocoa = "0.26"
 objc = "0.2"
 window-vibrancy = "0.6"
+
+[target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["user"] }
 
 [dependencies.tera]

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -226,6 +226,19 @@ const E2E_CAPTURE_DARK_BACKGROUND_SCRIPT: &str = r#"
 "#;
 
 fn main() {
+    // Root re-entry for the interactive activation fallback: `osascript ...
+    // with administrator privileges` re-executes this binary with this
+    // argument so the privileged step runs fixed Rust code instead of a
+    // generated shell script. Dispatched before anything else — the elevated
+    // process must never boot the GUI.
+    if std::env::args().nth(1).as_deref()
+        == Some(privileged_helper::root_activation::ROOT_ACTIVATE_ARG)
+    {
+        std::process::exit(privileged_helper::root_activation::run(
+            std::env::args().skip(2),
+        ));
+    }
+
     #[cfg(feature = "codegen")]
     if std::env::args().nth(1).as_deref() == Some("gen-schemas") {
         if let Err(error) = schema_gen::write_default_config_schemas() {

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -112,10 +112,40 @@ fn activate_store_path(
     // Account values are derived from the socket peer credentials; the
     // request's `user_name`/`user_id`/`home` are never trusted here.
     let account = user_account(peer.uid)?;
-    let argv = activation_argv(peer.uid, &account, request);
-    // Merge stderr into stdout (the old script's `2>&1`): consumers stream,
-    // log, and summarize the response's stdout only, and the activate script
-    // writes most of its output to stderr.
+    let argv = activation_argv(
+        peer.uid,
+        &account,
+        &request.activate_path,
+        request.ssh_auth_sock.as_deref(),
+    );
+    let (status, mut stdout) = run_activation_command(&argv)?;
+
+    // Profile maintenance runs only after a successful activation and is
+    // best-effort: the system switch already happened, so its failures
+    // surface as warnings instead of failing the apply.
+    if status.success() {
+        for warning in post_activation_maintenance(&request.activate_path) {
+            stdout.push_str(&format!("\n{HELPER_WARNING_PREFIX} {warning}"));
+        }
+    }
+
+    Ok(HelperResponse {
+        ok: status.success(),
+        code: status.code().unwrap_or(-1),
+        stdout,
+        stderr: String::new(),
+        error: None,
+    })
+}
+
+/// Runs a prepared activation argv with stderr merged into stdout (the old
+/// script's `2>&1`): consumers stream, log, and summarize a single output
+/// stream, and the activate script writes most of its output to stderr.
+/// Shared by the helper daemon and the interactive fallback's root re-entry
+/// (`privileged_helper::root_activation`).
+pub(crate) fn run_activation_command(
+    argv: &[String],
+) -> Result<(std::process::ExitStatus, String)> {
     let (mut reader, writer) = std::io::pipe().context("failed to create activation pipe")?;
     let mut command = Command::new(&argv[0]);
     command
@@ -134,32 +164,16 @@ fn activate_store_path(
     std::io::Read::read_to_end(&mut reader, &mut output)
         .context("failed to read activation output")?;
     let status = child.wait().context("failed to wait for activation")?;
-
-    let mut stdout = String::from_utf8_lossy(&output).to_string();
-    // Profile and link maintenance run only after a successful activation and
-    // are best-effort: the system switch already happened, so their failures
-    // surface as warnings instead of failing the apply.
-    if status.success() {
-        for warning in post_activation_maintenance(request) {
-            stdout.push_str(&format!("\n{HELPER_WARNING_PREFIX} {warning}"));
-        }
-    }
-
-    Ok(HelperResponse {
-        ok: status.success(),
-        code: status.code().unwrap_or(-1),
-        stdout,
-        stderr: String::new(),
-        error: None,
-    })
+    Ok((status, String::from_utf8_lossy(&output).to_string()))
 }
 
 /// Direct-exec activation command: no shell, absolute programs only, a fixed
 /// root-owned PATH, and an otherwise empty environment (`env -i`).
-fn activation_argv(
+pub(crate) fn activation_argv(
     uid: u32,
     account: &UserAccount,
-    request: &ActivateStorePathRequest,
+    activate_path: &str,
+    ssh_auth_sock: Option<&str>,
 ) -> Vec<String> {
     let mut argv = vec![
         "/bin/launchctl".to_string(),
@@ -172,20 +186,16 @@ fn activation_argv(
         format!("USER={}", account.name),
         format!("LOGNAME={}", account.name),
     ];
-    if let Some(sock) = request
-        .ssh_auth_sock
-        .as_deref()
-        .filter(|sock| !sock.is_empty())
-    {
+    if let Some(sock) = ssh_auth_sock.filter(|sock| !sock.is_empty()) {
         argv.push(format!("SSH_AUTH_SOCK={sock}"));
     }
-    argv.push(request.activate_path.clone());
+    argv.push(activate_path.to_string());
     argv
 }
 
-fn post_activation_maintenance(request: &ActivateStorePathRequest) -> Vec<String> {
+pub(crate) fn post_activation_maintenance(activate_path: &str) -> Vec<String> {
     let mut warnings = Vec::new();
-    if let Err(error) = set_system_profile(&request.activate_path) {
+    if let Err(error) = set_system_profile(activate_path) {
         warnings.push(format!("failed to update system profile: {error:#}"));
     }
     warnings
@@ -245,13 +255,16 @@ pub struct PeerIdentity {
     pub executable: Option<String>,
 }
 
-struct UserAccount {
+pub(crate) struct UserAccount {
     name: String,
     home: String,
 }
 
+/// Resolves the account name and home directory for `uid` from the user
+/// database, so privileged activation never trusts requester-supplied
+/// account values.
 #[cfg(target_os = "macos")]
-fn user_account(uid: u32) -> Result<UserAccount> {
+pub(crate) fn user_account(uid: u32) -> Result<UserAccount> {
     let user = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
         .context("failed to look up peer account")?
         .with_context(|| format!("no account found for peer uid {uid}"))?;
@@ -264,7 +277,7 @@ fn user_account(uid: u32) -> Result<UserAccount> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn user_account(_uid: u32) -> Result<UserAccount> {
+pub(crate) fn user_account(_uid: u32) -> Result<UserAccount> {
     bail!("peer account lookup is only implemented on macOS")
 }
 
@@ -390,7 +403,8 @@ mod tests {
         let argv = activation_argv(
             501,
             &account(),
-            &request("/nix/store/abc123-darwin-system-25.05.20260629/activate"),
+            "/nix/store/abc123-darwin-system-25.05.20260629/activate",
+            Some("/tmp/ssh.sock"),
         );
 
         assert_eq!(argv[0], "/bin/launchctl");
@@ -413,7 +427,8 @@ mod tests {
         let argv = activation_argv(
             501,
             &account(),
-            &request("/nix/store/abc123-darwin-system-25.05.20260629/activate"),
+            "/nix/store/abc123-darwin-system-25.05.20260629/activate",
+            Some("/tmp/ssh.sock"),
         );
 
         assert!(!argv.iter().any(|arg| arg.contains("/bin/sh")));
@@ -422,13 +437,17 @@ mod tests {
     }
 
     #[test]
-    fn activation_argv_omits_ssh_sock_when_absent() {
-        let mut without_sock = request("/nix/store/abc123-darwin-system-25.05.20260629/activate");
-        without_sock.ssh_auth_sock = None;
+    fn activation_argv_omits_ssh_sock_when_absent_or_empty() {
+        for sock in [None, Some("")] {
+            let argv = activation_argv(
+                501,
+                &account(),
+                "/nix/store/abc123-darwin-system-25.05.20260629/activate",
+                sock,
+            );
 
-        let argv = activation_argv(501, &account(), &without_sock);
-
-        assert!(!argv.iter().any(|arg| arg.starts_with("SSH_AUTH_SOCK=")));
+            assert!(!argv.iter().any(|arg| arg.starts_with("SSH_AUTH_SOCK=")));
+        }
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/mod.rs
+++ b/apps/native/src-tauri/src/privileged_helper/mod.rs
@@ -8,5 +8,6 @@ pub mod client;
 #[allow(dead_code)]
 pub mod helper_runtime;
 pub mod protocol;
+pub mod root_activation;
 pub mod service;
 pub mod sync_agent;

--- a/apps/native/src-tauri/src/privileged_helper/root_activation.rs
+++ b/apps/native/src-tauri/src/privileged_helper/root_activation.rs
@@ -1,0 +1,301 @@
+//! Root re-entry point for the interactive activation fallback.
+//!
+//! When the privileged helper is unavailable, the app elevates through one
+//! native admin prompt (`osascript ... with administrator privileges`). The
+//! privileged step used to be a generated shell script that wrote a temporary
+//! NOPASSWD rule to `/etc/sudoers.d/nixmac-activate-temp` and cleaned it up
+//! with an EXIT trap. That mechanism is gone: the unprivileged app now
+//! re-executes its own binary with [`ROOT_ACTIVATE_ARG`], and this mode
+//! applies the same hardening rules as the helper daemon — direct exec with
+//! absolute programs, a fixed root-owned PATH and otherwise empty environment
+//! (`env -i`), and account values derived from the target uid (no sudoers,
+//! no shell logic as root).
+
+use crate::privileged_helper::helper_runtime;
+use crate::privileged_helper::protocol::validate_canonical_activate_path;
+use anyhow::{Context, Result, bail};
+
+/// First argv element that switches the app binary into root-activation mode.
+/// Deliberately not a user-facing CLI subcommand: it exists only for the
+/// osascript elevation and is dispatched before any other argument parsing.
+pub const ROOT_ACTIVATE_ARG: &str = "__nixmac-root-activate";
+
+/// Sudoers rule older app versions wrote for the osascript fallback (and
+/// could leave behind if the elevated shell died before its EXIT trap ran).
+/// No longer written; removed on every root activation if present.
+const LEGACY_SUDOERS_PATH: &str = "/etc/sudoers.d/nixmac-activate-temp";
+
+/// Prefix on post-activation maintenance warnings, so they read as warnings
+/// (not activation output) in the streamed apply log.
+const WARNING_PREFIX: &str = "nixmac: warning:";
+
+/// Validated inputs of a root activation. Built by the unprivileged side
+/// (which knows its own uid and environment) and re-validated after the
+/// privilege boundary by [`parse_args`].
+#[derive(Debug)]
+pub struct RootActivationArgs {
+    pub uid: u32,
+    pub activate_path: String,
+    pub ssh_auth_sock: Option<String>,
+}
+
+/// The exact command line handed to `osascript ... with administrator
+/// privileges`: this binary re-executed in root-activation mode. Every
+/// element is an absolute path, a fixed literal, or a single-quoted value,
+/// and the leading `exec` makes the elevated shell replace itself with this
+/// argv instead of staying alive as its parent.
+pub fn shell_command(exe: &str, args: &RootActivationArgs) -> String {
+    let mut argv = vec![
+        exe.to_string(),
+        ROOT_ACTIVATE_ARG.to_string(),
+        "--uid".to_string(),
+        args.uid.to_string(),
+        "--activate".to_string(),
+        args.activate_path.clone(),
+    ];
+    if let Some(sock) = args
+        .ssh_auth_sock
+        .as_deref()
+        .filter(|sock| !sock.is_empty())
+    {
+        argv.push("--ssh-auth-sock".to_string());
+        argv.push(sock.to_string());
+    }
+    let quoted = argv
+        .iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("exec {quoted}")
+}
+
+/// Single-quotes `value` for /bin/sh: the only character that needs escaping
+/// inside single quotes is the single quote itself.
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// Parses and validates the argv after [`ROOT_ACTIVATE_ARG`]. Validation
+/// runs on the privileged side of the boundary: the activate path must be a
+/// canonical /nix/store activation script, exactly as the helper daemon
+/// requires.
+pub fn parse_args(args: impl IntoIterator<Item = String>) -> Result<RootActivationArgs> {
+    let mut uid = None;
+    let mut activate_path = None;
+    let mut ssh_auth_sock = None;
+
+    let mut args = args.into_iter();
+    while let Some(flag) = args.next() {
+        let value = args
+            .next()
+            .with_context(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--uid" => {
+                uid = Some(value.parse::<u32>().context("--uid must be an integer")?);
+            }
+            "--activate" => activate_path = Some(value),
+            "--ssh-auth-sock" => ssh_auth_sock = Some(value),
+            other => bail!("unknown root-activation argument: {other}"),
+        }
+    }
+
+    let uid = uid.context("--uid is required")?;
+    if uid == 0 {
+        bail!("root activation must target a non-root user");
+    }
+    let activate_path = activate_path.context("--activate is required")?;
+    validate_canonical_activate_path(&activate_path)?;
+
+    Ok(RootActivationArgs {
+        uid,
+        activate_path,
+        ssh_auth_sock,
+    })
+}
+
+/// Entry point for the root-activation dispatch in `main()`. Returns the
+/// process exit code: the activation's own code, or 1 when the mode itself
+/// fails before activation runs.
+pub fn run(args: impl IntoIterator<Item = String>) -> i32 {
+    match run_root_activation(args) {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("nixmac root activation failed: {error:#}");
+            1
+        }
+    }
+}
+
+fn run_root_activation(args: impl IntoIterator<Item = String>) -> Result<i32> {
+    let args = parse_args(args)?;
+    if !nix::unistd::Uid::effective().is_root() {
+        bail!(
+            "root-activation mode must run as root (it is only ever invoked via the admin prompt)"
+        );
+    }
+    let legacy_sudoers_warning = remove_legacy_sudoers();
+    // stderr is what `do shell script` surfaces on any failure — a nonzero
+    // activation or any early `?` return below — so emit the warning there
+    // eagerly; no failure path can lose it. A successful run discards stderr
+    // and returns stdout, so the success branch repeats it there.
+    if let Some(warning) = &legacy_sudoers_warning {
+        eprintln!("{WARNING_PREFIX} {warning}");
+    }
+
+    // Mirror the helper daemon: account values come from the uid lookup, and
+    // the activation is a direct exec of absolute programs with a fixed
+    // environment — the caller's environment never reaches root.
+    let account = helper_runtime::user_account(args.uid)?;
+    let argv = helper_runtime::activation_argv(
+        args.uid,
+        &account,
+        &args.activate_path,
+        args.ssh_auth_sock.as_deref(),
+    );
+    let (status, output) = helper_runtime::run_activation_command(&argv)?;
+
+    if status.success() {
+        // `do shell script` returns the elevated command's stdout as its
+        // result, which the app surfaces in the apply stream. stderr is
+        // discarded on success, so warnings must ride stdout.
+        print!("{output}");
+        // Warnings must start their own line even when the activation's
+        // last output line has no trailing newline.
+        if !output.is_empty() && !output.ends_with('\n') {
+            println!();
+        }
+        if let Some(warning) = &legacy_sudoers_warning {
+            println!("{WARNING_PREFIX} {warning}");
+        }
+        // Best-effort, same as the helper: the system switch already
+        // happened, so maintenance failures are warnings, not errors.
+        for warning in helper_runtime::post_activation_maintenance(&args.activate_path) {
+            println!("{WARNING_PREFIX} {warning}");
+        }
+    } else {
+        // A failed `do shell script` discards stdout and surfaces stderr
+        // through the AppleScript error, so route diagnostics there.
+        eprint!("{output}");
+    }
+    Ok(status.code().unwrap_or(-1))
+}
+
+/// Removes the legacy fallback sudoers rule, best-effort. Returns a warning
+/// when a stale NOPASSWD grant could not be removed: it must never go
+/// unnoticed, but must not block the activation either (blocking would not
+/// remove it any better). The caller routes it through whichever stream
+/// `do shell script` actually surfaces for the run's outcome.
+fn remove_legacy_sudoers() -> Option<String> {
+    match std::fs::remove_file(LEGACY_SUDOERS_PATH) {
+        Ok(()) => None,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => Some(format!(
+            "SECURITY: failed to remove legacy sudoers rule {LEGACY_SUDOERS_PATH}: {error}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACTIVATE: &str = "/nix/store/abc123-darwin-system-25.05.20260629/activate";
+
+    fn args(flags: &[&str]) -> Result<RootActivationArgs> {
+        parse_args(flags.iter().map(|flag| flag.to_string()))
+    }
+
+    #[test]
+    fn parse_accepts_full_argument_set() {
+        let parsed = args(&[
+            "--uid",
+            "501",
+            "--activate",
+            ACTIVATE,
+            "--ssh-auth-sock",
+            "/tmp/ssh.sock",
+        ])
+        .expect("valid args");
+
+        assert_eq!(parsed.uid, 501);
+        assert_eq!(parsed.activate_path, ACTIVATE);
+        assert_eq!(parsed.ssh_auth_sock.as_deref(), Some("/tmp/ssh.sock"));
+    }
+
+    #[test]
+    fn parse_rejects_root_uid() {
+        let error = args(&["--uid", "0", "--activate", ACTIVATE]).expect_err("uid 0 must fail");
+
+        assert!(error.to_string().contains("non-root user"));
+    }
+
+    #[test]
+    fn parse_rejects_missing_uid_and_missing_activate() {
+        assert!(args(&["--activate", ACTIVATE]).is_err());
+        assert!(args(&["--uid", "501"]).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_non_store_activate_path() {
+        assert!(args(&["--uid", "501", "--activate", "/tmp/activate"]).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_arguments() {
+        let error = args(&["--uid", "501", "--activate", ACTIVATE, "--shell", "/bin/sh"])
+            .expect_err("unknown flag must fail");
+
+        assert!(error.to_string().contains("unknown root-activation"));
+    }
+
+    fn full_args() -> RootActivationArgs {
+        RootActivationArgs {
+            uid: 501,
+            activate_path: ACTIVATE.to_string(),
+            ssh_auth_sock: Some("/tmp/ssh.sock".to_string()),
+        }
+    }
+
+    #[test]
+    fn shell_command_re_execs_the_app_binary_with_quoted_arguments() {
+        let command = shell_command(
+            "/Applications/nix mac.app/Contents/MacOS/nixmac",
+            &full_args(),
+        );
+
+        assert!(command.starts_with("exec '/Applications/nix mac.app/Contents/MacOS/nixmac'"));
+        assert!(command.contains(&format!("'{ROOT_ACTIVATE_ARG}'")));
+        assert!(command.contains("'--uid' '501'"));
+        assert!(command.contains(&format!("'--activate' '{ACTIVATE}'")));
+    }
+
+    #[test]
+    fn shell_command_never_builds_sudoers_traps_or_redirections() {
+        let command = shell_command(
+            "/Applications/nixmac.app/Contents/MacOS/nixmac",
+            &full_args(),
+        );
+
+        for forbidden in ["sudo", "sudoers", "trap", "rm ", "visudo", ">", "$", ";"] {
+            assert!(
+                !command.contains(forbidden),
+                "shell command must not contain {forbidden:?}: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_command_omits_empty_ssh_sock() {
+        let mut args = full_args();
+        args.ssh_auth_sock = Some(String::new());
+
+        let command = shell_command("/Applications/nixmac.app/Contents/MacOS/nixmac", &args);
+
+        assert!(!command.contains("--ssh-auth-sock"));
+    }
+
+    #[test]
+    fn shell_quote_escapes_single_quotes() {
+        assert_eq!(shell_quote("/Users/al'ice"), "'/Users/al'\\''ice'");
+    }
+}

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -4,7 +4,8 @@
 
 use crate::ai::log_summarizer;
 use crate::privileged_helper::{
-    client as helper_client, protocol as helper_protocol, service as helper_service,
+    client as helper_client, protocol as helper_protocol, root_activation,
+    service as helper_service,
 };
 use chrono::Local;
 use log::{error, info};
@@ -615,15 +616,17 @@ fn run_build_step(
 ///   calls `launchctl managername` and aborts with the "over SSH" error
 ///   whenever the result is not "Aqua" — even when called from a GUI app.
 ///
-/// Fix: from within the root osascript shell, use `launchctl asuser <uid>`
-///   to re-enter the user's Aqua bootstrap domain before invoking sudo.
+/// Fix: the elevated step uses `launchctl asuser <uid>` to re-enter the
+///   user's Aqua bootstrap domain before exec'ing the activation script.
 ///   fork()/exec() inherits the bootstrap port, so the activation script
 ///   sees `launchctl managername == "Aqua"` and the App Management check
 ///   proceeds correctly.
 ///
-///   A temporary NOPASSWD sudoers rule is created for the exact, content-
-///   addressed, immutable nix store activate path and is removed via a shell
-///   trap — no persistent system configuration is required.
+///   The elevated command is this binary re-executed in root-activation
+///   mode (`privileged_helper::root_activation`): fixed Rust code with the
+///   same hardening rules as the helper daemon — no shell script, no
+///   sudoers rules, no EXIT traps, absolute programs, and a fixed root-owned
+///   environment.
 fn run_activate_step(
     system_store_path: &Path,
     allow_helper: bool,
@@ -760,13 +763,8 @@ fn run_activate_with_path(
     activate_path: &str,
     allow_helper: bool,
 ) -> Result<ActivateResult, anyhow::Error> {
-    let nix_path = crate::system::nix::get_nix_path();
-    let home = std::env::var("HOME").unwrap_or_default();
-    let ssh_sock = std::env::var("SSH_AUTH_SOCK").unwrap_or_default();
-    let user = whoami::username().unwrap_or_else(|_| "root".to_string());
-
-    // Resolve the symlink to the real nix store path.
-    // sudo / visudo match against the canonical path, not the symlink.
+    // Resolve the symlink to the real nix store path: the privileged step
+    // only ever accepts canonical /nix/store activation paths.
     let real_activate = std::fs::canonicalize(activate_path)
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| activate_path.to_owned());
@@ -779,53 +777,35 @@ fn run_activate_with_path(
         info!("[darwin] Skipping privileged helper for App Management-sensitive activation");
     }
 
-    // Escape a value for safe embedding inside a shell single-quoted string.
-    let sq = |s: &str| s.replace('\'', "'\\''");
+    // Interactive fallback: one native admin prompt (Touch ID capable), then
+    // re-execute this binary in root-activation mode. The privileged step is
+    // fixed Rust code mirroring the helper daemon — direct exec of absolute
+    // programs with a fixed root-owned environment. No sudoers rules, EXIT
+    // traps, or requester-controlled PATH/HOME reach root.
+    let root_args = root_activation::RootActivationArgs {
+        // SAFETY: `getuid` is thread-safe, has no preconditions, and cannot fail.
+        uid: unsafe { libc::getuid() },
+        activate_path: real_activate,
+        ssh_auth_sock: std::env::var("SSH_AUTH_SOCK")
+            .ok()
+            .filter(|sock| !sock.is_empty()),
+    };
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("Failed to resolve current executable: {}", e))?;
+    let shell_command = root_activation::shell_command(&exe.to_string_lossy(), &root_args);
 
-    // Build the privileged shell script that runs as root via osascript.
-    // It:
-    //   1. Creates a temp NOPASSWD sudoers rule for this exact nix store path.
-    //   2. Uses `launchctl asuser` to switch into the user's Aqua bootstrap
-    //      domain before calling sudo, so the activation script sees
-    //      `launchctl managername == "Aqua"`.
-    //   3. Removes the temp sudoers file via a trap on exit.
-    let shell_script = format!(
-        "set -e\n\
-         ACTIVATE='{activate}'\n\
-         USER_ID=$(id -u '{user}')\n\
-         \n\
-         trap 'rm -f /etc/sudoers.d/nixmac-activate-temp' EXIT\n\
-         \n\
-         printf '%s ALL=(ALL) NOPASSWD: %s\\n' '{user}' \"$ACTIVATE\" \
-             > /etc/sudoers.d/nixmac-activate-temp\n\
-         chmod 440 /etc/sudoers.d/nixmac-activate-temp\n\
-         visudo -cf /etc/sudoers.d/nixmac-activate-temp >/dev/null\n\
-         \n\
-         export PATH='{path}'\n\
-         export HOME='{home}'\n\
-         export SSH_AUTH_SOCK='{sock}'\n\
-         launchctl asuser \"$USER_ID\" sudo -E -n \"$ACTIVATE\" 2>&1\n\
-         SYSTEM_PATH=$(dirname \"$ACTIVATE\")\n\
-         nix-env -p /nix/var/nix/profiles/system --set \"$SYSTEM_PATH\" || true",
-        activate = sq(&real_activate),
-        user = sq(&user),
-        path = sq(&nix_path),
-        home = sq(&home),
-        sock = sq(&ssh_sock),
-    );
-
-    // Escape the shell script for embedding in an AppleScript string literal:
+    // Escape the command for embedding in an AppleScript string literal:
     //   \ → \\ and " → \"
-    let escaped_script = shell_script.replace('\\', "\\\\").replace('"', "\\\"");
+    let escaped_command = shell_command.replace('\\', "\\\\").replace('"', "\\\"");
 
     let osascript_cmd = format!(
         "do shell script \"{}\" with administrator privileges",
-        escaped_script
+        escaped_command
     );
 
-    info!("[darwin] Running activation with launchctl asuser (Aqua bootstrap domain)");
+    info!("[darwin] Running interactive activation via root re-exec of the app binary");
 
-    let output = Command::new("osascript")
+    let output = Command::new("/usr/bin/osascript")
         .args(["-e", &osascript_cmd])
         .output()
         .map_err(|e| anyhow::anyhow!("Failed to run osascript: {}", e))?;
@@ -1187,7 +1167,8 @@ fn run_darwin_rebuild(
 
     if !activate_result.success {
         summarizer.complete(false);
-        // Write and emit activation output (osascript uses `2>&1`, so useful details are often in stdout)
+        // Write and emit activation output (the privileged step merges stderr
+        // into stdout, so useful details are often in stdout)
         let mut stdout_lines: Vec<String> = Vec::new();
         for line in activate_result.stdout.lines() {
             if !line.is_empty() {


### PR DESCRIPTION
## Summary

Same fixes as [A1](https://github.com/darkmatter/nixmac/pull/585) but for the path of no-helper

Internal code `A2`


## Test Plan

- [x] Manually tested activation via no-helper path

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
