### PR TITLE
fix: intended behavior of regex vs non-regex in `search_packages`

### DIFF
--- a/apps/native/src-tauri/src/evolve/search_packages.rs
+++ b/apps/native/src-tauri/src/evolve/search_packages.rs
@@ -72,6 +72,35 @@ fn channel_is_registered(registry_list: &str, channel: &str) -> bool {
     })
 }
 
+/// Splits the query terms into the appropriate argument(s) for the nix search command, handling regex vs. non-regex searches.
+fn build_search_queries(query: &str, use_regex: bool) -> Result<Vec<String>> {
+    // Nix search supports regex implicitly. So if the user wants non-"regex"
+    // search, we need to pin with ^$.
+    // It also returns search results for both name and description so there
+    // is no point to have separate "search types".
+    // It also treats multiple regex arguments as separate search terms.
+    // Anchor the overall search while allowing punctuation, such as "-",
+    // between terms:
+    //
+    // "google chrome" -> ["^google", "chrome$"]
+    if use_regex {
+        return Ok(vec![query.to_string()]);
+    }
+
+    // Anchor the first and last terms to avoid partial matches, but allow punctuation between terms.
+    let anchored_query = format!("^{}$", query);
+    let terms = anchored_query
+        .split_whitespace()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+
+    if terms.is_empty() {
+        anyhow::bail!("package search query cannot be empty");
+    }
+
+    Ok(terms)
+}
+
 /// Search a single channel and return a list of SearchPackageResult
 /// results.
 fn search_single_channel(
@@ -80,19 +109,12 @@ fn search_single_channel(
     use_regex: bool,
     channel: &str,
 ) -> Result<Vec<SearchPackageResult>> {
-    // Nix search supports regex implicitly. So if the user wants non-"regex"
-    // search, we need to pin it with ^$.
-    // It also returns search results for both name and description so there
-    // is no point to have separate "search types".
-    let search_query = match use_regex {
-        false => format!("^{}$", query_term), // Search in attr path (package name)
-        true => query_term.to_string(),
-    };
+    let search_queries = build_search_queries(query_term, use_regex)?;
 
     let mut cmd = Command::new("nix");
     cmd.args(["search", channel]);
 
-    cmd.arg(&search_query)
+    cmd.args(&search_queries)
         .arg("--json")
         .current_dir(config_dir)
         .env("PATH", crate::system::nix::get_nix_path())
@@ -493,5 +515,23 @@ mod tests {
             registry_list,
             "unregistered-channel"
         ));
+    }
+
+    #[test]
+    fn build_search_queries_no_regex() {
+        let query = "google chrome";
+        let use_regex = false;
+        let expected = vec!["^google", "chrome$"];
+        let result = build_search_queries(query, use_regex).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn build_search_queries_with_regex() {
+        let query = "google chrome";
+        let use_regex = true;
+        let expected = vec!["google chrome"];
+        let result = build_search_queries(query, use_regex).unwrap();
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
## Summary

`search_packages` is overly strict in a way that's not really intended, and that's resulting in a lot of unnecessary package searching during agent execution.

For example, if you tell the agent to "install google chrome", one possible (and quite likely) agent tool execution is to search packages for "google chrome". Previously we would translate that into a nix package search for `'^google chrome$'` -- note that's quoted, so it doesn't match `google-chrome` so we're at the mercy of the agent to retry with the correct thing. In some of my testing especially for less common packages it often runs out of luck doing that.

On the other hand, if we run a nix package search for `^google chrome$` -- no quotes, we can match `google-chrome` straight-away. That's because those are passed as separate arguments which as far as nix package search is concerned are separate searches. Again in my testing this seems to be a lot better experience. I considered whether we really even want the anchors anymore after this; I chose to leave them as it's a slightly smaller change.

In the rare case that the agent actually requests a real regex search, we pass a single argument to nix package search to make that work correctly.

<!-- What does this PR do? Why? -->

## Test Plan

New unit tests for the query-term builder, and manual testing for things like "jetbrains mono", "google chrome" etc.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed