### PR TITLE
fix: mark rebuild needed immediately after git pull

### DIFF
--- a/apps/native/src-tauri/src/commands/git.rs
+++ b/apps/native/src-tauri/src/commands/git.rs
@@ -168,8 +168,10 @@ pub async fn pull_from_upstream(app: AppHandle) -> Result<shared_types::OkResult
 
     match decision {
         git::auto_update::AutoUpdateDecision::UpdateAndRebuild { .. } => {
-            // Fast-forward succeeded; immediately hide the stale banner.
-            crate::state::git_state::set_upstream_update_available(&app, false);
+            // Fast-forward succeeded -- update the git state so that things
+            // that watch it (e.g. the UI rebuild-needed banner) can react to the new state.
+            // Marking rebuild-needed invalidates checks started against the pre-pull repository state.
+            crate::state::git_state::mark_upstream_update_applied(&app);
         }
         git::auto_update::AutoUpdateDecision::Noop(_) => {
             // The banner was stale: nothing needed updating. Clear it and
@@ -194,7 +196,6 @@ pub async fn pull_from_upstream(app: AppHandle) -> Result<shared_types::OkResult
             // (no rollback possible even though it suggests otherwise, plus
             // bogus diff rows between the previous commit and the HEAD would
             // be presented).
-            // TODO: Update the "Review" screen to handle this new use case properly.
             evolve_state::refresh(&app, &status.changes);
             if status.clean_head {
                 crate::state::change_map::clear(&app);

--- a/apps/native/src-tauri/src/state/git_state.rs
+++ b/apps/native/src-tauri/src/state/git_state.rs
@@ -13,9 +13,10 @@ use crate::shared_types::{GitState, GitStatus};
 
 pub const GIT_STATE_CHANGED_EVENT: &str = "git_state_changed";
 
-/// Coordinates asynchronous rebuild-needed checks with successful builds.
-/// A mutex makes validating a check revision and writing its result atomic
-/// with invalidating checks after activation.
+/// Coordinates asynchronous rebuild-needed checks with commands that already
+/// know the projection changed (like pulls and successful builds).
+/// The lock is held through the state write so an invalidation cannot race between
+/// validation and publication.
 static REBUILD_NEEDED_REVISION: Mutex<u64> = Mutex::new(0);
 
 pub fn load_observable<R: Runtime>(app: &AppHandle<R>) -> Observable<GitState> {
@@ -63,11 +64,8 @@ pub fn set_rebuild_needed_from_check<R: Runtime>(
     revision: u64,
     needed: bool,
 ) -> bool {
-    let should_apply = {
-        let current_revision = REBUILD_NEEDED_REVISION.lock().unwrap();
-        *current_revision == revision
-    };
-    if !should_apply {
+    let current_revision = REBUILD_NEEDED_REVISION.lock().unwrap();
+    if *current_revision != revision {
         return false;
     }
     set_rebuild_needed(app, needed);
@@ -78,12 +76,27 @@ pub fn set_rebuild_needed_from_check<R: Runtime>(
 /// in-flight check has been replaced or discarded. Invalidates older checks
 /// so they cannot publish a result derived from the previous working tree.
 pub fn invalidate_rebuild_needed<R: Runtime>(app: &AppHandle<R>) {
-    {
-        let mut revision = REBUILD_NEEDED_REVISION.lock().unwrap();
-        *revision = revision.wrapping_add(1);
-    }
+    set_known_rebuild_needed(app, false);
+}
 
-    set_rebuild_needed(app, false);
+/// Record a successful upstream fast-forward as one observable transition:
+/// the offered update is consumed and the new configuration needs activation.
+/// Invalidates older asynchronous checks so a result computed from the
+/// pre-update tree cannot clear the rebuild flag after this write.
+pub fn mark_upstream_update_applied<R: Runtime>(app: &AppHandle<R>) {
+    let mut revision = REBUILD_NEEDED_REVISION.lock().unwrap();
+    *revision = revision.wrapping_add(1);
+    app.state::<Observable<GitState>>()
+        .update_if_changed(|state| {
+            state.upstream_update_available = false;
+            state.rebuild_needed = true;
+        });
+}
+
+fn set_known_rebuild_needed<R: Runtime>(app: &AppHandle<R>, needed: bool) {
+    let mut revision = REBUILD_NEEDED_REVISION.lock().unwrap();
+    *revision = revision.wrapping_add(1);
+    set_rebuild_needed(app, needed);
 }
 
 /// Record a fresh status snapshot, clearing the external-build flag.


### PR DESCRIPTION
## Summary

This cleans up a (smaller-than-I-originally-expected) work item left over from the git fast-forward and rebuild detection, namely that we should immediately go to the Review screen instead of having to wait for the next rebuild-needed detection tick in the watcher.

<!-- What does this PR do? Why? -->

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed