### PR TITLE
feat(ai): native tools

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
           NIXMAC_ENV: production
   build:
     needs: rust-tests
-    runs-on: depot-macos-latest
+    runs-on: [self-hosted, macOS]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
           NIXMAC_ENV: production
   build:
     needs: rust-tests
-    runs-on: [self-hosted, macOS]
+    runs-on: depot-macos-latest
     permissions:
       contents: write
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,6 +3702,7 @@ dependencies = [
  "fuzzy-matcher",
  "git2",
  "hex",
+ "hmac",
  "http",
  "libc",
  "libsqlite3-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast-grep-core"
+version = "0.39.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057ae90e7256ebf85f840b1638268df0142c9d19467d500b790631fd301acc27"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex",
+ "thiserror 2.0.18",
+ "tree-sitter",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1247,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1689,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -2371,6 +2406,83 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "grep-cli"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf32d263c5d5cc2a23ce587097f5ddafdb188492ba2e6fb638eaccdc22453631"
+dependencies = [
+ "bstr",
+ "globset",
+ "libc",
+ "log",
+ "termcolor",
+ "winapi-util",
+]
+
+[[package]]
+name = "grep-matcher"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9417543f4870fc8f1c8e1af870afae2431007626d9e703fce6471c468d33847"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-pcre2"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b752bb6f57dd3716e55b63a33ca05b5825c3d66cd427468874a5564af6ca365c"
+dependencies = [
+ "grep-matcher",
+ "log",
+ "pcre2",
+]
+
+[[package]]
+name = "grep-printer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd76035e87871f51c1ee5b793e32122b3ccf9c692662d9622ef1686ff5321acb"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "grep-searcher",
+ "log",
+ "serde",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72348823a0eafc4bc2e9051064f28b5b42cc100b571b3a35d67918d711efcbc6"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
 ]
 
 [[package]]
@@ -3393,6 +3505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,9 +3701,7 @@ dependencies = [
  "futures-util",
  "fuzzy-matcher",
  "git2",
- "glob",
  "hex",
- "hmac",
  "http",
  "libc",
  "libsqlite3-sys",
@@ -3596,6 +3715,11 @@ dependencies = [
  "opentelemetry_sdk",
  "orpc",
  "orpc-specta",
+ "pi-ast",
+ "pi-iso",
+ "pi-uutils-ctx",
+ "pi-walker",
+ "pi_uu_grep",
  "plist",
  "r2d2",
  "regex",
@@ -4386,6 +4510,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pcre2"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e970b0fcce0c7ee6ef662744ff711f21ccd6f11b7cf03cd187a80e89797fc67"
+dependencies = [
+ "libc",
+ "log",
+ "pcre2-sys",
+]
+
+[[package]]
+name = "pcre2-sys"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b9073c1a2549bd409bf4a32c94d903bb1a09bf845bc306ae148897fa0760a4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4614,6 +4760,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pi-ast"
+version = "17.1.2"
+dependencies = [
+ "anyhow",
+ "ast-grep-core",
+ "globset",
+ "ignore",
+ "phf 0.13.1",
+ "serde",
+ "tree-sitter",
+ "tree-sitter-astro-next",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-clojure",
+ "tree-sitter-cmake",
+ "tree-sitter-cpp",
+ "tree-sitter-css",
+ "tree-sitter-dart",
+ "tree-sitter-diff",
+ "tree-sitter-dockerfile-updated",
+ "tree-sitter-elisp",
+ "tree-sitter-elixir",
+ "tree-sitter-erlang",
+ "tree-sitter-fortran",
+ "tree-sitter-go",
+ "tree-sitter-graphql",
+ "tree-sitter-haskell",
+ "tree-sitter-hcl",
+ "tree-sitter-html",
+ "tree-sitter-ini",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-julia",
+ "tree-sitter-just",
+ "tree-sitter-kotlin-sg",
+ "tree-sitter-lua",
+ "tree-sitter-make",
+ "tree-sitter-md",
+ "tree-sitter-nix",
+ "tree-sitter-objc",
+ "tree-sitter-ocaml",
+ "tree-sitter-odin",
+ "tree-sitter-php",
+ "tree-sitter-powershell",
+ "tree-sitter-proto",
+ "tree-sitter-python",
+ "tree-sitter-r",
+ "tree-sitter-regex",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-scala",
+ "tree-sitter-sequel",
+ "tree-sitter-solidity",
+ "tree-sitter-starlark",
+ "tree-sitter-svelte-next",
+ "tree-sitter-swift",
+ "tree-sitter-tlaplus",
+ "tree-sitter-toml-ng",
+ "tree-sitter-typescript",
+ "tree-sitter-verilog",
+ "tree-sitter-vue-next",
+ "tree-sitter-xml",
+ "tree-sitter-yaml",
+ "tree-sitter-zig",
+]
+
+[[package]]
+name = "pi-iso"
+version = "17.1.2"
+dependencies = [
+ "async-trait",
+ "libc",
+ "parking_lot",
+ "similar",
+ "tokio",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pi-uutils-ctx"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "pi-walker"
+version = "17.1.2"
+dependencies = [
+ "dashmap",
+ "globset",
+ "ignore",
+ "libc",
+ "parking_lot",
+ "rayon",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pi_uu_grep"
+version = "0.8.0"
+dependencies = [
+ "clap",
+ "globset",
+ "grep-cli",
+ "grep-matcher",
+ "grep-pcre2",
+ "grep-printer",
+ "grep-regex",
+ "grep-searcher",
+ "ignore",
+ "parking_lot",
+ "pi-uutils-ctx",
+ "pi-walker",
+ "serde_json",
 ]
 
 [[package]]
@@ -5118,6 +5384,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "read-progress-stream"
@@ -5820,6 +6106,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -6070,6 +6357,15 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "siphasher"
@@ -6458,6 +6754,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -7401,6 +7703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7923,6 +8234,588 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-astro-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a4a59fc2d88e49b4bc41fef9522d77184a36f4e68bbaf545cd1eb2364c46e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-clojure"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4004884cc509449a1d78fa3e1f02b4e953d0a8065984445304795e72e885338c"
+dependencies = [
+ "cc",
+ "tree-sitter",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cmake"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164e0c4f4236ec5ceff14824a5528615cf462e100467e49826442ff57d327061"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-css"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cbc5e18f29a2c6d6435891f42569525cf95435a3e01c2f1947abcde178686f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dart"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-diff"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe1e5ca280a65dfe5ba4205c1bcc84edf486464fed315db53dee6da9a335889"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dockerfile-updated"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e61eb704364be179ab9be89e2891c8e77c0041eca5891a5c04164a21f6df7a0"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-elisp"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2e9a6ab3cebf24ca41cdc1f985549b9b33f7ef25c19ac7d18e53a4ee24da09"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-erlang"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb442e728225d601db0661f60d64e166bd9b9a55c587f71d4e4f27378717cce"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-fortran"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5fea41363a9b59666001dc26c4b356d4e164da27c6ce31145e00aba6bf9b16"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-graphql"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efedc4cac157161cc23a0adc4553a2cedc908e1cd754b6cd033a919bb81ce5d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-haskell"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977c51e504548cba13fc27cb5a2edab2124cf6716a1934915d07ab99523b05a4"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ini"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387f79682cd53b7c0a5777c96e601a02b9965a787984ef86dbb8952bdab2d62f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-julia"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4144731a178812ee867619b1e98b3b91e54c1652304b26e5ebe3175b701de323"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-just"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd46794f2c270f43d73b2f2c8c256992471f3493c903604da0886df984771920"
+dependencies = [
+ "cc",
+ "tree-sitter",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-sg"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06ec43ae3c12165d4ac08afe4e1f5fc6757ffe274fa7bd5af9007ef11ba4319"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-make"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5998dc7cbcbdab19fae8aefef982bf2d6544513d8d2e69cc44aec4c63810104"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-nix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4952a9733f3a98f6683a0ccd1035d84ab7a52f7e84eeed58548d86765ad92de3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-objc"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca8bb556423fc176f0535e79d525f783a6684d3c9da81bf9d905303c129e1d2"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ocaml"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d19db582b3855f56b5f9ec484170fbfb9ee60b938ec7720d76d2ee788e8b640"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-odin"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24db210fe9ba2237c71c5030d7b146c7025420ba72dd8013d13cd822c3a8d77a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e410ccb5fa3cbd6bf7b8e512ecf7ad9d5254395b822bfe9f751b50fa978f31c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-r"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc9954ec870dcad6cffdd302b405306c68cf031ed79a78cd9746f6740d9fe20"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-regex"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8a59be9f0ac131fd8f062eaaba14882b2fa5a6a7882a20134cb1d60df2e625"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5a4a7ff23a55474ce6a741d52aaeca7a82fe9421bb982b86e98c6ac8629397"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-sequel"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-solidity"
+version = "1.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eacf8875b70879f0cb670c60b233ad0b68752d9e1474e6c3ef168eea8a90b25"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-starlark"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8934f282d085cc4b9ee28aa688aa3fbe8aa3766201c2a6252f411d45b4c3a721"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-svelte-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f88190d0743e897c3e148a7e241aba0a8844b8afe816943851426e3f7b9753"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-tlaplus"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddaacc0337bfee38f233a91a704dc36b887a0c385348163f65344d64b73f79e1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-verilog"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e7e0360395852f1f6ff5b7b82c72dc6557d181073188df1d60ec469ea69c66"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-vue-next"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ac89acaa8165aaabfa8ae9683aa423b0d2bf42c815dae5ca031a36a75525f1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-xml"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e670041f591d994f54d597ddcd8f4ebc930e282c4c76a42268743b71f0c8b6b3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ members = [
   "apps/native/src-tauri",
   "apps/native/src-tauri/configurable",
   "apps/native/src-tauri/configurable-derive",
+  # Vendored Oh My Pi extracts — see crates/vendor/oh-my-pi/VENDOR.md
+  "crates/vendor/oh-my-pi/pi-walker",
+  "crates/vendor/oh-my-pi/pi-uutils-ctx",
+  "crates/vendor/oh-my-pi/pi-uu-grep",
+  "crates/vendor/oh-my-pi/pi-iso",
+  "crates/vendor/oh-my-pi/pi-ast",
 ]
 resolver = "2"
 

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -57,7 +57,6 @@ tempfile = "3.23.0"
 async-openai = "0.30.1"
 futures-util = "0.3"
 async-trait = "0.1"
-glob = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 once_cell = "1.21.3"
@@ -116,6 +115,14 @@ tauri-plugin-opener = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-os = "2"
 tauri-plugin-macos-passkey = "0.1.0"
+
+# Vendored Oh My Pi extracts (not wired into evolve tools yet).
+# See crates/vendor/oh-my-pi/VENDOR.md
+pi-walker = { path = "../../../crates/vendor/oh-my-pi/pi-walker" }
+pi-uutils-ctx = { path = "../../../crates/vendor/oh-my-pi/pi-uutils-ctx" }
+pi_uu_grep = { path = "../../../crates/vendor/oh-my-pi/pi-uu-grep" }
+pi-iso = { path = "../../../crates/vendor/oh-my-pi/pi-iso" }
+pi-ast = { path = "../../../crates/vendor/oh-my-pi/pi-ast" }
 
 [dependencies.tauri-plugin-sql]
 features = ["sqlite"] # or "postgres", or "mysql"

--- a/apps/native/src-tauri/resources/schemas/env.schema.json
+++ b/apps/native/src-tauri/resources/schemas/env.schema.json
@@ -37,8 +37,8 @@
       "type": "string"
     },
     "NIXMAC_EVOLUTION_MEMORY_STRATEGY": {
-      "default": "",
-      "description": "One of: none, retention.",
+      "default": "retention",
+      "description": "One of: none, retention. Default retention expires stale tool results so the context window does not fill until only a handful of output tokens remain.",
       "title": "Evolution memory strategy",
       "type": "string"
     },

--- a/apps/native/src-tauri/src/env/config.rs
+++ b/apps/native/src-tauri/src/env/config.rs
@@ -90,10 +90,10 @@ pub struct NixmacEnvSettings {
     pub debug_skip_restore_all: bool,
 
     #[config(
-        default = "",
+        default = "retention",
         env_var = "NIXMAC_EVOLUTION_MEMORY_STRATEGY",
         label = "Evolution memory strategy",
-        help = "One of: none, retention."
+        help = "One of: none, retention. Default retention expires stale tool results so the context window does not fill until only a handful of output tokens remain."
     )]
     pub evolution_memory_strategy: String,
 

--- a/apps/native/src-tauri/src/evolve/context_budget.rs
+++ b/apps/native/src-tauri/src/evolve/context_budget.rs
@@ -1,0 +1,264 @@
+//! Keep evolve provider calls from requesting a tiny leftover completion budget.
+//!
+//! When the filtered message history nearly fills the model window, we drop the
+//! oldest keyed tool results until there is room for a meaningful response
+//! (or stop the run if the irreducible core is still too large).
+
+use super::{EvolutionMessage, filter_evolution_messages};
+use crate::ai::model_capabilities::capabilities_for_model;
+use crate::evolve::messages::Message;
+use crate::summarize::token_budgets::{TokenAllocation, compute_token_allocation};
+use log::warn;
+
+/// Minimum completion budget we will send on an evolve request. Below this the
+/// model tends to emit truncated / empty tool calls and rabbit-hole — better to
+/// compact or stop than to request ~32 leftover tokens.
+pub(crate) const EVOLVE_MIN_OUTPUT_TOKENS: u32 = 1024;
+
+const MAX_DROPS: usize = 32;
+
+/// Flatten provider messages into text for token estimation.
+fn estimate_messages_prompt_text(messages: &[Message]) -> String {
+    let mut out = String::new();
+    for message in messages {
+        match message {
+            Message::System { content }
+            | Message::User { content }
+            | Message::Tool { content, .. } => {
+                out.push_str(content);
+                out.push('\n');
+            }
+            Message::Assistant {
+                content,
+                tool_calls,
+            } => {
+                if let Some(text) = content {
+                    out.push_str(text);
+                }
+                if let Some(calls) = tool_calls {
+                    for call in calls {
+                        out.push_str(&call.name);
+                        out.push('\n');
+                        out.push_str(&call.arguments);
+                        out.push('\n');
+                    }
+                }
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+fn allocate_evolve_completion(
+    messages: &[Message],
+    model: &str,
+    requested_output_tokens: u32,
+) -> TokenAllocation {
+    let prompt = estimate_messages_prompt_text(messages);
+    let context_window = capabilities_for_model(model).context_window_tokens;
+    compute_token_allocation(&prompt, requested_output_tokens, context_window)
+}
+
+fn find_oldest_keyed_tool_index(messages: &[EvolutionMessage]) -> Option<usize> {
+    messages
+        .iter()
+        .position(|m| m.key.is_some() && matches!(m.message, Message::Tool { .. }))
+}
+
+/// True when the message before `tool_idx` is a lone assistant tool-call turn for
+/// this id (no text). Dropping that pair keeps the provider transcript valid.
+fn is_lone_tool_call_assistant(
+    messages: &[EvolutionMessage],
+    tool_idx: usize,
+    tool_call_id: &str,
+) -> bool {
+    if tool_idx == 0 {
+        return false;
+    }
+
+    let Message::Assistant {
+        tool_calls: Some(calls),
+        content,
+    } = &messages[tool_idx - 1].message
+    else {
+        return false;
+    };
+
+    if calls.len() != 1 || calls[0].id != tool_call_id {
+        return false;
+    }
+
+    content.as_ref().is_none_or(|c| c.trim().is_empty())
+}
+
+/// Drop the oldest keyed tool result (and its paired assistant tool-call turn when
+/// that turn only existed to produce this result). Used under context pressure so
+/// we free room for a meaningful completion instead of requesting ~32 tokens.
+fn drop_oldest_keyed_tool_result(messages: &mut Vec<EvolutionMessage>) -> bool {
+    let Some(tool_idx) = find_oldest_keyed_tool_index(messages) else {
+        return false;
+    };
+
+    let tool_call_id = match &messages[tool_idx].message {
+        Message::Tool { tool_call_id, .. } => tool_call_id.clone(),
+        _ => return false,
+    };
+
+    if is_lone_tool_call_assistant(messages, tool_idx, &tool_call_id) {
+        // Remove tool result first so indices stay valid, then the assistant turn.
+        messages.remove(tool_idx);
+        messages.remove(tool_idx - 1);
+        return true;
+    }
+
+    messages.remove(tool_idx);
+    true
+}
+
+fn context_full_error(provider_messages: &[Message], model: &str, output_tokens: u32) -> String {
+    format!(
+        "Context window is full ({}/{} tokens estimated for input) with only {} completion tokens left. \
+         Compaction could not free enough room for a meaningful response. Try a shorter prompt or a model with a larger context window.",
+        estimate_messages_prompt_text(provider_messages).len() / 4,
+        capabilities_for_model(model).context_window_tokens,
+        output_tokens
+    )
+}
+
+/// Ensure the active provider payload leaves enough room for a useful completion.
+/// Compacts by dropping oldest keyed tool results until the allocation clears the
+/// floor, or returns an error if even the irreducible core is too large.
+pub(crate) fn ensure_meaningful_completion_budget(
+    messages: &mut Vec<EvolutionMessage>,
+    iteration: usize,
+    made_build_check: bool,
+    model: &str,
+    requested_output_tokens: u32,
+) -> Result<u32, String> {
+    let min_required = EVOLVE_MIN_OUTPUT_TOKENS.min(requested_output_tokens);
+
+    for _ in 0..MAX_DROPS {
+        let active = filter_evolution_messages(messages, iteration, made_build_check);
+        let provider_messages: Vec<Message> = active.iter().map(|m| m.message.clone()).collect();
+        let allocation =
+            allocate_evolve_completion(&provider_messages, model, requested_output_tokens);
+
+        if allocation.output_tokens >= min_required {
+            return Ok(allocation.output_tokens.min(requested_output_tokens));
+        }
+
+        if !drop_oldest_keyed_tool_result(messages) {
+            return Err(context_full_error(
+                &provider_messages,
+                model,
+                allocation.output_tokens,
+            ));
+        }
+
+        warn!(
+            "Context pressure: dropped oldest keyed tool result to free completion budget (had {} output tokens available)",
+            allocation.output_tokens
+        );
+    }
+
+    Err(
+        "Context window remained too full after compaction; stopping before sending a truncated-completion request."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evolve::messages::ToolCall;
+
+    #[test]
+    fn drops_keyed_tool_results_under_pressure() {
+        let mut messages = vec![
+            EvolutionMessage::permanent(
+                Message::System {
+                    content: "System prompt".to_string(),
+                },
+                0,
+                None,
+            ),
+            EvolutionMessage::permanent(
+                Message::User {
+                    content: "do the thing".to_string(),
+                },
+                0,
+                None,
+            ),
+        ];
+
+        // Pair an assistant tool call with a large keyed tool result so the
+        // pressure gate must drop them. Unique tokens (not repeated chars) so
+        // tiktoken cannot compress the fixture under the model window.
+        let huge: String = (0..12_000).map(|i| format!("token{i} ")).collect();
+        messages.push(EvolutionMessage::permanent(
+            Message::Assistant {
+                content: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call-1".to_string(),
+                    name: "read_file".to_string(),
+                    arguments: "{\"path\":\"big.nix\"}".to_string(),
+                }]),
+            },
+            1,
+            None,
+        ));
+        messages.push(EvolutionMessage::recent(
+            Message::Tool {
+                tool_call_id: "call-1".to_string(),
+                content: huge,
+            },
+            1,
+            4,
+            Some("big.nix".to_string()),
+        ));
+
+        let before = messages.len();
+        let tokens = ensure_meaningful_completion_budget(
+            &mut messages,
+            2,
+            false,
+            "unknown-model", // 8k context window
+            4_000,
+        )
+        .expect("should compact enough room for a meaningful completion");
+
+        assert!(tokens >= EVOLVE_MIN_OUTPUT_TOKENS.min(4_000));
+        assert!(messages.len() < before);
+    }
+
+    #[test]
+    fn lone_assistant_tool_call_is_detected() {
+        let messages = vec![
+            EvolutionMessage::permanent(
+                Message::Assistant {
+                    content: None,
+                    tool_calls: Some(vec![ToolCall {
+                        id: "call-1".to_string(),
+                        name: "read_file".to_string(),
+                        arguments: "{}".to_string(),
+                    }]),
+                },
+                1,
+                None,
+            ),
+            EvolutionMessage::recent(
+                Message::Tool {
+                    tool_call_id: "call-1".to_string(),
+                    content: "ok".to_string(),
+                },
+                1,
+                4,
+                Some("path".to_string()),
+            ),
+        ];
+
+        assert!(is_lone_tool_call_assistant(&messages, 1, "call-1"));
+        assert!(!is_lone_tool_call_assistant(&messages, 1, "other"));
+    }
+}

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -106,6 +106,7 @@ where
     let content = std::fs::read_to_string(&full_path).with_context(|| fail("read"))?;
     let new_content = edit(&content).with_context(|| fail("edit"))?;
     std::fs::write(&full_path, new_content).with_context(|| fail("write"))?;
+    invalidate_walk_cache(&full_path);
 
     Ok(())
 }
@@ -387,6 +388,7 @@ pub fn apply_file_edits(
             }
             validate_file_content(&edit.path, &edit.replace)?;
             std::fs::write(&full_path, &edit.replace)?;
+            invalidate_walk_cache(&full_path);
             return Ok(());
         }
 
@@ -401,6 +403,7 @@ pub fn apply_file_edits(
         }
         validate_file_content(&edit.path, &edit.replace)?;
         std::fs::write(&full_path, &edit.replace)?;
+        invalidate_walk_cache(&full_path);
     } else {
         rewrite_existing_file_in_dir(
             base,
@@ -433,6 +436,11 @@ pub fn apply_file_edits(
     }
 
     Ok(())
+}
+
+/// Drop pi-walker scan-cache entries that cover `path` after an edit.
+fn invalidate_walk_cache(path: &Path) {
+    pi_walker::invalidate_path(path);
 }
 
 fn reject_gitignored_edit_path(

--- a/apps/native/src-tauri/src/evolve/isolation.rs
+++ b/apps/native/src-tauri/src/evolve/isolation.rs
@@ -1,0 +1,167 @@
+//! CoW workspace isolation for future evolve subagents (`pi-iso`).
+//!
+//! Creates a writable clone of a read-only config tree without a deep copy
+//! when the platform supports it (APFS clonefile on macOS, etc.), falling
+//! back to `git worktree` / recursive copy.
+//!
+//! No evolve caller yet; keep the API compiled so subagents can adopt it
+//! without reintroducing a path-only dep.
+#![allow(dead_code)]
+
+use anyhow::{Context, Result, anyhow};
+use log::info;
+use pi_iso::{BackendKind, IsoError, backend, resolve};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// A temporary isolated view of `lower` that is torn down on drop.
+pub struct IsolatedWorkspace {
+    _scratch: TempDir,
+    lower: PathBuf,
+    merged: PathBuf,
+    kind: BackendKind,
+}
+
+impl IsolatedWorkspace {
+    /// Absolute path of the writable merged tree (agent working directory).
+    pub fn merged(&self) -> &Path {
+        &self.merged
+    }
+
+    /// Absolute path of the read-only source tree that was cloned.
+    pub fn lower(&self) -> &Path {
+        &self.lower
+    }
+
+    /// Backend that materialised this workspace.
+    pub fn backend_kind(&self) -> BackendKind {
+        self.kind
+    }
+
+    /// Diff `merged` against `lower` (git diff when applicable).
+    pub async fn diff(&self) -> Result<pi_iso::Diff> {
+        backend(self.kind)
+            .diff(&self.lower, &self.merged)
+            .await
+            .map_err(iso_to_anyhow)
+    }
+}
+
+impl Drop for IsolatedWorkspace {
+    fn drop(&mut self) {
+        if let Err(err) = backend(self.kind).stop(&self.merged) {
+            log::warn!(
+                "isolation stop failed for {} ({}): {}",
+                self.merged.display(),
+                self.kind,
+                err
+            );
+        }
+    }
+}
+
+/// Probe and start an isolated writable clone of `lower` under a temp dir.
+///
+/// Retries remaining [`pi_iso::resolve`] candidates when `start` returns
+/// unavailable (e.g. APFS clone across volumes).
+pub fn create_isolated_workspace(lower: &Path) -> Result<IsolatedWorkspace> {
+    let lower = lower
+        .canonicalize()
+        .with_context(|| format!("canonicalize isolation lower {}", lower.display()))?;
+    if !lower.is_dir() {
+        return Err(anyhow!(
+            "isolation lower must be a directory: {}",
+            lower.display()
+        ));
+    }
+
+    let resolution = resolve(None);
+    let scratch = TempDir::new().context("create isolation scratch dir")?;
+    let merged = scratch.path().join("merged");
+
+    let mut last_err: Option<IsoError> = None;
+    for kind in resolution.candidates {
+        let be = backend(kind);
+        match be.start(&lower, &merged) {
+            Ok(()) => {
+                info!(
+                    "isolation started: backend={} lower={} merged={}",
+                    kind,
+                    lower.display(),
+                    merged.display()
+                );
+                return Ok(IsolatedWorkspace {
+                    _scratch: scratch,
+                    lower,
+                    merged,
+                    kind,
+                });
+            }
+            Err(err) if err.is_unavailable() => {
+                log::debug!("isolation backend {kind} unavailable: {err}");
+                last_err = Some(err);
+                let _ = std::fs::remove_dir_all(&merged);
+            }
+            Err(err) => return Err(iso_to_anyhow(err)),
+        }
+    }
+
+    Err(iso_to_anyhow(last_err.unwrap_or_else(|| {
+        IsoError::unavailable("no isolation backend available")
+    })))
+}
+
+fn iso_to_anyhow(err: IsoError) -> anyhow::Error {
+    anyhow!("isolation: {err}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_isolated_workspace;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn isolated_workspace_is_writable_clone() {
+        let lower = tempdir().expect("lower");
+        let repo = git2::Repository::init(lower.path()).expect("init git");
+        fs::write(lower.path().join("flake.nix"), "{ }").expect("seed");
+        // Seed an initial commit so backends that use git worktrees / git diff
+        // have a real HEAD (APFS clonefile itself does not need this).
+        {
+            let mut index = repo.index().expect("index");
+            index
+                .add_path(std::path::Path::new("flake.nix"))
+                .expect("add");
+            let tree_id = index.write_tree().expect("write_tree");
+            let tree = repo.find_tree(tree_id).expect("tree");
+            let sig = git2::Signature::now("test", "test@example.com").expect("sig");
+            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+                .expect("commit");
+        }
+
+        let iso = create_isolated_workspace(lower.path()).expect("start isolation");
+        assert!(iso.merged().join("flake.nix").is_file());
+        assert!(iso.lower().is_dir());
+        assert!(!iso.backend_kind().as_str().is_empty());
+        fs::write(iso.merged().join("extra.txt"), "from-agent").expect("write in merged");
+        assert!(
+            !lower.path().join("extra.txt").exists(),
+            "writes must not leak into lower"
+        );
+        assert_eq!(
+            fs::read_to_string(iso.merged().join("extra.txt")).expect("read"),
+            "from-agent"
+        );
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let diff = rt.block_on(iso.diff()).expect("diff");
+        assert!(
+            !diff.is_empty(),
+            "expected isolation diff to notice extra.txt"
+        );
+    }
+}

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -4,9 +4,11 @@ mod age;
 mod chat_memory;
 pub(crate) mod config;
 mod config_dir_context;
+mod context_budget;
 mod ensure_secret;
 pub(crate) mod file_ops;
 mod gitignore;
+pub(crate) mod isolation;
 pub mod messages;
 pub(crate) mod nix_file_editor;
 pub mod providers;
@@ -57,6 +59,7 @@ use chat_memory::{ChatMessage, Role as ChatMemoryRole, to_provider_context_messa
 
 pub(crate) use chat_memory::session_chat_memory_store;
 use config_dir_context::format_config_dir_context;
+use context_budget::ensure_meaningful_completion_budget;
 use messages::Message;
 use providers::{
     AiProvider, CliProvider, OllamaProvider, OpenAIProvider, ProviderError, StreamEvent,
@@ -76,9 +79,10 @@ impl MemoryStrategy {
             .evolution_memory_strategy
             .as_str()
         {
-            "" | "none" => MemoryStrategy::None,
-            "retention" => MemoryStrategy::Retention,
-            _ => MemoryStrategy::None,
+            // Empty inherits the profile default ("retention"). Opt out with "none".
+            "" | "retention" => MemoryStrategy::Retention,
+            "none" => MemoryStrategy::None,
+            _ => MemoryStrategy::Retention,
         }
     }
 }
@@ -517,16 +521,14 @@ fn retention_for_tool(tool_name: &str) -> Retention {
         // Multiple edits across iterations may be important but only temporarily.
         "edit_file" | "edit_nix_file" => Retention::Recent { keep_iterations: 3 },
 
-        // Everything else is informational or durable enough to keep for the whole run.
-        // In particular:
-        // 1. "search_packages", "search_docs", and "search_code" need to be durable so that the agent can
-        //      plan to add a bunch of requested packages in one shot toward the end.
-        // 2. "read_file" can be very large; however, the agent likes to read a
-        //      file up front, and then refer back to it at the end after it plans the edit.
-        // 3. "list_files" needs to persist because the agent tries to re-read things later,
-        //      and it's bad if it tries to read files that don't exist that are hallucinated
-        //      from training data.
-        // 4. "think" may contain the original plan up to the point where we start doing build checks.
+        // Large exploration payloads are the main context-window filler. Keep the
+        // latest copy via key dedup, but expire older reads/listings so long runs
+        // do not shrink remaining completion room to a few dozen tokens.
+        "read_file" | "list_files" => Retention::Recent { keep_iterations: 4 },
+
+        // Search results stay durable so the agent can plan multi-package edits
+        // toward the end of a turn without re-querying.
+        // "think" may contain the original plan up to the first build check.
         _ => Retention::Permanent,
     }
 }
@@ -1219,6 +1221,36 @@ pub async fn generate_evolution<R: Runtime>(
         }
 
         iteration += 1;
+
+        // Compact under context pressure before the provider call so we never
+        // send a request with only a handful of completion tokens left (that
+        // pattern produces truncated tool calls and agent loops).
+        let clamped_output_tokens = match ensure_meaningful_completion_budget(
+            &mut messages,
+            iteration,
+            made_build_check,
+            &provider.model_name(),
+            max_output_tokens_for_request,
+        ) {
+            Ok(tokens) => tokens,
+            Err(message) => {
+                warn!("Stopping evolution: {message}");
+                evolution.state = EvolutionState::Failed;
+                emit_evolve_event(
+                    app,
+                    EvolveEvent::error(start_time, Some(iteration), &message, &message),
+                );
+                return Err(EvolutionRunError::from_state(
+                    message,
+                    &evolution,
+                    iteration,
+                    build_attempts,
+                    total_tokens,
+                )
+                .into());
+            }
+        };
+        provider.set_max_output_tokens(clamped_output_tokens);
 
         // Run provider completion inside a short-lived block and select!
         // on it plus a cancellation signal. This lets the future borrow
@@ -2658,7 +2690,7 @@ mod tests {
         BUILD_OUTPUT_MAX_CHARS, DoneGate, Evolution, EvolutionMessage, EvolutionState, FileEdit,
         Message, Retention, ToolResult, filter_evolution_messages,
         normalize_openai_max_output_tokens, process_tool_result, read_file_dedup_key,
-        repeat_call_key, store_tool_result, truncate_build_output_for_model,
+        repeat_call_key, retention_for_tool, store_tool_result, truncate_build_output_for_model,
     };
 
     fn build_result(success: bool) -> ToolResult {
@@ -3032,14 +3064,36 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_evolution_messages_unknown_strategy_defaults_to_none() {
+    fn test_filter_evolution_messages_unknown_strategy_defaults_to_retention() {
         let (_lock, _restore) = set_memory_strategy_for_test("bogus-value");
         let messages = sample_messages();
 
         let out = filter_evolution_messages(&messages, 1000, false);
 
-        // Unknown values should safely default to none behavior.
-        assert!(out.len() == messages.len());
+        // Unknown values default to retention so production never silently
+        // disables compaction and fills the context window.
+        assert!(out.iter().all(
+            |m| !matches!(&m.message, Message::User { content } if content == "Short-lived message")
+        ));
+        assert!(out.iter().any(
+            |m| matches!(&m.message, Message::System { content } if content == "System prompt")
+        ));
+    }
+
+    #[test]
+    fn test_read_file_and_list_files_use_recent_retention() {
+        assert!(matches!(
+            retention_for_tool("read_file"),
+            Retention::Recent { keep_iterations: 4 }
+        ));
+        assert!(matches!(
+            retention_for_tool("list_files"),
+            Retention::Recent { keep_iterations: 4 }
+        ));
+        assert!(matches!(
+            retention_for_tool("search_packages"),
+            Retention::Permanent
+        ));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/evolve/providers/mod.rs
+++ b/apps/native/src-tauri/src/evolve/providers/mod.rs
@@ -255,6 +255,10 @@ pub trait AiProvider: Send + Sync {
     }
 
     fn model_name(&self) -> String;
+
+    /// Override the per-request completion budget. Used when context pressure
+    /// shrinks the remaining window so we do not request more tokens than fit.
+    fn set_max_output_tokens(&self, _max_output_tokens: u32) {}
 }
 
 /// Errors returned by AI providers in the evolve subsystem.

--- a/apps/native/src-tauri/src/evolve/providers/ollama.rs
+++ b/apps/native/src-tauri/src/evolve/providers/ollama.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 const DEFAULT_RETRY_ATTEMPTS: usize = 1;
 const RETRY_GUIDANCE: &str = "Retry the previous step. Return either valid structured tool_calls or concise assistant content. Do not emit empty content with no tool_calls. If using tool_calls, keep arguments as strict JSON only.";
@@ -12,7 +13,7 @@ pub struct OllamaProvider {
     client: reqwest_middleware::ClientWithMiddleware,
     base_url: String,
     model: String,
-    max_output_tokens: u32,
+    max_output_tokens: AtomicU32,
     record_chat_logs: bool,
 }
 
@@ -24,7 +25,7 @@ impl OllamaProvider {
             client: crate::http_client::logged(),
             base_url: base_url.trim_end_matches('/').to_string(),
             model,
-            max_output_tokens,
+            max_output_tokens: AtomicU32::new(max_output_tokens),
             record_chat_logs,
         }
     }
@@ -137,6 +138,11 @@ impl AiProvider for OllamaProvider {
         self.model.clone()
     }
 
+    fn set_max_output_tokens(&self, max_output_tokens: u32) {
+        self.max_output_tokens
+            .store(max_output_tokens.max(1), Ordering::Relaxed);
+    }
+
     fn supports_streaming(&self) -> bool {
         true
     }
@@ -157,7 +163,7 @@ impl AiProvider for OllamaProvider {
                 messages: ollama_messages.clone(),
                 stream: false,
                 options: OllamaOptions {
-                    num_predict: self.max_output_tokens,
+                    num_predict: self.max_output_tokens.load(Ordering::Relaxed),
                 },
                 tools: ollama_tools.clone(),
             };
@@ -285,7 +291,7 @@ impl AiProvider for OllamaProvider {
                 messages: ollama_messages.clone(),
                 stream: true,
                 options: OllamaOptions {
-                    num_predict: self.max_output_tokens,
+                    num_predict: self.max_output_tokens.load(Ordering::Relaxed),
                 },
                 tools: ollama_tools.clone(),
             };

--- a/apps/native/src-tauri/src/evolve/providers/openai.rs
+++ b/apps/native/src-tauri/src/evolve/providers/openai.rs
@@ -22,12 +22,13 @@ use async_trait::async_trait;
 use futures_util::StreamExt;
 use log::{info, warn};
 use reqwest::StatusCode;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 pub struct OpenAIProvider {
     client: Client<OpenAIConfig>,
     model: String,
     chat_completions_url: String,
-    max_output_tokens: u32,
+    max_output_tokens: AtomicU32,
 
     record_chat_logs: bool,
 }
@@ -45,7 +46,7 @@ impl OpenAIProvider {
             client,
             model,
             chat_completions_url,
-            max_output_tokens,
+            max_output_tokens: AtomicU32::new(max_output_tokens),
             record_chat_logs,
         }
     }
@@ -76,7 +77,7 @@ impl OpenAIProvider {
             request_builder.temperature(0.2);
         }
 
-        request_builder.max_completion_tokens(self.max_output_tokens);
+        request_builder.max_completion_tokens(self.max_output_tokens.load(Ordering::Relaxed));
 
         request_builder
             .build()
@@ -176,6 +177,11 @@ fn format_elapsed(start: std::time::Instant) -> String {
 impl AiProvider for OpenAIProvider {
     fn model_name(&self) -> String {
         self.model.clone()
+    }
+
+    fn set_max_output_tokens(&self, max_output_tokens: u32) {
+        self.max_output_tokens
+            .store(max_output_tokens.max(1), Ordering::Relaxed);
     }
 
     fn supports_streaming(&self) -> bool {

--- a/apps/native/src-tauri/src/evolve/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/search_code.rs
@@ -2,14 +2,36 @@ use super::gitignore::{GitignoreChecker, VisibleFiles};
 use super::utils::truncate_error;
 use anyhow::{Result, anyhow};
 use log::info;
+use pi_uutils_ctx::{ScopeIo, scope};
 use serde_json::Value;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io::{self, Write};
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
 
 // Maximum number of rg search results to return.
 const MAX_SEARCH_RESULTS: usize = 50;
 
-/// Execute a code search using ripgrep with a grep fallback.
+/// Sink that collects writes into a shared buffer (mirrors pi_uu_grep tests).
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .map_err(|_| io::Error::other("stdout buffer lock poisoned"))?
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Execute a code search using in-process ripgrep (`pi_uu_grep`).
 pub fn execute_search_code(
     base: &Path,
     pattern: &str,
@@ -22,25 +44,7 @@ pub fn execute_search_code(
         .map(|checker| checker.visible_files())
         .transpose()?;
 
-    let mut cmd = Command::new("rg");
-    cmd.args([
-        "--json",
-        "--color=never", // Disable color to simplify output parsing.
-        "--text",        // Treat all files as text to avoid binary file issues.
-        pattern,
-    ]);
-    // Do not pass --max-count here: that flag caps matches *per file*, so the
-    // total output could still far exceed MAX_SEARCH_RESULTS across many files.
-    // The global cap is enforced in format_rg_json_matches instead.
-
-    // Exclude common ignored directories from ripgrep results by adding
-    // negative glob patterns (e.g. `!.git/**/*`).
-    for d in super::IGNORED_DIRS {
-        cmd.arg("--glob").arg(format!("!{}/**/*", d));
-    }
-
     if let Some(fp) = file_pattern {
-        // Keep glob semantics for ripgrep while disallowing directory escapes.
         let fp_path = Path::new(fp);
         if fp_path.is_absolute() {
             return Err(anyhow!(
@@ -55,60 +59,69 @@ pub fn execute_search_code(
                 ));
             }
         }
-
-        cmd.arg("--glob").arg(fp);
     }
 
-    match cmd.current_dir(base).output() {
-        Ok(out) => {
-            let status = out.status;
-            if status.success() {
-                let formatted = format_rg_json_matches(&out.stdout, visible.as_ref());
-                if formatted.is_empty() {
-                    Ok("No matches found.".to_string())
-                } else {
-                    Ok(truncate_error(&formatted, 8000))
-                }
-            } else {
-                match status.code() {
-                    Some(1) => Ok("No matches found.".to_string()),
-                    Some(code) => {
-                        let stderr = String::from_utf8_lossy(&out.stderr);
-                        let truncated = truncate_error(&stderr, 8000);
-                        Err(anyhow!(
-                            "rg exited with status code {}: {}",
-                            code,
-                            truncated
-                        ))
-                    }
-                    None => {
-                        let stderr = String::from_utf8_lossy(&out.stderr);
-                        let truncated = truncate_error(&stderr, 8000);
-                        Err(anyhow!("rg terminated by signal: {}", truncated))
-                    }
-                }
-            }
-        }
-        Err(_) => {
-            // Fallback to grep if rg is not available.
-            let mut grep_cmd = Command::new("grep");
-            grep_cmd.arg("-rn");
-            grep_cmd
-                .arg("--max-count")
-                .arg(MAX_SEARCH_RESULTS.to_string());
-            for d in super::IGNORED_DIRS {
-                grep_cmd.arg(format!("--exclude-dir={}", d));
-            }
-            let output = grep_cmd.arg(pattern).arg(".").current_dir(base).output()?;
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let filtered = filter_grep_matches(&stdout, visible.as_ref());
-            if filtered.trim().is_empty() {
+    let (code, stdout, stderr) = run_inprocess_rg(base, pattern, file_pattern);
+    match code {
+        0 => {
+            let formatted = format_rg_json_matches(stdout.as_bytes(), visible.as_ref());
+            if formatted.is_empty() {
                 Ok("No matches found.".to_string())
             } else {
-                Ok(truncate_error(&filtered, 8000))
+                Ok(truncate_error(&formatted, 8000))
             }
         }
+        1 => Ok("No matches found.".to_string()),
+        code => {
+            let truncated = truncate_error(&stderr, 8000);
+            Err(anyhow!(
+                "rg exited with status code {}: {}",
+                code,
+                truncated
+            ))
+        }
     }
+}
+
+fn run_inprocess_rg(
+    base: &Path,
+    pattern: &str,
+    file_pattern: Option<&str>,
+) -> (i32, String, String) {
+    let out = Arc::new(Mutex::new(Vec::new()));
+    let err = Arc::new(Mutex::new(Vec::new()));
+    let io = ScopeIo {
+        stdin: Box::new(io::empty()),
+        stdin_fd: None,
+        stdin_is_search_input: false,
+        stdout: Box::new(SharedBuf(Arc::clone(&out))),
+        stderr: Box::new(SharedBuf(Arc::clone(&err))),
+        cwd: base.to_path_buf(),
+        env: HashMap::new(),
+        cancel: Arc::new(AtomicBool::new(false)),
+    };
+
+    let mut argv: Vec<OsString> = vec![
+        "rg".into(),
+        "--json".into(),
+        "--color=never".into(),
+        "--text".into(),
+    ];
+    for d in super::IGNORED_DIRS {
+        argv.push("--glob".into());
+        argv.push(format!("!{d}/**/*").into());
+    }
+    if let Some(fp) = file_pattern {
+        argv.push("--glob".into());
+        argv.push(fp.into());
+    }
+    argv.push(pattern.into());
+    argv.push(".".into());
+
+    let code = scope(io, || pi_uu_grep::run_rg(argv));
+    let stdout = String::from_utf8_lossy(&out.lock().expect("stdout lock")).into_owned();
+    let stderr = String::from_utf8_lossy(&err.lock().expect("stderr lock")).into_owned();
+    (code, stdout, stderr)
 }
 
 fn format_rg_json_matches(stdout: &[u8], visible: Option<&VisibleFiles>) -> String {
@@ -149,39 +162,6 @@ fn format_rg_json_matches(stdout: &[u8], visible: Option<&VisibleFiles>) -> Stri
     lines.join("\n")
 }
 
-fn filter_grep_matches(stdout: &str, visible: Option<&VisibleFiles>) -> String {
-    let mut lines: Vec<String> = Vec::new();
-
-    for line in stdout.lines() {
-        if lines.len() >= MAX_SEARCH_RESULTS {
-            break;
-        }
-
-        let mut parts = line.rsplitn(3, ':');
-        let Some(_text) = parts.next() else {
-            continue;
-        };
-        let Some(line_no) = parts.next() else {
-            continue;
-        };
-        let Some(path) = parts.next() else {
-            continue;
-        };
-
-        if line_no.parse::<u64>().is_err() {
-            continue;
-        }
-
-        if is_hidden_match(path, visible) {
-            continue;
-        }
-
-        lines.push(line.to_string());
-    }
-
-    lines.join("\n")
-}
-
 fn is_hidden_match(path: &str, visible: Option<&VisibleFiles>) -> bool {
     let rel = normalize_match_path(path);
     visible
@@ -202,7 +182,7 @@ fn normalize_match_path(path: &str) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_search_code, filter_grep_matches};
+    use super::execute_search_code;
     use crate::evolve::gitignore::GitignoreChecker;
     use std::fs;
     use tempfile::tempdir;
@@ -260,21 +240,5 @@ mod tests {
 
         assert!(output.contains("nested/visible.txt"), "output: {output}");
         assert!(!output.contains("nested/secret.txt"), "output: {output}");
-    }
-
-    #[test]
-    fn grep_fallback_parser_handles_colons_in_filename() {
-        let stdout = "dir:with:colon/file.txt:12:match text\ndir/file.txt:not-a-line:ignored\n";
-
-        let output = filter_grep_matches(stdout, None);
-
-        assert!(
-            output.contains("dir:with:colon/file.txt:12:match text"),
-            "output: {output}"
-        );
-        assert!(
-            !output.contains("dir/file.txt:not-a-line:ignored"),
-            "output: {output}"
-        );
     }
 }

--- a/apps/native/src-tauri/src/evolve/tools/list_files.rs
+++ b/apps/native/src-tauri/src/evolve/tools/list_files.rs
@@ -2,7 +2,8 @@
 
 use anyhow::{Result, anyhow};
 use log::{debug, info};
-use std::path::Component;
+use pi_walker::{CompiledWalkGlob, FollowLinks, WalkFilter, WalkRequest};
+use std::path::{Component, Path};
 
 use crate::evolve::IGNORED_DIRS;
 use crate::evolve::file_ops::{ensure_path_under_base, join_in_dir};
@@ -28,10 +29,8 @@ pub(crate) fn definition() -> Tool {
     }
 }
 
-/// The glob crate's `**` component matches *directories* (zero or more), not
-/// files, so a pattern ending in `**` — including the bare `**` models like
-/// to send — matches nothing once directories are filtered out. Treat a
-/// trailing `**` as `**/*`, which is what the caller invariably means.
+/// Trailing `**` alone matches directories, not files, in walk-relative globs
+/// (same as the old `glob` crate). Treat a trailing `**` as `**/*`.
 fn normalize_trailing_recursive_glob(pattern: &str) -> String {
     if pattern == "**" || pattern.ends_with("/**") {
         format!("{}/*", pattern)
@@ -43,12 +42,16 @@ fn normalize_trailing_recursive_glob(pattern: &str) -> String {
 pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     let repo_root = ctx.repo_root;
     let pattern = ctx.args["pattern"].as_str().unwrap_or("**/*");
-    let pattern = &normalize_trailing_recursive_glob(pattern);
-    // Validate and normalize the provided glob pattern so it cannot
-    // escape `base` (reject absolute/prefix components) and so any
-    // `..`/`.` components are resolved before we run the glob.
-    let full_pattern = join_in_dir(repo_root, pattern)?;
-    info!("Listing files matching: {}", full_pattern.display());
+    let pattern = normalize_trailing_recursive_glob(pattern);
+    // Validate the pattern cannot escape `base` (reject absolute / `..`).
+    // The walker matches against repo-relative paths, so keep `pattern` as the
+    // filter input — `join_in_dir` is validation only.
+    let _validated = join_in_dir(repo_root, &pattern)?;
+    info!(
+        "Listing files matching: {} under {}",
+        pattern,
+        repo_root.display()
+    );
 
     let visible = ctx
         .gitignore_matcher
@@ -56,27 +59,31 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
         .transpose()?;
 
     let ignored_dirs = IGNORED_DIRS;
-    let matched_files = glob::glob(full_pattern.to_str().unwrap())
-        .map_err(|e| anyhow!("Invalid glob pattern: {}", e))?
-        .filter_map(|p| p.ok())
-        .filter(|p| p.is_file())
-        .collect::<Vec<_>>();
+    let glob =
+        CompiledWalkGlob::new([&pattern]).map_err(|e| anyhow!("Invalid glob pattern: {}", e))?;
+    let filter = WalkFilter::files_only().glob(glob);
+
+    let matched = WalkRequest::new(repo_root)
+        .skip_git(true)
+        .skip_node_modules(true)
+        .gitignore(false) // nixmac VisibleFiles owns ignore policy
+        .follow_links(FollowLinks::Never)
+        .cache(true)
+        .filter(filter)
+        .collect_files()
+        .map_err(|e| anyhow!("list_files walk failed: {e}"))?;
 
     let mut files: Vec<String> = Vec::new();
     let mut escaped_matches: Vec<String> = Vec::new();
 
-    for p in matched_files {
-        if ensure_path_under_base(repo_root, &p).is_err() {
-            escaped_matches.push(p.display().to_string());
+    for entry in matched {
+        let abs = entry.absolute_path(repo_root);
+        if ensure_path_under_base(repo_root, &abs).is_err() {
+            escaped_matches.push(abs.display().to_string());
             continue;
         }
 
-        // Strip the normalized `base` so results are returned
-        // relative to the same directory we validated above.
-        let Some(rel) = p.strip_prefix(repo_root).ok() else {
-            continue;
-        };
-
+        let rel = Path::new(&entry.path);
         if let Some(Component::Normal(name)) = rel.components().next()
             && ignored_dirs.contains(&name.to_string_lossy().as_ref())
         {
@@ -89,18 +96,10 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
             continue;
         }
 
-        files.push(rel.to_string_lossy().to_string());
+        files.push(entry.path);
     }
 
     if !escaped_matches.is_empty() {
-        let _sample = escaped_matches
-            .iter()
-            .take(3)
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        // Don't return the sample as part of the error return since it contains local paths outside git repository.
         return Err(anyhow!(
             "list_files matched one or more files outside git repository after symlink resolution. pattern='{}' git repository='{}'. Fix: narrow the pattern to files under git repository and avoid symlink targets outside git repository.",
             pattern,
@@ -115,6 +114,12 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
 #[cfg(test)]
 mod tests {
     use super::normalize_trailing_recursive_glob;
+    use super::{ToolResult, execute};
+    use crate::evolve::gitignore::GitignoreChecker;
+    use crate::evolve::tools::ToolCtx;
+    use serde_json::json;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn trailing_recursive_glob_is_extended_to_match_files() {
@@ -135,24 +140,31 @@ mod tests {
         );
     }
 
-    // Prove the premise this fix rests on: the glob crate's `**` component
-    // matches directories only, so without normalization a bare `**` finds
-    // zero files in a populated tree.
     #[test]
-    fn glob_trailing_recursive_component_needs_the_normalization() {
-        let temp = tempfile::tempdir().expect("create temp dir");
-        std::fs::create_dir(temp.path().join("modules")).expect("create modules dir");
-        std::fs::write(temp.path().join("flake.nix"), "{}").expect("write flake.nix");
-        std::fs::write(temp.path().join("modules/home.nix"), "{}").expect("write home.nix");
+    fn walker_lists_files_and_skips_gitignored() {
+        let tmp = tempdir().expect("tempdir");
+        git2::Repository::init(tmp.path()).expect("init git repo");
+        fs::create_dir(tmp.path().join("modules")).expect("create modules");
+        fs::write(tmp.path().join("flake.nix"), "{}").expect("write flake");
+        fs::write(tmp.path().join("modules/home.nix"), "{}").expect("write home");
+        fs::write(tmp.path().join(".gitignore"), "secret.txt\n").expect("gitignore");
+        fs::write(tmp.path().join("secret.txt"), "x").expect("secret");
+        let gitignore = GitignoreChecker::new(tmp.path()).expect("matcher");
 
-        let count = |pat: &str| {
-            glob::glob(temp.path().join(pat).to_str().expect("utf8 path"))
-                .expect("valid glob")
-                .filter_map(|p| p.ok())
-                .filter(|p| p.is_file())
-                .count()
+        let ctx = ToolCtx {
+            repo_root: tmp.path(),
+            config_dir: tmp.path().to_str().expect("utf-8"),
+            host_attr: "dummy-host",
+            args: &json!({ "pattern": "**" }),
+            gitignore_matcher: gitignore.as_ref(),
+            auto_format: false,
+            on_build_output: None,
         };
-        assert_eq!(count("**"), 0, "premise: bare ** matches no files");
-        assert_eq!(count(&normalize_trailing_recursive_glob("**")), 2);
+        let ToolResult::Continue(out) = execute(&ctx).expect("list_files") else {
+            panic!("expected Continue");
+        };
+        assert!(out.contains("flake.nix"), "output: {out}");
+        assert!(out.contains("modules/home.nix"), "output: {out}");
+        assert!(!out.contains("secret.txt"), "output: {out}");
     }
 }

--- a/apps/native/src-tauri/src/evolve/tools/read_file.rs
+++ b/apps/native/src-tauri/src/evolve/tools/read_file.rs
@@ -1,7 +1,12 @@
 //! `read_file` tool: read a file's contents (gitignore-aware).
+//!
+//! Default reads return a tree-sitter structural outline via `pi-ast` when the
+//! language is recognized and bodies can be elided. Pass `full=true` or a
+//! `line_start`/`line_end` range for verbatim content.
 
 use anyhow::{Result, anyhow};
 use log::info;
+use pi_ast::summary::{SummaryOptions, SummaryResult, summarize_code};
 use std::path::Path;
 
 use crate::evolve::file_ops::resolve_existing_path_in_dir;
@@ -14,13 +19,29 @@ use super::{ToolCtx, ToolResult};
 pub(crate) fn definition() -> Tool {
     Tool {
         name: "read_file".to_string(),
-        description: "Read the contents of a file. Always read relevant files before making edits to understand the existing code structure and patterns.".to_string(),
+        description: "Read a file under the config repo. By default returns a structural outline \
+             (signatures/structure kept, large bodies elided) to save tokens. Pass full=true for \
+             the entire file, or line_start/line_end (1-based, inclusive) for a verbatim range. \
+             Always inspect relevant files before editing."
+            .to_string(),
         parameters: serde_json::json!({
             "type": "object",
             "properties": {
                 "path": {
                     "type": "string",
                     "description": "Relative path to the file"
+                },
+                "full": {
+                    "type": "boolean",
+                    "description": "If true, return the entire file verbatim (no outline)."
+                },
+                "line_start": {
+                    "type": "integer",
+                    "description": "1-based inclusive start line for a verbatim slice (requires line_end)."
+                },
+                "line_end": {
+                    "type": "integer",
+                    "description": "1-based inclusive end line for a verbatim slice (requires line_start)."
                 }
             },
             "required": ["path"]
@@ -45,5 +66,177 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     info!("Reading file: {}", full_path.display());
     let content = std::fs::read_to_string(&full_path)
         .map_err(|e| anyhow!("Failed to read {}: {}", path, e))?;
-    Ok(ToolResult::Continue(content))
+
+    let want_full = ctx.args["full"].as_bool().unwrap_or(false);
+    let line_start = ctx.args.get("line_start").and_then(|v| v.as_u64());
+    let line_end = ctx.args.get("line_end").and_then(|v| v.as_u64());
+
+    match (line_start, line_end) {
+        (Some(start), Some(end)) => {
+            let sliced = slice_lines(&content, start, end)?;
+            Ok(ToolResult::Continue(sliced))
+        }
+        (None, None) if want_full => Ok(ToolResult::Continue(content)),
+        (None, None) => Ok(ToolResult::Continue(outline_or_full(&content, path))),
+        _ => Err(anyhow!(
+            "read_file: line_start and line_end must both be provided for a line range"
+        )),
+    }
+}
+
+fn outline_or_full(content: &str, path: &str) -> String {
+    // unfold_until_lines = 0 keeps outermost bodies folded (max compression).
+    // Agents expand with full=true or a line range when they need verbatim text.
+    let summary = match summarize_code(SummaryOptions {
+        code: content.to_string(),
+        lang: None,
+        path: Some(path.to_string()),
+        min_body_lines: None,
+        min_comment_lines: None,
+        unfold_until_lines: None,
+        unfold_limit_lines: None,
+    }) {
+        Ok(summary) => summary,
+        Err(err) => {
+            log::warn!(
+                "read_file: outline failed for '{}': {:#}; returning full file",
+                path,
+                err
+            );
+            return content.to_string();
+        }
+    };
+
+    if !summary.parsed || !summary.elided {
+        return content.to_string();
+    }
+
+    format_outline(path, &summary)
+}
+
+fn format_outline(path: &str, summary: &SummaryResult) -> String {
+    let rendered = render_summary_segments(summary);
+    let lang = summary.language.as_deref().unwrap_or("unknown");
+    format!(
+        "[summarized outline of `{path}` — {lines} lines, language={lang}; large bodies elided. \
+Re-read with full=true for the entire file, or line_start/line_end for a verbatim range.]\n\n{rendered}",
+        lines = summary.total_lines,
+    )
+}
+
+fn render_summary_segments(summary: &SummaryResult) -> String {
+    summary
+        .segments
+        .iter()
+        .map(|segment| match segment.kind.as_str() {
+            "kept" => segment.text.clone().unwrap_or_default(),
+            _ => format!("... (lines {}–{})", segment.start_line, segment.end_line),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// 1-based inclusive line slice. Empty files and out-of-range bounds error.
+fn slice_lines(content: &str, line_start: u64, line_end: u64) -> Result<String> {
+    if line_start == 0 || line_end == 0 {
+        return Err(anyhow!(
+            "read_file: line_start and line_end must be 1-based (got {line_start}..{line_end})"
+        ));
+    }
+    if line_end < line_start {
+        return Err(anyhow!(
+            "read_file: line_end ({line_end}) must be >= line_start ({line_start})"
+        ));
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return Ok(String::new());
+    }
+
+    let start_idx = (line_start as usize).saturating_sub(1);
+    if start_idx >= lines.len() {
+        return Err(anyhow!(
+            "read_file: line_start {line_start} is past end of file ({} lines)",
+            lines.len()
+        ));
+    }
+    let end_idx = (line_end as usize).min(lines.len());
+    Ok(lines[start_idx..end_idx].join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_outline, outline_or_full, render_summary_segments, slice_lines};
+    use pi_ast::summary::{SummaryOptions, summarize_code};
+
+    #[test]
+    fn slice_lines_is_one_based_inclusive() {
+        let content = "a\nb\nc\nd\n";
+        assert_eq!(slice_lines(content, 2, 3).expect("slice"), "b\nc");
+        assert_eq!(slice_lines(content, 1, 1).expect("slice"), "a");
+        assert_eq!(slice_lines(content, 4, 10).expect("slice"), "d");
+    }
+
+    #[test]
+    fn slice_lines_rejects_inverted_or_zero_ranges() {
+        assert!(slice_lines("a\nb\n", 0, 1).is_err());
+        assert!(slice_lines("a\nb\n", 2, 1).is_err());
+        assert!(slice_lines("a\nb\n", 5, 6).is_err());
+    }
+
+    #[test]
+    fn outline_elides_rust_function_bodies() {
+        let code = "\
+fn keep_sig() -> i32 {\n\
+\tlet a = 1;\n\
+\tlet b = 2;\n\
+\tlet c = 3;\n\
+\ta + b + c\n\
+}\n\
+";
+        let out = outline_or_full(code, "fixture.rs");
+        assert!(
+            out.contains("summarized outline"),
+            "expected outline header: {out}"
+        );
+        assert!(out.contains("fn keep_sig() -> i32 {"), "output: {out}");
+        assert!(out.contains("... (lines"), "expected elision marker: {out}");
+        assert!(!out.contains("let a = 1"), "body should be elided: {out}");
+    }
+
+    #[test]
+    fn outline_passes_through_tiny_or_unparsed_files() {
+        let tiny = "x = 1\n";
+        assert_eq!(outline_or_full(tiny, "notes.txt"), tiny);
+
+        let short_rs = "fn f() {}\n";
+        let out = outline_or_full(short_rs, "short.rs");
+        assert_eq!(out, short_rs, "nothing to elide → full content");
+    }
+
+    #[test]
+    fn render_uses_line_range_placeholders() {
+        let result = summarize_code(SummaryOptions {
+            code: "\
+export function greet(name: string): string {\n\
+\tconst clean = name.trim();\n\
+\tconst label = clean || 'world';\n\
+\treturn `hello ${label}`;\n\
+}\n"
+            .to_string(),
+            lang: None,
+            path: Some("fixture.ts".to_string()),
+            min_body_lines: None,
+            min_comment_lines: None,
+            unfold_until_lines: None,
+            unfold_limit_lines: None,
+        })
+        .expect("summarize");
+        assert!(result.elided);
+        let rendered = render_summary_segments(&result);
+        assert!(rendered.contains("... (lines"));
+        let formatted = format_outline("fixture.ts", &result);
+        assert!(formatted.contains("full=true"));
+    }
 }

--- a/apps/native/src-tauri/src/evolve/tools/search_code.rs
+++ b/apps/native/src-tauri/src/evolve/tools/search_code.rs
@@ -1,4 +1,4 @@
-//! `search_code` tool: ripgrep over the codebase.
+//! `search_code` tool: in-process ripgrep (`pi_uu_grep`) over the codebase.
 
 use anyhow::{Result, anyhow};
 
@@ -10,7 +10,7 @@ use super::{ToolCtx, ToolResult};
 pub(crate) fn definition() -> Tool {
     Tool {
         name: "search_code".to_string(),
-        description: "Search for text patterns in the codebase using ripgrep. \
+        description: "Search for text patterns in the codebase (in-process ripgrep). \
                      This helps locate where functions or variables are defined or used. \
                      Output format: one match per line as file:line:text, where \
                      text is the matching line content."

--- a/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
+++ b/apps/native/src/components/widget/onboarding/inference/inference-setup.test.tsx
@@ -16,8 +16,6 @@ type AuthStatus = {
 type AccountStatus = {
   signedIn: boolean;
   account: { id: string; email: string } | null;
-  keyId: string | null;
-  serverUrl: string;
   githubReady: boolean;
   webAccount: { id: string; email: string } | null;
 };
@@ -139,8 +137,6 @@ describe("InferenceSetup", () => {
     mocks.status.mockResolvedValue({
       signedIn: false,
       account: null,
-      keyId: null,
-      serverUrl: "https://sync.nixmac.app",
       githubReady: false,
       webAccount: null,
     });
@@ -276,8 +272,6 @@ describe("InferenceSetup", () => {
     mocks.status.mockResolvedValue({
       signedIn: false,
       account: null,
-      keyId: null,
-      serverUrl: "https://sync.nixmac.app",
       githubReady: true,
       webAccount: { id: "acct_1", email: "ada@example.com" },
     });
@@ -293,8 +287,6 @@ describe("InferenceSetup", () => {
     mocks.status.mockResolvedValue({
       signedIn: false,
       account: null,
-      keyId: null,
-      serverUrl: "https://sync.nixmac.app",
       githubReady: true,
       webAccount: { id: "acct_1", email: "ada@example.com" },
     });
@@ -331,8 +323,6 @@ describe("InferenceSetup", () => {
     mocks.status.mockResolvedValue({
       signedIn: false,
       account: null,
-      keyId: null,
-      serverUrl: "https://sync.nixmac.app",
       githubReady: true,
       webAccount: { id: "acct_1", email: "ada@example.com" },
     });
@@ -368,8 +358,6 @@ describe("InferenceSetup", () => {
     mocks.status.mockResolvedValue({
       signedIn: false,
       account: null,
-      keyId: null,
-      serverUrl: "https://sync.nixmac.app",
       githubReady: true,
       webAccount: { id: "acct_1", email: "ada@example.com" },
     });
@@ -407,8 +395,6 @@ describe("InferenceSetup", () => {
     mocks.status.mockResolvedValue({
       signedIn: false,
       account: null,
-      keyId: null,
-      serverUrl: "https://sync.nixmac.app",
       githubReady: true,
       webAccount: { id: "acct_1", email: "ada@example.com" },
     });

--- a/crates/vendor/oh-my-pi/LICENSE
+++ b/crates/vendor/oh-my-pi/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Mario Zechner
+Copyright (c) 2025-2026 Can Bölük
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/vendor/oh-my-pi/VENDOR.md
+++ b/crates/vendor/oh-my-pi/VENDOR.md
@@ -1,0 +1,53 @@
+# Vendored Oh My Pi crates
+
+Pure-Rust extracts from [can1357/oh-my-pi](https://github.com/can1357/oh-my-pi) for nixmac’s evolve agent tools (file walk, in-process grep, AST summarize, CoW isolation).
+
+## Pin
+
+| Field | Value |
+| --- | --- |
+| Upstream | <https://github.com/can1357/oh-my-pi> |
+| Commit | `a38cd95d7d8c457a22f1b81c059b5491d78f79a3` |
+| Upstream version | 17.1.2 |
+| License | MIT (see `LICENSE`) — Mario Zechner, Can Bölük |
+
+## Crates
+
+| Crate | Role in nixmac |
+| --- | --- |
+| `pi-walker` | Directory walk / list_files / discovery cache |
+| `pi-uutils-ctx` | Thread-local stdio/cwd context required by `pi-uu-grep` |
+| `pi-uu-grep` | In-process ripgrep-backed search (`search_code`) |
+| `pi-ast` | Tree-sitter / ast-grep helpers for summarized `read_file` |
+| `pi-iso` | CoW isolation backends for subagent workspaces |
+
+**Not vendored:** `pi-natives` (N-API), `pi-shell` / brush / uu-\* (shell harness), `@oh-my-pi/hashline` (TypeScript).
+
+## Sync from upstream
+
+```bash
+git clone https://github.com/can1357/oh-my-pi /tmp/oh-my-pi
+cd /tmp/oh-my-pi && git checkout <new-sha>
+ROOT=<nixmac-root>
+for crate in pi-walker pi-uutils-ctx pi-uu-grep pi-iso pi-ast; do
+  rsync -a --delete \
+    --exclude target --exclude Cargo.lock \
+    "/tmp/oh-my-pi/crates/$crate/" \
+    "$ROOT/crates/vendor/oh-my-pi/$crate/"
+done
+# Re-apply standalone Cargo.toml edits (no workspace inherit / no host lints).
+# Update the commit SHA in this file.
+```
+
+Vendored `Cargo.toml` files are rewritten so packages do **not** inherit Oh My Pi’s workspace metadata or nixmac’s deny-level clippy lints. Prefer replaying those edits after a sync rather than copying upstream `Cargo.toml` verbatim.
+
+## Wiring status
+
+1. **Done:** Summarized `read_file` → `pi-ast` (`evolve/tools/read_file.rs`)
+1. **Done:** `list_files` → `pi-walker` (`evolve/tools/list_files.rs`, cache on)
+1. **Done:** `search_code` → `pi_uu_grep` (`evolve/search_code.rs`)
+1. **Done:** Walker cache invalidate after edits (`evolve/file_ops.rs`)
+1. **Done:** Isolation API → `pi-iso` (`evolve/isolation.rs` — `create_isolated_workspace` for subagents)
+1. Pending (optional): Trim `pi-ast` tree-sitter grammars
+
+Keep `evolve/file_ops.rs` + `edit_file` as the product security / validation boundary.

--- a/crates/vendor/oh-my-pi/pi-ast/Cargo.toml
+++ b/crates/vendor/oh-my-pi/pi-ast/Cargo.toml
@@ -1,0 +1,78 @@
+[package]
+name = "pi-ast"
+version = "17.1.2"
+edition = "2024"
+license = "MIT"
+authors = ["Can Boluk"]
+repository = "https://github.com/can1357/oh-my-pi"
+description = "ast-grep / tree-sitter helpers for summarized file reads (vendored from oh-my-pi)"
+
+# Vendored: do not inherit nixmac workspace deny-level clippy.
+# Grammar set is currently full upstream; trim later if compile cost hurts.
+
+[dependencies]
+anyhow = "1.0"
+ast-grep-core = { version = "0.39", default-features = false, features = [
+  "tree-sitter",
+] }
+globset = "0.4"
+ignore = "0.4"
+phf = { version = "0.13", features = ["macros"] }
+serde = { version = "1.0", features = ["derive"] }
+tree-sitter = "0.25"
+tree-sitter-astro = { version = "0.1.1", package = "tree-sitter-astro-next" }
+tree-sitter-bash = "0.25"
+tree-sitter-c = "0.24"
+tree-sitter-clojure = "0.1"
+tree-sitter-cmake = "0.7.1"
+tree-sitter-c-sharp = "0.23"
+tree-sitter-cpp = "0.23"
+tree-sitter-dart = "0.2"
+tree-sitter-css = "0.25"
+tree-sitter-diff = "0.1"
+tree-sitter-dockerfile = { version = "0.2.0", package = "tree-sitter-dockerfile-updated" }
+tree-sitter-elixir = "0.3"
+tree-sitter-elisp = "1.6.1"
+tree-sitter-erlang = "0.16.0"
+tree-sitter-fortran = "0.6.0"
+tree-sitter-go = "0.25"
+tree-sitter-graphql = "0.1.0"
+tree-sitter-haskell = "0.23"
+tree-sitter-hcl = "1.1"
+tree-sitter-html = "0.23"
+tree-sitter-ini = "1.4.0"
+tree-sitter-java = "0.23"
+tree-sitter-javascript = "0.25"
+tree-sitter-json = "0.24"
+tree-sitter-just = "0.2.0"
+tree-sitter-julia = "0.23"
+tree-sitter-kotlin = { version = "0.4", package = "tree-sitter-kotlin-sg" }
+tree-sitter-lua = "0.5"
+tree-sitter-make = "1.1"
+tree-sitter-md = "0.5"
+tree-sitter-nix = "0.3"
+tree-sitter-objc = "3.0"
+tree-sitter-ocaml = "0.24.2"
+tree-sitter-odin = "1.3"
+tree-sitter-php = "0.24"
+tree-sitter-powershell = "0.26.4"
+tree-sitter-proto = "0.4.0"
+tree-sitter-python = "0.25"
+tree-sitter-r = "1.2.0"
+tree-sitter-regex = "0.25"
+tree-sitter-ruby = "0.23"
+tree-sitter-rust = "0.24"
+tree-sitter-scala = "0.26"
+tree-sitter-solidity = "1.2"
+tree-sitter-sql = { version = "0.3.11", package = "tree-sitter-sequel" }
+tree-sitter-starlark = "1.3"
+tree-sitter-svelte = { version = "0.1.1", package = "tree-sitter-svelte-next" }
+tree-sitter-swift = "0.7"
+tree-sitter-toml-ng = "0.7"
+tree-sitter-tlaplus = "1.5"
+tree-sitter-typescript = "0.23"
+tree-sitter-verilog = "1.0"
+tree-sitter-vue = { version = "0.1.0", package = "tree-sitter-vue-next" }
+tree-sitter-xml = "0.7"
+tree-sitter-yaml = "0.7"
+tree-sitter-zig = "1.1"

--- a/crates/vendor/oh-my-pi/pi-ast/src/block.rs
+++ b/crates/vendor/oh-my-pi/pi-ast/src/block.rs
@@ -1,0 +1,688 @@
+//! Resolve the syntactic block that begins on a given source line.
+//!
+//! Powers the hashline `replace block N:` operator: given a 1-indexed line,
+//! parse the source with tree-sitter and return the line span of the outermost
+//! named node that *begins* on that line (excluding the whole-file root). Brace
+//! languages anchor a construct's block to its opening line, so pointing at the
+//! line that opens an `if` / `function` / `struct` resolves to that construct's
+//! full span; pointing at a continuation line or a lone closing delimiter
+//! resolves to nothing.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Result, anyhow};
+use ast_grep_core::tree_sitter::LanguageExt;
+use serde::{Deserialize, Serialize};
+use tree_sitter::{Parser, Point, TreeCursor};
+
+use crate::summary::{node_content_end_line, node_start_line, resolve_language};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockRangeOptions {
+    /// Source code to inspect.
+    pub code: String,
+    /// Language alias (e.g. "rust", "typescript") used before path inference.
+    pub lang: Option<String>,
+    /// File path used to infer language by extension when `lang` is omitted.
+    pub path: Option<String>,
+    /// 1-indexed source line the block must begin on.
+    pub line: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlockRange {
+    /// 1-indexed inclusive first line of the resolved block.
+    pub start_line: u32,
+    /// 1-indexed inclusive last line of the resolved block.
+    pub end_line: u32,
+}
+
+/// Count of leading space/tab bytes on `row` (0-indexed), i.e. the byte column
+/// of the first content character. Returns `None` when `row` is out of range
+/// or the line is blank / whitespace-only — there is no block to resolve there.
+fn first_content_column(code: &str, row: usize) -> Option<usize> {
+    let line = code.split('\n').nth(row)?;
+    for (col, byte) in line.bytes().enumerate() {
+        if byte != b' ' && byte != b'\t' {
+            return Some(col);
+        }
+    }
+    None
+}
+
+/// Resolve the block beginning on `options.line`.
+///
+/// Returns `None` (a soft "no block here", surfaced as a hard error one layer
+/// up) when the language is unrecognized, the line is out of range / blank, no
+/// node begins on that line, or the resolved subtree contains a syntax error.
+pub fn block_range_at(options: BlockRangeOptions) -> Result<Option<BlockRange>> {
+    let BlockRangeOptions {
+        code,
+        lang,
+        path,
+        line,
+    } = options;
+    if line == 0 || code.is_empty() {
+        return Ok(None);
+    }
+    let Some(language) = resolve_language(lang.as_deref(), path.as_deref()) else {
+        return Ok(None);
+    };
+    let row = (line - 1) as usize;
+    let Some(col) = first_content_column(&code, row) else {
+        return Ok(None);
+    };
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language.get_ts_language())
+        .map_err(|err| anyhow!("Failed to load tree-sitter language: {err}"))?;
+    let Some(tree) = parser.parse(&code, None) else {
+        return Ok(None);
+    };
+    let root = tree.root_node();
+
+    // Query a one-column-wide range over the first content character rather
+    // than a zero-width point. Some grammars (e.g. tree-sitter-swift) insert a
+    // zero-width separator node at the start of a statement that follows a
+    // blank line. An empty point range at that node's start gets absorbed into
+    // the invisible node, which has no children and is not "relevant", so
+    // `named_descendant_for_point_range` bubbles back up to the last visible
+    // ancestor (the enclosing body, or the file root). That made `replace
+    // block` on a line like `var body: some View {` preceded by a blank line
+    // resolve to the whole enclosing type body and then fail. Spanning the
+    // first character skips the zero-width node (its end is < the range end)
+    // and forces the descent into the node that begins on `row`.
+    let point = Point::new(row, col);
+    let point_end = Point::new(row, col + 1);
+    let Some(leaf) = root.named_descendant_for_point_range(point, point_end) else {
+        return Ok(None);
+    };
+    // A leaf whose own start row is earlier than `row` means `point` landed on
+    // a continuation line or a closing delimiter of a block that opened earlier
+    // — there is no block *beginning* on line N.
+    if leaf.start_position().row != row {
+        return Ok(None);
+    }
+    // Climb to the outermost named ancestor that still begins on `row`,
+    // excluding the whole-file root. Ancestors can only begin on an earlier
+    // row, so the first parent that starts before `row` stops the climb.
+    let mut node = leaf;
+    while let Some(parent) = node.parent() {
+        if parent.id() == root.id() {
+            break;
+        }
+        if parent.start_position().row != row {
+            break;
+        }
+        node = parent;
+    }
+    // Refuse degenerate error-recovery spans: a missing brace can make
+    // tree-sitter wrap a huge region in an ERROR node. Checking only the
+    // resolved node's subtree (not the whole file) keeps an unrelated syntax
+    // error elsewhere from disabling the feature.
+    if node.has_error() {
+        return Ok(None);
+    }
+    Ok(Some(BlockRange {
+        start_line: node_start_line(node),
+        end_line: node_content_end_line(node),
+    }))
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LineRange {
+    /// 1-indexed inclusive first visible line.
+    pub start_line: u32,
+    /// 1-indexed inclusive last visible line.
+    pub end_line: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclosingBoundaryOptions {
+    /// Source code to inspect.
+    pub code: String,
+    /// Language alias (e.g. "rust", "typescript") used before path inference.
+    pub lang: Option<String>,
+    /// File path used to infer language by extension when `lang` is omitted.
+    pub path: Option<String>,
+    /// 1-indexed inclusive visible line ranges (the lines actually shown).
+    pub ranges: Vec<LineRange>,
+}
+
+/// Sort, drop invalid, and merge adjacent/overlapping ranges so visibility
+/// tests can binary-search a non-overlapping list.
+fn normalize_ranges(mut ranges: Vec<LineRange>) -> Vec<LineRange> {
+    ranges.retain(|range| range.start_line > 0 && range.end_line >= range.start_line);
+    ranges.sort_by(|a, b| {
+        a.start_line
+            .cmp(&b.start_line)
+            .then(a.end_line.cmp(&b.end_line))
+    });
+    let mut merged: Vec<LineRange> = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        if let Some(last) = merged.last_mut()
+            && range.start_line <= last.end_line.saturating_add(1)
+        {
+            last.end_line = last.end_line.max(range.end_line);
+            continue;
+        }
+        merged.push(range);
+    }
+    merged
+}
+
+fn is_visible(merged: &[LineRange], line: u32) -> bool {
+    merged
+        .binary_search_by(|range| {
+            if line < range.start_line {
+                std::cmp::Ordering::Greater
+            } else if line > range.end_line {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        })
+        .is_ok()
+}
+
+/// Depth-first walk collecting boundary lines from every multi-line named node
+/// that straddles a visible-range edge. A single reused [`TreeCursor`] keeps
+/// the traversal allocation-free.
+fn collect_boundaries(cursor: &mut TreeCursor<'_>, merged: &[LineRange], out: &mut BTreeSet<u32>) {
+    let node = cursor.node();
+    // Skip the whole-file root: its only "boundary" is EOF, never a useful
+    // matching line (mirrors `block_range_at` excluding the root).
+    if node.is_named() && node.parent().is_some() {
+        let start = node_start_line(node);
+        let end = node_content_end_line(node);
+        if end > start {
+            let start_visible = is_visible(merged, start);
+            let end_visible = is_visible(merged, end);
+            // Opener shown, closer off-window → surface the closer (and vice
+            // versa). A node fully inside or fully outside the window adds
+            // nothing.
+            if start_visible && !end_visible {
+                out.insert(end);
+            } else if end_visible && !start_visible {
+                out.insert(start);
+            }
+        }
+    }
+    if cursor.goto_first_child() {
+        loop {
+            collect_boundaries(cursor, merged, out);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+}
+
+/// Generalize "show the matching bracket" to every tree-sitter block: for each
+/// multi-line named node whose span crosses the visible window, return the
+/// boundary line sitting *outside* that window.
+///
+/// - node opens on a visible line but closes past the window → its closing line
+/// - node closes on a visible line but opens before the window → its opening
+///   line
+///
+/// Because the trigger is an endpoint *inside* the window, the result is
+/// bounded by the window size (not nesting depth), exactly like a bracket scan
+/// — but it also covers indentation languages (Python) and uses real syntactic
+/// spans.
+///
+/// Returns `None` when the language is unrecognized or the source fails to
+/// parse / carries a syntax error (caller falls back to a lexical bracket
+/// scan); `Some(sorted unique boundary lines)` otherwise (possibly empty).
+pub fn enclosing_block_boundaries(options: EnclosingBoundaryOptions) -> Result<Option<Vec<u32>>> {
+    let EnclosingBoundaryOptions {
+        code,
+        lang,
+        path,
+        ranges,
+    } = options;
+    let merged = normalize_ranges(ranges);
+    if code.is_empty() || merged.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let Some(language) = resolve_language(lang.as_deref(), path.as_deref()) else {
+        return Ok(None);
+    };
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language.get_ts_language())
+        .map_err(|err| anyhow!("Failed to load tree-sitter language: {err}"))?;
+    let Some(tree) = parser.parse(&code, None) else {
+        return Ok(None);
+    };
+    let root = tree.root_node();
+    // A file-level syntax error makes error-recovery spans unreliable; defer to
+    // the lexical scanner rather than emit boundaries off a broken tree.
+    if root.has_error() {
+        return Ok(None);
+    }
+
+    let mut boundaries = BTreeSet::new();
+    let mut cursor = root.walk();
+    collect_boundaries(&mut cursor, &merged, &mut boundaries);
+    Ok(Some(boundaries.into_iter().collect()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolve(code: &str, path: &str, line: u32) -> Option<BlockRange> {
+        block_range_at(BlockRangeOptions {
+            code: code.to_string(),
+            lang: None,
+            path: Some(path.to_string()),
+            line,
+        })
+        .expect("block resolution succeeds")
+    }
+
+    const TS_EXAMPLE: &str = "function x() {\n  if (y) {\n  }\n}\n";
+
+    #[test]
+    fn resolves_inner_if_block() {
+        assert_eq!(
+            resolve(TS_EXAMPLE, "x.ts", 2),
+            Some(BlockRange {
+                start_line: 2,
+                end_line: 3
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_enclosing_function_block() {
+        assert_eq!(
+            resolve(TS_EXAMPLE, "x.ts", 1),
+            Some(BlockRange {
+                start_line: 1,
+                end_line: 4
+            })
+        );
+    }
+
+    #[test]
+    fn lone_closing_brace_resolves_to_nothing() {
+        // Line 3 is `  }` — the closing delimiter of a block that opened on an
+        // earlier line, so no block *begins* there.
+        assert_eq!(resolve(TS_EXAMPLE, "x.ts", 3), None);
+    }
+
+    #[test]
+    fn blank_line_resolves_to_nothing() {
+        let code = "function x() {\n\n  return 1;\n}\n";
+        assert_eq!(resolve(code, "x.ts", 2), None);
+    }
+
+    #[test]
+    fn out_of_range_line_resolves_to_nothing() {
+        assert_eq!(resolve(TS_EXAMPLE, "x.ts", 99), None);
+        assert_eq!(resolve(TS_EXAMPLE, "x.ts", 0), None);
+    }
+
+    #[test]
+    fn unrecognized_extension_resolves_to_nothing() {
+        assert_eq!(resolve(TS_EXAMPLE, "x.unknownext", 2), None);
+    }
+
+    #[test]
+    fn resolves_zsh_if_block_in_extensionless_rc_file() {
+        // Regression: an extensionless shell rc file (`zshrc`/`.zshrc`) must
+        // infer the bash grammar so `replace block` / `insert after block`
+        // works. Previously `Path::extension` returned `None`, leaving block
+        // ops permanently unresolvable on these files.
+        let code = "ZSH_COMPDUMP=x\nif [[ -f \"$ZSH_COMPDUMP\" ]]; then\n  compinit -C\nelse\n  \
+		            compinit\nfi\n";
+        let span = Some(BlockRange {
+            start_line: 2,
+            end_line: 6,
+        });
+        assert_eq!(resolve(code, "modules/zsh/zshrc", 2), span);
+        assert_eq!(resolve(code, ".zshrc", 2), span);
+        assert_eq!(resolve(code, "/home/u/.bashrc", 2), span);
+    }
+
+    #[test]
+    fn resolves_top_level_python_def() {
+        let code = "x = 1\ndef greet():\n    return 1\n";
+        assert_eq!(
+            resolve(code, "g.py", 2),
+            Some(BlockRange {
+                start_line: 2,
+                end_line: 3
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_inner_python_block() {
+        // Point at the `for` loop inside the function body. The suite's first
+        // statement is `total = 0` (line 2), so the `for` at line 3 is not the
+        // suite's first child and climbs only to the `for_statement`, not the
+        // whole function suite.
+        let code =
+            "def f(xs):\n    total = 0\n    for x in xs:\n        total += x\n    return total\n";
+        assert_eq!(
+            resolve(code, "f.py", 3),
+            Some(BlockRange {
+                start_line: 3,
+                end_line: 4
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_nested_block_to_outermost_on_line() {
+        // Point at the inner `if` line; it resolves the whole `if` block
+        // (header through its closing brace), not just the call inside it.
+        let code = "function f() {\n  if (a) {\n    g();\n  }\n}\n";
+        assert_eq!(
+            resolve(code, "f.ts", 2),
+            Some(BlockRange {
+                start_line: 2,
+                end_line: 4
+            })
+        );
+    }
+
+    #[test]
+    fn multi_statement_line_resolves_first_statement_node() {
+        // `let a = 1; let b = 2;` — pointing at the line resolves the first
+        // statement that begins at the line's first content column.
+        let code = "let a = 1; let b = 2;\n";
+        let range = resolve(code, "m.ts", 1);
+        assert!(
+            range.is_some(),
+            "expected a block on a single-statement-bearing line"
+        );
+        assert_eq!(range.unwrap().start_line, 1);
+    }
+
+    #[test]
+    fn continuation_line_resolves_to_nothing() {
+        // A bare argument-continuation line whose first content does not open a
+        // new named node beginning on that row.
+        let code = "foo(\n  a,\n  b,\n);\n";
+        // Line 2 (`  a,`) is an argument — `a` is an identifier beginning on the
+        // row, so it DOES resolve. Use the closing `);` line instead, which is
+        // a continuation/closer of the call begun earlier.
+        assert_eq!(resolve(code, "c.ts", 4), None);
+    }
+
+    #[test]
+    fn error_subtree_resolves_to_nothing() {
+        // Missing closing brace: the function's subtree carries an ERROR, so we
+        // refuse to resolve a degenerate recovery span.
+        let code = "function broken() {\n  if (y) {\n}\n";
+        assert_eq!(resolve(code, "b.ts", 1), None);
+    }
+
+    #[test]
+    fn resolves_rust_struct_block() {
+        let code = "struct A;\nstruct B {\n    x: u32,\n}\n";
+        assert_eq!(
+            resolve(code, "r.rs", 2),
+            Some(BlockRange {
+                start_line: 2,
+                end_line: 4
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_swift_computed_property_after_blank_line() {
+        // Regression: a block whose opening line is preceded by a blank line
+        // (here the SwiftUI `var body: some View {` computed property) used to
+        // resolve to nothing. tree-sitter-swift inserts a zero-width separator
+        // node at the start of a statement that follows a blank line; a
+        // zero-width point query at the first content column gets absorbed into
+        // that invisible node and bubbles back up to the enclosing type body. A
+        // one-column-wide query skips the zero-width node and descends into the
+        // property that actually begins on the line.
+        let code = "struct MenuBarUsage: View {\n    let metric: AccountMetric\n\n    var body: \
+		            some View {\n        VStack {\n            Text(\"Usage\")\n        }\n    \
+		            }\n}\n";
+        assert_eq!(
+            resolve(code, "MenuBarUsage.swift", 4),
+            Some(BlockRange {
+                start_line: 4,
+                end_line: 8
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_swift_top_level_decl_after_blank_line() {
+        // Same zero-width-separator regression one level up: a top-level
+        // declaration following a blank line. Without the fix the query
+        // resolved to the whole `source_file` root and was rejected.
+        let code = "import Foundation\n\nfunc greet() {\n    print(\"hi\")\n}\n";
+        assert_eq!(
+            resolve(code, "g.swift", 3),
+            Some(BlockRange {
+                start_line: 3,
+                end_line: 5
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_emacs_lisp_defun_block() {
+        let code = "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name))\n";
+        assert_eq!(
+            resolve(code, "init.el", 1),
+            Some(BlockRange {
+                start_line: 1,
+                end_line: 3
+            })
+        );
+    }
+    #[test]
+    fn resolves_emacs_lisp_dot_emacs_block() {
+        let code = "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name))\n";
+        assert_eq!(
+            resolve(code, ".emacs", 1),
+            Some(BlockRange {
+                start_line: 1,
+                end_line: 3
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_emacs_lisp_macro_style_list_block() {
+        let code = "(ert-deftest ogent-zen-test ()\n  \"Doc.\"\n  (should t))\n";
+        assert_eq!(
+            resolve(code, "test/ogent-zen-tests.el", 1),
+            Some(BlockRange {
+                start_line: 1,
+                end_line: 3
+            })
+        );
+    }
+
+    #[test]
+    fn emacs_lisp_closing_paren_resolves_to_nothing() {
+        let code = "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name)\n)\n";
+        assert_eq!(resolve(code, "init.el", 4), None);
+    }
+
+    #[test]
+    fn emacs_lisp_visible_opener_surfaces_closer() {
+        let code = "(defun greet (name)\n  \"Doc.\"\n  (let ((message (format \"Hello %s\" \
+		            name)))\n    (message \"%s\" message))\n)\n";
+        assert_eq!(boundaries(code, "init.el", &[(1, 1)]), Some(vec![5]));
+    }
+
+    #[test]
+    fn emacs_lisp_top_level_macro_forms_resolve_as_single_sexprs() {
+        let cases = [
+            (
+                "use-package",
+                "(use-package magit\n  :commands (magit-status)\n  :config\n  (setq \
+				 magit-save-repository-buffers nil))\n",
+                4,
+            ),
+            (
+                "with-eval-after-load",
+                "(with-eval-after-load 'org\n  (setq org-startup-indented t)\n  (add-hook \
+				 'org-mode-hook #'visual-line-mode))\n",
+                3,
+            ),
+            (
+                "pcase",
+                "(pcase major-mode\n  ('emacs-lisp-mode\n   (message \"elisp\"))\n  (_\n   (message \
+				 \"other\")))\n",
+                5,
+            ),
+        ];
+
+        for (name, code, end_line) in cases {
+            assert_eq!(
+                resolve(code, "init.el", 1),
+                Some(BlockRange {
+                    start_line: 1,
+                    end_line
+                }),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolves_emacs_lisp_explicit_language_block() {
+        let result = block_range_at(BlockRangeOptions {
+            code: "(defun greet (name)\n  \"Doc.\"\n  (message \"Hello %s\" name))\n".to_string(),
+            lang: Some("emacs-lisp".to_string()),
+            path: None,
+            line: 1,
+        })
+        .expect("block resolution succeeds");
+        assert_eq!(
+            result,
+            Some(BlockRange {
+                start_line: 1,
+                end_line: 3
+            })
+        );
+    }
+
+    fn boundaries(code: &str, path: &str, ranges: &[(u32, u32)]) -> Option<Vec<u32>> {
+        enclosing_block_boundaries(EnclosingBoundaryOptions {
+            code: code.to_string(),
+            lang: None,
+            path: Some(path.to_string()),
+            ranges: ranges
+                .iter()
+                .map(|&(start_line, end_line)| LineRange {
+                    start_line,
+                    end_line,
+                })
+                .collect(),
+        })
+        .expect("boundary resolution succeeds")
+    }
+
+    const TS_FN: &str = "function outer() {\n  const a = 1;\n  const b = 2;\n  const c = 3;\n  \
+	                     return a + b + c;\n}\nafter();\n";
+
+    #[test]
+    fn surfaces_closing_brace_for_visible_opener() {
+        // Window is the opening line only; its block closes on line 6.
+        assert_eq!(boundaries(TS_FN, "x.ts", &[(1, 1)]), Some(vec![6]));
+    }
+
+    #[test]
+    fn surfaces_opening_brace_for_visible_closer() {
+        // Window is the closing line only; its block opens on line 1.
+        assert_eq!(boundaries(TS_FN, "x.ts", &[(6, 6)]), Some(vec![1]));
+    }
+
+    #[test]
+    fn interior_only_window_adds_no_boundary() {
+        // Neither the opener (1) nor the closer (6) is visible, so the bracket
+        // scan would add nothing — and neither do we.
+        assert_eq!(boundaries(TS_FN, "x.ts", &[(3, 4)]), Some(vec![]));
+    }
+
+    #[test]
+    fn whole_file_window_adds_no_boundary() {
+        assert_eq!(boundaries(TS_FN, "x.ts", &[(1, 7)]), Some(vec![]));
+    }
+
+    #[test]
+    fn python_indentation_block_uses_syntactic_span() {
+        // Python has no closing delimiter — the def's span ends at the last
+        // body line. Showing the `def` header surfaces that end line.
+        let code = "def greet(name):\n    a = 1\n    b = 2\n    return a + b\n";
+        assert_eq!(boundaries(code, "g.py", &[(1, 1)]), Some(vec![4]));
+    }
+
+    #[test]
+    fn syntax_error_falls_back_to_none() {
+        let code = "function broken() {\n  if (y) {\n";
+        assert_eq!(boundaries(code, "b.ts", &[(1, 1)]), None);
+    }
+
+    #[test]
+    fn unrecognized_language_falls_back_to_none() {
+        assert_eq!(boundaries(TS_FN, "x.unknownext", &[(1, 1)]), None);
+    }
+
+    const MD_DOC: &str = "# H1\nintro\n\n## H2 alpha\nbody a\nmore a\n\n### H3 deep\ndeep \
+	                      body\n\n## H2 beta\nbody b\n";
+
+    #[test]
+    fn resolves_markdown_h2_to_whole_section() {
+        // tree-sitter-md nests the heading and its body (including deeper
+        // subsections) in one `section` node, so anchoring the `## H2 alpha`
+        // line (4) resolves the whole section — heading through the nested
+        // `### H3 deep` and its trailing blank, up to the next `## H2 beta`.
+        assert_eq!(
+            resolve(MD_DOC, "plan.md", 4),
+            Some(BlockRange {
+                start_line: 4,
+                end_line: 10
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_markdown_h3_to_its_subsection() {
+        // A deeper heading resolves only its own subsection, not the enclosing
+        // `## H2` — the `### H3 deep` section spans line 8 through its body.
+        assert_eq!(
+            resolve(MD_DOC, "plan.md", 8),
+            Some(BlockRange {
+                start_line: 8,
+                end_line: 10
+            })
+        );
+    }
+
+    #[test]
+    fn resolves_markdown_h1_to_whole_document_section() {
+        // The top-level heading owns every nested section, so `# H1` resolves
+        // the entire document body.
+        assert_eq!(
+            resolve(MD_DOC, "plan.md", 1),
+            Some(BlockRange {
+                start_line: 1,
+                end_line: 12
+            })
+        );
+    }
+
+    #[test]
+    fn markdown_blank_line_resolves_to_nothing() {
+        // A blank separator line opens no section.
+        assert_eq!(resolve(MD_DOC, "plan.md", 3), None);
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-ast/src/language/mod.rs
+++ b/crates/vendor/oh-my-pi/pi-ast/src/language/mod.rs
@@ -1,0 +1,830 @@
+//! Vendored and extended language definitions for ast-grep integration.
+//!
+//! Originally derived from `ast-grep-language` v0.39.9, stripped of
+//! serde/ignore machinery, and extended with additional languages.
+
+mod parsers;
+
+use std::{borrow::Cow, collections::HashMap, fmt, path::Path, sync::LazyLock};
+
+use ast_grep_core::{
+    Doc, Language, Node,
+    matcher::{KindMatcher, Pattern, PatternBuilder, PatternError},
+    meta_var::MetaVariable,
+    tree_sitter::{LanguageExt, StrDoc, TSLanguage, TSRange},
+};
+use phf::phf_map;
+
+/// Implements a stub language (no expando / `pre_process_pattern` needed).
+/// Use when the language grammar accepts `$VAR` as valid identifiers.
+macro_rules! impl_lang {
+    ($lang:ident, $func:ident) => {
+        #[derive(Clone, Copy, Debug)]
+        pub struct $lang;
+        impl Language for $lang {
+            fn kind_to_id(&self, kind: &str) -> u16 {
+                self.get_ts_language().id_for_node_kind(kind, true)
+            }
+
+            fn field_to_id(&self, field: &str) -> Option<u16> {
+                self.get_ts_language()
+                    .field_id_for_name(field)
+                    .map(|f| f.get())
+            }
+
+            fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+                builder.build(|src| StrDoc::try_new(src, *self))
+            }
+        }
+        impl LanguageExt for $lang {
+            fn get_ts_language(&self) -> TSLanguage {
+                parsers::$func().into()
+            }
+        }
+    };
+}
+
+fn pre_process_pattern(expando: char, query: &str) -> Cow<'_, str> {
+    let mut ret = Vec::with_capacity(query.len());
+    let mut dollar_count = 0;
+    for c in query.chars() {
+        if c == '$' {
+            dollar_count += 1;
+            continue;
+        }
+        let need_replace = matches!(c, 'A'..='Z' | '_') || dollar_count == 3;
+        let sigil = if need_replace { expando } else { '$' };
+        ret.extend(std::iter::repeat_n(sigil, dollar_count));
+        dollar_count = 0;
+        ret.push(c);
+    }
+    let sigil = if dollar_count == 3 { expando } else { '$' };
+    ret.extend(std::iter::repeat_n(sigil, dollar_count));
+    Cow::Owned(ret.into_iter().collect())
+}
+
+/// Implements a language with `expando_char` / `pre_process_pattern`.
+/// Use when the language does NOT accept `$` as a valid identifier character.
+macro_rules! impl_lang_expando {
+    ($lang:ident, $func:ident, $char:expr) => {
+        #[derive(Clone, Copy, Debug)]
+        pub struct $lang;
+        impl Language for $lang {
+            fn kind_to_id(&self, kind: &str) -> u16 {
+                self.get_ts_language().id_for_node_kind(kind, true)
+            }
+
+            fn field_to_id(&self, field: &str) -> Option<u16> {
+                self.get_ts_language()
+                    .field_id_for_name(field)
+                    .map(|f| f.get())
+            }
+
+            fn expando_char(&self) -> char {
+                $char
+            }
+
+            fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
+                pre_process_pattern(self.expando_char(), query)
+            }
+
+            fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+                builder.build(|src| StrDoc::try_new(src, *self))
+            }
+        }
+        impl LanguageExt for $lang {
+            fn get_ts_language(&self) -> TSLanguage {
+                parsers::$func().into()
+            }
+        }
+    };
+}
+
+// ── Customized languages with expando_char ──────────────────────────────
+
+impl_lang_expando!(C, language_c, '𐀀');
+impl_lang_expando!(Cpp, language_cpp, '𐀀');
+impl_lang_expando!(CSharp, language_c_sharp, 'µ');
+impl_lang_expando!(Cmake, language_cmake, 'µ');
+impl_lang_expando!(Css, language_css, '_');
+impl_lang_expando!(Dockerfile, language_dockerfile, 'µ');
+impl_lang_expando!(Elixir, language_elixir, 'µ');
+impl_lang_expando!(Erlang, language_erlang, 'µ');
+impl_lang_expando!(Fortran, language_fortran, '𐀀');
+impl_lang_expando!(Go, language_go, 'µ');
+impl_lang!(Graphql, language_graphql);
+impl_lang_expando!(Haskell, language_haskell, 'µ');
+impl_lang_expando!(Hcl, language_hcl, 'µ');
+impl_lang_expando!(Ini, language_ini, 'µ');
+impl_lang_expando!(Just, language_just, 'µ');
+impl_lang_expando!(Kotlin, language_kotlin, 'µ');
+impl_lang_expando!(Nix, language_nix, '_');
+impl_lang_expando!(Ocaml, language_ocaml, 'µ');
+impl_lang_expando!(Php, language_php, 'µ');
+impl_lang_expando!(Powershell, language_powershell, 'µ');
+impl_lang_expando!(Proto, language_proto, 'µ');
+impl_lang_expando!(Python, language_python, 'µ');
+impl_lang_expando!(R, language_r, 'µ');
+impl_lang_expando!(Ruby, language_ruby, 'µ');
+impl_lang_expando!(Rust, language_rust, 'µ');
+impl_lang_expando!(Sql, language_sql, 'µ');
+impl_lang_expando!(Swift, language_swift, 'µ');
+
+// New expando languages
+impl_lang_expando!(Make, language_make, 'µ');
+impl_lang_expando!(ObjC, language_objc, '𐀀');
+impl_lang_expando!(Starlark, language_starlark, 'µ');
+impl_lang_expando!(Odin, language_odin, 'µ');
+impl_lang_expando!(Julia, language_julia, 'µ');
+impl_lang_expando!(Verilog, language_verilog, 'µ');
+impl_lang_expando!(Zig, language_zig, 'µ');
+impl_lang_expando!(Tlaplus, language_tlaplus, 'µ');
+
+// ── Stub languages ($ accepted in grammar) ──────────────────────────────
+
+impl_lang!(Astro, language_astro);
+impl_lang!(Bash, language_bash);
+impl_lang!(Clojure, language_clojure);
+impl_lang!(Java, language_java);
+impl_lang!(JavaScript, language_javascript);
+impl_lang!(Json, language_json);
+impl_lang!(Lua, language_lua);
+impl_lang!(Scala, language_scala);
+impl_lang!(Solidity, language_solidity);
+impl_lang!(Svelte, language_svelte);
+impl_lang!(Tsx, language_tsx);
+impl_lang!(TypeScript, language_typescript);
+impl_lang!(Vue, language_vue);
+impl_lang!(Yaml, language_yaml);
+
+// New stub languages
+impl_lang!(Markdown, language_markdown);
+impl_lang!(Toml, language_toml);
+impl_lang!(Diff, language_diff);
+impl_lang!(Xml, language_xml);
+impl_lang!(Regex, language_regex);
+impl_lang!(Dart, language_dart);
+impl_lang!(EmacsLisp, language_elisp);
+
+// ── Html (custom implementation with injection support) ──────────────────
+
+#[derive(Clone, Copy, Debug)]
+pub struct Html;
+
+impl Language for Html {
+    fn expando_char(&self) -> char {
+        'z'
+    }
+
+    fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
+        pre_process_pattern(self.expando_char(), query)
+    }
+
+    fn kind_to_id(&self, kind: &str) -> u16 {
+        self.get_ts_language().id_for_node_kind(kind, true)
+    }
+
+    fn field_to_id(&self, field: &str) -> Option<u16> {
+        self.get_ts_language()
+            .field_id_for_name(field)
+            .map(|f| f.get())
+    }
+
+    fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+        builder.build(|src| StrDoc::try_new(src, *self))
+    }
+}
+
+impl LanguageExt for Html {
+    fn get_ts_language(&self) -> TSLanguage {
+        parsers::language_html()
+    }
+
+    fn injectable_languages(&self) -> Option<&'static [&'static str]> {
+        Some(&["css", "js", "ts", "tsx", "scss", "less", "stylus", "coffee"])
+    }
+
+    fn extract_injections<L: LanguageExt>(
+        &self,
+        root: Node<StrDoc<L>>,
+    ) -> HashMap<String, Vec<TSRange>> {
+        let lang = root.lang();
+        let mut map = HashMap::new();
+        let matcher = KindMatcher::new("script_element", lang.clone());
+        for script in root.find_all(matcher) {
+            let injected = find_html_lang(&script).unwrap_or_else(|| "js".into());
+            let content = script.children().find(|c| c.kind() == "raw_text");
+            if let Some(content) = content {
+                map.entry(injected)
+                    .or_insert_with(Vec::new)
+                    .push(node_to_range(&content));
+            }
+        }
+        let matcher = KindMatcher::new("style_element", lang.clone());
+        for style in root.find_all(matcher) {
+            let injected = find_html_lang(&style).unwrap_or_else(|| "css".into());
+            let content = style.children().find(|c| c.kind() == "raw_text");
+            if let Some(content) = content {
+                map.entry(injected)
+                    .or_insert_with(Vec::new)
+                    .push(node_to_range(&content));
+            }
+        }
+        map
+    }
+}
+
+fn find_html_lang<D: Doc>(node: &Node<D>) -> Option<String> {
+    let html = node.lang();
+    let attr_matcher = KindMatcher::new("attribute", html.clone());
+    let name_matcher = KindMatcher::new("attribute_name", html.clone());
+    let val_matcher = KindMatcher::new("attribute_value", html.clone());
+    node.find_all(attr_matcher).find_map(|attr| {
+        let name = attr.find(&name_matcher)?;
+        if name.text() != "lang" {
+            return None;
+        }
+        let val = attr.find(&val_matcher)?;
+        Some(val.text().to_string())
+    })
+}
+
+fn node_to_range<D: Doc>(node: &Node<D>) -> TSRange {
+    let r = node.range();
+    let start = node.start_pos();
+    let sp = start.byte_point();
+    let sp = tree_sitter::Point::new(sp.0, sp.1);
+    let end = node.end_pos();
+    let ep = end.byte_point();
+    let ep = tree_sitter::Point::new(ep.0, ep.1);
+    TSRange {
+        start_byte: r.start,
+        end_byte: r.end,
+        start_point: sp,
+        end_point: ep,
+    }
+}
+
+// ── SupportLang enum ────────────────────────────────────────────────────
+
+/// All supported languages for ast-grep structural search/replace.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SupportLang {
+    Astro,
+    Bash,
+    C,
+    Cmake,
+    Cpp,
+    CSharp,
+    Dart,
+    Clojure,
+    Css,
+    Diff,
+    Dockerfile,
+    EmacsLisp,
+    Elixir,
+    Erlang,
+    Fortran,
+    Go,
+    Graphql,
+    Haskell,
+    Hcl,
+    Html,
+    Ini,
+    Java,
+    JavaScript,
+    Json,
+    Just,
+    Julia,
+    Kotlin,
+    Lua,
+    Make,
+    Markdown,
+    Nix,
+    ObjC,
+    Ocaml,
+    Odin,
+    Php,
+    Powershell,
+    Proto,
+    Python,
+    R,
+    Regex,
+    Ruby,
+    Rust,
+    Scala,
+    Solidity,
+    Sql,
+    Starlark,
+    Svelte,
+    Swift,
+    Toml,
+    Tlaplus,
+    Tsx,
+    TypeScript,
+    Verilog,
+    Vue,
+    Xml,
+    Yaml,
+    Zig,
+}
+
+static SORTED_ALIASES: LazyLock<Box<[&'static str]>> = LazyLock::new(|| {
+    let mut aliases = LANG_ALIASES.keys().copied().collect::<Box<[_]>>();
+    aliases.sort_unstable();
+    aliases
+});
+
+impl SupportLang {
+    pub const fn all_langs() -> &'static [Self] {
+        use SupportLang::*;
+        &[
+            Astro, Bash, C, Cmake, Cpp, CSharp, Dart, Clojure, Css, Diff, Dockerfile, EmacsLisp,
+            Elixir, Erlang, Fortran, Go, Graphql, Haskell, Hcl, Html, Ini, Java, JavaScript, Json,
+            Just, Julia, Kotlin, Lua, Make, Markdown, Nix, ObjC, Ocaml, Odin, Php, Powershell,
+            Proto, Python, R, Regex, Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift,
+            Toml, Tlaplus, Tsx, TypeScript, Verilog, Vue, Xml, Yaml, Zig,
+        ]
+    }
+
+    /// The canonical lowercase name used as a stable key in alias maps,
+    /// file-type inference results, and error messages.
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Astro => "astro",
+            Self::Bash => "bash",
+            Self::C => "c",
+            Self::Cmake => "cmake",
+            Self::Cpp => "cpp",
+            Self::CSharp => "csharp",
+            Self::Dart => "dart",
+            Self::Clojure => "clojure",
+            Self::Css => "css",
+            Self::Diff => "diff",
+            Self::Dockerfile => "dockerfile",
+            Self::EmacsLisp => "emacs-lisp",
+            Self::Elixir => "elixir",
+            Self::Erlang => "erlang",
+            Self::Fortran => "fortran",
+            Self::Go => "go",
+            Self::Graphql => "graphql",
+            Self::Haskell => "haskell",
+            Self::Hcl => "hcl",
+            Self::Html => "html",
+            Self::Ini => "ini",
+            Self::Java => "java",
+            Self::JavaScript => "javascript",
+            Self::Json => "json",
+            Self::Just => "just",
+            Self::Julia => "julia",
+            Self::Kotlin => "kotlin",
+            Self::Lua => "lua",
+            Self::Make => "make",
+            Self::Markdown => "markdown",
+            Self::Nix => "nix",
+            Self::ObjC => "objc",
+            Self::Ocaml => "ocaml",
+            Self::Odin => "odin",
+            Self::Php => "php",
+            Self::Powershell => "powershell",
+            Self::Proto => "protobuf",
+            Self::Python => "python",
+            Self::R => "r",
+            Self::Regex => "regex",
+            Self::Ruby => "ruby",
+            Self::Rust => "rust",
+            Self::Scala => "scala",
+            Self::Solidity => "solidity",
+            Self::Sql => "sql",
+            Self::Starlark => "starlark",
+            Self::Svelte => "svelte",
+            Self::Swift => "swift",
+            Self::Toml => "toml",
+            Self::Tlaplus => "tlaplus",
+            Self::Tsx => "tsx",
+            Self::TypeScript => "typescript",
+            Self::Verilog => "verilog",
+            Self::Vue => "vue",
+            Self::Xml => "xml",
+            Self::Yaml => "yaml",
+            Self::Zig => "zig",
+        }
+    }
+
+    pub fn from_alias(value: &str) -> Option<Self> {
+        let lowered = value.trim().to_ascii_lowercase();
+        LANG_ALIASES.get(lowered.as_str()).copied()
+    }
+
+    pub fn from_path(path: &Path) -> Option<Self> {
+        from_extension(path)
+    }
+
+    pub fn sorted_aliases() -> &'static [&'static str] {
+        &SORTED_ALIASES
+    }
+}
+
+impl fmt::Display for SupportLang {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+// ── Dispatch macro ──────────────────────────────────────────────────────
+
+macro_rules! execute_lang_method {
+	($me:expr, $method:ident, $($pname:tt),*) => {
+		use SupportLang as S;
+		match *$me {
+			S::Astro => Astro.$method($($pname,)*),
+			S::Bash => Bash.$method($($pname,)*),
+			S::C => C.$method($($pname,)*),
+			S::Cmake => Cmake.$method($($pname,)*),
+			S::Cpp => Cpp.$method($($pname,)*),
+			S::CSharp => CSharp.$method($($pname,)*),
+			S::Dart => Dart.$method($($pname,)*),
+			S::Clojure => Clojure.$method($($pname,)*),
+			S::Css => Css.$method($($pname,)*),
+			S::Diff => Diff.$method($($pname,)*),
+			S::Dockerfile => Dockerfile.$method($($pname,)*),
+			S::EmacsLisp => EmacsLisp.$method($($pname,)*),
+			S::Elixir => Elixir.$method($($pname,)*),
+			S::Erlang => Erlang.$method($($pname,)*),
+			S::Fortran => Fortran.$method($($pname,)*),
+			S::Go => Go.$method($($pname,)*),
+			S::Graphql => Graphql.$method($($pname,)*),
+			S::Haskell => Haskell.$method($($pname,)*),
+			S::Hcl => Hcl.$method($($pname,)*),
+			S::Html => Html.$method($($pname,)*),
+			S::Ini => Ini.$method($($pname,)*),
+			S::Java => Java.$method($($pname,)*),
+			S::JavaScript => JavaScript.$method($($pname,)*),
+			S::Json => Json.$method($($pname,)*),
+			S::Just => Just.$method($($pname,)*),
+			S::Julia => Julia.$method($($pname,)*),
+			S::Kotlin => Kotlin.$method($($pname,)*),
+			S::Lua => Lua.$method($($pname,)*),
+			S::Make => Make.$method($($pname,)*),
+			S::Markdown => Markdown.$method($($pname,)*),
+			S::Nix => Nix.$method($($pname,)*),
+			S::ObjC => ObjC.$method($($pname,)*),
+			S::Ocaml => Ocaml.$method($($pname,)*),
+			S::Odin => Odin.$method($($pname,)*),
+			S::Php => Php.$method($($pname,)*),
+			S::Powershell => Powershell.$method($($pname,)*),
+			S::Proto => Proto.$method($($pname,)*),
+			S::Python => Python.$method($($pname,)*),
+			S::R => R.$method($($pname,)*),
+			S::Regex => Regex.$method($($pname,)*),
+			S::Ruby => Ruby.$method($($pname,)*),
+			S::Rust => Rust.$method($($pname,)*),
+			S::Scala => Scala.$method($($pname,)*),
+			S::Solidity => Solidity.$method($($pname,)*),
+			S::Sql => Sql.$method($($pname,)*),
+			S::Starlark => Starlark.$method($($pname,)*),
+			S::Svelte => Svelte.$method($($pname,)*),
+			S::Swift => Swift.$method($($pname,)*),
+			S::Toml => Toml.$method($($pname,)*),
+			S::Tlaplus => Tlaplus.$method($($pname,)*),
+			S::Tsx => Tsx.$method($($pname,)*),
+			S::TypeScript => TypeScript.$method($($pname,)*),
+			S::Verilog => Verilog.$method($($pname,)*),
+			S::Vue => Vue.$method($($pname,)*),
+			S::Xml => Xml.$method($($pname,)*),
+			S::Yaml => Yaml.$method($($pname,)*),
+			S::Zig => Zig.$method($($pname,)*),
+		}
+	};
+}
+
+macro_rules! impl_lang_method {
+	($method:ident, ($($pname:tt: $ptype:ty),*) => $return_type:ty) => {
+		#[inline]
+		fn $method(&self, $($pname: $ptype),*) -> $return_type {
+			execute_lang_method! { self, $method, $($pname),* }
+		}
+	};
+}
+
+impl Language for SupportLang {
+    impl_lang_method!(kind_to_id, (kind: &str) => u16);
+
+    impl_lang_method!(field_to_id, (field: &str) => Option<u16>);
+
+    impl_lang_method!(meta_var_char, () => char);
+
+    impl_lang_method!(expando_char, () => char);
+
+    impl_lang_method!(extract_meta_var, (source: &str) => Option<MetaVariable>);
+
+    impl_lang_method!(build_pattern, (builder: &PatternBuilder) => Result<Pattern, PatternError>);
+
+    fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
+        execute_lang_method! { self, pre_process_pattern, query }
+    }
+
+    fn from_path<P: AsRef<Path>>(path: P) -> Option<Self> {
+        from_extension(path.as_ref())
+    }
+}
+
+impl LanguageExt for SupportLang {
+    impl_lang_method!(get_ts_language, () => TSLanguage);
+
+    impl_lang_method!(injectable_languages, () => Option<&'static [&'static str]>);
+
+    fn extract_injections<L: LanguageExt>(
+        &self,
+        root: Node<StrDoc<L>>,
+    ) -> HashMap<String, Vec<TSRange>> {
+        match self {
+            Self::Html => Html.extract_injections(root),
+            _ => HashMap::new(),
+        }
+    }
+}
+
+// ── File extension mapping ──────────────────────────────────────────────
+
+const fn extensions(lang: SupportLang) -> &'static [&'static str] {
+    use SupportLang::*;
+    match lang {
+        Astro => &["astro"],
+        Bash => &[
+            "bash", "bats", "cgi", "command", "env", "fcgi", "ksh", "sh", "tmux", "tool", "zsh",
+        ],
+        C => &["c", "h"],
+        Cmake => &["cmake"],
+        Cpp => &["cc", "hpp", "cpp", "c++", "hh", "cxx", "cu", "ino"],
+        CSharp => &["cs"],
+        Dart => &["dart"],
+        Clojure => &["clj", "cljs", "cljc", "edn"],
+        Css => &["css", "scss"],
+        Diff => &["diff", "patch"],
+        Dockerfile => &["dockerfile"],
+        EmacsLisp => &["el"],
+        Elixir => &["ex", "exs"],
+        Erlang => &["erl", "hrl"],
+        Fortran => &["f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08"],
+        Go => &["go"],
+        Graphql => &["graphql", "gql"],
+        Haskell => &["hs"],
+        Hcl => &["hcl", "tf", "tfvars"],
+        Html => &["html", "htm", "xhtml"],
+        Ini => &["ini", "cfg", "conf", "properties"],
+        Java => &["java"],
+        JavaScript => &["cjs", "js", "mjs", "jsx"],
+        Json => &["json"],
+        Just => &[],
+        Julia => &["jl"],
+        Kotlin => &["kt", "ktm", "kts"],
+        Lua => &["lua"],
+        Make => &["mk", "mak"],
+        Markdown => &["md", "markdown", "mdx"],
+        Nix => &["nix"],
+        ObjC => &["m"],
+        Ocaml => &["ml"],
+        Odin => &["odin"],
+        Php => &["php"],
+        Powershell => &["ps1", "psm1"],
+        Proto => &["proto"],
+        Python => &["py", "py3", "pyi", "bzl"],
+        R => &["r"],
+        Regex => &[],
+        Ruby => &["rb", "rbw", "gemspec"],
+        Rust => &["rs"],
+        Scala => &["scala", "sc", "sbt"],
+        Solidity => &["sol"],
+        Sql => &["sql"],
+        Starlark => &["star", "bzl"],
+        Svelte => &["svelte"],
+        Swift => &["swift"],
+        Toml => &["toml"],
+        Tlaplus => &["tla"],
+        Tsx => &["tsx"],
+        TypeScript => &["ts", "cts", "mts"],
+        Verilog => &["v", "sv", "svh", "vh"],
+        Vue => &["vue"],
+        Xml => &["xml", "xsl", "xslt", "svg", "plist"],
+        Yaml => &["yaml", "yml"],
+        Zig => &["zig"],
+    }
+}
+
+/// Guess language from file extension.
+fn from_extension(path: &Path) -> Option<SupportLang> {
+    let name = path.file_name()?.to_str()?;
+    if name == "Makefile" || name == "makefile" || name == "GNUmakefile" {
+        return Some(SupportLang::Make);
+    }
+    if name == "Justfile" || name == "justfile" {
+        return Some(SupportLang::Just);
+    }
+    if name == "CMakeLists.txt" {
+        return Some(SupportLang::Cmake);
+    }
+    if name == "Dockerfile"
+        || name == "dockerfile"
+        || name.starts_with("Dockerfile.")
+        || name.starts_with("dockerfile.")
+        || name == "Containerfile"
+        || name == "containerfile"
+    {
+        return Some(SupportLang::Dockerfile);
+    }
+    if name == ".emacs" {
+        return Some(SupportLang::EmacsLisp);
+    }
+
+    // Extensionless shell rc/profile files. `Path::extension` returns `None`
+    // for both bare (`zshrc`) and dotfile (`.zshrc`) forms, so they would
+    // otherwise resolve to no language and disable block-aware ops on them.
+    let stem = name.strip_prefix('.').unwrap_or(name);
+    if matches!(
+        stem,
+        "zshrc"
+            | "zshenv"
+            | "zprofile"
+            | "zlogin"
+            | "zlogout"
+            | "zsh_aliases"
+            | "bashrc"
+            | "bash_profile"
+            | "bash_login"
+            | "bash_logout"
+            | "bash_aliases"
+            | "profile"
+            | "kshrc"
+            | "mkshrc"
+            | "shrc"
+    ) {
+        return Some(SupportLang::Bash);
+    }
+
+    let ext = path.extension()?.to_str()?;
+    SupportLang::all_langs()
+        .iter()
+        .copied()
+        .find(|&l| extensions(l).contains(&ext))
+}
+
+static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
+"astro"          => SupportLang::Astro,
+"bash"           => SupportLang::Bash,
+"sh"             => SupportLang::Bash,
+"zsh"            => SupportLang::Bash,
+"ksh"            => SupportLang::Bash,
+"bats"           => SupportLang::Bash,
+"c"              => SupportLang::C,
+"h"              => SupportLang::C,
+"cmake"          => SupportLang::Cmake,
+"cpp"            => SupportLang::Cpp,
+"c++"            => SupportLang::Cpp,
+"cc"             => SupportLang::Cpp,
+"cxx"            => SupportLang::Cpp,
+"hh"             => SupportLang::Cpp,
+"hpp"            => SupportLang::Cpp,
+"cu"             => SupportLang::Cpp,
+"ino"            => SupportLang::Cpp,
+"csharp"         => SupportLang::CSharp,
+"c#"             => SupportLang::CSharp,
+"cs"             => SupportLang::CSharp,
+"dart"           => SupportLang::Dart,
+"css"            => SupportLang::Css,
+"clj"            => SupportLang::Clojure,
+"cljc"           => SupportLang::Clojure,
+"cljs"           => SupportLang::Clojure,
+"clojure"        => SupportLang::Clojure,
+"clojurescript"  => SupportLang::Clojure,
+"edn"            => SupportLang::Clojure,
+"diff"           => SupportLang::Diff,
+"patch"          => SupportLang::Diff,
+"docker"         => SupportLang::Dockerfile,
+"dockerfile"     => SupportLang::Dockerfile,
+"containerfile"  => SupportLang::Dockerfile,
+"emacs-lisp"     => SupportLang::EmacsLisp,
+"emacslisp"      => SupportLang::EmacsLisp,
+"elisp"          => SupportLang::EmacsLisp,
+"el"             => SupportLang::EmacsLisp,
+"elixir"         => SupportLang::Elixir,
+"ex"             => SupportLang::Elixir,
+"exs"            => SupportLang::Elixir,
+"erlang"         => SupportLang::Erlang,
+"erl"            => SupportLang::Erlang,
+"hrl"            => SupportLang::Erlang,
+"fortran"        => SupportLang::Fortran,
+"f90"            => SupportLang::Fortran,
+"f95"            => SupportLang::Fortran,
+"f03"            => SupportLang::Fortran,
+"f08"            => SupportLang::Fortran,
+"go"             => SupportLang::Go,
+"golang"         => SupportLang::Go,
+"graphql"        => SupportLang::Graphql,
+"gql"            => SupportLang::Graphql,
+"haskell"        => SupportLang::Haskell,
+"hs"             => SupportLang::Haskell,
+"hcl"            => SupportLang::Hcl,
+"tf"             => SupportLang::Hcl,
+"tfvars"         => SupportLang::Hcl,
+"terraform"      => SupportLang::Hcl,
+"html"           => SupportLang::Html,
+"htm"            => SupportLang::Html,
+"xhtml"          => SupportLang::Html,
+"ini"            => SupportLang::Ini,
+"cfg"            => SupportLang::Ini,
+"conf"           => SupportLang::Ini,
+"config"         => SupportLang::Ini,
+"properties"     => SupportLang::Ini,
+"java"           => SupportLang::Java,
+"javascript"     => SupportLang::JavaScript,
+"js"             => SupportLang::JavaScript,
+"jsx"            => SupportLang::JavaScript,
+"mjs"            => SupportLang::JavaScript,
+"cjs"            => SupportLang::JavaScript,
+"json"           => SupportLang::Json,
+"just"           => SupportLang::Just,
+"justfile"       => SupportLang::Just,
+"julia"          => SupportLang::Julia,
+"jl"             => SupportLang::Julia,
+"kotlin"         => SupportLang::Kotlin,
+"kt"             => SupportLang::Kotlin,
+"kts"            => SupportLang::Kotlin,
+"ktm"            => SupportLang::Kotlin,
+"lua"            => SupportLang::Lua,
+"make"           => SupportLang::Make,
+"makefile"       => SupportLang::Make,
+"gnumake"        => SupportLang::Make,
+"mk"             => SupportLang::Make,
+"mak"            => SupportLang::Make,
+"markdown"       => SupportLang::Markdown,
+"md"             => SupportLang::Markdown,
+"mdx"            => SupportLang::Markdown,
+"nix"            => SupportLang::Nix,
+"objc"           => SupportLang::ObjC,
+"obj-c"          => SupportLang::ObjC,
+"objective-c"    => SupportLang::ObjC,
+"m"              => SupportLang::ObjC,
+"mm"             => SupportLang::ObjC,
+"ocaml"          => SupportLang::Ocaml,
+"ml"             => SupportLang::Ocaml,
+"odin"           => SupportLang::Odin,
+"php"            => SupportLang::Php,
+"powershell"     => SupportLang::Powershell,
+"ps1"            => SupportLang::Powershell,
+"psm1"           => SupportLang::Powershell,
+"protobuf"       => SupportLang::Proto,
+"proto"          => SupportLang::Proto,
+"python"         => SupportLang::Python,
+"py"             => SupportLang::Python,
+"py3"            => SupportLang::Python,
+"pyi"            => SupportLang::Python,
+"r"              => SupportLang::R,
+"regex"          => SupportLang::Regex,
+"re"             => SupportLang::Regex,
+"ruby"           => SupportLang::Ruby,
+"rb"             => SupportLang::Ruby,
+"rbw"            => SupportLang::Ruby,
+"gemspec"        => SupportLang::Ruby,
+"rust"           => SupportLang::Rust,
+"rs"             => SupportLang::Rust,
+"scala"          => SupportLang::Scala,
+"sc"             => SupportLang::Scala,
+"sbt"            => SupportLang::Scala,
+"solidity"       => SupportLang::Solidity,
+"sol"            => SupportLang::Solidity,
+"sql"            => SupportLang::Sql,
+"starlark"       => SupportLang::Starlark,
+"star"           => SupportLang::Starlark,
+"bzl"            => SupportLang::Starlark,
+"bazel"          => SupportLang::Starlark,
+"skylark"        => SupportLang::Starlark,
+"svelte"         => SupportLang::Svelte,
+"swift"          => SupportLang::Swift,
+"toml"           => SupportLang::Toml,
+"tla"            => SupportLang::Tlaplus,
+"tla+"           => SupportLang::Tlaplus,
+"tlaplus"        => SupportLang::Tlaplus,
+"pluscal"        => SupportLang::Tlaplus,
+"pcal"           => SupportLang::Tlaplus,
+"tsx"            => SupportLang::Tsx,
+"typescript"     => SupportLang::TypeScript,
+"ts"             => SupportLang::TypeScript,
+"mts"            => SupportLang::TypeScript,
+"cts"            => SupportLang::TypeScript,
+"verilog"        => SupportLang::Verilog,
+"systemverilog"  => SupportLang::Verilog,
+"sv"             => SupportLang::Verilog,
+"svh"            => SupportLang::Verilog,
+"vh"             => SupportLang::Verilog,
+"v"              => SupportLang::Verilog,
+"vue"            => SupportLang::Vue,
+"xml"            => SupportLang::Xml,
+"xsl"            => SupportLang::Xml,
+"xslt"           => SupportLang::Xml,
+"svg"            => SupportLang::Xml,
+"plist"          => SupportLang::Xml,
+"yaml"           => SupportLang::Yaml,
+"yml"            => SupportLang::Yaml,
+"zig"            => SupportLang::Zig,
+};

--- a/crates/vendor/oh-my-pi/pi-ast/src/language/parsers.rs
+++ b/crates/vendor/oh-my-pi/pi-ast/src/language/parsers.rs
@@ -1,0 +1,175 @@
+//! Tree-sitter parser functions for all supported languages.
+
+use ast_grep_core::tree_sitter::TSLanguage;
+
+pub fn language_astro() -> TSLanguage {
+    tree_sitter_astro::LANGUAGE.into()
+}
+pub fn language_bash() -> TSLanguage {
+    tree_sitter_bash::LANGUAGE.into()
+}
+pub fn language_c() -> TSLanguage {
+    tree_sitter_c::LANGUAGE.into()
+}
+pub fn language_clojure() -> TSLanguage {
+    tree_sitter_clojure::LANGUAGE.into()
+}
+pub fn language_cmake() -> TSLanguage {
+    tree_sitter_cmake::LANGUAGE.into()
+}
+pub fn language_cpp() -> TSLanguage {
+    tree_sitter_cpp::LANGUAGE.into()
+}
+pub fn language_c_sharp() -> TSLanguage {
+    tree_sitter_c_sharp::LANGUAGE.into()
+}
+pub fn language_dart() -> TSLanguage {
+    tree_sitter_dart::LANGUAGE.into()
+}
+pub fn language_css() -> TSLanguage {
+    tree_sitter_css::LANGUAGE.into()
+}
+pub fn language_diff() -> TSLanguage {
+    tree_sitter_diff::LANGUAGE.into()
+}
+pub fn language_dockerfile() -> TSLanguage {
+    tree_sitter_dockerfile::language()
+}
+pub fn language_elixir() -> TSLanguage {
+    tree_sitter_elixir::LANGUAGE.into()
+}
+pub fn language_elisp() -> TSLanguage {
+    tree_sitter_elisp::LANGUAGE.into()
+}
+pub fn language_erlang() -> TSLanguage {
+    tree_sitter_erlang::LANGUAGE.into()
+}
+pub fn language_fortran() -> TSLanguage {
+    tree_sitter_fortran::LANGUAGE.into()
+}
+pub fn language_go() -> TSLanguage {
+    tree_sitter_go::LANGUAGE.into()
+}
+pub fn language_graphql() -> TSLanguage {
+    tree_sitter_graphql::LANGUAGE.into()
+}
+pub fn language_haskell() -> TSLanguage {
+    tree_sitter_haskell::LANGUAGE.into()
+}
+pub fn language_hcl() -> TSLanguage {
+    tree_sitter_hcl::LANGUAGE.into()
+}
+pub fn language_html() -> TSLanguage {
+    tree_sitter_html::LANGUAGE.into()
+}
+pub fn language_ini() -> TSLanguage {
+    tree_sitter_ini::LANGUAGE.into()
+}
+pub fn language_java() -> TSLanguage {
+    tree_sitter_java::LANGUAGE.into()
+}
+pub fn language_javascript() -> TSLanguage {
+    tree_sitter_javascript::LANGUAGE.into()
+}
+pub fn language_json() -> TSLanguage {
+    tree_sitter_json::LANGUAGE.into()
+}
+pub fn language_just() -> TSLanguage {
+    tree_sitter_just::LANGUAGE.into()
+}
+pub fn language_julia() -> TSLanguage {
+    tree_sitter_julia::LANGUAGE.into()
+}
+pub fn language_kotlin() -> TSLanguage {
+    tree_sitter_kotlin::LANGUAGE.into()
+}
+pub fn language_lua() -> TSLanguage {
+    tree_sitter_lua::LANGUAGE.into()
+}
+pub fn language_make() -> TSLanguage {
+    tree_sitter_make::LANGUAGE.into()
+}
+pub fn language_markdown() -> TSLanguage {
+    tree_sitter_md::LANGUAGE.into()
+}
+pub fn language_nix() -> TSLanguage {
+    tree_sitter_nix::LANGUAGE.into()
+}
+pub fn language_objc() -> TSLanguage {
+    tree_sitter_objc::LANGUAGE.into()
+}
+pub fn language_ocaml() -> TSLanguage {
+    tree_sitter_ocaml::LANGUAGE_OCAML.into()
+}
+pub fn language_odin() -> TSLanguage {
+    tree_sitter_odin::LANGUAGE.into()
+}
+pub fn language_php() -> TSLanguage {
+    tree_sitter_php::LANGUAGE_PHP_ONLY.into()
+}
+pub fn language_powershell() -> TSLanguage {
+    tree_sitter_powershell::LANGUAGE.into()
+}
+pub fn language_proto() -> TSLanguage {
+    tree_sitter_proto::LANGUAGE.into()
+}
+pub fn language_python() -> TSLanguage {
+    tree_sitter_python::LANGUAGE.into()
+}
+pub fn language_r() -> TSLanguage {
+    tree_sitter_r::LANGUAGE.into()
+}
+pub fn language_regex() -> TSLanguage {
+    tree_sitter_regex::LANGUAGE.into()
+}
+pub fn language_ruby() -> TSLanguage {
+    tree_sitter_ruby::LANGUAGE.into()
+}
+pub fn language_rust() -> TSLanguage {
+    tree_sitter_rust::LANGUAGE.into()
+}
+pub fn language_scala() -> TSLanguage {
+    tree_sitter_scala::LANGUAGE.into()
+}
+pub fn language_solidity() -> TSLanguage {
+    tree_sitter_solidity::LANGUAGE.into()
+}
+pub fn language_sql() -> TSLanguage {
+    tree_sitter_sql::LANGUAGE.into()
+}
+pub fn language_starlark() -> TSLanguage {
+    tree_sitter_starlark::LANGUAGE.into()
+}
+pub fn language_svelte() -> TSLanguage {
+    tree_sitter_svelte::LANGUAGE.into()
+}
+pub fn language_swift() -> TSLanguage {
+    tree_sitter_swift::LANGUAGE.into()
+}
+pub fn language_toml() -> TSLanguage {
+    tree_sitter_toml_ng::LANGUAGE.into()
+}
+pub fn language_tsx() -> TSLanguage {
+    tree_sitter_typescript::LANGUAGE_TSX.into()
+}
+pub fn language_typescript() -> TSLanguage {
+    tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+}
+pub fn language_tlaplus() -> TSLanguage {
+    tree_sitter_tlaplus::LANGUAGE.into()
+}
+pub fn language_verilog() -> TSLanguage {
+    tree_sitter_verilog::LANGUAGE.into()
+}
+pub fn language_vue() -> TSLanguage {
+    tree_sitter_vue::LANGUAGE.into()
+}
+pub fn language_xml() -> TSLanguage {
+    tree_sitter_xml::LANGUAGE_XML.into()
+}
+pub fn language_yaml() -> TSLanguage {
+    tree_sitter_yaml::LANGUAGE.into()
+}
+pub fn language_zig() -> TSLanguage {
+    tree_sitter_zig::LANGUAGE.into()
+}

--- a/crates/vendor/oh-my-pi/pi-ast/src/lib.rs
+++ b/crates/vendor/oh-my-pi/pi-ast/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod block;
+pub mod language;
+pub mod ops;
+pub mod summary;
+
+pub use language::SupportLang;

--- a/crates/vendor/oh-my-pi/pi-ast/src/ops.rs
+++ b/crates/vendor/oh-my-pi/pi-ast/src/ops.rs
@@ -1,0 +1,461 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use ast_grep_core::{
+    MatchStrictness,
+    matcher::{Pattern, PatternError},
+    source::Edit,
+    tree_sitter::LanguageExt,
+};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use ignore::WalkBuilder;
+
+use crate::language::SupportLang;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AstMatchStrictness {
+    Cst,
+    Smart,
+    Ast,
+    Relaxed,
+    Signature,
+    Template,
+}
+
+impl From<AstMatchStrictness> for MatchStrictness {
+    fn from(value: AstMatchStrictness) -> Self {
+        match value {
+            AstMatchStrictness::Cst => Self::Cst,
+            AstMatchStrictness::Smart => Self::Smart,
+            AstMatchStrictness::Ast => Self::Ast,
+            AstMatchStrictness::Relaxed => Self::Relaxed,
+            AstMatchStrictness::Signature => Self::Signature,
+            AstMatchStrictness::Template => Self::Template,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AstMatch {
+    pub line: usize,
+    pub column: usize,
+    pub end_line: usize,
+    pub end_column: usize,
+    pub byte_start: usize,
+    pub byte_end: usize,
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchedFile {
+    pub absolute_path: PathBuf,
+    pub relative_path: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompiledRewrite {
+    pub out: String,
+    pub patterns: Vec<Pattern>,
+}
+
+#[must_use]
+pub fn resolve_strictness(value: Option<AstMatchStrictness>) -> MatchStrictness {
+    value.map_or(MatchStrictness::Smart, Into::into)
+}
+
+#[must_use]
+pub fn supported_lang_list() -> String {
+    SupportLang::sorted_aliases().join(", ")
+}
+
+pub fn resolve_supported_lang(value: &str) -> Result<SupportLang> {
+    SupportLang::from_alias(value).ok_or_else(|| {
+        anyhow!(
+            "Unsupported language '{value}'. Supported: {}",
+            supported_lang_list()
+        )
+    })
+}
+
+pub fn resolve_language(lang: Option<&str>, file_path: &Path) -> Result<SupportLang> {
+    if let Some(lang) = lang.map(str::trim).filter(|lang| !lang.is_empty()) {
+        return resolve_supported_lang(lang);
+    }
+    SupportLang::from_path(file_path).ok_or_else(|| {
+        anyhow!(
+            "Unable to infer language from file extension: {}. Specify `lang` explicitly.",
+            file_path.display()
+        )
+    })
+}
+
+#[must_use]
+pub fn is_supported_file(file_path: &Path, explicit_lang: Option<&str>) -> bool {
+    if explicit_lang.is_some() {
+        return true;
+    }
+    resolve_language(None, file_path).is_ok()
+}
+
+pub fn compile_pattern(
+    pattern: &str,
+    selector: Option<&str>,
+    strictness: &MatchStrictness,
+    lang: SupportLang,
+) -> Result<Pattern> {
+    let selector = selector.map(str::trim).filter(|s| !s.is_empty());
+    let mut compiled = if let Some(selector) = selector {
+        Pattern::contextual(pattern, selector, lang)
+            .map_err(|err| anyhow!("Invalid pattern: {err}"))?
+    } else {
+        match Pattern::try_new(pattern, lang) {
+            Ok(compiled) => compiled,
+            // A fragment like `"key": $V` parses to multiple root nodes and is
+            // rejected as `MultipleNode`; auto-wrap it in a single-node context
+            // before giving up. Any other error, or a failed fallback, keeps the
+            // original message so genuinely-bad patterns behave as before.
+            Err(err @ PatternError::MultipleNode(_)) => {
+                match compile_wrapped_fallback(pattern, strictness, lang) {
+                    Some(compiled) => return Ok(compiled),
+                    None => return Err(anyhow!("Invalid pattern: {err}")),
+                }
+            }
+            Err(err) => return Err(anyhow!("Invalid pattern: {err}")),
+        }
+    };
+    compiled.strictness = strictness.clone();
+    Ok(compiled)
+}
+
+/// Language-specific wrapper template used to turn a multi-node fragment into a
+/// single selectable node. `None` for languages without a template — those keep
+/// the original `MultipleNode` error.
+const fn wrapper_template(lang: SupportLang) -> Option<(&'static str, &'static str, &'static str)> {
+    // (prefix, suffix, selector-kind); the fragment is spliced between
+    // prefix/suffix.
+    match lang {
+        SupportLang::Json => Some(("{", "}", "pair")),
+        _ => None,
+    }
+}
+
+/// Retry a fragment that failed as `MultipleNode` by wrapping it in a minimal
+/// valid context and selecting the node kind that spans it. Returns the
+/// compiled pattern (with `strictness` applied) or `None` if this language has
+/// no template or the wrapped form still fails to compile.
+fn compile_wrapped_fallback(
+    pattern: &str,
+    strictness: &MatchStrictness,
+    lang: SupportLang,
+) -> Option<Pattern> {
+    let (prefix, suffix, selector) = wrapper_template(lang)?;
+    // JSON only accepts a bare `$V` inside a string, so quote value-position
+    // metavars; ast-grep still reads the quoted `"$V"` as capture `V`.
+    let prepared = if lang == SupportLang::Json {
+        quote_bare_metavars(pattern)
+    } else {
+        pattern.to_string()
+    };
+    let context = format!("{prefix} {prepared} {suffix}");
+    let mut compiled = Pattern::contextual(&context, selector, lang).ok()?;
+    compiled.strictness = strictness.clone();
+    Some(compiled)
+}
+
+/// Wrap bare `$NAME` / `$$$NAME` metavars in double quotes so a JSON wrapper
+/// parses. Metavars already inside a string literal (including `"$V"`) are left
+/// untouched; a quote toggles in/out of string context.
+fn quote_bare_metavars(pattern: &str) -> String {
+    let bytes = pattern.as_bytes();
+    let mut out = String::with_capacity(pattern.len() + 4);
+    let mut in_string = false;
+    let mut index = 0;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if byte == b'"' && (index == 0 || bytes[index - 1] != b'\\') {
+            in_string = !in_string;
+            out.push('"');
+            index += 1;
+            continue;
+        }
+        if byte == b'$' && !in_string {
+            // Consume `$`, an optional `$$` ellipsis, then the identifier.
+            let start = index;
+            index += 1;
+            if bytes[index..].starts_with(b"$$") {
+                index += 2;
+            }
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+            {
+                index += 1;
+            }
+            out.push('"');
+            out.push_str(&pattern[start..index]);
+            out.push('"');
+            continue;
+        }
+        // Copy this byte's full UTF-8 char so multi-byte content is preserved.
+        let char_end = next_char_boundary(bytes, index);
+        out.push_str(&pattern[index..char_end]);
+        index = char_end;
+    }
+    out
+}
+
+/// Byte index of the end of the UTF-8 character starting at `index`.
+fn next_char_boundary(bytes: &[u8], index: usize) -> usize {
+    let mut end = index + 1;
+    while end < bytes.len() && (bytes[end] & 0b1100_0000) == 0b1000_0000 {
+        end += 1;
+    }
+    end
+}
+
+pub fn compile_search_patterns(
+    pattern: &str,
+    language: SupportLang,
+) -> Result<Vec<Pattern>, PatternError> {
+    let mut compiled = match Pattern::try_new(pattern, language) {
+        Ok(compiled) => vec![compiled],
+        // Multi-node fragments (e.g. `"key": $V`) get the same auto-wrap fallback
+        // as the edit path; other errors propagate unchanged.
+        Err(err @ PatternError::MultipleNode(_)) => {
+            match compile_wrapped_fallback(pattern, &MatchStrictness::Smart, language) {
+                Some(compiled) => vec![compiled],
+                None => return Err(err),
+            }
+        }
+        Err(err) => return Err(err),
+    };
+    if language == SupportLang::Rust {
+        let trimmed = pattern.trim_end();
+        if let Some(contextual) = compile_rust_contextual_pattern(trimmed) {
+            compiled.push(contextual);
+        }
+    }
+    Ok(compiled)
+}
+
+pub fn compile_rewrite_rules(
+    rules: &[(String, String)],
+    language: SupportLang,
+) -> Result<Vec<CompiledRewrite>, (usize, PatternError)> {
+    rules
+        .iter()
+        .enumerate()
+        .map(|(index, (pattern, out))| {
+            compile_search_patterns(pattern, language)
+                .map(|patterns| CompiledRewrite {
+                    out: out.clone(),
+                    patterns,
+                })
+                .map_err(|error| (index, error))
+        })
+        .collect()
+}
+
+#[must_use]
+pub fn collect_matches(source: &str, language: SupportLang, patterns: &[Pattern]) -> Vec<AstMatch> {
+    let ast = language.ast_grep(source);
+    let mut matches = Vec::new();
+    for pattern in patterns {
+        for matched in ast.root().find_all(pattern.clone()) {
+            let start = matched.start_pos();
+            let end = matched.end_pos();
+            let range = matched.range();
+            let node = matched.get_node();
+            matches.push(AstMatch {
+                line: start.line() + 1,
+                column: start.column(node) + 1,
+                end_line: end.line() + 1,
+                end_column: end.column(node) + 1,
+                byte_start: range.start,
+                byte_end: range.end,
+                text: matched.text().into_owned(),
+            });
+        }
+    }
+    matches
+}
+
+pub fn rewrite_source(
+    source: &str,
+    language: SupportLang,
+    ops: &[CompiledRewrite],
+) -> Result<(String, u32), String> {
+    let mut ast = language.ast_grep(source);
+    let mut replacements = 0_u32;
+    for op in ops {
+        for pattern in &op.patterns {
+            let edits = ast.root().replace_all(pattern.clone(), op.out.as_str());
+            if edits.is_empty() {
+                continue;
+            }
+            replacements = replacements.saturating_add(edits.len() as u32);
+            let updated = apply_edits(ast.root().text().as_ref(), &edits)
+                .map_err(|error| error.to_string())?;
+            ast = language.ast_grep(updated);
+        }
+    }
+    Ok((ast.root().text().into_owned(), replacements))
+}
+
+pub fn apply_edits(content: &str, edits: &[Edit<String>]) -> Result<String> {
+    let mut sorted: Vec<&Edit<String>> = edits.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.position
+            .cmp(&b.position)
+            .then(a.deleted_length.cmp(&b.deleted_length))
+            .then(a.inserted_text.cmp(&b.inserted_text))
+    });
+    // Byte-identical edits (same span, same replacement) are one deterministic
+    // edit: multiple patterns matching the same node collapse instead of
+    // tripping the overlap check. Only divergent overlaps are ambiguous.
+    sorted.dedup_by(|a, b| {
+        a.position == b.position
+            && a.deleted_length == b.deleted_length
+            && a.inserted_text == b.inserted_text
+    });
+    let mut prev_end = 0usize;
+    for edit in &sorted {
+        if edit.position < prev_end {
+            return Err(anyhow!(
+                "Overlapping replacements detected; refine pattern to avoid ambiguous edits"
+            ));
+        }
+        prev_end = edit.position.saturating_add(edit.deleted_length);
+    }
+
+    let mut output = content.to_string();
+    for edit in sorted.into_iter().rev() {
+        let start = edit.position;
+        let end = edit.position.saturating_add(edit.deleted_length);
+        if end > output.len() || start > end {
+            return Err(anyhow!("Computed edit range is out of bounds"));
+        }
+        let replacement = std::str::from_utf8(&edit.inserted_text)
+            .map_err(|err| anyhow!("Replacement text is not valid UTF-8: {err}"))?;
+        output.replace_range(start..end, replacement);
+    }
+    Ok(output)
+}
+
+pub fn collect_matched_files(
+    cwd: &Path,
+    patterns: &[String],
+) -> Result<Vec<MatchedFile>, std::io::Error> {
+    let globset = build_globset(patterns)?;
+    let mut builder = WalkBuilder::new(cwd);
+    builder
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true);
+    let mut files = Vec::new();
+    for entry in builder.build() {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => return Err(std::io::Error::other(error)),
+        };
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        let absolute_path = entry.into_path();
+        let relative_path = absolute_path
+            .strip_prefix(cwd)
+            .unwrap_or(&absolute_path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if globset.is_match(&relative_path)
+            || patterns.iter().any(|pattern| pattern == &relative_path)
+        {
+            files.push(MatchedFile {
+                absolute_path,
+                relative_path,
+            });
+        }
+    }
+    files.sort_unstable_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(files)
+}
+
+fn build_globset(patterns: &[String]) -> Result<GlobSet, std::io::Error> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        if has_glob_syntax(pattern) {
+            let glob = Glob::new(pattern).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("invalid glob `{pattern}`: {error}"),
+                )
+            })?;
+            builder.add(glob);
+        }
+    }
+    builder.build().map_err(std::io::Error::other)
+}
+
+#[must_use]
+pub fn has_glob_syntax(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?') || pattern.contains('[')
+}
+
+fn compile_rust_contextual_pattern(pattern: &str) -> Option<Pattern> {
+    let language = SupportLang::Rust;
+    let context = format!("fn __rwp_wrapper() {{ {pattern}; }}");
+    let ast = language.ast_grep(&context);
+    let selector = ast.root().find("expression_statement")?;
+    Pattern::contextual(pattern, selector.kind().as_ref(), language).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use ast_grep_core::source::Edit;
+
+    use super::{SupportLang, apply_edits, compile_search_patterns};
+
+    #[test]
+    fn compile_search_patterns_compiles_rust_patterns() {
+        let patterns = compile_search_patterns("foo($$$ARGS)", SupportLang::Rust)
+            .expect("rust pattern should compile");
+        assert!(!patterns.is_empty());
+    }
+
+    #[test]
+    fn apply_edits_rejects_overlaps() {
+        let source = "abcdef";
+        let edits = vec![
+            Edit::<String> {
+                position: 1,
+                deleted_length: 3,
+                inserted_text: b"x".to_vec(),
+            },
+            Edit::<String> {
+                position: 2,
+                deleted_length: 1,
+                inserted_text: b"y".to_vec(),
+            },
+        ];
+        assert!(apply_edits(source, &edits).is_err());
+    }
+
+    #[test]
+    fn apply_edits_dedupes_identical_edits() {
+        let source = "abcdef";
+        let edits = vec![
+            Edit::<String> {
+                position: 1,
+                deleted_length: 3,
+                inserted_text: b"x".to_vec(),
+            },
+            Edit::<String> {
+                position: 1,
+                deleted_length: 3,
+                inserted_text: b"x".to_vec(),
+            },
+        ];
+        let output = apply_edits(source, &edits).expect("identical edits should collapse to one");
+        assert_eq!(output, "axef");
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-ast/src/summary.rs
+++ b/crates/vendor/oh-my-pi/pi-ast/src/summary.rs
@@ -1,0 +1,1455 @@
+//! Structural source summaries powered by tree-sitter.
+
+use std::{collections::BTreeSet, path::Path};
+
+use anyhow::{Result, anyhow};
+use ast_grep_core::tree_sitter::LanguageExt;
+use serde::{Deserialize, Serialize};
+use tree_sitter::{Node, Parser};
+
+use crate::language::SupportLang;
+
+const DEFAULT_MIN_BODY_LINES: u32 = 4;
+const DEFAULT_MIN_COMMENT_LINES: u32 = 6;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SummaryOptions {
+    /// Source code to summarize.
+    pub code: String,
+    /// Language alias (e.g. "rust", "typescript") used before path inference.
+    pub lang: Option<String>,
+    /// File path used to infer language by extension when `lang` is omitted.
+    pub path: Option<String>,
+    /// Minimum total node lines before eliding a body/literal node.
+    pub min_body_lines: Option<u32>,
+    /// Minimum total comment lines before eliding a multiline block comment.
+    pub min_comment_lines: Option<u32>,
+    /// Target visible-line count for BFS unfold. Starting from every elidable
+    /// span folded, this progressively reveals outer-then-inner spans until
+    /// the visible line count meets the target. `None` or `0` disables BFS
+    /// and keeps only the outermost elisions (every nested span stays hidden
+    /// behind its parent).
+    pub unfold_until_lines: Option<u32>,
+    /// Hard ceiling for BFS unfold. If a candidate unfold would push the
+    /// visible count past this value, revert that step and stop. Defaults
+    /// to `unfold_until_lines * 2` when omitted (with `unfold_until_lines`
+    /// itself as the floor so a single threshold also works).
+    pub unfold_limit_lines: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SummarySegment {
+    /// "kept" or "elided".
+    pub kind: String,
+    /// 1-based inclusive start line.
+    pub start_line: u32,
+    /// 1-based inclusive end line.
+    pub end_line: u32,
+    /// Verbatim text for kept segments; absent for elided segments.
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SummaryResult {
+    /// Canonical language name when parsing succeeded.
+    pub language: Option<String>,
+    /// True when tree-sitter parsed the source without syntax errors.
+    pub parsed: bool,
+    /// True when at least one elision span was emitted.
+    pub elided: bool,
+    /// Total source lines.
+    pub total_lines: u32,
+    /// Kept/elided segments in source order.
+    pub segments: Vec<SummarySegment>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct LineSpan {
+    start: u32,
+    end: u32,
+}
+
+impl LineSpan {
+    const fn lines(self) -> u32 {
+        self.end.saturating_sub(self.start).saturating_add(1)
+    }
+}
+
+/// One elidable region plus its directly-nested elidable descendants. The
+/// forest is built by AST traversal in source order, so `children` reflects
+/// the structural hierarchy: a child's span is always strictly contained
+/// within its parent's.
+#[derive(Debug)]
+struct SpanNode {
+    span: LineSpan,
+    children: Vec<usize>,
+}
+
+/// Flat arena of elidable spans organized as a forest. `roots` lists the
+/// topmost spans — anything whose AST ancestors held no elidable container.
+#[derive(Debug, Default)]
+struct ElidableForest {
+    nodes: Vec<SpanNode>,
+    roots: Vec<usize>,
+}
+
+impl ElidableForest {
+    fn push(&mut self, parent: Option<usize>, span: LineSpan) -> usize {
+        let idx = self.nodes.len();
+        self.nodes.push(SpanNode {
+            span,
+            children: Vec::new(),
+        });
+        match parent {
+            Some(p) => self.nodes[p].children.push(idx),
+            None => self.roots.push(idx),
+        }
+        idx
+    }
+}
+
+/// BFS unfold. Start with every root span folded (matches the legacy
+/// outermost-only behavior) and progressively replace folded spans with
+/// their elidable children, breadth-first, until the visible line count
+/// reaches `unfold_until`. A candidate unfold whose revealed lines would
+/// push the visible count past `unfold_limit` is skipped — that span stays
+/// folded and its subtree is not explored — while the BFS keeps unfolding
+/// the remaining queued siblings. A single oversized, un-unfoldable leaf
+/// (e.g. a `<style>` raw-text block) therefore no longer aborts the whole
+/// pass and starve its siblings. `unfold_until == 0` short-circuits to the
+/// legacy behavior.
+fn select_folded_spans(
+    forest: &ElidableForest,
+    total_lines: u32,
+    unfold_until: u32,
+    unfold_limit: u32,
+) -> Vec<LineSpan> {
+    use std::collections::{HashSet, VecDeque};
+
+    let nodes = &forest.nodes;
+    let mut folded: HashSet<usize> = forest.roots.iter().copied().collect();
+    if unfold_until == 0 || folded.is_empty() {
+        return folded.into_iter().map(|i| nodes[i].span).collect();
+    }
+
+    let folded_line_total: u32 = folded.iter().map(|&i| nodes[i].span.lines()).sum();
+    let mut visible = total_lines.saturating_sub(folded_line_total);
+    let mut queue: VecDeque<usize> = forest.roots.iter().copied().collect();
+
+    while let Some(idx) = queue.pop_front() {
+        if visible >= unfold_until {
+            break;
+        }
+        if !folded.contains(&idx) {
+            continue;
+        }
+        let node = &nodes[idx];
+        let child_line_total: u32 = node.children.iter().map(|&c| nodes[c].span.lines()).sum();
+        // Unfolding swaps the parent's span for its children's, so the visible
+        // gain is the difference between them. `saturating_sub` keeps the math
+        // honest if children somehow over-cover (they shouldn't by construction).
+        let revealed = node.span.lines().saturating_sub(child_line_total);
+        let new_visible = visible.saturating_add(revealed);
+        if new_visible > unfold_limit {
+            continue;
+        }
+        folded.remove(&idx);
+        for &c in &node.children {
+            folded.insert(c);
+            queue.push_back(c);
+        }
+        visible = new_visible;
+    }
+
+    folded.into_iter().map(|i| nodes[i].span).collect()
+}
+
+pub fn summarize_code(options: SummaryOptions) -> Result<SummaryResult> {
+    let source = options.code;
+    let total_lines = count_lines(&source);
+    if source.is_empty() {
+        return Ok(unparsed_result(source, total_lines));
+    }
+
+    let Some(language) = resolve_language(options.lang.as_deref(), options.path.as_deref()) else {
+        return Ok(unparsed_result(source, total_lines));
+    };
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language.get_ts_language())
+        .map_err(|err| anyhow!("Failed to load tree-sitter language: {err}"))?;
+    let Some(tree) = parser.parse(&source, None) else {
+        return Ok(unparsed_result(source, total_lines));
+    };
+    let root = tree.root_node();
+    if root.has_error() {
+        return Ok(unparsed_result(source, total_lines));
+    }
+
+    let min_body_lines = options
+        .min_body_lines
+        .unwrap_or(DEFAULT_MIN_BODY_LINES)
+        .max(2);
+    let min_comment_lines = options
+        .min_comment_lines
+        .unwrap_or(DEFAULT_MIN_COMMENT_LINES)
+        .max(4);
+    let unfold_until = options.unfold_until_lines.unwrap_or(0);
+    let unfold_limit = options
+        .unfold_limit_lines
+        .unwrap_or_else(|| unfold_until.saturating_mul(2));
+    let mut forest = ElidableForest::default();
+    collect_elidable_tree(
+        root,
+        None,
+        language,
+        min_body_lines,
+        min_comment_lines,
+        &mut forest,
+    );
+    let spans = select_folded_spans(&forest, total_lines, unfold_until, unfold_limit);
+    let spans = normalize_spans(spans, total_lines);
+    let segments = build_segments(&source, total_lines, &spans);
+
+    Ok(SummaryResult {
+        language: Some(language.canonical_name().to_string()),
+        parsed: true,
+        elided: !spans.is_empty(),
+        total_lines,
+        segments,
+    })
+}
+
+pub(crate) fn resolve_language(lang: Option<&str>, path: Option<&str>) -> Option<SupportLang> {
+    if let Some(lang) = lang.map(str::trim).filter(|lang| !lang.is_empty()) {
+        return SupportLang::from_alias(lang);
+    }
+    let path = path?.trim();
+    if path.is_empty() {
+        return None;
+    }
+    SupportLang::from_path(Path::new(path))
+}
+
+fn unparsed_result(source: String, total_lines: u32) -> SummaryResult {
+    let segments = if source.is_empty() {
+        Vec::new()
+    } else {
+        vec![SummarySegment {
+            kind: "kept".to_string(),
+            start_line: 1,
+            end_line: total_lines,
+            text: Some(source),
+        }]
+    };
+    SummaryResult {
+        language: None,
+        parsed: false,
+        elided: false,
+        total_lines,
+        segments,
+    }
+}
+
+fn count_lines(source: &str) -> u32 {
+    if source.is_empty() {
+        0
+    } else {
+        source.lines().count().max(1).min(u32::MAX as usize) as u32
+    }
+}
+
+fn collect_elidable_tree(
+    node: Node<'_>,
+    elidable_parent: Option<usize>,
+    language: SupportLang,
+    min_body_lines: u32,
+    min_comment_lines: u32,
+    forest: &mut ElidableForest,
+) {
+    let total_lines = node_line_count(node);
+    if is_comment_kind(language, node.kind()) {
+        if total_lines >= min_comment_lines {
+            let start_line = node_start_line(node) + 2;
+            let end_line = node_end_line(node).saturating_sub(1);
+            if start_line <= end_line {
+                forest.push(
+                    elidable_parent,
+                    LineSpan {
+                        start: start_line,
+                        end: end_line,
+                    },
+                );
+            }
+        }
+        return;
+    }
+
+    let mut current_parent = elidable_parent;
+    if is_elidable_kind(language, node.kind()) && total_lines >= min_body_lines {
+        let start_line = node_start_line(node) + 1;
+        let end_line = node_end_line(node).saturating_sub(1);
+        if start_line <= end_line {
+            // Unlike the legacy outermost-only collector, we DO recurse into
+            // the elided node so nested elisions are recorded as children.
+            // The BFS unfold pass decides which level actually fires.
+            current_parent = Some(forest.push(
+                elidable_parent,
+                LineSpan {
+                    start: start_line,
+                    end: end_line,
+                },
+            ));
+        }
+    }
+
+    // Detect consecutive runs of groupable siblings (e.g. import statements).
+    // When the run's total line span meets `min_body_lines`, elide the lines
+    // strictly between the first and last sibling's content, leaving the
+    // boundary statements visible.
+    let child_count = node.child_count();
+    let mut run_first: Option<Node<'_>> = None;
+    let mut run_last: Option<Node<'_>> = None;
+    let mut run_count: u32 = 0;
+    for index in 0..child_count {
+        let Some(child) = node.child(index) else {
+            continue;
+        };
+        if is_groupable_kind(language, child.kind()) {
+            if run_first.is_none() {
+                run_first = Some(child);
+            }
+            run_last = Some(child);
+            run_count += 1;
+        } else {
+            flush_groupable_run(
+                run_first,
+                run_last,
+                run_count,
+                min_body_lines,
+                forest,
+                current_parent,
+            );
+            run_first = None;
+            run_last = None;
+            run_count = 0;
+        }
+    }
+    flush_groupable_run(
+        run_first,
+        run_last,
+        run_count,
+        min_body_lines,
+        forest,
+        current_parent,
+    );
+
+    for index in 0..child_count {
+        if let Some(child) = node.child(index) {
+            collect_elidable_tree(
+                child,
+                current_parent,
+                language,
+                min_body_lines,
+                min_comment_lines,
+                forest,
+            );
+        }
+    }
+}
+
+fn flush_groupable_run(
+    first: Option<Node<'_>>,
+    last: Option<Node<'_>>,
+    count: u32,
+    min_body_lines: u32,
+    forest: &mut ElidableForest,
+    parent: Option<usize>,
+) {
+    if count < 2 {
+        return;
+    }
+    let (Some(first), Some(last)) = (first, last) else {
+        return;
+    };
+    let first_start = node_start_line(first);
+    let last_start = node_start_line(last);
+    let last_end = node_end_line(last);
+    let span_lines = last_end.saturating_sub(first_start).saturating_add(1);
+    if span_lines < min_body_lines {
+        return;
+    }
+    // Use the line of the first node's last visible content as the lower bound
+    // (some grammars include trailing newlines in the node range, which would
+    // otherwise place `end_line` on the next sibling's first line).
+    let first_content_end = node_content_end_line(first).min(last_start.saturating_sub(1));
+    let start = first_content_end.saturating_add(1);
+    let end = last_start.saturating_sub(1);
+    if start <= end {
+        forest.push(parent, LineSpan { start, end });
+    }
+}
+
+pub(crate) fn node_start_line(node: Node<'_>) -> u32 {
+    node.start_position()
+        .row
+        .saturating_add(1)
+        .min(u32::MAX as usize) as u32
+}
+
+fn node_end_line(node: Node<'_>) -> u32 {
+    node.end_position()
+        .row
+        .saturating_add(1)
+        .min(u32::MAX as usize) as u32
+}
+
+/// Last source line containing a content byte from `node`.
+///
+/// Tree-sitter reports `end_position` as the position one past the last byte.
+/// When that byte is a newline, the resulting position lands at column 0 of
+/// the next row, which makes the naive `row + 1` answer one greater than the
+/// row of the last visible content. This helper subtracts that off.
+pub(crate) fn node_content_end_line(node: Node<'_>) -> u32 {
+    let pos = node.end_position();
+    let row = if pos.column == 0 && pos.row > 0 {
+        pos.row - 1
+    } else {
+        pos.row
+    };
+    row.saturating_add(1).min(u32::MAX as usize) as u32
+}
+
+fn node_line_count(node: Node<'_>) -> u32 {
+    node_end_line(node)
+        .saturating_sub(node_start_line(node))
+        .saturating_add(1)
+}
+
+fn is_comment_kind(language: SupportLang, kind: &str) -> bool {
+    match language {
+        SupportLang::TypeScript | SupportLang::Tsx | SupportLang::JavaScript => kind == "comment",
+        SupportLang::Rust => kind == "block_comment",
+        SupportLang::Python => kind == "comment",
+        SupportLang::Go => kind == "comment",
+        SupportLang::Fortran => kind == "comment",
+        SupportLang::Java => kind == "block_comment",
+        SupportLang::C | SupportLang::Cpp | SupportLang::ObjC => kind == "comment",
+        SupportLang::CSharp => kind == "comment",
+        SupportLang::Ruby => kind == "comment",
+        SupportLang::Php => kind == "comment",
+        SupportLang::Swift => kind == "comment",
+        SupportLang::Kotlin => kind == "block_comment",
+        SupportLang::Scala => kind == "block_comment",
+        SupportLang::Lua => kind == "comment",
+        SupportLang::EmacsLisp => kind == "comment",
+        _ => false,
+    }
+}
+
+fn is_elidable_kind(language: SupportLang, kind: &str) -> bool {
+    match language {
+        SupportLang::TypeScript | SupportLang::Tsx | SupportLang::JavaScript => matches!(
+            kind,
+            "statement_block"
+                | "function_body"
+                | "object"
+                | "array"
+                | "template_string"
+                | "class_body"
+                | "interface_body"
+                | "enum_body"
+                | "object_type"
+                | "switch_body"
+                | "jsx_element"
+                | "jsx_self_closing_element"
+        ),
+        SupportLang::Rust => matches!(
+            kind,
+            "block"
+                | "array_expression"
+                | "tuple_expression"
+                | "struct_expression"
+                | "match_block"
+                | "raw_string_literal"
+                | "declaration_list"
+                | "field_declaration_list"
+                | "ordered_field_declaration_list"
+                | "enum_variant_list"
+                | "where_clause"
+                | "use_list"
+                | "macro_definition"
+                | "token_tree"
+        ),
+        SupportLang::Python => matches!(
+            kind,
+            "block"
+                | "dictionary"
+                | "list"
+                | "set"
+                | "string"
+                | "tuple"
+                | "argument_list"
+                | "parameters"
+                | "parenthesized_expression"
+                | "list_comprehension"
+                | "set_comprehension"
+                | "dictionary_comprehension"
+                | "generator_expression"
+                | "import_from_statement"
+                | "subscript"
+        ),
+        SupportLang::Go => matches!(
+            kind,
+            "block"
+                | "composite_literal"
+                | "interpreted_string_literal"
+                | "raw_string_literal"
+                | "import_spec_list"
+                | "const_declaration"
+                | "var_declaration"
+                | "field_declaration_list"
+                | "interface_type"
+                | "expression_switch_statement"
+                | "type_switch_statement"
+                | "select_statement"
+        ),
+        SupportLang::Java => matches!(
+            kind,
+            "block"
+                | "array_initializer"
+                | "class_body"
+                | "interface_body"
+                | "enum_body"
+                | "annotation_type_body"
+                | "constructor_body"
+                | "switch_block"
+                | "string_literal"
+        ),
+        SupportLang::C => matches!(
+            kind,
+            "compound_statement"
+                | "initializer_list"
+                | "string_literal"
+                | "field_declaration_list"
+                | "enumerator_list"
+                | "concatenated_string"
+        ),
+        SupportLang::Cpp => matches!(
+            kind,
+            "compound_statement"
+                | "initializer_list"
+                | "string_literal"
+                | "field_declaration_list"
+                | "enumerator_list"
+                | "concatenated_string"
+                | "declaration_list"
+                | "raw_string_literal"
+                | "requires_clause"
+        ),
+        SupportLang::ObjC => matches!(
+            kind,
+            "compound_statement"
+                | "initializer_list"
+                | "string_literal"
+                | "protocol_declaration"
+                | "class_interface"
+                | "class_implementation"
+                | "instance_variables"
+                | "array_literal"
+                | "dictionary_literal"
+        ),
+        SupportLang::CSharp => matches!(
+            kind,
+            "block"
+                | "initializer_expression"
+                | "array_initializer_expression"
+                | "declaration_list"
+                | "enum_member_declaration_list"
+                | "switch_expression"
+                | "raw_string_literal"
+                | "interpolated_string_expression"
+        ),
+        SupportLang::Ruby => matches!(
+            kind,
+            "body_statement"
+                | "method"
+                | "do_block"
+                | "array"
+                | "hash"
+                | "block"
+                | "case"
+                | "heredoc_body"
+        ),
+        SupportLang::Php => matches!(
+            kind,
+            "compound_statement"
+                | "array_creation_expression"
+                | "declaration_list"
+                | "enum_declaration_list"
+                | "match_block"
+                | "heredoc"
+                | "nowdoc"
+        ),
+        SupportLang::Swift => matches!(
+            kind,
+            "function_body"
+                | "array_literal"
+                | "dictionary_literal"
+                | "multi_line_string_literal"
+                | "class_body"
+                | "protocol_body"
+                | "enum_class_body"
+                | "computed_property"
+                | "lambda_literal"
+        ),
+        SupportLang::Kotlin => matches!(
+            kind,
+            "function_body"
+                | "collection_literal"
+                | "multi_line_string_literal"
+                | "class_body"
+                | "enum_class_body"
+                | "when_expression"
+                | "import_list"
+        ),
+        SupportLang::Scala => matches!(
+            kind,
+            "block"
+                | "collection_literal"
+                | "template_body"
+                | "enum_body"
+                | "match_expression"
+                | "for_expression"
+                | "string"
+        ),
+        SupportLang::Lua => matches!(kind, "block" | "table_constructor" | "string"),
+        SupportLang::Dart => matches!(
+            kind,
+            "block"
+                | "function_expression_body"
+                | "class_body"
+                | "enum_body"
+                | "extension_body"
+                | "mixin_body"
+                | "list_literal"
+                | "set_or_map_literal"
+                | "string_literal"
+        ),
+        SupportLang::Bash => matches!(
+            kind,
+            "compound_statement"
+                | "if_statement"
+                | "case_statement"
+                | "do_group"
+                | "subshell"
+                | "array"
+                | "heredoc_body"
+        ),
+        SupportLang::Powershell => matches!(
+            kind,
+            "script_block"
+                | "statement_block"
+                | "class_statement"
+                | "param_block"
+                | "hash_literal_expression"
+                | "array_expression"
+                | "expandable_here_string_literal"
+                | "verbatim_here_string_characters"
+        ),
+        SupportLang::Haskell => matches!(
+            kind,
+            "imports"
+                | "data_type"
+                | "class"
+                | "instance"
+                | "function"
+                | "do"
+                | "case"
+                | "let"
+                | "local_binds"
+                | "list"
+                | "tuple"
+        ),
+        SupportLang::Ocaml => matches!(
+            kind,
+            "structure"
+                | "signature"
+                | "variant_declaration"
+                | "record_declaration"
+                | "match_expression"
+                | "match_case"
+                | "let_expression"
+                | "value_definition"
+                | "list_expression"
+        ),
+        SupportLang::Elixir => matches!(kind, "do_block" | "list" | "map" | "string" | "sigil"),
+        SupportLang::Erlang => matches!(
+            kind,
+            "fun_decl"
+                | "case_expr"
+                | "if_expr"
+                | "receive_expr"
+                | "record_decl"
+                | "list"
+                | "map_expr"
+                | "tuple"
+        ),
+        SupportLang::EmacsLisp => matches!(
+            kind,
+            "function_definition"
+                | "macro_definition"
+                | "special_form"
+                | "list"
+                | "vector"
+                | "hash_table"
+                | "bytecode"
+                | "string_text_properties"
+                | "string"
+        ),
+        SupportLang::Clojure => {
+            matches!(
+                kind,
+                "list_lit" | "map_lit" | "vec_lit" | "set_lit" | "str_lit"
+            )
+        }
+        SupportLang::Solidity => {
+            matches!(
+                kind,
+                "contract_body" | "function_body" | "struct_body" | "enum_body"
+            )
+        }
+        SupportLang::Sql => matches!(kind, "column_definitions" | "case"),
+        SupportLang::Zig => matches!(kind, "Block" | "ContainerDecl" | "InitList"),
+        SupportLang::Odin => matches!(
+            kind,
+            "block" | "struct_declaration" | "enum_declaration" | "union_declaration" | "struct"
+        ),
+        SupportLang::Verilog => matches!(
+            kind,
+            "module_declaration"
+                | "seq_block"
+                | "case_statement"
+                | "function_declaration"
+                | "task_declaration"
+                | "list_of_port_declarations"
+        ),
+        SupportLang::Tlaplus => matches!(kind, "module" | "theorem" | "let_in"),
+        SupportLang::Nix => matches!(
+            kind,
+            "attrset_expression"
+                | "list_expression"
+                | "let_expression"
+                | "indented_string_expression"
+        ),
+        SupportLang::Proto => matches!(kind, "message_body" | "enum_body" | "oneof" | "service"),
+        SupportLang::Julia => matches!(
+            kind,
+            "function_definition"
+                | "struct_definition"
+                | "module_definition"
+                | "do_clause"
+                | "vector_expression"
+                | "string_literal"
+        ),
+        SupportLang::R => matches!(kind, "braced_expression" | "call" | "string"),
+        SupportLang::Starlark => matches!(kind, "block" | "list" | "dictionary" | "string"),
+        SupportLang::Astro => {
+            matches!(
+                kind,
+                "frontmatter_js_block" | "script_element" | "style_element" | "element"
+            )
+        }
+        SupportLang::Vue => {
+            matches!(
+                kind,
+                "template_element" | "script_element" | "style_element" | "element"
+            )
+        }
+        SupportLang::Svelte => matches!(kind, "script_element" | "style_element" | "element"),
+        SupportLang::Html => matches!(kind, "element" | "script_element" | "style_element"),
+        SupportLang::Css => matches!(kind, "block" | "keyframe_block_list"),
+        SupportLang::Json => matches!(kind, "object" | "array"),
+        SupportLang::Xml => kind == "element",
+        SupportLang::Markdown => matches!(kind, "fenced_code_block" | "pipe_table" | "list"),
+        SupportLang::Graphql => matches!(
+            kind,
+            "fields_definition"
+                | "enum_values_definition"
+                | "input_fields_definition"
+                | "schema_definition"
+        ),
+        SupportLang::Hcl => matches!(kind, "body" | "object"),
+        SupportLang::Dockerfile => kind == "shell_command",
+        SupportLang::Cmake => matches!(kind, "argument_list" | "body"),
+        SupportLang::Make => kind == "recipe",
+        SupportLang::Just => kind == "recipe_body",
+        SupportLang::Fortran => false,
+        // Skip: data formats with no closing-token anchor (Yaml mappings,
+        // Toml tables, Ini sections), the diff format whose informational
+        // content IS the lines inside hunks, and the leaf-token-only Regex
+        // grammar. Eliding any of these deletes the only content worth
+        // reading.
+        SupportLang::Yaml
+        | SupportLang::Toml
+        | SupportLang::Ini
+        | SupportLang::Diff
+        | SupportLang::Regex => false,
+    }
+}
+
+fn is_groupable_kind(language: SupportLang, kind: &str) -> bool {
+    match language {
+        SupportLang::TypeScript | SupportLang::Tsx | SupportLang::JavaScript => {
+            kind == "import_statement"
+        }
+        SupportLang::Rust => matches!(kind, "use_declaration" | "extern_crate_declaration"),
+        SupportLang::Python => {
+            matches!(
+                kind,
+                "import_statement" | "import_from_statement" | "future_import_statement"
+            )
+        }
+        SupportLang::Go => kind == "import_declaration",
+        SupportLang::Java => kind == "import_declaration",
+        SupportLang::C | SupportLang::Cpp => kind == "preproc_include",
+        SupportLang::ObjC => matches!(kind, "preproc_include" | "import_declaration"),
+        SupportLang::CSharp => kind == "using_directive",
+        SupportLang::Php => kind == "namespace_use_declaration",
+        SupportLang::Swift => kind == "import_declaration",
+        SupportLang::Scala => matches!(kind, "import_declaration" | "import"),
+        SupportLang::Dart => kind == "import_or_export",
+        SupportLang::Ocaml => kind == "open_module",
+        SupportLang::Solidity => kind == "import_directive",
+        SupportLang::Julia => matches!(kind, "import_statement" | "using_statement"),
+        SupportLang::Proto => kind == "import",
+        SupportLang::Fortran => kind == "use_statement",
+        // Languages where imports either have no run pattern, are wrapped in a
+        // single AST node already covered by `is_elidable_kind` (Kotlin's
+        // `import_list`, Haskell's `imports`), or live inside a too-generic
+        // container (Powershell `statement_list`).
+        SupportLang::Kotlin
+        | SupportLang::Haskell
+        | SupportLang::Powershell
+        | SupportLang::Ruby
+        | SupportLang::Lua
+        | SupportLang::Elixir
+        | SupportLang::Erlang
+        | SupportLang::EmacsLisp
+        | SupportLang::Clojure
+        | SupportLang::Sql
+        | SupportLang::Zig
+        | SupportLang::Odin
+        | SupportLang::Verilog
+        | SupportLang::Tlaplus
+        | SupportLang::Nix
+        | SupportLang::R
+        | SupportLang::Starlark
+        | SupportLang::Bash
+        | SupportLang::Astro
+        | SupportLang::Vue
+        | SupportLang::Svelte
+        | SupportLang::Html
+        | SupportLang::Css
+        | SupportLang::Json
+        | SupportLang::Xml
+        | SupportLang::Markdown
+        | SupportLang::Graphql
+        | SupportLang::Hcl
+        | SupportLang::Dockerfile
+        | SupportLang::Cmake
+        | SupportLang::Make
+        | SupportLang::Just
+        | SupportLang::Yaml
+        | SupportLang::Toml
+        | SupportLang::Ini
+        | SupportLang::Diff
+        | SupportLang::Regex => false,
+    }
+}
+
+fn normalize_spans(mut spans: Vec<LineSpan>, total_lines: u32) -> Vec<LineSpan> {
+    if total_lines == 0 {
+        return Vec::new();
+    }
+    spans.retain(|span| span.start <= span.end && span.start <= total_lines);
+    for span in &mut spans {
+        span.end = span.end.min(total_lines);
+    }
+    spans.sort_by_key(|span| (span.start, span.end));
+    let mut merged: Vec<LineSpan> = Vec::new();
+    for span in spans {
+        if let Some(last) = merged.last_mut()
+            && span.start <= last.end.saturating_add(1)
+        {
+            last.end = last.end.max(span.end);
+            continue;
+        }
+        merged.push(span);
+    }
+    merged
+}
+
+fn build_segments(source: &str, total_lines: u32, spans: &[LineSpan]) -> Vec<SummarySegment> {
+    if total_lines == 0 {
+        return Vec::new();
+    }
+    let source_lines: Vec<&str> = source.lines().collect();
+    let elided_lines = spans
+        .iter()
+        .flat_map(|span| span.start..=span.end)
+        .collect::<BTreeSet<_>>();
+    let mut segments = Vec::new();
+    let mut current_kind: Option<&str> = None;
+    let mut current_start = 1;
+    let mut current_lines: Vec<&str> = Vec::new();
+
+    for line_number in 1..=total_lines {
+        let is_elided = elided_lines.contains(&line_number);
+        let kind = if is_elided { "elided" } else { "kept" };
+        if current_kind.is_some_and(|existing| existing != kind) {
+            push_segment(
+                &mut segments,
+                current_kind.expect("kind set"),
+                current_start,
+                line_number - 1,
+                &current_lines,
+            );
+            current_start = line_number;
+            current_lines.clear();
+        }
+        current_kind = Some(kind);
+        if !is_elided {
+            let index = line_number.saturating_sub(1) as usize;
+            current_lines.push(source_lines.get(index).copied().unwrap_or_default());
+        }
+    }
+
+    if let Some(kind) = current_kind {
+        push_segment(
+            &mut segments,
+            kind,
+            current_start,
+            total_lines,
+            &current_lines,
+        );
+    }
+    segments
+}
+
+fn push_segment(
+    segments: &mut Vec<SummarySegment>,
+    kind: &str,
+    start_line: u32,
+    end_line: u32,
+    lines: &[&str],
+) {
+    segments.push(SummarySegment {
+        kind: kind.to_string(),
+        start_line,
+        end_line,
+        text: (kind == "kept").then(|| lines.join("\n")),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summarize(code: &str, path: &str) -> SummaryResult {
+        summarize_code(SummaryOptions {
+            code: code.to_string(),
+            lang: None,
+            path: Some(path.to_string()),
+            min_body_lines: None,
+            min_comment_lines: None,
+            unfold_until_lines: None,
+            unfold_limit_lines: None,
+        })
+        .expect("summary succeeds")
+    }
+
+    fn segment_kinds(result: &SummaryResult) -> Vec<&str> {
+        result
+            .segments
+            .iter()
+            .map(|segment| segment.kind.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn summarizes_typescript_function_body() {
+        let result = summarize(
+            "export function greet(name: string): string {\n\tconst clean = name.trim();\n\tconst \
+			 label = clean || 'world';\n\treturn `hello ${label}`;\n}\n",
+            "fixture.ts",
+        );
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(result.language.as_deref(), Some("typescript"));
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+        assert_eq!(
+            result.segments[0].text.as_deref(),
+            Some("export function greet(name: string): string {")
+        );
+        assert_eq!(result.segments[1].start_line, 2);
+        assert_eq!(result.segments[1].end_line, 4);
+        assert_eq!(result.segments[2].text.as_deref(), Some("}"));
+    }
+
+    #[test]
+    fn summarizes_rust_method_body_but_keeps_impl_boundaries() {
+        let result = summarize(
+            "struct Greeter;\n\nimpl Greeter {\n\tfn greet(&self) -> String {\n\t\tlet name = \
+			 \"world\";\n\t\tlet label = name.to_uppercase();\n\t\tformat!(\"hello \
+			 {label}\")\n\t}\n}\n",
+            "fixture.rs",
+        );
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        let rendered = result
+            .segments
+            .iter()
+            .map(|segment| segment.text.clone().unwrap_or_else(|| "...".to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("impl Greeter {\n...\n}"));
+    }
+
+    #[test]
+    fn summarizes_python_function_body() {
+        let result = summarize(
+            "class Greeter:\n    def greet(self, name: str) -> str:\n        clean = \
+				 name.strip()\n        label = clean or 'world'\n        return f'hello {label}'\n",
+            "fixture.py",
+        );
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+        assert!(
+            result.segments[0]
+                .text
+                .as_deref()
+                .unwrap_or_default()
+                .contains("def greet")
+        );
+        assert!(
+            result.segments[2]
+                .text
+                .as_deref()
+                .unwrap_or_default()
+                .contains("return")
+        );
+    }
+
+    #[test]
+    fn summarizes_fortran_program() {
+        let result = summarize(
+            "program hello\n  print *, 'hi'\nend program hello\n",
+            "fixture.f90",
+        );
+
+        assert!(result.parsed);
+        assert_eq!(result.language.as_deref(), Some("fortran"));
+        assert!(!result.segments.is_empty());
+    }
+
+    #[test]
+    fn summarizes_emacs_lisp_defun_body() {
+        let code = "(defun greet (name)\n  \"Doc.\"\n  (let ((message (format \"Hello %s\" \
+		            name)))\n    (message \"%s\" message)\n    message)\n)\n";
+        let result = summarize(code, "fixture.el");
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(result.language.as_deref(), Some("emacs-lisp"));
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+    }
+
+    #[test]
+    fn summarizes_emacs_lisp_special_form() {
+        let code =
+            "(let ((count 0))\n  (setq count (1+ count))\n  (setq count (1+ count))\n  count\n)\n";
+        let result = summarize(code, "fixture.el");
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+    }
+
+    #[test]
+    fn min_body_lines_controls_short_body_elision() {
+        let code = "function small() {\n\treturn 1;\n}\n";
+        let default_result = summarize(code, "fixture.ts");
+        assert!(default_result.parsed);
+        assert!(!default_result.elided);
+
+        let override_result = summarize_code(SummaryOptions {
+            code: code.to_string(),
+            lang: Some("typescript".to_string()),
+            path: None,
+            min_body_lines: Some(3),
+            min_comment_lines: None,
+            unfold_until_lines: None,
+            unfold_limit_lines: None,
+        })
+        .expect("summary succeeds");
+        assert!(override_result.elided);
+    }
+
+    #[test]
+    fn parse_failure_falls_back_to_unparsed() {
+        let result = summarize("export function broken( {\n", "fixture.ts");
+        assert!(!result.parsed);
+        assert!(!result.elided);
+        assert_eq!(result.segments.len(), 1);
+    }
+
+    #[test]
+    fn unsupported_language_is_unparsed() {
+        let result = summarize("plain text\nwith lines\n", "fixture.txt");
+        assert!(!result.parsed);
+        assert_eq!(
+            result.segments[0].text.as_deref(),
+            Some("plain text\nwith lines\n")
+        );
+    }
+
+    #[test]
+    fn summarizes_typescript_interface_body() {
+        let result = summarize(
+            "export interface Args {\n\tcwd?: string;\n\tprovider?: string;\n\tmodel?: \
+			 string;\n\tapiKey?: string;\n}\n",
+            "fixture.ts",
+        );
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+        assert_eq!(
+            result.segments[0].text.as_deref(),
+            Some("export interface Args {")
+        );
+        assert_eq!(result.segments[2].text.as_deref(), Some("}"));
+    }
+
+    #[test]
+    fn summarizes_typescript_class_body() {
+        let result = summarize(
+            "export class Greeter {\n\tname: string = \"world\";\n\tlength(): number { return \
+			 this.name.length; }\n\tgreet(): string { return this.name; }\n\tshout(): string { \
+			 return this.name.toUpperCase(); }\n}\n",
+            "fixture.ts",
+        );
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+        assert!(
+            result.segments[0]
+                .text
+                .as_deref()
+                .unwrap_or_default()
+                .contains("class Greeter")
+        );
+        assert_eq!(result.segments[2].text.as_deref(), Some("}"));
+    }
+
+    #[test]
+    fn summarizes_rust_trait_declaration_list() {
+        let result = summarize(
+            "pub trait Greeter {\n\tfn greet(&self) -> String;\n\tfn length(&self) -> usize;\n\tfn \
+			 shout(&self) -> String;\n\tfn whisper(&self) -> String;\n}\n",
+            "fixture.rs",
+        );
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+        assert_eq!(
+            result.segments[0].text.as_deref(),
+            Some("pub trait Greeter {")
+        );
+        assert_eq!(result.segments[2].text.as_deref(), Some("}"));
+    }
+
+    #[test]
+    fn summarizes_java_class_body() {
+        let result = summarize(
+            "public class Greeter {\n\tprivate String name;\n\tpublic Greeter(String n) { this.name \
+			 = n; }\n\tpublic String greet() { return name; }\n\tpublic int length() { return \
+			 name.length(); }\n}\n",
+            "fixture.java",
+        );
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        assert_eq!(segment_kinds(&result), vec!["kept", "elided", "kept"]);
+        assert!(
+            result.segments[0]
+                .text
+                .as_deref()
+                .unwrap_or_default()
+                .contains("class Greeter")
+        );
+        assert_eq!(result.segments[2].text.as_deref(), Some("}"));
+    }
+
+    #[test]
+    fn summarizes_typescript_import_run() {
+        let code = "import a from \"a\";\nimport b from \"b\";\nimport c from \"c\";\nimport d from \
+		            \"d\";\nimport e from \"e\";\nimport f from \"f\";\n\nexport function main() \
+		            {}\n";
+        let result = summarize(code, "fixture.ts");
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        // Lines 2-5 are between the first and last imports and must be elided.
+        let elided = result
+            .segments
+            .iter()
+            .find(|seg| seg.kind == "elided")
+            .expect("elided segment");
+        assert_eq!(elided.start_line, 2);
+        assert_eq!(elided.end_line, 5);
+        // First import line is kept.
+        assert!(
+            result.segments[0]
+                .text
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("import a from")
+        );
+    }
+
+    #[test]
+    fn does_not_elide_short_typescript_import_run() {
+        // 3 imports → total span 3 lines, below default min_body_lines (4).
+        let result = summarize(
+            "import a from \"a\";\nimport b from \"b\";\nimport c from \"c\";\n",
+            "fixture.ts",
+        );
+        assert!(result.parsed);
+        assert!(!result.elided);
+    }
+
+    #[test]
+    fn summarizes_python_import_run() {
+        let code = "import os\nimport sys\nfrom typing import List\nfrom pathlib import \
+		            Path\nimport json\nimport re\n\nprint('go')\n";
+        let result = summarize(code, "fixture.py");
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        let elided = result
+            .segments
+            .iter()
+            .find(|seg| seg.kind == "elided")
+            .expect("elided segment");
+        assert_eq!(elided.start_line, 2);
+        assert_eq!(elided.end_line, 5);
+    }
+
+    #[test]
+    fn summarizes_c_preproc_include_run() {
+        // C grammar puts each #include's `end_position` at column 0 of the next
+        // row (the trailing `\n`). Without `node_content_end_line`, the run
+        // elision would emit a span that starts past the second include and
+        // only collapse the third — verify the boundary statements stay
+        // visible and the middle is collapsed.
+        let code = "#include <stdio.h>\n#include \"a.h\"\n#include \"b.h\"\n#include \
+		            \"c.h\"\n#include <string.h>\nint main(void) { return 0; }\n";
+        let result = summarize(code, "fixture.c");
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        let elided = result
+            .segments
+            .iter()
+            .find(|seg| seg.kind == "elided")
+            .expect("elided segment");
+        assert_eq!(elided.start_line, 2);
+        assert_eq!(elided.end_line, 4);
+    }
+
+    #[test]
+    fn summarizes_rust_use_run() {
+        let code = "use std::fs;\nuse std::path::Path;\nuse std::collections::HashMap;\nuse \
+		            std::sync::Arc;\nuse std::io;\n\nfn main() {}\n";
+        let result = summarize(code, "fixture.rs");
+
+        assert!(result.parsed);
+        assert!(result.elided);
+        let elided = result
+            .segments
+            .iter()
+            .find(|seg| seg.kind == "elided")
+            .expect("elided segment");
+        assert_eq!(elided.start_line, 2);
+        assert_eq!(elided.end_line, 4);
+    }
+
+    fn summarize_with_unfold(code: &str, path: &str, until: u32, limit: u32) -> SummaryResult {
+        summarize_code(SummaryOptions {
+            code: code.to_string(),
+            lang: None,
+            path: Some(path.to_string()),
+            min_body_lines: None,
+            min_comment_lines: None,
+            unfold_until_lines: Some(until),
+            unfold_limit_lines: Some(limit),
+        })
+        .expect("summary succeeds")
+    }
+
+    #[test]
+    fn bfs_unfold_reveals_nested_json_when_root_collapses() {
+        // Top-level JSON object: legacy outermost-only collector emits one big
+        // elision covering lines 2..=N which the renderer collapses to a
+        // useless `{ .. }`. BFS unfold should peel the root open so individual
+        // keys stay visible and only their nested values fold.
+        let body = (0..30)
+            .map(|i| format!("\t\"key{i}\": {i}"))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        let nested =
+            "\t\"deps\": {\n\t\t\"a\": 1,\n\t\t\"b\": 2,\n\t\t\"c\": 3,\n\t\t\"d\": 4\n\t}";
+        let code = format!("{{\n{body},\n{nested}\n}}\n");
+
+        let legacy = summarize_with_unfold(&code, "pkg.json", 0, 0);
+        assert!(legacy.elided);
+        // Legacy emits a single span spanning every line except the braces.
+        let legacy_kept_lines: u32 = legacy
+            .segments
+            .iter()
+            .filter(|s| s.kind == "kept")
+            .map(|s| s.end_line - s.start_line + 1)
+            .sum();
+        assert_eq!(legacy_kept_lines, 2);
+
+        // With BFS, the root unfolds and nested `deps` stays elided.
+        let unfolded = summarize_with_unfold(&code, "pkg.json", 20, 100);
+        assert!(unfolded.elided, "deps body should remain elided");
+        let kept_text = unfolded
+            .segments
+            .iter()
+            .filter(|s| s.kind == "kept")
+            .filter_map(|s| s.text.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(kept_text.contains("\"key0\""));
+        assert!(kept_text.contains("\"key29\""));
+        assert!(kept_text.contains("\"deps\""));
+        // The nested object's inner lines must not appear in kept content.
+        assert!(!kept_text.contains("\"a\": 1"));
+    }
+
+    #[test]
+    fn bfs_unfold_stops_when_visible_already_exceeds_target() {
+        // 10 small functions: legacy visible count is signature + close brace
+        // per function plus blank separators = 30 lines. Setting unfold_until
+        // below that initial count short-circuits BFS so every body stays
+        // folded — same as the legacy outermost-only collector.
+        let code = (0..10)
+			.map(|i| {
+				format!(
+					"export function fn{i}(): number {{\n\tconst a = {i};\n\tconst b = {i};\n\tconst c \
+					 = {i};\n\treturn a + b + c;\n}}"
+				)
+			})
+			.collect::<Vec<_>>()
+			.join("\n\n");
+
+        let result = summarize_with_unfold(&code, "fixture.ts", 10, 100);
+        assert!(result.elided);
+        let elided_count = result
+            .segments
+            .iter()
+            .filter(|s| s.kind == "elided")
+            .count();
+        assert_eq!(elided_count, 10);
+    }
+
+    #[test]
+    fn bfs_unfold_reverts_when_next_step_overflows_limit() {
+        // A single huge body whose unfold would massively overshoot the limit
+        // must stay folded — the BFS should detect overflow and abort.
+        let body = (0..40)
+            .map(|i| format!("\tconst x{i} = {i};"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let code = format!("export function big(): void {{\n{body}\n}}\n");
+        // unfold_until = 10, unfold_limit = 30. Initial visible is just the
+        // signature + closing brace = 2 lines; unfolding the body adds 40
+        // (no nested elidable children) → would overflow the limit, so the
+        // BFS reverts and leaves the body folded.
+        let result = summarize_with_unfold(&code, "big.ts", 10, 30);
+        // Exactly one elided segment for the function body.
+        assert_eq!(
+            result
+                .segments
+                .iter()
+                .filter(|s| s.kind == "elided")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn bfs_unfold_skips_unfoldable_leaf_and_continues_to_siblings() {
+        // Repro for the "useless HTML summary" report: a big <style> raw-text
+        // block (no elidable children) sits before a structured <body>. The
+        // style block's only unfold candidate is its entire 120-line body,
+        // which overflows unfold_limit. The BFS must SKIP it (leave it folded)
+        // and keep unfolding the sibling <body>/<div> subtree, instead of
+        // aborting the whole pass and collapsing the body into one dead `...`.
+        let css = (0..120)
+            .map(|i| format!("\t.rule{i} {{ color: #{i:06x}; }}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let sections = (0..6)
+			.map(|i| {
+				format!(
+					"<section class=\"sec{i}\">\n<h2>Heading {i}</h2>\n<p>para a {i}</p>\n<p>para b \
+					 {i}</p>\n<p>para c {i}</p>\n</section>"
+				)
+			})
+			.collect::<Vec<_>>()
+			.join("\n");
+        let code = format!(
+            "<!doctype html>\n<html \
+			 lang=\"en\">\n<head>\n<title>T</title>\n<style>\n{css}\n</style>\n</head>\n<body>\n<div \
+			 class=\"page\">\n{sections}\n</div>\n</body>\n</html>\n"
+        );
+
+        let result = summarize_with_unfold(&code, "page.html", 50, 100);
+        assert!(result.parsed);
+        assert!(result.elided);
+        let kept_text = result
+            .segments
+            .iter()
+            .filter(|s| s.kind == "kept")
+            .filter_map(|s| s.text.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n");
+        // The body div was unfolded: its child <section> structure is visible.
+        assert!(
+            kept_text.contains("<section class=\"sec0\">"),
+            "body div should unfold to show sections"
+        );
+        assert!(
+            kept_text.contains("<section class=\"sec5\">"),
+            "all sibling sections should surface"
+        );
+        // The <style> raw text stays folded as one elided span — no CSS interior leaks
+        // into kept content.
+        assert!(
+            !kept_text.contains(".rule0 {"),
+            "oversized style body must stay folded"
+        );
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/Cargo.toml
+++ b/crates/vendor/oh-my-pi/pi-iso/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "pi-iso"
+version = "17.1.2"
+edition = "2024"
+license = "MIT"
+authors = ["Can Boluk"]
+repository = "https://github.com/can1357/oh-my-pi"
+description = "Cross-platform CoW isolation backends (vendored from oh-my-pi)"
+
+# Vendored: do not inherit nixmac workspace deny-level clippy.
+
+[dependencies]
+async-trait = "0.1"
+similar = "3.1.0"
+tokio = { version = "1", features = ["full"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+parking_lot = "0.12.5"
+
+[target.'cfg(windows)'.dependencies]
+parking_lot = "0.12.5"
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_Storage_ProjectedFileSystem",
+  "Win32_System_Com",
+  "Win32_System_LibraryLoader",
+  "Win32_System_IO",
+  "Win32_System_Ioctl",
+] }

--- a/crates/vendor/oh-my-pi/pi-iso/src/apfs.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/apfs.rs
@@ -1,0 +1,163 @@
+//! macOS APFS clonefile-based isolation.
+//!
+//! `clonefile(2)` recursively reflinks an entire directory tree in a single
+//! syscall. Both paths share the same on-disk blocks until either side is
+//! modified; the kernel handles per-block copy-on-write. The destination is
+//! a fully independent directory tree from the caller's perspective — there
+//! is no mount to undo, so [`stop`](IsolationBackend::stop) is a recursive
+//! remove.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+#[cfg(not(target_os = "macos"))]
+use crate::IsoError;
+use crate::{BackendKind, IsoResult, IsolationBackend, ProbeResult};
+
+pub struct ApfsBackend;
+
+pub fn backend() -> &'static dyn IsolationBackend {
+    &ApfsBackend
+}
+
+#[async_trait]
+impl IsolationBackend for ApfsBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::Apfs
+    }
+
+    fn probe(&self) -> ProbeResult {
+        #[cfg(target_os = "macos")]
+        {
+            ProbeResult::available()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            ProbeResult::unavailable("APFS clonefile isolation is only available on macOS")
+        }
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "macos")]
+        {
+            imp::start(lower, merged)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (lower, merged);
+            Err(IsoError::unavailable(
+                "APFS clonefile isolation is only available on macOS",
+            ))
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "macos")]
+        {
+            imp::stop(merged)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = merged;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::{
+        ffi::CString,
+        fs,
+        os::unix::ffi::OsStrExt,
+        path::{Path, PathBuf},
+    };
+
+    use crate::{IsoError, IsoResult};
+
+    pub fn start(lower: &Path, merged: &Path) -> IsoResult<()> {
+        let lower = canonical_existing_dir(lower)?;
+        if let Some(parent) = merged.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                IsoError::other(format!(
+                    "unable to create parent of {}: {err}",
+                    merged.display()
+                ))
+            })?;
+        }
+        // `clonefile` refuses to overwrite. Drop any stale tree first.
+        if merged.exists() {
+            fs::remove_dir_all(merged).map_err(|err| {
+                IsoError::other(format!(
+                    "unable to clear {} before clone: {err}",
+                    merged.display()
+                ))
+            })?;
+        }
+
+        let src_c = to_cstring(lower.as_os_str().as_bytes(), "lower")?;
+        let dst_c = to_cstring(merged.as_os_str().as_bytes(), "merged")?;
+
+        // SAFETY: both pointers are valid CStrings whose backing storage lives
+        // until after the call. `clonefile` with `flags = 0` performs a
+        // recursive reflink clone and does not retain the pointers past the
+        // syscall.
+        let rc = unsafe { libc::clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        if let Some(code) = err.raw_os_error()
+            && matches!(code, libc::ENOTSUP | libc::EOPNOTSUPP | libc::EXDEV)
+        {
+            return Err(IsoError::unavailable(format!(
+                "APFS clonefile unsupported on this volume ({err}); {} -> {}",
+                lower.display(),
+                merged.display()
+            )));
+        }
+        Err(IsoError::other(format!(
+            "clonefile {} -> {}: {err}",
+            lower.display(),
+            merged.display()
+        )))
+    }
+
+    pub fn stop(merged: &Path) -> IsoResult<()> {
+        match fs::remove_dir_all(merged) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(IsoError::other(format!(
+                "unable to remove cloned tree {}: {err}",
+                merged.display()
+            ))),
+        }
+    }
+
+    fn canonical_existing_dir(path: &Path) -> IsoResult<PathBuf> {
+        let resolved = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+        };
+        let meta = fs::metadata(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "invalid clone source {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !meta.is_dir() {
+            return Err(IsoError::other(format!(
+                "clone source {} is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn to_cstring(bytes: &[u8], label: &str) -> IsoResult<CString> {
+        CString::new(bytes)
+            .map_err(|err| IsoError::other(format!("{label} path contains NUL byte: {err}")))
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/btrfs.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/btrfs.rs
@@ -1,0 +1,267 @@
+//! Linux btrfs subvolume snapshot isolation.
+//!
+//! When `lower` is a btrfs subvolume, `btrfs subvolume snapshot` creates an
+//! O(1) writable snapshot at `merged`. The CLI owns the filesystem-specific
+//! details; this backend only validates paths, invokes it without a shell, and
+//! removes the snapshot on [`stop`](IsolationBackend::stop).
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+#[cfg(not(target_os = "linux"))]
+use crate::IsoError;
+use crate::{BackendKind, IsoResult, IsolationBackend, ProbeResult};
+
+pub struct BtrfsBackend;
+
+pub fn backend() -> &'static dyn IsolationBackend {
+    &BtrfsBackend
+}
+
+#[async_trait]
+impl IsolationBackend for BtrfsBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::Btrfs
+    }
+
+    fn probe(&self) -> ProbeResult {
+        #[cfg(target_os = "linux")]
+        {
+            imp::probe()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            ProbeResult::unavailable("btrfs snapshot isolation is only available on Linux")
+        }
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            imp::start(lower, merged)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (lower, merged);
+            Err(IsoError::unavailable(
+                "btrfs snapshot isolation is only available on Linux",
+            ))
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            imp::stop(merged)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = merged;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        process::{Command, Stdio},
+    };
+
+    use crate::{IsoError, IsoResult, ProbeResult};
+
+    pub fn probe() -> ProbeResult {
+        match Command::new("btrfs")
+            .arg("version")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+        {
+            Ok(status) if status.success() => ProbeResult::available(),
+            Ok(status) => ProbeResult::unavailable(format!(
+                "btrfs CLI probe failed with exit {}",
+                status.code().unwrap_or(-1)
+            )),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                ProbeResult::unavailable("`btrfs` CLI not on PATH")
+            }
+            Err(err) => ProbeResult::unavailable(format!("unable to probe btrfs CLI: {err}")),
+        }
+    }
+
+    pub fn start(lower: &Path, merged: &Path) -> IsoResult<()> {
+        let lower = canonical_existing_dir(lower)?;
+        prepare_destination(merged)?;
+
+        let output = Command::new("btrfs")
+            .args(["subvolume", "snapshot"])
+            .arg(&lower)
+            .arg(merged)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|err| {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    IsoError::unavailable("`btrfs` CLI not on PATH")
+                } else {
+                    IsoError::other(format!("spawn btrfs subvolume snapshot: {err}"))
+                }
+            })?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let _ = delete_subvolume_or_tree(merged);
+        let message = command_message(&output.stderr, &output.stdout);
+        if is_unsupported_btrfs_failure(&message) {
+            return Err(IsoError::unavailable(format!(
+                "btrfs snapshot unsupported for {} -> {}: {message}",
+                lower.display(),
+                merged.display()
+            )));
+        }
+        Err(IsoError::other(format!(
+            "btrfs subvolume snapshot {} -> {} (exit {}): {message}",
+            lower.display(),
+            merged.display(),
+            output.status.code().unwrap_or(-1)
+        )))
+    }
+
+    pub fn stop(merged: &Path) -> IsoResult<()> {
+        delete_subvolume_or_tree(merged)
+    }
+
+    fn canonical_existing_dir(path: &Path) -> IsoResult<PathBuf> {
+        let resolved = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+        };
+        let meta = fs::metadata(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "invalid btrfs snapshot source {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !meta.is_dir() {
+            return Err(IsoError::other(format!(
+                "btrfs snapshot source {} is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn prepare_destination(merged: &Path) -> IsoResult<()> {
+        if let Some(parent) = merged.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                IsoError::other(format!("create parent of {}: {err}", merged.display()))
+            })?;
+        }
+        delete_subvolume_or_tree(merged).map_err(|err| match err {
+            IsoError::Other(message) => IsoError::other(format!(
+                "unable to clear {} before btrfs snapshot: {message}",
+                merged.display()
+            )),
+            other => other,
+        })
+    }
+
+    fn delete_subvolume_or_tree(path: &Path) -> IsoResult<()> {
+        if !path_exists(path)? {
+            return Ok(());
+        }
+
+        match Command::new("btrfs")
+            .args(["subvolume", "delete"])
+            .arg(path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+        {
+            Ok(output) if output.status.success() => Ok(()),
+            Ok(output) => {
+                let message = command_message(&output.stderr, &output.stdout);
+                if is_not_subvolume_failure(&message) || is_unsupported_btrfs_failure(&message) {
+                    remove_tree_if_present(path)
+                } else {
+                    Err(IsoError::other(format!(
+                        "btrfs subvolume delete {} (exit {}): {message}",
+                        path.display(),
+                        output.status.code().unwrap_or(-1)
+                    )))
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => remove_tree_if_present(path),
+            Err(err) => Err(IsoError::other(format!(
+                "spawn btrfs subvolume delete: {err}"
+            ))),
+        }
+    }
+
+    fn remove_tree_if_present(path: &Path) -> IsoResult<()> {
+        match fs::symlink_metadata(path) {
+            Ok(meta) if meta.is_dir() => fs::remove_dir_all(path)
+                .map_err(|err| IsoError::other(format!("remove {}: {err}", path.display()))),
+            Ok(_) => fs::remove_file(path)
+                .map_err(|err| IsoError::other(format!("remove {}: {err}", path.display()))),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(IsoError::other(format!(
+                "inspect {}: {err}",
+                path.display()
+            ))),
+        }
+    }
+
+    fn path_exists(path: &Path) -> IsoResult<bool> {
+        match fs::symlink_metadata(path) {
+            Ok(_) => Ok(true),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(IsoError::other(format!(
+                "inspect {}: {err}",
+                path.display()
+            ))),
+        }
+    }
+
+    fn command_message(stderr: &[u8], stdout: &[u8]) -> String {
+        let stderr = String::from_utf8_lossy(stderr);
+        let stderr = stderr.trim();
+        if !stderr.is_empty() {
+            return stderr.to_owned();
+        }
+        let stdout = String::from_utf8_lossy(stdout);
+        let stdout = stdout.trim();
+        if stdout.is_empty() {
+            "no command output".to_string()
+        } else {
+            stdout.to_owned()
+        }
+    }
+
+    fn is_unsupported_btrfs_failure(message: &str) -> bool {
+        let message = message.to_ascii_lowercase();
+        message.contains("not a btrfs filesystem")
+            || message.contains("not a btrfs file system")
+            || message.contains("not a subvolume")
+            || message.contains("not btrfs")
+            || message.contains("invalid argument")
+            || message.contains("operation not supported")
+            || message.contains("inappropriate ioctl")
+    }
+
+    fn is_not_subvolume_failure(message: &str) -> bool {
+        let message = message.to_ascii_lowercase();
+        message.contains("not a subvolume")
+            || message.contains("not a btrfs filesystem")
+            || message.contains("not a btrfs file system")
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/diff.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/diff.rs
@@ -1,0 +1,464 @@
+//! Backend-agnostic change capture.
+//!
+//! Two code paths, both producing a [`Diff`] = list of [`FileChange`]:
+//!
+//! - **Git mode.** When `merged/.git` exists we shell `git diff --no-color
+//!   HEAD` plus `git ls-files --others --exclude-standard` (for untracked),
+//!   split the output on `diff --git` headers, and emit one [`FileChange`] per
+//!   file. Binary entries surface as `diff: None`.
+//! - **Plain mode.** No `.git`; we walk both trees in parallel, short-circuit
+//!   on `(size, mtime-truncated-to-seconds)` equality, and emit a unified diff
+//!   for each surviving pair via `similar`. NUL within the first 8 KiB
+//!   classifies the file as binary → `diff: None`.
+//!
+//! Per the PAL contract: for binary files we don't materialize the bytes
+//! in the patch — callers that want them read directly from `merged`
+//! (for `Added`/`Modified`) or `lower` (for `Removed`).
+
+use std::{
+    collections::BTreeMap,
+    fs::Metadata,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use tokio::process::Command;
+
+use crate::{IsoError, IsoResult, command_failed};
+
+/// Captured changes between a `lower` baseline and a `merged` view.
+#[derive(Debug, Clone, Default)]
+pub struct Diff {
+    pub files: Vec<FileChange>,
+}
+
+impl Diff {
+    pub const fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Concatenated unified-diff text for every text-representable entry.
+    /// Binary entries are skipped — enumerate via [`files`](Self::files)
+    /// and copy them out-of-band if you need their contents.
+    pub fn unified_text(&self) -> String {
+        let mut out = String::new();
+        for file in &self.files {
+            let Some(diff) = &file.diff else { continue };
+            if diff.is_empty() {
+                continue;
+            }
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str(diff);
+        }
+        out
+    }
+}
+
+/// One entry in a [`Diff`].
+///
+/// `path` is relative to `merged`. `diff = None` means the file is binary
+/// or otherwise text-unrepresentable — copy the contents from the merged
+/// tree if you need them (or skip if you only care about text).
+#[derive(Debug, Clone)]
+pub struct FileChange {
+    pub path: PathBuf,
+    pub op: ChangeKind,
+    pub diff: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeKind {
+    Added,
+    Modified,
+    Removed,
+}
+
+/// Default backend diff: git when available, mtime-skipped walk otherwise.
+pub async fn default_diff(lower: &Path, merged: &Path) -> IsoResult<Diff> {
+    if is_git_tree(merged).await {
+        git_diff(merged).await
+    } else {
+        walk_diff(lower, merged).await
+    }
+}
+
+async fn is_git_tree(merged: &Path) -> bool {
+    tokio::fs::symlink_metadata(merged.join(".git"))
+        .await
+        .is_ok()
+}
+
+// ─── git mode ───────────────────────────────────────────────────────────────
+
+async fn git_diff(merged: &Path) -> IsoResult<Diff> {
+    // `--no-color`: keep ANSI out of patch text.
+    // No `--binary`: we *want* git's `Binary files … differ` placeholder
+    // so we can map it to `diff: None`.
+    let tracked = git_run(
+        merged,
+        &["-c", "core.quotepath=off", "diff", "--no-color", "HEAD"],
+    )
+    .await?;
+
+    let untracked_list = git_run(
+        merged,
+        &[
+            "-c",
+            "core.quotepath=off",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "-z",
+        ],
+    )
+    .await?;
+
+    let mut files = parse_git_diff(&tracked);
+
+    let mut untracked_paths: Vec<&[u8]> = untracked_list
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .collect();
+    untracked_paths.sort_unstable();
+
+    for path_bytes in untracked_paths {
+        let path_str = std::str::from_utf8(path_bytes)
+            .map_err(|err| IsoError::other(format!("untracked path is not valid UTF-8: {err}")))?;
+        let one = git_run_allow_exit1(
+            merged,
+            &[
+                "-c",
+                "core.quotepath=off",
+                "diff",
+                "--no-color",
+                "--no-index",
+                git_null_path(),
+                path_str,
+            ],
+        )
+        .await?;
+        files.extend(parse_git_diff(&one));
+    }
+
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(Diff { files })
+}
+
+#[cfg(windows)]
+const fn git_null_path() -> &'static str {
+    "NUL"
+}
+
+#[cfg(not(windows))]
+const fn git_null_path() -> &'static str {
+    "/dev/null"
+}
+
+/// Format a failed `git` invocation, rendering a signal death as `exit ?`.
+fn git_failure(args: &[&str], output: &std::process::Output) -> IsoError {
+    command_failed(
+        format_args!("git {}", args.join(" ")),
+        output
+            .status
+            .code()
+            .map_or_else(|| "?".into(), |c| c.to_string()),
+        &output.stderr,
+    )
+}
+
+async fn git_run(cwd: &Path, args: &[&str]) -> IsoResult<Vec<u8>> {
+    let output = git_spawn(cwd, args).await?;
+    if !output.status.success() {
+        return Err(git_failure(args, &output));
+    }
+    Ok(output.stdout)
+}
+
+/// `git diff --no-index` returns exit code 1 when files differ — that's
+/// not an error for us, treat it as success with the produced patch.
+async fn git_run_allow_exit1(cwd: &Path, args: &[&str]) -> IsoResult<Vec<u8>> {
+    let output = git_spawn(cwd, args).await?;
+    if output.status.success() || output.status.code() == Some(1) {
+        return Ok(output.stdout);
+    }
+    Err(git_failure(args, &output))
+}
+
+async fn git_spawn(cwd: &Path, args: &[&str]) -> IsoResult<std::process::Output> {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(cwd).args(args);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.output().await.map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            IsoError::unavailable("`git` not on PATH; cannot capture diff for git-tracked tree")
+        } else {
+            IsoError::other(format!("spawn git: {err}"))
+        }
+    })
+}
+
+/// Split a `git diff` blob into per-file [`FileChange`] entries. Each
+/// entry covers exactly one `diff --git a/<path> b/<path>` block. Binary
+/// blocks are emitted with `diff: None`; the rest carry their original
+/// unified-diff slice unchanged so `git apply` produces byte-identical
+/// results downstream.
+fn parse_git_diff(blob: &[u8]) -> Vec<FileChange> {
+    let Ok(text) = std::str::from_utf8(blob) else {
+        return Vec::new();
+    };
+    let mut out = Vec::<FileChange>::new();
+    let iter = text.split_inclusive('\n');
+    let mut buf = String::new();
+    let mut header_path: Option<PathBuf> = None;
+    let mut header_kind = ChangeKind::Modified;
+    let mut header_binary = false;
+
+    let flush = |buf: &mut String,
+                 path: &mut Option<PathBuf>,
+                 kind: &mut ChangeKind,
+                 binary: &mut bool,
+                 out: &mut Vec<FileChange>| {
+        if let Some(p) = path.take() {
+            let diff = if *binary {
+                None
+            } else {
+                Some(std::mem::take(buf))
+            };
+            out.push(FileChange {
+                path: p,
+                op: *kind,
+                diff,
+            });
+        }
+        buf.clear();
+        *kind = ChangeKind::Modified;
+        *binary = false;
+    };
+
+    for line in iter {
+        if let Some(rest) = line.strip_prefix("diff --git ") {
+            flush(
+                &mut buf,
+                &mut header_path,
+                &mut header_kind,
+                &mut header_binary,
+                &mut out,
+            );
+            let trimmed = rest.trim_end_matches('\n');
+            if let Some((_, b)) = trimmed.split_once(' ') {
+                let path = b.strip_prefix("b/").unwrap_or(b);
+                header_path = Some(PathBuf::from(path));
+            }
+            buf.push_str(line);
+            continue;
+        }
+        if header_path.is_some() {
+            if line.starts_with("new file mode ") {
+                header_kind = ChangeKind::Added;
+            } else if line.starts_with("deleted file mode ") {
+                header_kind = ChangeKind::Removed;
+            } else if line.starts_with("Binary files ") || line.starts_with("GIT binary patch") {
+                header_binary = true;
+            }
+            buf.push_str(line);
+        }
+    }
+    flush(
+        &mut buf,
+        &mut header_path,
+        &mut header_kind,
+        &mut header_binary,
+        &mut out,
+    );
+    out
+}
+
+// ─── plain mode ─────────────────────────────────────────────────────────────
+
+async fn walk_diff(lower: &Path, merged: &Path) -> IsoResult<Diff> {
+    let lower = lower.to_path_buf();
+    let merged = merged.to_path_buf();
+    tokio::task::spawn_blocking(move || walk_diff_blocking(&lower, &merged))
+        .await
+        .map_err(|err| IsoError::other(format!("walk_diff join: {err}")))?
+}
+
+fn walk_diff_blocking(lower: &Path, merged: &Path) -> IsoResult<Diff> {
+    let lower_index = index_tree(lower)?;
+    let merged_index = index_tree(merged)?;
+
+    let mut files: Vec<FileChange> = Vec::new();
+
+    for (rel, m_meta) in &merged_index {
+        match lower_index.get(rel) {
+            None => files.push(plain_change(merged, rel, ChangeKind::Added, None)?),
+            Some(l_meta) => {
+                if metas_equal(l_meta, m_meta) {
+                    continue;
+                }
+                files.push(plain_change(
+                    merged,
+                    rel,
+                    ChangeKind::Modified,
+                    Some(lower),
+                )?);
+            }
+        }
+    }
+    for rel in lower_index.keys() {
+        if !merged_index.contains_key(rel) {
+            files.push(plain_change(lower, rel, ChangeKind::Removed, None)?);
+        }
+    }
+
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(Diff { files })
+}
+
+fn metas_equal(a: &Metadata, b: &Metadata) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    match (a.modified(), b.modified()) {
+        (Ok(ma), Ok(mb)) => systime_eq(ma, mb),
+        _ => false,
+    }
+}
+
+fn systime_eq(a: SystemTime, b: SystemTime) -> bool {
+    // Filesystems carry mtime at different resolutions (HFS+ seconds, APFS
+    // nanos, FAT 2 seconds). Compare at second granularity so a metadata-
+    // preserving copy that flushed through a coarse layer doesn't look
+    // modified.
+    let to_secs = |t: SystemTime| {
+        t.duration_since(SystemTime::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs())
+    };
+    to_secs(a) == to_secs(b)
+}
+
+fn index_tree(root: &Path) -> IsoResult<BTreeMap<PathBuf, Metadata>> {
+    let mut out = BTreeMap::new();
+    if !root.exists() {
+        return Ok(out);
+    }
+    walk(root, root, &mut out)?;
+    Ok(out)
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<PathBuf, Metadata>) -> IsoResult<()> {
+    let entries = std::fs::read_dir(dir)
+        .map_err(|err| IsoError::other(format!("read_dir {}: {err}", dir.display())))?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|err| IsoError::other(format!("dir entry in {}: {err}", dir.display())))?;
+        let path = entry.path();
+        let meta = entry
+            .metadata()
+            .map_err(|err| IsoError::other(format!("metadata {}: {err}", path.display())))?;
+        if meta.is_symlink() {
+            let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+            out.insert(rel, meta);
+            continue;
+        }
+        if meta.is_dir() {
+            walk(root, &path, out)?;
+            continue;
+        }
+        let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+        out.insert(rel, meta);
+    }
+    Ok(())
+}
+
+/// Build a [`FileChange`] for an entry observed by [`walk_diff_blocking`].
+///
+/// `op == Modified` requires `peer_root = Some(lower)` so we can read the
+/// counterpart; `Added`/`Removed` only need the side we already know about.
+fn plain_change(
+    side: &Path,
+    rel: &Path,
+    op: ChangeKind,
+    peer_root: Option<&Path>,
+) -> IsoResult<FileChange> {
+    let full = side.join(rel);
+    let primary = std::fs::read(&full)
+        .map_err(|err| IsoError::other(format!("read {}: {err}", full.display())))?;
+    if looks_binary(&primary) {
+        return Ok(FileChange {
+            path: rel.to_path_buf(),
+            op,
+            diff: None,
+        });
+    }
+    let (old_bytes, new_bytes) = match op {
+        ChangeKind::Added => (Vec::new(), primary),
+        ChangeKind::Removed => (primary, Vec::new()),
+        ChangeKind::Modified => {
+            let peer = peer_root.expect("modified change requires peer root");
+            let peer_full = peer.join(rel);
+            let peer_bytes = std::fs::read(&peer_full)
+                .map_err(|err| IsoError::other(format!("read {}: {err}", peer_full.display())))?;
+            if looks_binary(&peer_bytes) {
+                return Ok(FileChange {
+                    path: rel.to_path_buf(),
+                    op,
+                    diff: None,
+                });
+            }
+            (peer_bytes, primary)
+        }
+    };
+    let (Ok(old_text), Ok(new_text)) = (
+        std::str::from_utf8(&old_bytes),
+        std::str::from_utf8(&new_bytes),
+    ) else {
+        return Ok(FileChange {
+            path: rel.to_path_buf(),
+            op,
+            diff: None,
+        });
+    };
+    Ok(FileChange {
+        path: rel.to_path_buf(),
+        op,
+        diff: Some(render_unified(rel, op, old_text, new_text)),
+    })
+}
+
+fn render_unified(rel: &Path, op: ChangeKind, old: &str, new: &str) -> String {
+    let rel_str = rel.to_string_lossy();
+    let (from_label, to_label) = match op {
+        ChangeKind::Added => (String::from("/dev/null"), format!("b/{rel_str}")),
+        ChangeKind::Removed => (format!("a/{rel_str}"), String::from("/dev/null")),
+        ChangeKind::Modified => (format!("a/{rel_str}"), format!("b/{rel_str}")),
+    };
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "diff --git a/{rel_str} b/{rel_str}");
+    match op {
+        ChangeKind::Added => {
+            let _ = writeln!(out, "new file mode 100644");
+        }
+        ChangeKind::Removed => {
+            let _ = writeln!(out, "deleted file mode 100644");
+        }
+        ChangeKind::Modified => {}
+    }
+    let body = similar::TextDiff::from_lines(old, new)
+        .unified_diff()
+        .context_radius(3)
+        .header(&from_label, &to_label)
+        .to_string();
+    out.push_str(&body);
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn looks_binary(bytes: &[u8]) -> bool {
+    bytes.iter().take(8192).any(|&b| b == 0)
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/lib.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/lib.rs
@@ -1,0 +1,405 @@
+//! Cross-platform isolation PAL.
+//!
+//! A backend gives the caller a writable "merged" view of a read-only
+//! "lower" tree without paying for a deep copy:
+//!
+//! - **macOS** uses `clonefile(2)` to seed an APFS copy-on-write clone.
+//! - **Linux** mounts a kernel `overlay` filesystem, falling back to
+//!   `fuse-overlayfs` when the syscall is denied.
+//! - **Windows** projects an existing tree through `ProjFS`.
+//! - **`Rcopy`** is the cross-platform fallback: `git worktree` if `lower` is a
+//!   git repo, plain recursive copy otherwise.
+//!
+//! Every backend also knows how to surface the changes the workload made.
+//! When `merged` is a git repository — true for every git-backed task in
+//! omp regardless of which lifecycle backend was used —
+//! [`IsolationBackend::diff`] delegates to `git diff` so the output is
+//! byte-identical to what `git apply` consumes downstream. For non-git trees
+//! (only reachable via `Rcopy`) it walks both trees, using `(size, mtime)` as a
+//! cheap short-circuit before doing a content diff.
+
+#![cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", windows)),
+    allow(
+        unused_imports,
+        dead_code,
+        reason = "platform without an isolation backend"
+    )
+)]
+
+use std::{fmt, path::Path};
+
+use async_trait::async_trait;
+
+mod apfs;
+mod btrfs;
+mod diff;
+mod linux_reflink;
+mod overlayfs;
+mod projfs;
+mod rcopy;
+mod windows_block_clone;
+mod zfs;
+
+pub use diff::{ChangeKind, Diff, FileChange};
+
+/// Stable identifier for which backend a build was compiled with.
+///
+/// Exposed to callers so they can render diagnostics or pick mode-specific
+/// configuration without re-implementing the per-OS branching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BackendKind {
+    /// APFS `clonefile(2)` reflink clone (macOS).
+    Apfs,
+    /// btrfs `subvolume snapshot` clone (Linux + btrfs).
+    Btrfs,
+    /// ZFS dataset snapshot+clone (Linux/FreeBSD/macOS + a ZFS pool).
+    Zfs,
+    /// Linux `FICLONE` per-file reflink tree (btrfs, XFS+reflink, bcachefs, …).
+    LinuxReflink,
+    /// Kernel `overlay` filesystem (Linux), with optional `fuse-overlayfs`
+    /// fallback.
+    Overlayfs,
+    /// Windows `FSCTL_DUPLICATE_EXTENTS_TO_FILE` block clone tree (NTFS/ReFS).
+    WindowsBlockClone,
+    /// Windows Projected File System.
+    Projfs,
+    /// `git worktree` when `lower` is a git repo, otherwise plain recursive
+    /// copy. Always available; the universal fallback.
+    Rcopy,
+}
+
+impl BackendKind {
+    /// Short, stable string identifier. Used by the napi shim.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Apfs => "apfs",
+            Self::Btrfs => "btrfs",
+            Self::Zfs => "zfs",
+            Self::LinuxReflink => "linux-reflink",
+            Self::Overlayfs => "overlayfs",
+            Self::WindowsBlockClone => "windows-block-clone",
+            Self::Projfs => "projfs",
+            Self::Rcopy => "rcopy",
+        }
+    }
+
+    /// Parse the inverse of [`Self::as_str`]. Returns `None` for unknown
+    /// strings so callers can surface a precise error.
+    #[allow(
+        clippy::should_implement_trait,
+        reason = "Option<Self> return is more ergonomic than FromStr's Result"
+    )]
+    pub fn from_str(s: &str) -> Option<Self> {
+        Some(match s {
+            "apfs" => Self::Apfs,
+            "btrfs" => Self::Btrfs,
+            "zfs" => Self::Zfs,
+            "linux-reflink" | "reflink" => Self::LinuxReflink,
+            "overlayfs" => Self::Overlayfs,
+            "windows-block-clone" | "block-clone" => Self::WindowsBlockClone,
+            "projfs" => Self::Projfs,
+            "rcopy" => Self::Rcopy,
+            _ => return None,
+        })
+    }
+
+    /// Backend chosen for the current build target when the caller doesn't
+    /// specify one. Platform-native `CoW` first, [`Rcopy`](Self::Rcopy) as the
+    /// last resort.
+    pub const fn native() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self::Apfs
+        }
+        #[cfg(target_os = "linux")]
+        {
+            Self::Overlayfs
+        }
+        #[cfg(windows)]
+        {
+            Self::Projfs
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+        {
+            Self::Rcopy
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+const MACOS_AUTO_ORDER: &[BackendKind] = &[BackendKind::Apfs, BackendKind::Zfs, BackendKind::Rcopy];
+#[cfg(target_os = "linux")]
+const LINUX_AUTO_ORDER: &[BackendKind] = &[
+    BackendKind::Btrfs,
+    BackendKind::Zfs,
+    BackendKind::LinuxReflink,
+    BackendKind::Overlayfs,
+    BackendKind::Rcopy,
+];
+#[cfg(windows)]
+const WINDOWS_AUTO_ORDER: &[BackendKind] = &[
+    BackendKind::WindowsBlockClone,
+    BackendKind::Projfs,
+    BackendKind::Rcopy,
+];
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+const FALLBACK_AUTO_ORDER: &[BackendKind] = &[BackendKind::Rcopy];
+
+impl fmt::Display for BackendKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Result of a backend probe.
+///
+/// `available == false` means [`IsolationBackend::start`] will fail with
+/// [`IsoError::Unavailable`]; `reason` is a human-readable explanation
+/// suitable for surfacing in a UI.
+#[derive(Debug, Clone)]
+pub struct ProbeResult {
+    pub available: bool,
+    pub reason: Option<String>,
+}
+
+impl ProbeResult {
+    pub const fn available() -> Self {
+        Self {
+            available: true,
+            reason: None,
+        }
+    }
+
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            available: false,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Error returned by every backend operation.
+///
+/// `Unavailable` is the only variant callers are expected to treat specially —
+/// it indicates the platform prerequisite is missing (no `ProjFS` DLL, no
+/// `overlay` support, etc.) and the workload should fall back rather than
+/// surface a hard failure.
+#[derive(Debug, Clone)]
+pub enum IsoError {
+    Unavailable(String),
+    Other(String),
+}
+
+impl IsoError {
+    pub fn unavailable(msg: impl Into<String>) -> Self {
+        Self::Unavailable(msg.into())
+    }
+
+    pub fn other(msg: impl Into<String>) -> Self {
+        Self::Other(msg.into())
+    }
+
+    pub const fn is_unavailable(&self) -> bool {
+        matches!(self, Self::Unavailable(_))
+    }
+
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Unavailable(m) | Self::Other(m) => m,
+        }
+    }
+}
+
+impl fmt::Display for IsoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl std::error::Error for IsoError {}
+
+pub type IsoResult<T> = Result<T, IsoError>;
+
+/// Build the [`IsoError::Other`] for a failed external command, rendered as
+/// `<what> (exit <code>): <trimmed stderr>`.
+///
+/// `stderr` is decoded lossily. `code` is preformatted by the caller so
+/// per-site conventions for signal deaths (`-1` vs `?`) are preserved.
+pub(crate) fn command_failed(
+    what: impl fmt::Display,
+    code: impl fmt::Display,
+    stderr: &[u8],
+) -> IsoError {
+    let stderr = String::from_utf8_lossy(stderr);
+    IsoError::other(format!("{what} (exit {code}): {}", stderr.trim()))
+}
+
+/// Backend contract.
+///
+/// `lower` is the read-only source tree; `merged` is the destination where
+/// the writable view is materialised. Implementations are responsible for
+/// creating any auxiliary directories (e.g. overlayfs upper/work dirs) and
+/// for tearing them down in [`stop`](Self::stop).
+///
+/// `start` / `stop` are synchronous because the platform primitives they
+/// wrap (`mount`, `clonefile`, `PrjStartVirtualizing`) are blocking
+/// syscalls that callers are expected to drive from `spawn_blocking`.
+/// [`diff`](Self::diff) is async because it does heavy I/O — walking
+/// trees, reading files, spawning git — and benefits from the runtime
+/// interleaving requests with other work.
+#[async_trait]
+pub trait IsolationBackend: Send + Sync {
+    fn kind(&self) -> BackendKind;
+
+    fn probe(&self) -> ProbeResult;
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()>;
+
+    fn stop(&self, merged: &Path) -> IsoResult<()>;
+
+    /// Capture the changes between `lower` and the current state of
+    /// `merged`. The default implementation delegates to `git diff` when
+    /// `merged` is a git working tree, otherwise walks both trees using
+    /// `(size, mtime)` to skip equal files before falling back to a
+    /// content comparison.
+    ///
+    /// Backends are free to override when they know a cheaper path —
+    /// overlayfs can scan the upper dir, `ProjFS` can query the placeholder
+    /// set — but the default is correct everywhere.
+    async fn diff(&self, lower: &Path, merged: &Path) -> IsoResult<Diff> {
+        diff::default_diff(lower, merged).await
+    }
+}
+
+/// Returns the backend selected for the current build target.
+///
+/// Each backend is a unit struct with no per-call state, so we hand out a
+/// `&'static` reference and avoid the indirection of building a fresh trait
+/// object on every call.
+pub fn default_backend() -> &'static dyn IsolationBackend {
+    backend(BackendKind::native())
+}
+
+/// Look up a backend by [`BackendKind`].
+///
+/// Every kind is dispatchable in every build; backends that aren't compiled
+/// in for the current target (`Apfs` off Linux/macOS, `Projfs` off Windows…)
+/// return their own platform stub which fails
+/// [`probe`](IsolationBackend::probe) with `available = false` and rejects
+/// [`start`](IsolationBackend::start) with [`IsoError::Unavailable`]. This way
+/// the napi shim can mirror the user's `task.isolation.mode` setting without an
+/// extra "is this platform" check.
+pub fn backend(kind: BackendKind) -> &'static dyn IsolationBackend {
+    match kind {
+        BackendKind::Apfs => apfs::backend(),
+        BackendKind::Btrfs => btrfs::backend(),
+        BackendKind::Zfs => zfs::backend(),
+        BackendKind::LinuxReflink => linux_reflink::backend(),
+        BackendKind::Overlayfs => overlayfs::backend(),
+        BackendKind::WindowsBlockClone => windows_block_clone::backend(),
+        BackendKind::Projfs => projfs::backend(),
+        BackendKind::Rcopy => &rcopy::RcopyBackend,
+    }
+}
+
+/// Convenience accessor for [`default_backend`]'s [`BackendKind`].
+pub fn backend_kind() -> BackendKind {
+    default_backend().kind()
+}
+
+/// Backend preference order for automatic isolation on this build target.
+///
+/// The order is intentionally broader than [`BackendKind::native`]: it tries
+/// filesystem-native snapshot/reflink mechanisms first, then mount/projection
+/// overlays, and keeps [`BackendKind::Rcopy`] as the universal final fallback.
+pub const fn auto_order() -> &'static [BackendKind] {
+    #[cfg(target_os = "macos")]
+    {
+        MACOS_AUTO_ORDER
+    }
+    #[cfg(target_os = "linux")]
+    {
+        LINUX_AUTO_ORDER
+    }
+    #[cfg(windows)]
+    {
+        WINDOWS_AUTO_ORDER
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        FALLBACK_AUTO_ORDER
+    }
+}
+
+/// Outcome of [`resolve`].
+///
+/// `kind` is the first host-available backend to try. `candidates` contains
+/// every host-available backend in fallback order, starting with `kind`, so
+/// callers can retry when a backend is unavailable for a specific filesystem
+/// path. `fell_back` is `true` when a `preferred` choice (or earlier automatic
+/// candidate) was unusable. `reason` carries the first unavailable probe's
+/// explanation when available.
+#[derive(Debug, Clone)]
+pub struct Resolution {
+    pub kind: BackendKind,
+    pub candidates: Vec<BackendKind>,
+    pub fell_back: bool,
+    pub reason: Option<String>,
+}
+
+/// Pick the best backend whose host-level prerequisites are available.
+///
+/// Caller priority:
+/// 1. If `preferred` is `Some` and its [`probe`](IsolationBackend::probe)
+///    reports `available`, use it as-is.
+/// 2. Otherwise walk [`auto_order`], skipping `preferred` if present.
+/// 3. [`BackendKind::Rcopy`] is the final automatic candidate and is expected
+///    to be available on every platform.
+///
+/// This is only a host-level probe. Some backends still reject a specific
+/// `lower`/`merged` pair at [`IsolationBackend::start`] time (cross-device
+/// reflinks, non-subvolume btrfs paths, non-ZFS mountpoints). Callers that can
+/// recover should retry the remaining automatic candidates when `start`
+/// returns [`IsoError::Unavailable`].
+pub fn resolve(preferred: Option<BackendKind>) -> Resolution {
+    let mut reason = None;
+    let mut candidates = Vec::with_capacity(auto_order().len() + usize::from(preferred.is_some()));
+
+    if let Some(p) = preferred {
+        let probe = backend(p).probe();
+        if probe.available {
+            candidates.push(p);
+        } else {
+            reason = probe.reason;
+        }
+    }
+
+    for candidate in auto_order() {
+        if Some(*candidate) == preferred {
+            continue;
+        }
+        let probe = backend(*candidate).probe();
+        if probe.available {
+            candidates.push(*candidate);
+        } else if reason.is_none() {
+            reason = probe.reason;
+        }
+    }
+
+    if candidates.is_empty() {
+        candidates.push(BackendKind::Rcopy);
+    }
+    let kind = candidates[0];
+    let fell_back = match preferred {
+        Some(p) => kind != p,
+        None => kind != auto_order()[0],
+    };
+
+    Resolution {
+        kind,
+        candidates,
+        fell_back,
+        reason,
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/linux_reflink.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/linux_reflink.rs
@@ -1,0 +1,288 @@
+//! Linux FICLONE-based copy-on-write tree materialisation.
+//!
+//! This backend recursively builds a writable directory tree at `merged` from
+//! `lower`. Directories and symlinks are recreated, while regular files are
+//! cloned with the Linux `FICLONE` ioctl so filesystems such as btrfs, XFS,
+//! OCFS2, and bcachefs can share extents until either side is modified. There
+//! is no mount or kernel state to undo, so [`stop`](IsolationBackend::stop) is
+//! a recursive remove.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+#[cfg(not(target_os = "linux"))]
+use crate::IsoError;
+use crate::{BackendKind, IsoResult, IsolationBackend, ProbeResult};
+
+pub struct LinuxReflinkBackend;
+
+pub fn backend() -> &'static dyn IsolationBackend {
+    &LinuxReflinkBackend
+}
+
+#[async_trait]
+impl IsolationBackend for LinuxReflinkBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::LinuxReflink
+    }
+
+    fn probe(&self) -> ProbeResult {
+        #[cfg(target_os = "linux")]
+        {
+            ProbeResult::available()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            ProbeResult::unavailable("Linux FICLONE reflink isolation is only available on Linux")
+        }
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            imp::start(lower, merged)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (lower, merged);
+            Err(IsoError::unavailable(
+                "Linux FICLONE reflink isolation is only available on Linux",
+            ))
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            imp::stop(merged)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = merged;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::{
+        ffi::CString,
+        fs::{self, File, OpenOptions},
+        os::{
+            fd::AsRawFd,
+            unix::{
+                ffi::OsStrExt,
+                fs::{MetadataExt, PermissionsExt},
+            },
+        },
+        path::{Path, PathBuf},
+    };
+
+    use crate::{IsoError, IsoResult};
+
+    // `libc::Ioctl` is `c_int` on musl and `c_ulong` on glibc; the constant fits
+    // both.
+    const FICLONE: libc::Ioctl = 0x4004_9409;
+
+    pub fn start(lower: &Path, merged: &Path) -> IsoResult<()> {
+        let lower = canonical_existing_dir(lower)?;
+        prepare_destination(merged)?;
+
+        let result = recursive_reflink(&lower, merged);
+        if result.is_err() {
+            let _ = fs::remove_dir_all(merged);
+        }
+        result
+    }
+
+    pub fn stop(merged: &Path) -> IsoResult<()> {
+        match fs::remove_dir_all(merged) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(IsoError::other(format!(
+                "unable to remove reflink tree {}: {err}",
+                merged.display()
+            ))),
+        }
+    }
+
+    fn canonical_existing_dir(path: &Path) -> IsoResult<PathBuf> {
+        let resolved = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+        };
+        let meta = fs::metadata(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "invalid reflink source {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !meta.is_dir() {
+            return Err(IsoError::other(format!(
+                "reflink source {} is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn prepare_destination(merged: &Path) -> IsoResult<()> {
+        if let Some(parent) = merged.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                IsoError::other(format!("create parent of {}: {err}", merged.display()))
+            })?;
+        }
+        match fs::symlink_metadata(merged) {
+            Ok(meta) if meta.is_dir() => fs::remove_dir_all(merged).map_err(|err| {
+                IsoError::other(format!(
+                    "unable to clear {} before reflink clone: {err}",
+                    merged.display()
+                ))
+            })?,
+            Ok(_) => fs::remove_file(merged).map_err(|err| {
+                IsoError::other(format!(
+                    "unable to clear {} before reflink clone: {err}",
+                    merged.display()
+                ))
+            })?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(IsoError::other(format!(
+                    "unable to inspect {} before reflink clone: {err}",
+                    merged.display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn recursive_reflink(src: &Path, dst: &Path) -> IsoResult<()> {
+        let meta = fs::symlink_metadata(src)
+            .map_err(|err| IsoError::other(format!("symlink_metadata {}: {err}", src.display())))?;
+        fs::create_dir(dst)
+            .map_err(|err| IsoError::other(format!("create {}: {err}", dst.display())))?;
+
+        let entries = fs::read_dir(src)
+            .map_err(|err| IsoError::other(format!("read_dir {}: {err}", src.display())))?;
+        for entry in entries {
+            let entry = entry
+                .map_err(|err| IsoError::other(format!("dir entry in {}: {err}", src.display())))?;
+            let file_type = entry.file_type().map_err(|err| {
+                IsoError::other(format!("file_type {}: {err}", entry.path().display()))
+            })?;
+            let src_path = entry.path();
+            let dst_path = dst.join(entry.file_name());
+            if file_type.is_symlink() {
+                clone_symlink(&src_path, &dst_path)?;
+            } else if file_type.is_dir() {
+                recursive_reflink(&src_path, &dst_path)?;
+            } else if file_type.is_file() {
+                clone_file(&src_path, &dst_path)?;
+            } else {
+                return Err(IsoError::other(format!(
+                    "unsupported file type in reflink source: {}",
+                    src_path.display()
+                )));
+            }
+        }
+
+        preserve_permissions(dst, &meta)?;
+        let _ = set_times_nofollow(dst, &meta);
+        Ok(())
+    }
+
+    fn clone_symlink(src: &Path, dst: &Path) -> IsoResult<()> {
+        let target = fs::read_link(src)
+            .map_err(|err| IsoError::other(format!("read_link {}: {err}", src.display())))?;
+        std::os::unix::fs::symlink(target, dst)
+            .map_err(|err| IsoError::other(format!("symlink {}: {err}", dst.display())))?;
+        if let Ok(meta) = fs::symlink_metadata(src) {
+            let _ = set_times_nofollow(dst, &meta);
+        }
+        Ok(())
+    }
+
+    fn clone_file(src: &Path, dst: &Path) -> IsoResult<()> {
+        let meta = fs::symlink_metadata(src)
+            .map_err(|err| IsoError::other(format!("symlink_metadata {}: {err}", src.display())))?;
+        let src_file = File::open(src)
+            .map_err(|err| IsoError::other(format!("open {}: {err}", src.display())))?;
+        let dst_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dst)
+            .map_err(|err| IsoError::other(format!("create {}: {err}", dst.display())))?;
+
+        // SAFETY: both file descriptors are valid for the duration of the call.
+        // FICLONE copies metadata into `dst_file` and does not retain either fd.
+        let rc = unsafe { libc::ioctl(dst_file.as_raw_fd(), FICLONE, src_file.as_raw_fd()) };
+        if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            let _ = fs::remove_file(dst);
+            return Err(map_clone_error(src, dst, err));
+        }
+
+        preserve_permissions(dst, &meta)?;
+        let _ = set_times_nofollow(dst, &meta);
+        Ok(())
+    }
+
+    fn map_clone_error(src: &Path, dst: &Path, err: std::io::Error) -> IsoError {
+        if let Some(code) = err.raw_os_error()
+            && matches!(
+                code,
+                libc::EXDEV | libc::EOPNOTSUPP | libc::ENOTTY | libc::EINVAL | libc::ENOSYS
+            )
+        {
+            return IsoError::unavailable(format!(
+                "FICLONE unsupported for {} -> {}: {err}",
+                src.display(),
+                dst.display()
+            ));
+        }
+        IsoError::other(format!(
+            "FICLONE {} -> {}: {err}",
+            src.display(),
+            dst.display()
+        ))
+    }
+
+    fn preserve_permissions(path: &Path, meta: &fs::Metadata) -> IsoResult<()> {
+        let mode = meta.permissions().mode();
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))
+            .map_err(|err| IsoError::other(format!("set permissions on {}: {err}", path.display())))
+    }
+
+    fn set_times_nofollow(path: &Path, meta: &fs::Metadata) -> std::io::Result<()> {
+        let times = [
+            libc::timespec {
+                tv_sec: meta.atime() as libc::time_t,
+                tv_nsec: meta.atime_nsec() as libc::c_long,
+            },
+            libc::timespec {
+                tv_sec: meta.mtime() as libc::time_t,
+                tv_nsec: meta.mtime_nsec() as libc::c_long,
+            },
+        ];
+        let c_path = CString::new(path.as_os_str().as_bytes())?;
+        // SAFETY: `c_path` and `times` live until the syscall returns; the
+        // kernel does not retain either pointer. AT_SYMLINK_NOFOLLOW preserves
+        // symlink timestamps instead of mutating the link target.
+        let rc = unsafe {
+            libc::utimensat(
+                libc::AT_FDCWD,
+                c_path.as_ptr(),
+                times.as_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/overlayfs.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/overlayfs.rs
@@ -1,0 +1,356 @@
+//! Linux overlayfs-based isolation.
+//!
+//! Tries to stack a kernel `overlay` filesystem at `merged` over the
+//! read-only `lower` tree. The mount uses sibling `upper` and `work`
+//! directories derived from `merged.parent()` so a single caller-owned base
+//! directory cleans up with one `rm -rf`.
+//!
+//! When the kernel rejects the mount (typically `EPERM` outside a user
+//! namespace, or `ENODEV` if the module is absent) we fall back to
+//! `fuse-overlayfs(1)` because that is what the project shipped before and
+//! existing user environments rely on it.
+//!
+//! Backend selection is remembered per-mount so
+//! [`stop`](IsolationBackend::stop) dispatches to the correct teardown path
+//! (`umount2` vs `fusermount[3] -u`).
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+#[cfg(not(target_os = "linux"))]
+use crate::IsoError;
+use crate::{BackendKind, IsoResult, IsolationBackend, ProbeResult};
+
+pub struct OverlayfsBackend;
+
+pub fn backend() -> &'static dyn IsolationBackend {
+    &OverlayfsBackend
+}
+
+#[async_trait]
+impl IsolationBackend for OverlayfsBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::Overlayfs
+    }
+
+    fn probe(&self) -> ProbeResult {
+        #[cfg(target_os = "linux")]
+        {
+            imp::probe()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            ProbeResult::unavailable("overlayfs isolation is only available on Linux")
+        }
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            imp::start(lower, merged)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (lower, merged);
+            Err(IsoError::unavailable(
+                "overlayfs isolation is only available on Linux",
+            ))
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            imp::stop(merged)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = merged;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::{
+        collections::BTreeMap,
+        ffi::CString,
+        fs,
+        os::unix::ffi::OsStrExt,
+        path::{Path, PathBuf},
+        process::{Command, Stdio},
+        sync::LazyLock,
+    };
+
+    use parking_lot::Mutex;
+
+    use crate::{IsoError, IsoResult, ProbeResult, command_failed};
+
+    #[derive(Clone, Copy)]
+    enum MountFlavor {
+        Kernel,
+        Fuse,
+    }
+
+    static ACTIVE_MOUNTS: LazyLock<Mutex<BTreeMap<PathBuf, MountFlavor>>> =
+        LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+    pub fn probe() -> ProbeResult {
+        if kernel_overlay_supported() {
+            return ProbeResult::available();
+        }
+        if fuse_overlayfs_available() {
+            return ProbeResult::available();
+        }
+        ProbeResult::unavailable(
+            "overlay filesystem unavailable: kernel `overlay` module missing and `fuse-overlayfs` \
+			 not on PATH",
+        )
+    }
+
+    pub fn start(lower: &Path, merged: &Path) -> IsoResult<()> {
+        let lower = canonical_existing_dir(lower)?;
+        let merged = absolutize(merged);
+        let base = merged.parent().ok_or_else(|| {
+            IsoError::other(format!("merged path has no parent: {}", merged.display()))
+        })?;
+        let upper = base.join("upper");
+        let work = base.join("work");
+
+        remove_dir_if_exists(&upper, "stale overlay upper")?;
+        remove_dir_if_exists(&work, "stale overlay work")?;
+        remove_dir_if_exists(&merged, "stale overlay merged")?;
+
+        fs::create_dir_all(&upper).map_err(|err| {
+            IsoError::other(format!("create upper dir {}: {err}", upper.display()))
+        })?;
+        fs::create_dir_all(&work)
+            .map_err(|err| IsoError::other(format!("create work dir {}: {err}", work.display())))?;
+        fs::create_dir_all(&merged).map_err(|err| {
+            IsoError::other(format!("create merged dir {}: {err}", merged.display()))
+        })?;
+
+        let opts = format!(
+            "lowerdir={},upperdir={},workdir={}",
+            lower.display(),
+            upper.display(),
+            work.display()
+        );
+
+        match kernel_mount(&merged, &opts) {
+            Ok(()) => {
+                ACTIVE_MOUNTS.lock().insert(merged, MountFlavor::Kernel);
+                Ok(())
+            }
+            Err(err) if err.is_unavailable() => {
+                fuse_mount(&lower, &upper, &work, &merged)?;
+                ACTIVE_MOUNTS.lock().insert(merged, MountFlavor::Fuse);
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn stop(merged: &Path) -> IsoResult<()> {
+        let merged = absolutize(merged);
+        let result = {
+            let flavor = ACTIVE_MOUNTS.lock().remove(&merged);
+            match flavor {
+                Some(MountFlavor::Fuse) => fuse_umount(&merged),
+                Some(MountFlavor::Kernel) | None => {
+                    // `None` covers callers that skipped `start` (probe-style flow)
+                    // or processes that re-attached after a crash; try a kernel
+                    // umount first, fall back to fusermount so we don't silently
+                    // leak a mount.
+                    kernel_umount(&merged).or_else(|err| {
+                        if err.is_unavailable() {
+                            fuse_umount(&merged)
+                        } else {
+                            Err(err)
+                        }
+                    })
+                }
+            }
+        };
+        result?;
+
+        if let Some(base) = merged.parent() {
+            remove_dir_if_exists(&base.join("upper"), "overlay upper")?;
+            remove_dir_if_exists(&base.join("work"), "overlay work")?;
+        }
+        remove_dir_if_exists(&merged, "overlay merged")
+    }
+
+    fn kernel_mount(merged: &Path, opts: &str) -> IsoResult<()> {
+        let target = to_cstring(merged.as_os_str().as_bytes(), "merged")?;
+        let source = CString::new("overlay").expect("static source");
+        let fstype = CString::new("overlay").expect("static fstype");
+        let opts_c = to_cstring(opts.as_bytes(), "overlay options")?;
+
+        // SAFETY: all pointers are valid CString-backed and outlive the call.
+        let rc = unsafe {
+            libc::mount(
+                source.as_ptr(),
+                target.as_ptr(),
+                fstype.as_ptr(),
+                0,
+                opts_c.as_ptr().cast::<libc::c_void>(),
+            )
+        };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        let raw = err.raw_os_error();
+        if matches!(
+            raw,
+            Some(libc::EPERM | libc::EACCES | libc::ENODEV | libc::ENOENT | libc::EINVAL)
+        ) {
+            return Err(IsoError::unavailable(format!(
+                "kernel overlay mount denied ({err}); falling back to fuse-overlayfs"
+            )));
+        }
+        Err(IsoError::other(format!(
+            "overlay mount {}: {err}",
+            merged.display()
+        )))
+    }
+
+    fn kernel_umount(merged: &Path) -> IsoResult<()> {
+        let target = to_cstring(merged.as_os_str().as_bytes(), "merged")?;
+        // SAFETY: `target` lives until after the syscall returns.
+        let rc = unsafe { libc::umount2(target.as_ptr(), libc::MNT_DETACH) };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::EINVAL | libc::ENOENT) => {
+                // Nothing mounted there — already torn down.
+                Ok(())
+            }
+            Some(libc::EPERM | libc::EACCES) => Err(IsoError::unavailable(format!(
+                "kernel umount denied: {err}"
+            ))),
+            _ => Err(IsoError::other(format!(
+                "umount {}: {err}",
+                merged.display()
+            ))),
+        }
+    }
+
+    fn fuse_mount(lower: &Path, upper: &Path, work: &Path, merged: &Path) -> IsoResult<()> {
+        let opts = format!(
+            "lowerdir={},upperdir={},workdir={}",
+            lower.display(),
+            upper.display(),
+            work.display()
+        );
+        let output = Command::new("fuse-overlayfs")
+            .args(["-o", &opts])
+            .arg(merged)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+        let output = match output {
+            Ok(out) => out,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(IsoError::unavailable(
+                    "fuse-overlayfs not found on PATH; install it to enable overlay isolation",
+                ));
+            }
+            Err(err) => return Err(IsoError::other(format!("spawn fuse-overlayfs: {err}"))),
+        };
+        if output.status.success() {
+            return Ok(());
+        }
+        Err(command_failed(
+            "fuse-overlayfs mount failed",
+            output.status.code().unwrap_or(-1),
+            &output.stderr,
+        ))
+    }
+
+    fn fuse_umount(merged: &Path) -> IsoResult<()> {
+        for binary in ["fusermount3", "fusermount"] {
+            let result = Command::new(binary)
+                .arg("-u")
+                .arg(merged)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .output();
+            match result {
+                Ok(out) if out.status.success() => return Ok(()),
+                Ok(_) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(IsoError::other(format!("spawn {binary}: {err}"))),
+            }
+        }
+        // Last resort — try the lazy kernel umount; it works for both kernel
+        // overlay and any fuse mount the user can reach.
+        kernel_umount(merged)
+    }
+
+    fn kernel_overlay_supported() -> bool {
+        let Ok(text) = fs::read_to_string("/proc/filesystems") else {
+            return false;
+        };
+        text.lines()
+            .any(|line| line.split_whitespace().any(|word| word == "overlay"))
+    }
+
+    fn fuse_overlayfs_available() -> bool {
+        Command::new("fuse-overlayfs")
+            .arg("--version")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok()
+    }
+
+    fn canonical_existing_dir(path: &Path) -> IsoResult<PathBuf> {
+        let resolved = absolutize(path);
+        let meta = fs::metadata(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "invalid overlay lower {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !meta.is_dir() {
+            return Err(IsoError::other(format!(
+                "overlay lower {} is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn absolutize(path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+        }
+    }
+
+    fn remove_dir_if_exists(path: &Path, label: &str) -> IsoResult<()> {
+        match fs::remove_dir_all(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(IsoError::other(format!(
+                "remove {label} {}: {err}",
+                path.display()
+            ))),
+        }
+    }
+
+    fn to_cstring(bytes: &[u8], label: &str) -> IsoResult<CString> {
+        CString::new(bytes)
+            .map_err(|err| IsoError::other(format!("{label} path contains NUL byte: {err}")))
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/projfs.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/projfs.rs
@@ -1,0 +1,1007 @@
+//! Windows Projected File System backend.
+//!
+//! Ported from the original `pi_natives::projfs_overlay`; the napi-derived
+//! types and the `Result<()>` alias from `napi::bindgen_prelude` are
+//! replaced with the platform-neutral [`crate::IsoError`] /
+//! [`crate::ProbeResult`].
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+#[cfg(not(windows))]
+use crate::IsoError;
+use crate::{BackendKind, IsoResult, IsolationBackend, ProbeResult};
+
+pub struct ProjfsBackend;
+
+pub fn backend() -> &'static dyn IsolationBackend {
+    &ProjfsBackend
+}
+
+#[async_trait]
+impl IsolationBackend for ProjfsBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::Projfs
+    }
+
+    fn probe(&self) -> ProbeResult {
+        #[cfg(windows)]
+        {
+            // ProjFS's native bindings misbehave when the process is x64
+            // running under Windows ARM64 emulation — `LoadLibrary` succeeds
+            // but the callbacks crash on first invocation. Refuse early so
+            // `resolve()` falls back to a different backend instead of
+            // surfacing a hard crash to the caller.
+            if x64_under_arm64_emulation() {
+                return ProbeResult::unavailable(
+                    "ProjFS is disabled on Windows ARM64 under x64 emulation (use a native ARM64 build)",
+                );
+            }
+            imp::probe()
+        }
+        #[cfg(not(windows))]
+        {
+            ProbeResult::unavailable("ProjFS isolation is only available on Windows")
+        }
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        #[cfg(windows)]
+        {
+            imp::start(&lower.to_string_lossy(), &merged.to_string_lossy())
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = (lower, merged);
+            Err(IsoError::unavailable(
+                "ProjFS isolation is only available on Windows",
+            ))
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        #[cfg(windows)]
+        {
+            imp::stop(&merged.to_string_lossy());
+            Ok(())
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = merged;
+            Ok(())
+        }
+    }
+}
+
+/// `true` when the current process is x64 running under Windows ARM64
+/// emulation (WOW64-on-ARM64). Detected by the `PROCESSOR_ARCHITEW6432`
+/// environment variable Windows sets in WOW64 children, plus the legacy
+/// `PROCESSOR_ARCHITECTURE` slot for completeness. Off Windows the
+/// answer is always `false`.
+#[cfg_attr(
+    not(windows),
+    allow(dead_code, reason = "windows-only ARM64 emulation guard")
+)]
+fn x64_under_arm64_emulation() -> bool {
+    if !cfg!(windows) || !cfg!(target_arch = "x86_64") {
+        return false;
+    }
+    let env_value = |var: &str| std::env::var(var).ok();
+    vars_indicate_arm64_emulation(
+        env_value("PROCESSOR_ARCHITEW6432").as_deref(),
+        env_value("PROCESSOR_ARCHITECTURE").as_deref(),
+    )
+}
+
+fn vars_indicate_arm64_emulation(wow64_arch: Option<&str>, process_arch: Option<&str>) -> bool {
+    let matches_arm64 =
+        |value: Option<&str>| value.is_some_and(|v| v.eq_ignore_ascii_case("ARM64"));
+    matches_arm64(wow64_arch) || matches_arm64(process_arch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{vars_indicate_arm64_emulation, x64_under_arm64_emulation};
+
+    #[test]
+    fn detects_windows_arm64_emulation_markers() {
+        assert!(vars_indicate_arm64_emulation(Some("ARM64"), None));
+        assert!(vars_indicate_arm64_emulation(None, Some("arm64")));
+        assert!(!vars_indicate_arm64_emulation(Some("AMD64"), Some("x86")));
+        assert!(!vars_indicate_arm64_emulation(None, None));
+    }
+
+    #[test]
+    fn returns_false_off_windows_or_non_x64() {
+        // Sanity: just calling it shouldn't panic. The result depends on
+        // build target + ambient env vars, both of which are stable in CI.
+        let _ = x64_under_arm64_emulation();
+    }
+}
+
+#[cfg(windows)]
+#[allow(
+    clippy::undocumented_unsafe_blocks,
+    reason = "Windows ProjFS bridge is FFI-heavy and safety is validated by pointer and handle \
+	          checks"
+)]
+mod imp {
+    use std::{
+        collections::{BTreeMap, btree_map::Entry},
+        ffi::{OsStr, OsString, c_void},
+        fs,
+        io::{self, ErrorKind, Read, Seek, SeekFrom},
+        mem,
+        os::windows::{
+            ffi::{OsStrExt, OsStringExt},
+            fs::MetadataExt,
+        },
+        path::{Path, PathBuf},
+        sync::{Arc, LazyLock},
+    };
+
+    use parking_lot::Mutex;
+    use windows_sys::{
+        Win32::{
+            Foundation::{
+                ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_FILE_SYSTEM_VIRTUALIZATION_BUSY,
+                ERROR_FILE_SYSTEM_VIRTUALIZATION_INVALID_OPERATION,
+                ERROR_FILE_SYSTEM_VIRTUALIZATION_METADATA_CORRUPT,
+                ERROR_FILE_SYSTEM_VIRTUALIZATION_PROVIDER_UNKNOWN,
+                ERROR_FILE_SYSTEM_VIRTUALIZATION_UNAVAILABLE, ERROR_HANDLE_EOF,
+                ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER,
+                ERROR_MOD_NOT_FOUND, ERROR_NOT_SUPPORTED, ERROR_OLD_WIN_VERSION, ERROR_OUTOFMEMORY,
+                ERROR_PROC_NOT_FOUND, FreeLibrary, GetLastError, HMODULE,
+            },
+            Storage::ProjectedFileSystem::{
+                PRJ_CALLBACK_DATA, PRJ_CALLBACKS, PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN,
+                PRJ_CB_DATA_FLAG_ENUM_RETURN_SINGLE_ENTRY, PRJ_DIR_ENTRY_BUFFER_HANDLE,
+                PRJ_EXT_INFO_TYPE_SYMLINK, PRJ_EXTENDED_INFO, PRJ_EXTENDED_INFO_0,
+                PRJ_EXTENDED_INFO_0_0, PRJ_FILE_BASIC_INFO, PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
+                PRJ_PLACEHOLDER_INFO, PRJ_STARTVIRTUALIZING_OPTIONS,
+            },
+            System::{
+                Com::CoCreateGuid,
+                LibraryLoader::{GetProcAddress, LoadLibraryW},
+            },
+        },
+        core::{GUID, HRESULT, PCSTR, PCWSTR},
+    };
+
+    use crate::{IsoError, IsoResult, ProbeResult};
+
+    const EMPTY_WIDE: [u16; 1] = [0];
+    const MAX_READ_CHUNK: usize = 1024 * 1024;
+    const E_NOTIMPL: HRESULT = 0x8000_4001_u32 as i32;
+    const E_FAIL: HRESULT = 0x8000_4005_u32 as i32;
+
+    type PrjAllocateAlignedBufferFn =
+        unsafe extern "system" fn(PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT, usize) -> *mut c_void;
+    type PrjFreeAlignedBufferFn = unsafe extern "system" fn(*const c_void);
+    type PrjFileNameCompareFn = unsafe extern "system" fn(PCWSTR, PCWSTR) -> i32;
+    type PrjFileNameMatchFn = unsafe extern "system" fn(PCWSTR, PCWSTR) -> bool;
+    type PrjMarkDirectoryAsPlaceholderFn =
+        unsafe extern "system" fn(PCWSTR, PCWSTR, *const c_void, *const GUID) -> HRESULT;
+    type PrjStartVirtualizingFn = unsafe extern "system" fn(
+        PCWSTR,
+        *const PRJ_CALLBACKS,
+        *const c_void,
+        *const PRJ_STARTVIRTUALIZING_OPTIONS,
+        *mut PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
+    ) -> HRESULT;
+    type PrjStopVirtualizingFn = unsafe extern "system" fn(PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT);
+    type PrjFillDirEntryBuffer2Fn = unsafe extern "system" fn(
+        PRJ_DIR_ENTRY_BUFFER_HANDLE,
+        PCWSTR,
+        *const PRJ_FILE_BASIC_INFO,
+        *const PRJ_EXTENDED_INFO,
+    ) -> HRESULT;
+    type PrjWriteFileDataFn = unsafe extern "system" fn(
+        PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
+        *const GUID,
+        *const c_void,
+        u64,
+        u32,
+    ) -> HRESULT;
+    type PrjWritePlaceholderInfo2Fn = unsafe extern "system" fn(
+        PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
+        PCWSTR,
+        *const PRJ_PLACEHOLDER_INFO,
+        u32,
+        *const PRJ_EXTENDED_INFO,
+    ) -> HRESULT;
+
+    struct ProjfsApi {
+        module: HMODULE,
+        prj_allocate_aligned_buffer: PrjAllocateAlignedBufferFn,
+        prj_free_aligned_buffer: PrjFreeAlignedBufferFn,
+        prj_file_name_compare: PrjFileNameCompareFn,
+        prj_file_name_match: PrjFileNameMatchFn,
+        prj_mark_directory_as_placeholder: PrjMarkDirectoryAsPlaceholderFn,
+        prj_start_virtualizing: PrjStartVirtualizingFn,
+        prj_stop_virtualizing: PrjStopVirtualizingFn,
+        prj_fill_dir_entry_buffer2: PrjFillDirEntryBuffer2Fn,
+        prj_write_file_data: PrjWriteFileDataFn,
+        prj_write_placeholder_info2: PrjWritePlaceholderInfo2Fn,
+    }
+
+    unsafe impl Send for ProjfsApi {}
+    unsafe impl Sync for ProjfsApi {}
+
+    impl Drop for ProjfsApi {
+        fn drop(&mut self) {
+            if !self.module.is_null() {
+                unsafe {
+                    FreeLibrary(self.module);
+                }
+            }
+        }
+    }
+
+    impl ProjfsApi {
+        fn load() -> std::result::Result<Self, String> {
+            let library_name = to_wide(OsStr::new("ProjectedFSLib.dll"));
+            let module = unsafe { LoadLibraryW(library_name.as_ptr()) };
+            if module.is_null() {
+                let win32 = unsafe { GetLastError() };
+                return Err(format!(
+                    "ProjectedFSLib.dll could not be loaded (win32={win32})"
+                ));
+            }
+
+            macro_rules! load_symbol {
+                ($name:literal, $ty:ty) => {{
+                    let proc = unsafe {
+                        GetProcAddress(module, concat!($name, "\0").as_ptr().cast::<u8>() as PCSTR)
+                    };
+                    let Some(proc) = proc else {
+                        unsafe {
+                            FreeLibrary(module);
+                        }
+                        return Err(format!("ProjectedFSLib.dll missing symbol {}", $name));
+                    };
+                    unsafe { mem::transmute::<unsafe extern "system" fn() -> isize, $ty>(proc) }
+                }};
+            }
+
+            Ok(Self {
+                module,
+                prj_allocate_aligned_buffer: load_symbol!(
+                    "PrjAllocateAlignedBuffer",
+                    PrjAllocateAlignedBufferFn
+                ),
+                prj_free_aligned_buffer: load_symbol!(
+                    "PrjFreeAlignedBuffer",
+                    PrjFreeAlignedBufferFn
+                ),
+                prj_file_name_compare: load_symbol!("PrjFileNameCompare", PrjFileNameCompareFn),
+                prj_file_name_match: load_symbol!("PrjFileNameMatch", PrjFileNameMatchFn),
+                prj_mark_directory_as_placeholder: load_symbol!(
+                    "PrjMarkDirectoryAsPlaceholder",
+                    PrjMarkDirectoryAsPlaceholderFn
+                ),
+                prj_start_virtualizing: load_symbol!(
+                    "PrjStartVirtualizing",
+                    PrjStartVirtualizingFn
+                ),
+                prj_stop_virtualizing: load_symbol!("PrjStopVirtualizing", PrjStopVirtualizingFn),
+                prj_fill_dir_entry_buffer2: load_symbol!(
+                    "PrjFillDirEntryBuffer2",
+                    PrjFillDirEntryBuffer2Fn
+                ),
+                prj_write_file_data: load_symbol!("PrjWriteFileData", PrjWriteFileDataFn),
+                prj_write_placeholder_info2: load_symbol!(
+                    "PrjWritePlaceholderInfo2",
+                    PrjWritePlaceholderInfo2Fn
+                ),
+            })
+        }
+    }
+
+    struct DirectoryEntry {
+        name_wide: Vec<u16>,
+        basic_info: PRJ_FILE_BASIC_INFO,
+        symlink_target: Option<Vec<u16>>,
+    }
+
+    #[derive(Default)]
+    struct DirectoryEnumeration {
+        entries: Vec<DirectoryEntry>,
+        cursor: usize,
+        search_expression: Option<Vec<u16>>,
+    }
+
+    struct ProviderContext {
+        lower_root: PathBuf,
+        api: Arc<ProjfsApi>,
+        enumerations: Mutex<BTreeMap<u128, DirectoryEnumeration>>,
+    }
+
+    struct ProjfsSession {
+        virtualization_context: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
+        provider_context: *mut ProviderContext,
+        callbacks: Box<PRJ_CALLBACKS>,
+        api_handle: Arc<ProjfsApi>,
+    }
+
+    // SAFETY: Session ownership is synchronized through `PROJFS_SESSIONS`; raw
+    // pointers are only created/freed on controlled start/stop paths and not
+    // concurrently aliased.
+    unsafe impl Send for ProjfsSession {}
+
+    enum ProjfsSessionState {
+        Starting,
+        Active(ProjfsSession),
+    }
+
+    static PROJFS_SESSIONS: LazyLock<Mutex<BTreeMap<String, ProjfsSessionState>>> =
+        LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+    pub fn probe() -> ProbeResult {
+        match ProjfsApi::load() {
+            Ok(_) => ProbeResult {
+                available: true,
+                reason: None,
+            },
+            Err(reason) => ProbeResult {
+                available: false,
+                reason: Some(reason),
+            },
+        }
+    }
+
+    pub fn start(lower_root: &str, projection_root: &str) -> IsoResult<()> {
+        let api = Arc::new(ProjfsApi::load().map_err(unavailable_error)?);
+        let lower_root_path = resolve_existing_dir(lower_root)?;
+        let projection_root_path = resolve_projection_root(projection_root)?;
+        let projection_key = normalize_session_key(&projection_root_path);
+
+        {
+            let mut sessions = PROJFS_SESSIONS.lock();
+            if sessions.contains_key(&projection_key) {
+                return Err(IsoError::other(format!(
+                    "ProjFS overlay is already active for {}",
+                    projection_root_path.display()
+                )));
+            }
+            sessions.insert(projection_key.clone(), ProjfsSessionState::Starting);
+        }
+
+        let mut instance_id = GUID::default();
+        let guid_hr = unsafe { CoCreateGuid(&raw mut instance_id) };
+        if is_failed(guid_hr) {
+            PROJFS_SESSIONS.lock().remove(&projection_key);
+            return Err(IsoError::other(format!(
+                "Unable to create ProjFS instance identifier ({})",
+                format_hresult(guid_hr)
+            )));
+        }
+
+        let root_wide = to_wide(projection_root_path.as_os_str());
+        let mark_hr = unsafe {
+            (api.prj_mark_directory_as_placeholder)(
+                root_wide.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                &raw const instance_id,
+            )
+        };
+        if is_failed(mark_hr) {
+            PROJFS_SESSIONS.lock().remove(&projection_key);
+            return Err(classify_start_error("mark placeholder root", mark_hr));
+        }
+
+        let provider_context = Box::new(ProviderContext {
+            lower_root: lower_root_path,
+            api: api.clone(),
+            enumerations: Mutex::new(BTreeMap::new()),
+        });
+        let provider_context_ptr = Box::into_raw(provider_context);
+        let callbacks = Box::new(PRJ_CALLBACKS {
+            StartDirectoryEnumerationCallback: Some(start_directory_enumeration_callback),
+            EndDirectoryEnumerationCallback: Some(end_directory_enumeration_callback),
+            GetDirectoryEnumerationCallback: Some(get_directory_enumeration_callback),
+            GetPlaceholderInfoCallback: Some(get_placeholder_info_callback),
+            GetFileDataCallback: Some(get_file_data_callback),
+            ..Default::default()
+        });
+
+        let mut virtualization_context: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT = std::ptr::null_mut();
+        let start_hr = unsafe {
+            (api.prj_start_virtualizing)(
+                root_wide.as_ptr(),
+                callbacks.as_ref(),
+                provider_context_ptr.cast::<c_void>(),
+                std::ptr::null(),
+                &raw mut virtualization_context,
+            )
+        };
+        if is_failed(start_hr) {
+            PROJFS_SESSIONS.lock().remove(&projection_key);
+            // SAFETY: `provider_context_ptr` comes from `Box::into_raw` above and start
+            // failed, so ProjFS never took ownership and this function remains the sole
+            // owner.
+            unsafe {
+                drop(Box::from_raw(provider_context_ptr));
+            }
+            if !virtualization_context.is_null() {
+                // SAFETY: `virtualization_context` is only used when ProjFS returned a non-null
+                // context during `PrjStartVirtualizing`; stopping it here prevents a partially
+                // started instance from remaining active after start failure.
+                unsafe {
+                    (api.prj_stop_virtualizing)(virtualization_context);
+                }
+            }
+            return Err(classify_start_error("start virtualization", start_hr));
+        }
+
+        let started_session = ProjfsSession {
+            virtualization_context,
+            provider_context: provider_context_ptr,
+            callbacks,
+            api_handle: api,
+        };
+
+        let error_message = {
+            let mut sessions = PROJFS_SESSIONS.lock();
+            match sessions.entry(projection_key) {
+                Entry::Occupied(mut entry)
+                    if matches!(entry.get(), ProjfsSessionState::Starting) =>
+                {
+                    entry.insert(ProjfsSessionState::Active(started_session));
+                    return Ok(());
+                }
+                Entry::Occupied(_) => {
+                    format!(
+                        "ProjFS overlay is already active for {}",
+                        projection_root_path.display()
+                    )
+                }
+                Entry::Vacant(_) => {
+                    format!(
+                        "ProjFS overlay start was canceled for {}",
+                        projection_root_path.display()
+                    )
+                }
+            }
+        };
+        stop_projfs_session(started_session);
+        Err(IsoError::other(error_message))
+    }
+
+    pub fn stop(projection_root: &str) {
+        let projection_root_path = resolve_absolute_path(Path::new(projection_root));
+        let projection_root_path =
+            fs::canonicalize(&projection_root_path).unwrap_or(projection_root_path);
+        let key = normalize_session_key(&projection_root_path);
+        let session_state = PROJFS_SESSIONS.lock().remove(&key);
+        let Some(ProjfsSessionState::Active(session)) = session_state else {
+            return;
+        };
+
+        stop_projfs_session(session);
+    }
+
+    fn stop_projfs_session(session: ProjfsSession) {
+        // SAFETY: The session holds the live ProjFS context and provider pointer
+        // created in `start`; this function consumes ownership and runs the
+        // corresponding one-time teardown.
+        unsafe {
+            (session.api_handle.prj_stop_virtualizing)(session.virtualization_context);
+            drop(Box::from_raw(session.provider_context));
+        }
+        drop(session.callbacks);
+    }
+
+    unsafe extern "system" fn start_directory_enumeration_callback(
+        callback_data: *const PRJ_CALLBACK_DATA,
+        enumeration_id: *const GUID,
+    ) -> HRESULT {
+        let Ok((callback_data, context)) = callback_context(callback_data) else {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        };
+        if enumeration_id.is_null() {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        }
+
+        let target_path = callback_relative_path(callback_data);
+        let entries = match list_directory_entries(context, &target_path) {
+            Ok(entries) => entries,
+            Err(err) => return io_error_to_hresult(&err),
+        };
+
+        let mut enumerations = context.enumerations.lock();
+        enumerations.insert(
+            guid_to_u128(unsafe { &*enumeration_id }),
+            DirectoryEnumeration {
+                entries,
+                cursor: 0,
+                search_expression: None,
+            },
+        );
+        0
+    }
+
+    unsafe extern "system" fn end_directory_enumeration_callback(
+        callback_data: *const PRJ_CALLBACK_DATA,
+        enumeration_id: *const GUID,
+    ) -> HRESULT {
+        let Ok((_, context)) = callback_context(callback_data) else {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        };
+        if enumeration_id.is_null() {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        }
+
+        context
+            .enumerations
+            .lock()
+            .remove(&guid_to_u128(unsafe { &*enumeration_id }));
+        0
+    }
+
+    unsafe extern "system" fn get_directory_enumeration_callback(
+        callback_data: *const PRJ_CALLBACK_DATA,
+        enumeration_id: *const GUID,
+        search_expression: PCWSTR,
+        dir_entry_buffer_handle: PRJ_DIR_ENTRY_BUFFER_HANDLE,
+    ) -> HRESULT {
+        let Ok((callback_data, context)) = callback_context(callback_data) else {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        };
+        if enumeration_id.is_null() {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        }
+
+        let enum_key = guid_to_u128(unsafe { &*enumeration_id });
+        let mut enumerations = context.enumerations.lock();
+        let Some(enumeration) = enumerations.get_mut(&enum_key) else {
+            return 0;
+        };
+
+        if callback_data.Flags & PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN != 0 {
+            enumeration.cursor = 0;
+            enumeration.search_expression = None;
+        }
+        if !search_expression.is_null() {
+            let expression = read_pcwstr(search_expression);
+            if !expression.is_empty() {
+                let mut with_nul = expression;
+                with_nul.push(0);
+                enumeration.search_expression = Some(with_nul);
+            }
+        }
+
+        while enumeration.cursor < enumeration.entries.len() {
+            let entry = &enumeration.entries[enumeration.cursor];
+            let matched = if let Some(expression) = &enumeration.search_expression {
+                unsafe {
+                    (context.api.prj_file_name_match)(entry.name_wide.as_ptr(), expression.as_ptr())
+                }
+            } else {
+                true
+            };
+
+            if matched {
+                let extended_info =
+                    entry
+                        .symlink_target
+                        .as_deref()
+                        .map(|target| PRJ_EXTENDED_INFO {
+                            InfoType: PRJ_EXT_INFO_TYPE_SYMLINK,
+                            NextInfoOffset: 0,
+                            Anonymous: PRJ_EXTENDED_INFO_0 {
+                                Symlink: PRJ_EXTENDED_INFO_0_0 {
+                                    TargetName: target.as_ptr(),
+                                },
+                            },
+                        });
+                let extended_info_ptr = extended_info
+                    .as_ref()
+                    .map_or(std::ptr::null(), |info| info as *const _);
+                let hr = unsafe {
+                    (context.api.prj_fill_dir_entry_buffer2)(
+                        dir_entry_buffer_handle,
+                        entry.name_wide.as_ptr(),
+                        &raw const entry.basic_info,
+                        extended_info_ptr,
+                    )
+                };
+                if is_failed(hr) {
+                    if win32_from_hresult(hr) == Some(ERROR_INSUFFICIENT_BUFFER) {
+                        break;
+                    }
+                    return hr;
+                }
+            }
+
+            enumeration.cursor += 1;
+            if callback_data.Flags & PRJ_CB_DATA_FLAG_ENUM_RETURN_SINGLE_ENTRY != 0 {
+                break;
+            }
+        }
+
+        0
+    }
+
+    unsafe extern "system" fn get_placeholder_info_callback(
+        callback_data: *const PRJ_CALLBACK_DATA,
+    ) -> HRESULT {
+        let Ok((callback_data, context)) = callback_context(callback_data) else {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        };
+
+        let relative_path = callback_relative_path(callback_data);
+        let source_path = context.lower_root.join(relative_path);
+        let metadata = match fs::symlink_metadata(&source_path) {
+            Ok(metadata) => metadata,
+            Err(err) => return io_error_to_hresult(&err),
+        };
+        let symlink_target = match symlink_target_wide(&source_path, &metadata) {
+            Ok(target) => target,
+            Err(err) => return io_error_to_hresult(&err),
+        };
+        let extended_info = symlink_target.as_deref().map(|target| PRJ_EXTENDED_INFO {
+            InfoType: PRJ_EXT_INFO_TYPE_SYMLINK,
+            NextInfoOffset: 0,
+            Anonymous: PRJ_EXTENDED_INFO_0 {
+                Symlink: PRJ_EXTENDED_INFO_0_0 {
+                    TargetName: target.as_ptr(),
+                },
+            },
+        });
+        let extended_info_ptr = extended_info
+            .as_ref()
+            .map_or(std::ptr::null(), |info| info as *const _);
+
+        let placeholder_info = PRJ_PLACEHOLDER_INFO {
+            FileBasicInfo: to_basic_info(&metadata),
+            ..Default::default()
+        };
+
+        let destination = if callback_data.FilePathName.is_null() {
+            EMPTY_WIDE.as_ptr()
+        } else {
+            callback_data.FilePathName
+        };
+
+        unsafe {
+            (context.api.prj_write_placeholder_info2)(
+                callback_data.NamespaceVirtualizationContext,
+                destination,
+                &raw const placeholder_info,
+                mem::size_of::<PRJ_PLACEHOLDER_INFO>() as u32,
+                extended_info_ptr,
+            )
+        }
+    }
+
+    unsafe extern "system" fn get_file_data_callback(
+        callback_data: *const PRJ_CALLBACK_DATA,
+        byte_offset: u64,
+        length: u32,
+    ) -> HRESULT {
+        let Ok((callback_data, context)) = callback_context(callback_data) else {
+            return hresult_from_win32(ERROR_INVALID_PARAMETER);
+        };
+        if length == 0 {
+            return 0;
+        }
+
+        let relative_path = callback_relative_path(callback_data);
+        let source_path = context.lower_root.join(relative_path);
+        let mut file = match fs::File::open(&source_path) {
+            Ok(file) => file,
+            Err(err) => return io_error_to_hresult(&err),
+        };
+        if let Err(err) = file.seek(SeekFrom::Start(byte_offset)) {
+            return io_error_to_hresult(&err);
+        }
+
+        let chunk_size = usize::min(length as usize, MAX_READ_CHUNK);
+        let aligned_ptr = unsafe {
+            (context.api.prj_allocate_aligned_buffer)(
+                callback_data.NamespaceVirtualizationContext,
+                chunk_size,
+            )
+        };
+        if aligned_ptr.is_null() {
+            return hresult_from_win32(ERROR_OUTOFMEMORY);
+        }
+        let mut aligned_buffer = AlignedBuffer::new(context.api.clone(), aligned_ptr, chunk_size);
+
+        let mut written = 0usize;
+        while written < length as usize {
+            let to_read = usize::min(aligned_buffer.len(), length as usize - written);
+            if let Err(err) = file.read_exact(&mut aligned_buffer.as_mut_slice()[..to_read]) {
+                return io_error_to_hresult(&err);
+            }
+
+            let hr = unsafe {
+                (context.api.prj_write_file_data)(
+                    callback_data.NamespaceVirtualizationContext,
+                    &raw const callback_data.DataStreamId,
+                    aligned_buffer.as_mut_slice().as_ptr().cast::<c_void>(),
+                    byte_offset + written as u64,
+                    to_read as u32,
+                )
+            };
+            if is_failed(hr) {
+                return hr;
+            }
+
+            written += to_read;
+        }
+
+        0
+    }
+
+    struct AlignedBuffer {
+        api: Arc<ProjfsApi>,
+        ptr: *mut c_void,
+        len: usize,
+    }
+
+    impl AlignedBuffer {
+        const fn new(api: Arc<ProjfsApi>, ptr: *mut c_void, len: usize) -> Self {
+            Self { api, ptr, len }
+        }
+
+        const fn len(&self) -> usize {
+            self.len
+        }
+
+        const fn as_mut_slice(&mut self) -> &mut [u8] {
+            unsafe { std::slice::from_raw_parts_mut(self.ptr.cast::<u8>(), self.len) }
+        }
+    }
+
+    impl Drop for AlignedBuffer {
+        fn drop(&mut self) {
+            unsafe {
+                (self.api.prj_free_aligned_buffer)(self.ptr);
+            }
+        }
+    }
+
+    fn callback_context(
+        callback_data: *const PRJ_CALLBACK_DATA,
+    ) -> std::result::Result<(&'static PRJ_CALLBACK_DATA, &'static ProviderContext), HRESULT> {
+        if callback_data.is_null() {
+            return Err(hresult_from_win32(ERROR_INVALID_PARAMETER));
+        }
+        let callback_data = unsafe { &*callback_data };
+        if callback_data.InstanceContext.is_null() {
+            return Err(hresult_from_win32(ERROR_INVALID_PARAMETER));
+        }
+        let context = unsafe { &*(callback_data.InstanceContext.cast::<ProviderContext>()) };
+        Ok((callback_data, context))
+    }
+
+    fn list_directory_entries(
+        context: &ProviderContext,
+        relative_path: &Path,
+    ) -> io::Result<Vec<DirectoryEntry>> {
+        let source_dir = context.lower_root.join(relative_path);
+        let mut entries = Vec::new();
+        for entry in fs::read_dir(&source_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)?;
+            let symlink_target = symlink_target_wide(&path, &metadata)?;
+            let name = entry.file_name();
+            let mut name_wide = to_wide(name.as_os_str());
+            if name_wide.is_empty() {
+                continue;
+            }
+            entries.push(DirectoryEntry {
+                name_wide: {
+                    name_wide.shrink_to_fit();
+                    name_wide
+                },
+                basic_info: to_basic_info(&metadata),
+                symlink_target,
+            });
+        }
+
+        entries.sort_by(|left, right| {
+            let compare = unsafe {
+                (context.api.prj_file_name_compare)(
+                    left.name_wide.as_ptr(),
+                    right.name_wide.as_ptr(),
+                )
+            };
+            compare.cmp(&0)
+        });
+        Ok(entries)
+    }
+
+    fn to_basic_info(metadata: &fs::Metadata) -> PRJ_FILE_BASIC_INFO {
+        PRJ_FILE_BASIC_INFO {
+            IsDirectory: metadata.is_dir(),
+            FileSize: metadata.file_size() as i64,
+            CreationTime: metadata.creation_time() as i64,
+            LastAccessTime: metadata.last_access_time() as i64,
+            LastWriteTime: metadata.last_write_time() as i64,
+            ChangeTime: metadata.last_write_time() as i64,
+            FileAttributes: metadata.file_attributes(),
+        }
+    }
+
+    fn symlink_target_wide(path: &Path, metadata: &fs::Metadata) -> io::Result<Option<Vec<u16>>> {
+        if !metadata.file_type().is_symlink() {
+            return Ok(None);
+        }
+        let mut target = to_wide(fs::read_link(path)?.as_os_str());
+        target.shrink_to_fit();
+        Ok(Some(target))
+    }
+
+    fn callback_relative_path(callback_data: &PRJ_CALLBACK_DATA) -> PathBuf {
+        if callback_data.FilePathName.is_null() {
+            return PathBuf::new();
+        }
+        let raw = read_pcwstr(callback_data.FilePathName);
+        if raw.is_empty() {
+            return PathBuf::new();
+        }
+        PathBuf::from(OsString::from_wide(&raw))
+    }
+
+    fn read_pcwstr(value: PCWSTR) -> Vec<u16> {
+        if value.is_null() {
+            return Vec::new();
+        }
+
+        let mut len = 0usize;
+        unsafe {
+            while *value.add(len) != 0 {
+                len += 1;
+            }
+            std::slice::from_raw_parts(value, len).to_vec()
+        }
+    }
+
+    fn resolve_existing_dir(path: &str) -> crate::IsoResult<PathBuf> {
+        let resolved = resolve_absolute_path(Path::new(path));
+        let metadata = fs::metadata(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "Invalid ProjFS lower root {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !metadata.is_dir() {
+            return Err(IsoError::other(format!(
+                "Invalid ProjFS lower root {}: path is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn resolve_projection_root(path: &str) -> crate::IsoResult<PathBuf> {
+        let resolved = resolve_absolute_path(Path::new(path));
+        fs::create_dir_all(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "Unable to create ProjFS projection root {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        let metadata = fs::metadata(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "Unable to access ProjFS projection root {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !metadata.is_dir() {
+            return Err(IsoError::other(format!(
+                "Invalid ProjFS projection root {}: path is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn resolve_absolute_path(path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+        }
+    }
+
+    fn normalize_session_key(path: &Path) -> String {
+        path.to_string_lossy().to_ascii_lowercase()
+    }
+
+    fn to_wide(value: &OsStr) -> Vec<u16> {
+        let mut encoded: Vec<u16> = value.encode_wide().collect();
+        encoded.push(0);
+        encoded
+    }
+
+    fn unavailable_error(reason: String) -> IsoError {
+        IsoError::unavailable(reason)
+    }
+
+    fn classify_start_error(phase: &str, hr: HRESULT) -> IsoError {
+        let detail = format!("ProjFS {phase} failed ({})", format_hresult(hr));
+        if is_unavailable_hresult(hr) {
+            return unavailable_error(detail);
+        }
+        IsoError::other(detail)
+    }
+
+    const fn is_unavailable_hresult(hr: HRESULT) -> bool {
+        if hr == E_NOTIMPL {
+            return true;
+        }
+        let Some(win32) = win32_from_hresult(hr) else {
+            return false;
+        };
+        matches!(
+            win32,
+            ERROR_NOT_SUPPORTED
+                | ERROR_INVALID_FUNCTION
+                | ERROR_MOD_NOT_FOUND
+                | ERROR_PROC_NOT_FOUND
+                | ERROR_OLD_WIN_VERSION
+                | ERROR_FILE_SYSTEM_VIRTUALIZATION_UNAVAILABLE
+                | ERROR_FILE_SYSTEM_VIRTUALIZATION_PROVIDER_UNKNOWN
+                | ERROR_FILE_SYSTEM_VIRTUALIZATION_METADATA_CORRUPT
+                | ERROR_FILE_SYSTEM_VIRTUALIZATION_INVALID_OPERATION
+                | ERROR_FILE_SYSTEM_VIRTUALIZATION_BUSY
+        )
+    }
+
+    fn format_hresult(hr: HRESULT) -> String {
+        if let Some(win32) = win32_from_hresult(hr) {
+            format!("HRESULT=0x{:08X}, win32={win32}", hr as u32)
+        } else {
+            format!("HRESULT=0x{:08X}", hr as u32)
+        }
+    }
+
+    const fn win32_from_hresult(hr: HRESULT) -> Option<u32> {
+        let raw = hr as u32;
+        if (raw & 0xffff_0000) == 0x8007_0000 {
+            Some(raw & 0xffff)
+        } else {
+            None
+        }
+    }
+
+    const fn hresult_from_win32(code: u32) -> HRESULT {
+        if code == 0 {
+            0
+        } else {
+            ((code & 0x0000_ffff) | 0x8007_0000) as i32
+        }
+    }
+
+    fn io_error_to_hresult(err: &io::Error) -> HRESULT {
+        if let Some(code) = err.raw_os_error()
+            && code > 0
+        {
+            return hresult_from_win32(code as u32);
+        }
+
+        match err.kind() {
+            ErrorKind::NotFound => hresult_from_win32(ERROR_FILE_NOT_FOUND),
+            ErrorKind::PermissionDenied => hresult_from_win32(ERROR_ACCESS_DENIED),
+            ErrorKind::UnexpectedEof => hresult_from_win32(ERROR_HANDLE_EOF),
+            ErrorKind::OutOfMemory => hresult_from_win32(ERROR_OUTOFMEMORY),
+            _ => E_FAIL,
+        }
+    }
+
+    fn guid_to_u128(guid: &GUID) -> u128 {
+        let bytes: [u8; 16] = unsafe { mem::transmute(*guid) };
+        u128::from_le_bytes(bytes)
+    }
+
+    const fn is_failed(hr: HRESULT) -> bool {
+        hr < 0
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/rcopy.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/rcopy.rs
@@ -1,0 +1,577 @@
+//! Cross-platform fallback isolation: git worktree, or plain recursive copy.
+//!
+//! When `lower` is a git working tree, [`start`](IsolationBackend::start)
+//! materializes `merged` via `git worktree add --detach <merged> HEAD`.
+//! Stop tears it down with `git worktree remove --force`. This lets git
+//! itself manage refs/index/HEAD inside `merged`, keeping
+//! [`diff`](IsolationBackend::diff) on the `git diff` path.
+//!
+//! Otherwise we do a vanilla recursive copy, preserving file modes and
+//! mtimes so the default mtime-skipping diff path stays fast. There is no
+//! file-system magic; the caller pays full filesystem-copy cost up front
+//! and an `rm -rf` on teardown.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use crate::{BackendKind, IsoError, IsoResult, IsolationBackend, ProbeResult, command_failed};
+
+pub struct RcopyBackend;
+
+#[async_trait]
+impl IsolationBackend for RcopyBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::Rcopy
+    }
+
+    fn probe(&self) -> ProbeResult {
+        // Pure-stdlib fallback path is always available. We don't probe for
+        // `git` here because the non-git branch doesn't need it; the git
+        // branch will surface a clear unavailable-error if `lower` is a git
+        // tree but `git` is missing from PATH.
+        ProbeResult::available()
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        let lower = canonical_existing_dir(lower)?;
+        let merged = absolutize(merged);
+        prepare_destination(&merged)?;
+        if is_git_worktree(&lower) {
+            git_worktree_add(&lower, &merged)?;
+            // `worktree add --detach HEAD` lands on a clean checkout. omp
+            // (and friends) expect `merged` to mirror `lower`'s **live**
+            // working tree, so seed the index + working tree + untracked
+            // files exactly as they exist in lower. No applyBaseline call
+            // in the caller — every backend's post-`start` invariant is
+            // the same.
+            seed_dirty_state(&lower, &merged)
+        } else {
+            recursive_copy(&lower, &merged)
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        // Best-effort: if we recognise this path as a registered worktree,
+        // use git to remove it (so the parent repo's worktree list stays
+        // consistent). Otherwise just rm -rf.
+        if is_git_worktree(merged) {
+            let _ = git_worktree_remove(merged);
+        }
+        match std::fs::remove_dir_all(merged) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(IsoError::other(format!(
+                "unable to remove {}: {err}",
+                merged.display()
+            ))),
+        }
+    }
+}
+
+fn canonical_existing_dir(path: &Path) -> IsoResult<PathBuf> {
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+    };
+    let meta = std::fs::metadata(&resolved).map_err(|err| {
+        IsoError::other(format!(
+            "invalid rcopy source {}: {err}",
+            resolved.display()
+        ))
+    })?;
+    if !meta.is_dir() {
+        return Err(IsoError::other(format!(
+            "rcopy source {} is not a directory",
+            resolved.display()
+        )));
+    }
+    Ok(std::fs::canonicalize(&resolved).unwrap_or(resolved))
+}
+
+fn absolutize(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+    }
+}
+
+fn prepare_destination(merged: &Path) -> IsoResult<()> {
+    if let Some(parent) = merged.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            IsoError::other(format!("create parent of {}: {err}", merged.display()))
+        })?;
+    }
+    match std::fs::remove_dir_all(merged) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(IsoError::other(format!(
+                "unable to clear {} before rcopy: {err}",
+                merged.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn is_git_worktree(path: &Path) -> bool {
+    // A regular working tree has `.git` as a dir; a linked worktree has it
+    // as a `gitdir: …` text file. Either way, presence of `.git` is the
+    // signal git itself uses.
+    std::fs::symlink_metadata(path.join(".git")).is_ok()
+}
+
+fn git_worktree_add(lower: &Path, merged: &Path) -> IsoResult<()> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(lower)
+        .args(["worktree", "add", "--detach"])
+        .arg(merged)
+        .arg("HEAD")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                IsoError::unavailable(
+                    "`git` not on PATH; rcopy cannot materialise a worktree from a git source",
+                )
+            } else {
+                IsoError::other(format!("spawn git worktree add: {err}"))
+            }
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(command_failed(
+        "git worktree add",
+        output.status.code().unwrap_or(-1),
+        &output.stderr,
+    ))
+}
+
+fn git_worktree_remove(merged: &Path) -> IsoResult<()> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(merged)
+        .args(["worktree", "remove", "--force"])
+        .arg(merged)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|err| IsoError::other(format!("spawn git worktree remove: {err}")))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(command_failed(
+        "git worktree remove",
+        output.status.code().unwrap_or(-1),
+        &output.stderr,
+    ))
+}
+
+/// Replicate `lower`'s live working tree on top of a freshly-checked-out
+/// worktree at `merged`. Three passes mirror what `git status` would
+/// report at `lower`:
+///
+///  1. **Staged** — `git diff --binary --cached` from lower, applied to both
+///     the index and the working tree of `merged`.
+///  2. **Unstaged** — `git diff --binary` from lower, applied to the working
+///     tree only.
+///  3. **Untracked** — every path listed by `git ls-files --others
+///     --exclude-standard -z` from lower, recursively copied into the same
+///     relative location under `merged`.
+///
+/// Result: `git status` inside `merged` reports the same dirty set as
+/// `lower` at the moment `start()` was called, so the rest of the PAL
+/// contract ("merged mirrors lower's live working tree") holds for
+/// rcopy on git inputs too.
+fn seed_dirty_state(lower: &Path, merged: &Path) -> IsoResult<()> {
+    let staged = git_capture(lower, &["diff", "--binary", "--no-color", "--cached"])?;
+    if !staged.is_empty() {
+        git_apply(merged, &staged, &["--cached"])?;
+        git_apply(merged, &staged, &[])?;
+    }
+
+    let unstaged = git_capture(lower, &["diff", "--binary", "--no-color"])?;
+    if !unstaged.is_empty() {
+        git_apply(merged, &unstaged, &[])?;
+    }
+
+    let untracked = git_capture(lower, &["ls-files", "--others", "--exclude-standard", "-z"])?;
+    for path_bytes in untracked.split(|b| *b == 0) {
+        if path_bytes.is_empty() {
+            continue;
+        }
+        let rel = std::str::from_utf8(path_bytes)
+            .map_err(|err| IsoError::other(format!("untracked path is not valid UTF-8: {err}")))?;
+        let src = lower.join(rel);
+        let dst = merged.join(rel);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|err| IsoError::other(format!("create {}: {err}", parent.display())))?;
+        }
+        copy_path(&src, &dst)?;
+    }
+
+    Ok(())
+}
+
+fn git_capture(cwd: &Path, args: &[&str]) -> IsoResult<Vec<u8>> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                IsoError::unavailable(
+                    "`git` not on PATH; rcopy cannot seed dirty state from a git source",
+                )
+            } else {
+                IsoError::other(format!(
+                    "spawn git {}: {err}",
+                    args.first().unwrap_or(&"<args>")
+                ))
+            }
+        })?;
+    if !output.status.success() {
+        return Err(command_failed(
+            format_args!("git {}", args.join(" ")),
+            output.status.code().unwrap_or(-1),
+            &output.stderr,
+        ));
+    }
+    Ok(output.stdout)
+}
+
+fn git_apply(cwd: &Path, patch: &[u8], extra: &[&str]) -> IsoResult<()> {
+    git_apply_with_program(Path::new("git"), cwd, patch, extra)
+}
+
+fn git_apply_with_program(
+    program: &Path,
+    cwd: &Path,
+    patch: &[u8],
+    extra: &[&str],
+) -> IsoResult<()> {
+    use std::io::{Read as _, Write as _};
+    let mut child = std::process::Command::new(program)
+        .arg("-C")
+        .arg(cwd)
+        .args(["apply", "--binary", "--whitespace=nowarn"])
+        .args(extra)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                IsoError::unavailable(
+                    "`git` not on PATH; rcopy cannot seed dirty state from a git source",
+                )
+            } else {
+                IsoError::other(format!("spawn git apply: {err}"))
+            }
+        })?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| IsoError::other("git apply: child stderr was not piped".to_string()))?;
+    let stderr_reader = std::thread::Builder::new()
+        .name("pi-iso-git-apply-stderr".to_string())
+        .spawn(move || {
+            let mut bytes = Vec::new();
+            stderr.read_to_end(&mut bytes).map(|_| bytes)
+        })
+        .map_err(|err| IsoError::other(format!("spawn git apply stderr reader: {err}")))?;
+    let write_result = {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| IsoError::other("git apply: child stdin was not piped".to_string()))?;
+        let result = stdin.write_all(patch);
+        drop(stdin);
+        result
+    };
+    let status = child
+        .wait()
+        .map_err(|err| IsoError::other(format!("wait git apply: {err}")))?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| IsoError::other("wait git apply: stderr reader panicked".to_string()))?
+        .map_err(|err| IsoError::other(format!("read git apply stderr: {err}")))?;
+    if status.success() {
+        write_result.map_err(|err| IsoError::other(format!("write patch to git apply: {err}")))?;
+        return Ok(());
+    }
+    Err(command_failed(
+        "git apply",
+        status.code().unwrap_or(-1),
+        &stderr,
+    ))
+}
+
+/// Copy a single path (regular file, symlink, or directory) from `src`
+/// to `dst`, preserving mode and mtime on supported platforms. Used by
+/// the untracked-files pass; directories are recursed via the existing
+/// [`copy_dir_contents`] helper.
+fn copy_path(src: &Path, dst: &Path) -> IsoResult<()> {
+    let meta = std::fs::symlink_metadata(src)
+        .map_err(|err| IsoError::other(format!("stat {}: {err}", src.display())))?;
+    if meta.file_type().is_symlink() {
+        copy_symlink(src, dst)
+    } else if meta.file_type().is_dir() {
+        std::fs::create_dir_all(dst)
+            .map_err(|err| IsoError::other(format!("create {}: {err}", dst.display())))?;
+        copy_dir_contents(src, dst)?;
+        copy_dir_mtime(src, dst);
+        Ok(())
+    } else {
+        std::fs::copy(src, dst).map_err(|err| {
+            IsoError::other(format!(
+                "copy {} -> {}: {err}",
+                src.display(),
+                dst.display()
+            ))
+        })?;
+        copy_file_mtime(src, dst);
+        Ok(())
+    }
+}
+
+/// Recursive copy preserving file modes (unix) and mtimes on both unix
+/// and windows. We don't use `std::fs::copy` for the final mtime fix-up
+/// because `copy` already preserves mtime on the macOS/Linux platforms we
+/// care about — but we still set it explicitly to keep behaviour
+/// consistent across hosts where the stdlib promise is weaker.
+fn recursive_copy(lower: &Path, merged: &Path) -> IsoResult<()> {
+    std::fs::create_dir_all(merged)
+        .map_err(|err| IsoError::other(format!("create {}: {err}", merged.display())))?;
+    copy_dir_contents(lower, merged)
+}
+
+fn copy_dir_contents(src: &Path, dst: &Path) -> IsoResult<()> {
+    let entries = std::fs::read_dir(src)
+        .map_err(|err| IsoError::other(format!("read_dir {}: {err}", src.display())))?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|err| IsoError::other(format!("dir entry in {}: {err}", src.display())))?;
+        let file_type = entry.file_type().map_err(|err| {
+            IsoError::other(format!("file_type {}: {err}", entry.path().display()))
+        })?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if file_type.is_symlink() {
+            copy_symlink(&src_path, &dst_path)?;
+        } else if file_type.is_dir() {
+            std::fs::create_dir_all(&dst_path)
+                .map_err(|err| IsoError::other(format!("create {}: {err}", dst_path.display())))?;
+            copy_dir_contents(&src_path, &dst_path)?;
+            copy_dir_mtime(&src_path, &dst_path);
+        } else {
+            std::fs::copy(&src_path, &dst_path).map_err(|err| {
+                IsoError::other(format!(
+                    "copy {} -> {}: {err}",
+                    src_path.display(),
+                    dst_path.display()
+                ))
+            })?;
+            copy_file_mtime(&src_path, &dst_path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(src: &Path, dst: &Path) -> IsoResult<()> {
+    let target = std::fs::read_link(src)
+        .map_err(|err| IsoError::other(format!("read_link {}: {err}", src.display())))?;
+    std::os::unix::fs::symlink(target, dst)
+        .map_err(|err| IsoError::other(format!("symlink {}: {err}", dst.display())))
+}
+
+#[cfg(windows)]
+fn copy_symlink(src: &Path, dst: &Path) -> IsoResult<()> {
+    let target = std::fs::read_link(src)
+        .map_err(|err| IsoError::other(format!("read_link {}: {err}", src.display())))?;
+    let meta = std::fs::symlink_metadata(src)
+        .map_err(|err| IsoError::other(format!("symlink_metadata {}: {err}", src.display())))?;
+    let res = if meta.file_type().is_dir() {
+        std::os::windows::fs::symlink_dir(target, dst)
+    } else {
+        std::os::windows::fs::symlink_file(target, dst)
+    };
+    res.map_err(|err| IsoError::other(format!("symlink {}: {err}", dst.display())))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn copy_symlink(_src: &Path, _dst: &Path) -> IsoResult<()> {
+    Err(IsoError::other("symlink copy unsupported on this platform"))
+}
+
+/// Mirror `src`'s mtime onto `dst`. Failures are silently ignored — the
+/// mtime hint is an optimisation for [`crate::diff`], not a correctness
+/// requirement.
+fn copy_file_mtime(src: &Path, dst: &Path) {
+    let Ok(meta) = std::fs::metadata(src) else {
+        return;
+    };
+    let Ok(mtime) = meta.modified() else { return };
+    let _ = filetime_set(dst, mtime);
+}
+
+fn copy_dir_mtime(src: &Path, dst: &Path) {
+    let Ok(meta) = std::fs::metadata(src) else {
+        return;
+    };
+    let Ok(mtime) = meta.modified() else { return };
+    let _ = filetime_set(dst, mtime);
+}
+
+#[cfg(unix)]
+fn filetime_set(path: &Path, mtime: std::time::SystemTime) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let dur = mtime
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(std::io::Error::other)?;
+    let times = [
+        libc::timespec {
+            tv_sec: dur.as_secs() as libc::time_t,
+            tv_nsec: 0,
+        },
+        libc::timespec {
+            tv_sec: dur.as_secs() as libc::time_t,
+            tv_nsec: dur.subsec_nanos() as libc::c_long,
+        },
+    ];
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())?;
+    // SAFETY: `c_path` and `times` outlive the syscall; the kernel does
+    // not retain the pointers.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn filetime_set(path: &Path, mtime: std::time::SystemTime) -> std::io::Result<()> {
+    use std::{
+        fs::OpenOptions,
+        os::windows::{fs::OpenOptionsExt, io::AsRawHandle},
+    };
+
+    use windows_sys::Win32::{
+        Foundation::FILETIME,
+        Storage::FileSystem::{FILE_FLAG_BACKUP_SEMANTICS, SetFileTime},
+    };
+
+    let dur = mtime
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|err| std::io::Error::other(err.to_string()))?;
+    // Windows FILETIME = 100-ns ticks since 1601-01-01.
+    const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
+    let ticks = EPOCH_DIFF_100NS + dur.as_secs() * 10_000_000 + u64::from(dur.subsec_nanos() / 100);
+    let ft = FILETIME {
+        dwLowDateTime: (ticks & 0xffff_ffff) as u32,
+        dwHighDateTime: (ticks >> 32) as u32,
+    };
+
+    let mut opts = OpenOptions::new();
+    opts.write(true);
+    opts.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+    let file = opts.open(path)?;
+    // SAFETY: file owns the HANDLE for the duration of the call.
+    let ok = unsafe {
+        SetFileTime(
+            file.as_raw_handle() as _,
+            std::ptr::null(),
+            std::ptr::null(),
+            &raw const ft,
+        )
+    };
+    if ok != 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn filetime_set(_path: &Path, _mtime: std::time::SystemTime) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    struct TempDirGuard(PathBuf);
+
+    impl TempDirGuard {
+        fn new() -> Self {
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos();
+            let dir = std::env::temp_dir().join(format!(
+                "pi-iso-rcopy-test-{}-{nanos}-{}",
+                std::process::id(),
+                COUNTER.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&dir).expect("create temp test directory");
+            Self(dir)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_apply_drains_stderr_while_writing_stdin() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = TempDirGuard::new();
+        let fake_git = root.path().join("git");
+        fs::write(
+            &fake_git,
+            "#!/bin/sh\nprintf 'simulated apply failure\\n' >&2\nyes x | head -c 4194304 >&2\ncat \
+			 >/dev/null\nexit 42\n",
+        )
+        .expect("write fake git");
+        fs::set_permissions(&fake_git, fs::Permissions::from_mode(0o755))
+            .expect("make fake git executable");
+
+        let patch = vec![b'p'; 4 * 1024 * 1024];
+        let err = git_apply_with_program(&fake_git, root.path(), &patch, &[])
+            .expect_err("fake git apply should fail after consuming stdin");
+        let message = err.to_string();
+        assert!(message.starts_with("git apply (exit 42): simulated apply failure"));
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/windows_block_clone.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/windows_block_clone.rs
@@ -1,0 +1,398 @@
+//! Windows block-clone based isolation.
+//!
+//! `FSCTL_DUPLICATE_EXTENTS_TO_FILE` asks NTFS/ReFS to share file extents
+//! copy-on-write between a source file and a destination file. The backend
+//! recursively materializes the directory tree and block-clones each regular
+//! file. There is no mount/session state to undo, so
+//! [`stop`](IsolationBackend::stop) is a recursive remove.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+#[cfg(not(windows))]
+use crate::IsoError;
+use crate::{BackendKind, IsoResult, IsolationBackend, ProbeResult};
+
+pub struct WindowsBlockCloneBackend;
+
+pub fn backend() -> &'static dyn IsolationBackend {
+    &WindowsBlockCloneBackend
+}
+
+#[async_trait]
+impl IsolationBackend for WindowsBlockCloneBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::WindowsBlockClone
+    }
+
+    fn probe(&self) -> ProbeResult {
+        #[cfg(windows)]
+        {
+            ProbeResult::available()
+        }
+        #[cfg(not(windows))]
+        {
+            ProbeResult::unavailable("Windows block-clone isolation is only available on Windows")
+        }
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        #[cfg(windows)]
+        {
+            imp::start(lower, merged)
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = (lower, merged);
+            Err(IsoError::unavailable(
+                "Windows block-clone isolation is only available on Windows",
+            ))
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        #[cfg(windows)]
+        {
+            imp::stop(merged)
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = merged;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::{
+        fs::{self, File, OpenOptions},
+        io,
+        os::windows::{
+            fs::{FileTypeExt, OpenOptionsExt},
+            io::AsRawHandle,
+        },
+        path::{Path, PathBuf},
+    };
+
+    use windows_sys::Win32::{
+        Foundation::{
+            ERROR_ACCESS_DENIED, ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER,
+            ERROR_NOT_SAME_DEVICE, ERROR_NOT_SUPPORTED, FILETIME,
+        },
+        Storage::FileSystem::{
+            FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, SetFileTime,
+        },
+        System::{
+            IO::DeviceIoControl,
+            Ioctl::{DUPLICATE_EXTENTS_DATA, FSCTL_DUPLICATE_EXTENTS_TO_FILE},
+        },
+    };
+
+    use crate::{IsoError, IsoResult};
+
+    pub fn start(lower: &Path, merged: &Path) -> IsoResult<()> {
+        let lower = canonical_existing_dir(lower)?;
+        prepare_destination(merged)?;
+
+        let result = recursive_block_clone(&lower, merged);
+        if result.is_err() {
+            let _ = remove_path(merged);
+        }
+        result
+    }
+
+    pub fn stop(merged: &Path) -> IsoResult<()> {
+        remove_path(merged).map_err(|err| {
+            IsoError::other(format!(
+                "unable to remove block-cloned tree {}: {err}",
+                merged.display()
+            ))
+        })
+    }
+
+    fn canonical_existing_dir(path: &Path) -> IsoResult<PathBuf> {
+        let resolved = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+        };
+        let meta = fs::metadata(&resolved).map_err(|err| {
+            IsoError::other(format!(
+                "invalid block-clone source {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !meta.is_dir() {
+            return Err(IsoError::other(format!(
+                "block-clone source {} is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn prepare_destination(merged: &Path) -> IsoResult<()> {
+        if let Some(parent) = merged.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                IsoError::other(format!("create parent of {}: {err}", merged.display()))
+            })?;
+        }
+        remove_path(merged).map_err(|err| {
+            IsoError::other(format!(
+                "unable to clear {} before block clone: {err}",
+                merged.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn remove_path(path: &Path) -> io::Result<()> {
+        let meta = match fs::symlink_metadata(path) {
+            Ok(meta) => meta,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        let file_type = meta.file_type();
+        if file_type.is_dir() && !file_type.is_symlink() {
+            for entry in fs::read_dir(path)? {
+                remove_path(&entry?.path())?;
+            }
+            clear_readonly(path, &meta);
+            fs::remove_dir(path)
+        } else {
+            clear_readonly(path, &meta);
+            fs::remove_file(path)
+        }
+    }
+
+    fn clear_readonly(path: &Path, meta: &fs::Metadata) {
+        if meta.file_type().is_symlink() {
+            return;
+        }
+        let mut permissions = meta.permissions();
+        if permissions.readonly() {
+            // This backend only removes a temporary Windows block-clone tree; clearing
+            // the readonly file attribute is required so removal can proceed.
+            #[allow(
+                clippy::permissions_set_readonly_false,
+                reason = "Windows block-clone cleanup must clear the readonly file attribute before \
+				          deletion"
+            )]
+            permissions.set_readonly(false);
+            let _ = fs::set_permissions(path, permissions);
+        }
+    }
+
+    fn recursive_block_clone(lower: &Path, merged: &Path) -> IsoResult<()> {
+        fs::create_dir_all(merged)
+            .map_err(|err| IsoError::other(format!("create {}: {err}", merged.display())))?;
+        clone_dir_contents(lower, merged)?;
+        copy_metadata_best_effort(lower, merged);
+        Ok(())
+    }
+
+    fn clone_dir_contents(src: &Path, dst: &Path) -> IsoResult<()> {
+        let entries = fs::read_dir(src)
+            .map_err(|err| IsoError::other(format!("read_dir {}: {err}", src.display())))?;
+        for entry in entries {
+            let entry = entry
+                .map_err(|err| IsoError::other(format!("dir entry in {}: {err}", src.display())))?;
+            let file_type = entry.file_type().map_err(|err| {
+                IsoError::other(format!("file_type {}: {err}", entry.path().display()))
+            })?;
+            let src_path = entry.path();
+            let dst_path = dst.join(entry.file_name());
+
+            if file_type.is_symlink() {
+                clone_symlink(&src_path, &dst_path)?;
+                copy_metadata_best_effort(&src_path, &dst_path);
+            } else if file_type.is_dir() {
+                fs::create_dir_all(&dst_path).map_err(|err| {
+                    IsoError::other(format!("create {}: {err}", dst_path.display()))
+                })?;
+                clone_dir_contents(&src_path, &dst_path)?;
+                copy_metadata_best_effort(&src_path, &dst_path);
+            } else if file_type.is_file() {
+                clone_regular_file(&src_path, &dst_path)?;
+                copy_metadata_best_effort(&src_path, &dst_path);
+            } else {
+                return Err(IsoError::other(format!(
+                    "unsupported filesystem entry for block clone: {}",
+                    src_path.display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn clone_symlink(src: &Path, dst: &Path) -> IsoResult<()> {
+        let target = fs::read_link(src)
+            .map_err(|err| IsoError::other(format!("read_link {}: {err}", src.display())))?;
+        let file_type = fs::symlink_metadata(src)
+            .map_err(|err| IsoError::other(format!("symlink_metadata {}: {err}", src.display())))?
+            .file_type();
+        let res = if file_type.is_symlink_dir() {
+            std::os::windows::fs::symlink_dir(target, dst)
+        } else {
+            std::os::windows::fs::symlink_file(target, dst)
+        };
+        res.map_err(|err| IsoError::other(format!("symlink {}: {err}", dst.display())))
+    }
+
+    fn clone_regular_file(src: &Path, dst: &Path) -> IsoResult<()> {
+        let src_meta = fs::metadata(src)
+            .map_err(|err| IsoError::other(format!("metadata {}: {err}", src.display())))?;
+        let len = src_meta.len();
+
+        let src_file = OpenOptions::new().read(true).open(src).map_err(|err| {
+            IsoError::other(format!("open block-clone source {}: {err}", src.display()))
+        })?;
+        let dst_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dst)
+            .map_err(|err| {
+                IsoError::other(format!(
+                    "create block-clone destination {}: {err}",
+                    dst.display()
+                ))
+            })?;
+        dst_file
+            .set_len(len)
+            .map_err(|err| IsoError::other(format!("set_len {} to {len}: {err}", dst.display())))?;
+
+        if len != 0 {
+            duplicate_extents(&src_file, &dst_file, len, src, dst)?;
+        }
+        Ok(())
+    }
+
+    fn duplicate_extents(
+        src_file: &File,
+        dst_file: &File,
+        len: u64,
+        src: &Path,
+        dst: &Path,
+    ) -> IsoResult<()> {
+        let byte_count = i64::try_from(len).map_err(|_| {
+            IsoError::other(format!(
+                "{} is too large for Windows block clone",
+                src.display()
+            ))
+        })?;
+        let data = DUPLICATE_EXTENTS_DATA {
+            FileHandle: src_file.as_raw_handle() as _,
+            SourceFileOffset: 0,
+            TargetFileOffset: 0,
+            ByteCount: byte_count,
+        };
+        let mut returned = 0u32;
+        let in_size = u32::try_from(std::mem::size_of::<DUPLICATE_EXTENTS_DATA>())
+            .expect("DUPLICATE_EXTENTS_DATA size fits u32");
+
+        // SAFETY: `dst_file` and `src_file` own valid handles for the duration of
+        // the call. `data` points to an initialized DUPLICATE_EXTENTS_DATA buffer,
+        // and no output buffer is required by FSCTL_DUPLICATE_EXTENTS_TO_FILE.
+        let ok = unsafe {
+            DeviceIoControl(
+                dst_file.as_raw_handle() as _,
+                FSCTL_DUPLICATE_EXTENTS_TO_FILE,
+                &raw const data as *const _,
+                in_size,
+                std::ptr::null_mut(),
+                0,
+                &raw mut returned,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok != 0 {
+            return Ok(());
+        }
+
+        let err = io::Error::last_os_error();
+        if is_unavailable_error(&err) {
+            Err(IsoError::unavailable(format!(
+                "Windows block clone unsupported for {} -> {}: {err}",
+                src.display(),
+                dst.display()
+            )))
+        } else {
+            Err(IsoError::other(format!(
+                "FSCTL_DUPLICATE_EXTENTS_TO_FILE {} -> {}: {err}",
+                src.display(),
+                dst.display()
+            )))
+        }
+    }
+
+    fn is_unavailable_error(err: &io::Error) -> bool {
+        let Some(code) = err.raw_os_error() else {
+            return false;
+        };
+        let code = code as u32;
+        matches!(
+            code,
+            ERROR_INVALID_FUNCTION
+                | ERROR_NOT_SUPPORTED
+                | ERROR_NOT_SAME_DEVICE
+                | ERROR_INVALID_PARAMETER
+                | ERROR_ACCESS_DENIED
+        )
+    }
+
+    fn copy_metadata_best_effort(src: &Path, dst: &Path) {
+        let Ok(meta) = fs::symlink_metadata(src) else {
+            return;
+        };
+        set_times_best_effort(dst, &meta);
+        if !meta.file_type().is_symlink() {
+            let _ = fs::set_permissions(dst, meta.permissions());
+        }
+    }
+
+    fn set_times_best_effort(path: &Path, meta: &fs::Metadata) {
+        let created = meta.created().ok().and_then(system_time_to_filetime);
+        let accessed = meta.accessed().ok().and_then(system_time_to_filetime);
+        let modified = meta.modified().ok().and_then(system_time_to_filetime);
+        if created.is_none() && accessed.is_none() && modified.is_none() {
+            return;
+        }
+
+        let mut opts = OpenOptions::new();
+        opts.write(true);
+        opts.custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+        let Ok(file) = opts.open(path) else { return };
+        // SAFETY: `file` owns the HANDLE for the duration of the call. The optional
+        // FILETIME pointers either reference stack locals that outlive the call or
+        // are null when the corresponding timestamp is unavailable.
+        let _ = unsafe {
+            SetFileTime(
+                file.as_raw_handle() as _,
+                created
+                    .as_ref()
+                    .map_or(std::ptr::null(), |ft| ft as *const FILETIME),
+                accessed
+                    .as_ref()
+                    .map_or(std::ptr::null(), |ft| ft as *const FILETIME),
+                modified
+                    .as_ref()
+                    .map_or(std::ptr::null(), |ft| ft as *const FILETIME),
+            )
+        };
+    }
+
+    fn system_time_to_filetime(time: std::time::SystemTime) -> Option<FILETIME> {
+        let dur = time.duration_since(std::time::UNIX_EPOCH).ok()?;
+        // Windows FILETIME = 100-ns ticks since 1601-01-01.
+        const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
+        let ticks = EPOCH_DIFF_100NS
+            .checked_add(dur.as_secs().checked_mul(10_000_000)?)?
+            .checked_add(u64::from(dur.subsec_nanos() / 100))?;
+        Some(FILETIME {
+            dwLowDateTime: (ticks & 0xffff_ffff) as u32,
+            dwHighDateTime: (ticks >> 32) as u32,
+        })
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-iso/src/zfs.rs
+++ b/crates/vendor/oh-my-pi/pi-iso/src/zfs.rs
@@ -1,0 +1,368 @@
+//! ZFS snapshot/clone-based isolation.
+//!
+//! ZFS can create a writable clone from a point-in-time snapshot without
+//! copying file data. This backend only accepts a `lower` path that exactly
+//! matches a mounted ZFS dataset mountpoint, snapshots that dataset, and clones
+//! it to a sibling dataset mounted at `merged`.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+#[cfg(not(unix))]
+use crate::IsoError;
+use crate::{BackendKind, IsoResult, IsolationBackend, ProbeResult};
+
+pub struct ZfsBackend;
+
+pub fn backend() -> &'static dyn IsolationBackend {
+    &ZfsBackend
+}
+
+#[async_trait]
+impl IsolationBackend for ZfsBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::Zfs
+    }
+
+    fn probe(&self) -> ProbeResult {
+        #[cfg(unix)]
+        {
+            imp::probe()
+        }
+        #[cfg(not(unix))]
+        {
+            ProbeResult::unavailable("ZFS clone isolation is only available on Unix platforms")
+        }
+    }
+
+    fn start(&self, lower: &Path, merged: &Path) -> IsoResult<()> {
+        #[cfg(unix)]
+        {
+            imp::start(lower, merged)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (lower, merged);
+            Err(IsoError::unavailable(
+                "ZFS clone isolation is only available on Unix platforms",
+            ))
+        }
+    }
+
+    fn stop(&self, merged: &Path) -> IsoResult<()> {
+        #[cfg(unix)]
+        {
+            imp::stop(merged)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = merged;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(unix)]
+mod imp {
+    use std::{
+        fs, io,
+        path::{Path, PathBuf},
+        process::{Command, Output},
+    };
+
+    use crate::{IsoError, IsoResult, ProbeResult};
+
+    const SNAP_PREFIX: &str = "pi-iso-";
+
+    pub fn probe() -> ProbeResult {
+        if command_available(["version"]) || command_available(["list", "-H"]) {
+            ProbeResult::available()
+        } else {
+            ProbeResult::unavailable("zfs CLI is unavailable or cannot list datasets")
+        }
+    }
+
+    pub fn start(lower: &Path, merged: &Path) -> IsoResult<()> {
+        ensure_zfs_available()?;
+
+        let lower = canonical_existing_dir(lower)?;
+        let merged = absolute_path(merged);
+        let source = dataset_for_mountpoint(&lower)?.ok_or_else(|| {
+            IsoError::unavailable(format!(
+                "{} is not exactly a mounted ZFS dataset mountpoint",
+                lower.display()
+            ))
+        })?;
+
+        if let Some(parent) = merged.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                IsoError::other(format!(
+                    "unable to create parent of {}: {err}",
+                    merged.display()
+                ))
+            })?;
+        }
+
+        stop(&merged)?;
+
+        let suffix = dataset_suffix(&merged);
+        let snapshot = format!("{source}@{SNAP_PREFIX}{suffix}");
+        let clone = sibling_dataset(&source, &format!("{SNAP_PREFIX}{suffix}"));
+
+        clear_stale_clone(&clone, &source)?;
+        let _ = run_zfs_status(["destroy", snapshot.as_str()]);
+
+        run_zfs_other(["snapshot", snapshot.as_str()])?;
+        let mountpoint = merged.to_string_lossy();
+        let mount_opt = format!("mountpoint={mountpoint}");
+        match run_zfs_other([
+            "clone",
+            "-o",
+            mount_opt.as_str(),
+            snapshot.as_str(),
+            clone.as_str(),
+        ]) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                let _ = run_zfs_status(["destroy", snapshot.as_str()]);
+                Err(err)
+            }
+        }
+    }
+
+    pub fn stop(merged: &Path) -> IsoResult<()> {
+        let merged = absolute_path(merged);
+        if !merged.exists() {
+            return Ok(());
+        }
+        match dataset_for_mountpoint(&merged)? {
+            Some(dataset) => {
+                let origin = zfs_get_value("origin", &dataset)?;
+                if !is_own_clone(&dataset, &origin) {
+                    return Err(IsoError::other(format!(
+                        "refusing to destroy unrelated ZFS dataset {dataset} mounted at {}",
+                        merged.display()
+                    )));
+                }
+                run_zfs_other(["destroy", dataset.as_str()])?;
+                run_zfs_other(["destroy", origin.as_str()])?;
+                Ok(())
+            }
+            None => match fs::remove_dir_all(&merged) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(IsoError::other(format!(
+                    "unable to remove ZFS clone mountpoint {}: {err}",
+                    merged.display()
+                ))),
+            },
+        }
+    }
+
+    fn ensure_zfs_available() -> IsoResult<()> {
+        if command_available(["version"]) || command_available(["list", "-H"]) {
+            Ok(())
+        } else {
+            Err(IsoError::unavailable(
+                "zfs CLI is unavailable or cannot list datasets",
+            ))
+        }
+    }
+
+    fn canonical_existing_dir(path: &Path) -> IsoResult<PathBuf> {
+        let resolved = absolute_path(path);
+        let meta = fs::metadata(&resolved).map_err(|err| {
+            IsoError::unavailable(format!(
+                "invalid ZFS clone source {}: {err}",
+                resolved.display()
+            ))
+        })?;
+        if !meta.is_dir() {
+            return Err(IsoError::unavailable(format!(
+                "ZFS clone source {} is not a directory",
+                resolved.display()
+            )));
+        }
+        Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+    }
+
+    fn dataset_for_mountpoint(path: &Path) -> IsoResult<Option<String>> {
+        let wanted = normalize_path(path);
+        let output = run_zfs_output(["list", "-H", "-o", "name,mountpoint", "-t", "filesystem"])?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            let mut fields = line.splitn(2, '\t');
+            let Some(name) = fields.next() else { continue };
+            let Some(mountpoint) = fields.next() else {
+                continue;
+            };
+            if mountpoint == "-" || mountpoint == "none" || mountpoint == "legacy" {
+                continue;
+            }
+            if normalize_path(Path::new(mountpoint)) == wanted {
+                return Ok(Some(name.to_owned()));
+            }
+        }
+        Ok(None)
+    }
+
+    fn clear_stale_clone(clone: &str, source: &str) -> IsoResult<()> {
+        let output = run_zfs_status(["get", "-H", "-o", "value", "origin", clone]);
+        match output {
+            Ok(output) if output.status.success() => {
+                let origin = trim_stdout(&output);
+                if origin.starts_with(source)
+                    && origin[source.len()..].starts_with('@')
+                    && is_own_snapshot(origin)
+                {
+                    run_zfs_other(["destroy", "-r", clone])
+                } else {
+                    Err(IsoError::other(format!(
+                        "refusing to destroy existing non-stale ZFS dataset {clone}"
+                    )))
+                }
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if stderr_is_unavailable(&stderr) {
+                    Ok(())
+                } else {
+                    Err(IsoError::other(format!(
+                        "zfs get origin {clone}: {}",
+                        stderr.trim()
+                    )))
+                }
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                Err(IsoError::unavailable("zfs CLI is unavailable"))
+            }
+            Err(err) => Err(IsoError::other(format!("zfs get origin {clone}: {err}"))),
+        }
+    }
+
+    fn zfs_get_value(property: &str, dataset: &str) -> IsoResult<String> {
+        let output = run_zfs_output(["get", "-H", "-o", "value", property, dataset])?;
+        Ok(trim_stdout(&output).to_owned())
+    }
+
+    fn run_zfs_other<const N: usize>(args: [&str; N]) -> IsoResult<()> {
+        let output = run_zfs_status(args).map_err(|err| {
+            if err.kind() == io::ErrorKind::NotFound {
+                IsoError::unavailable("zfs CLI is unavailable")
+            } else {
+                IsoError::other(format!("unable to execute zfs: {err}"))
+            }
+        })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr_is_unavailable(&stderr) {
+            Err(IsoError::unavailable(stderr.trim().to_owned()))
+        } else {
+            Err(IsoError::other(format!("zfs failed: {}", stderr.trim())))
+        }
+    }
+
+    fn run_zfs_output<const N: usize>(args: [&str; N]) -> IsoResult<Output> {
+        let output = run_zfs_status(args).map_err(|err| {
+            if err.kind() == io::ErrorKind::NotFound {
+                IsoError::unavailable("zfs CLI is unavailable")
+            } else {
+                IsoError::other(format!("unable to execute zfs: {err}"))
+            }
+        })?;
+        if output.status.success() {
+            return Ok(output);
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr_is_unavailable(&stderr) {
+            Err(IsoError::unavailable(stderr.trim().to_owned()))
+        } else {
+            Err(IsoError::other(format!("zfs failed: {}", stderr.trim())))
+        }
+    }
+
+    fn run_zfs_status<const N: usize>(args: [&str; N]) -> io::Result<Output> {
+        Command::new("zfs").args(args).output()
+    }
+
+    fn command_available<const N: usize>(args: [&str; N]) -> bool {
+        matches!(run_zfs_status(args), Ok(output) if output.status.success())
+    }
+
+    fn stderr_is_unavailable(stderr: &str) -> bool {
+        let stderr = stderr.to_ascii_lowercase();
+        stderr.contains("dataset does not exist")
+            || stderr.contains("no datasets available")
+            || stderr.contains("not a zfs filesystem")
+            || stderr.contains("not a zfs file system")
+            || stderr.contains("operation not supported")
+            || stderr.contains("not supported")
+            || stderr.contains("no such pool")
+            || stderr.contains("modules are not loaded")
+            || stderr.contains("failed to initialize libzfs")
+    }
+
+    fn sibling_dataset(source: &str, child: &str) -> String {
+        match source.rsplit_once('/') {
+            Some((parent, _)) => format!("{parent}/{child}"),
+            None => format!("{source}/{child}"),
+        }
+    }
+
+    fn dataset_suffix(path: &Path) -> String {
+        let normalized = normalize_path(&absolute_path(path));
+        let bytes = normalized.as_bytes();
+        let a = fnv1a64(bytes, 0xcbf29ce484222325);
+        let b = fnv1a64(bytes, 0x84222325cbf29ce4 ^ bytes.len() as u64);
+        format!("{a:016x}-{b:016x}")
+    }
+
+    fn fnv1a64(bytes: &[u8], seed: u64) -> u64 {
+        let mut hash = seed;
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        hash
+    }
+
+    fn is_own_name(name: &str) -> bool {
+        name.starts_with(SNAP_PREFIX)
+            && name[SNAP_PREFIX.len()..].bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':')
+            })
+    }
+
+    fn is_own_snapshot(snapshot: &str) -> bool {
+        let Some((_, name)) = snapshot.rsplit_once('@') else {
+            return false;
+        };
+        is_own_name(name)
+    }
+
+    fn is_own_clone(dataset: &str, origin: &str) -> bool {
+        let Some(name) = dataset.rsplit('/').next() else {
+            return false;
+        };
+        is_own_name(name) && is_own_snapshot(origin)
+    }
+
+    fn absolute_path(path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+        }
+    }
+
+    fn normalize_path(path: &Path) -> String {
+        path.to_string_lossy().trim_end_matches('/').to_owned()
+    }
+
+    fn trim_stdout(output: &Output) -> &str {
+        std::str::from_utf8(&output.stdout).unwrap_or("").trim()
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-uu-grep/Cargo.toml
+++ b/crates/vendor/oh-my-pi/pi-uu-grep/Cargo.toml
@@ -1,0 +1,31 @@
+# grep implemented from scratch on top of the ripgrep libraries (grep-regex +
+# grep-searcher), with I/O and path resolution routed through pi-uutils-ctx so it
+# can run in-process as a shell builtin. Entry point: `pi_uu_grep::run`.
+[package]
+name = "pi_uu_grep"
+version = "0.8.0"
+edition = "2024"
+license = "MIT"
+description = "grep ~ ripgrep-backed pattern search (in-process shell builtin)"
+
+[lib]
+path = "src/lib.rs"
+
+# Vendored: do not inherit nixmac workspace deny-level clippy.
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+pi-uutils-ctx = { path = "../pi-uutils-ctx" }
+pi-walker = { path = "../pi-walker" }
+grep-cli = "0.1"
+grep-matcher = "0.1"
+grep-pcre2 = "0.1"
+grep-printer = "0.3"
+grep-regex = "0.1"
+grep-searcher = "0.1"
+ignore = "0.4"
+globset = "0.4"
+serde_json = "1"
+
+[dev-dependencies]
+parking_lot = "0.12.5"

--- a/crates/vendor/oh-my-pi/pi-uu-grep/src/lib.rs
+++ b/crates/vendor/oh-my-pi/pi-uu-grep/src/lib.rs
@@ -1,0 +1,1947 @@
+//! `grep` implemented as an in-process shell builtin on top of the ripgrep
+//! libraries (`grep-regex` for the matcher, `grep-searcher` for line scanning),
+//! with directory recursion via `pi-walker` and `--include` filtering via
+//! `globset`. All I/O and path resolution is routed through `pi-uutils-ctx` so
+//! the builtin writes to the command's redirected file descriptors and resolves
+//! relative paths against the shell's working directory.
+//!
+//! Entry point: [`run`]. It never calls `std::process::exit`; clap
+//! help/usage/error output is rendered to the context streams and an exit code
+//! is returned following the GNU convention (0 = matched, 1 = no match,
+//! 2 = error).
+
+mod rg;
+
+use std::{
+    borrow::Cow,
+    ffi::{OsStr, OsString},
+    fs::File,
+    io::{self, BufWriter, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, ValueEnum, parser::ValueSource};
+use globset::{Glob, GlobMatcher};
+use grep_matcher::{LineTerminator, Matcher};
+use grep_pcre2::{RegexMatcher as PcreMatcher, RegexMatcherBuilder as PcreMatcherBuilder};
+use grep_regex::{RegexMatcher, RegexMatcherBuilder};
+use grep_searcher::{
+    BinaryDetection, Searcher, SearcherBuilder, Sink, SinkContext, SinkFinish, SinkMatch,
+};
+pub use rg::run as run_rg;
+
+#[derive(Parser, Debug)]
+#[command(
+	name = "grep",
+	version = concat!("grep (pi-uu-grep) ", env!("CARGO_PKG_VERSION")),
+	about = "Search for PATTERN in each FILE or standard input.",
+	disable_help_flag = true,
+	disable_version_flag = true,
+	args_override_self = true
+)]
+struct Cli {
+    /// Use PATTERN for matching (may be repeated; all patterns are OR-ed).
+    #[arg(short = 'e', long = "regexp", value_name = "PATTERN")]
+    patterns: Vec<String>,
+
+    /// Read patterns from FILE, one per line.
+    #[arg(short = 'f', long = "file", value_name = "FILE")]
+    pattern_files: Vec<OsString>,
+
+    /// Interpret PATTERN as a strict extended regular expression.
+    #[arg(short = 'E', long = "extended-regexp")]
+    extended: bool,
+
+    /// Interpret PATTERN using the default basic-compatible mode.
+    #[arg(short = 'G', long = "basic-regexp")]
+    basic: bool,
+
+    /// Interpret PATTERN as a fixed string.
+    #[arg(short = 'F', long = "fixed-strings")]
+    fixed: bool,
+
+    /// Interpret PATTERN as a Perl-compatible regular expression.
+    #[arg(short = 'P', long = "perl-regexp")]
+    perl: bool,
+
+    /// Ignore case distinctions in patterns and data.
+    #[arg(short = 'i', short_alias = 'y', long = "ignore-case")]
+    ignore_case: bool,
+
+    /// Restore case-sensitive matching after an earlier -i.
+    #[arg(long = "no-ignore-case")]
+    no_ignore_case: bool,
+
+    /// Select non-matching lines.
+    #[arg(short = 'v', long = "invert-match")]
+    invert: bool,
+
+    /// Match only whole words.
+    #[arg(short = 'w', long = "word-regexp")]
+    word: bool,
+
+    /// Match only whole lines.
+    #[arg(short = 'x', long = "line-regexp")]
+    line_regexp: bool,
+
+    /// Print only a count of selected lines per FILE.
+    #[arg(short = 'c', long = "count")]
+    count: bool,
+
+    /// Print only the names of FILEs with at least one selected line.
+    #[arg(short = 'l', long = "files-with-matches")]
+    files_with_matches: bool,
+
+    /// Print only the names of FILEs with no selected lines.
+    #[arg(short = 'L', long = "files-without-match")]
+    files_without_match: bool,
+
+    /// Stop after NUM selected lines in each input.
+    #[arg(
+        short = 'm',
+        long = "max-count",
+        value_name = "NUM",
+        allow_hyphen_values = true
+    )]
+    max_count: Option<i64>,
+
+    /// Print only the matched non-empty parts of selected lines.
+    #[arg(short = 'o', long = "only-matching")]
+    only_matching: bool,
+
+    /// Quiet; suppress normal output and stop after the first selected line.
+    #[arg(short = 'q', long = "quiet", visible_alias = "silent")]
+    quiet: bool,
+
+    /// Suppress error messages about nonexistent or unreadable files.
+    #[arg(short = 's', long = "no-messages")]
+    no_messages: bool,
+
+    /// Prefix output with the zero-based byte offset.
+    #[arg(short = 'b', long = "byte-offset")]
+    byte_offset: bool,
+
+    /// Always print the file name with output lines.
+    #[arg(short = 'H', long = "with-filename")]
+    with_filename: bool,
+
+    /// Never print the file name with output lines.
+    #[arg(short = 'h', long = "no-filename")]
+    no_filename: bool,
+
+    /// Use LABEL as the displayed name for standard input.
+    #[arg(long = "label", value_name = "LABEL")]
+    label: Option<OsString>,
+
+    /// Prefix each output line with its one-based line number.
+    #[arg(short = 'n', long = "line-number")]
+    line_number: bool,
+
+    /// Align line content on a tab stop after output prefixes.
+    #[arg(short = 'T', long = "initial-tab")]
+    initial_tab: bool,
+
+    /// Write NUL instead of the separator following a file name.
+    #[arg(short = 'Z', long = "null")]
+    null_paths: bool,
+
+    /// Print NUM lines of trailing context after selected lines.
+    #[arg(short = 'A', long = "after-context", value_name = "NUM")]
+    after_context: Option<usize>,
+
+    /// Print NUM lines of leading context before selected lines.
+    #[arg(short = 'B', long = "before-context", value_name = "NUM")]
+    before_context: Option<usize>,
+
+    /// Print NUM lines of leading and trailing context.
+    #[arg(short = 'C', long = "context", value_name = "NUM")]
+    context: Option<usize>,
+
+    /// Print STRING between non-adjacent groups of context lines.
+    #[arg(long = "group-separator", value_name = "STRING")]
+    group_separator: Option<String>,
+
+    /// Do not print a separator between context groups.
+    #[arg(long = "no-group-separator")]
+    no_group_separator: bool,
+
+    /// Process binary input as text.
+    #[arg(short = 'a', long = "text")]
+    text: bool,
+
+    /// Treat binary input as having no selected lines.
+    #[arg(short = 'I')]
+    binary_without_match: bool,
+
+    /// Choose how binary input is searched.
+    #[arg(long = "binary-files", value_name = "TYPE")]
+    binary_files: Option<BinaryFiles>,
+
+    /// Choose how device, FIFO, and socket operands are handled.
+    #[arg(short = 'D', long = "devices", value_name = "ACTION")]
+    devices: Option<DeviceAction>,
+
+    /// Choose how directory operands are handled.
+    #[arg(short = 'd', long = "directories", value_name = "ACTION")]
+    directories: Option<DirectoryAction>,
+
+    /// Search files matching GLOB.
+    #[arg(long = "include", value_name = "GLOB")]
+    include: Vec<String>,
+
+    /// Skip files matching GLOB.
+    #[arg(long = "exclude", value_name = "GLOB")]
+    exclude: Vec<String>,
+
+    /// Read file exclusion globs from FILE.
+    #[arg(long = "exclude-from", value_name = "FILE")]
+    exclude_from: Vec<OsString>,
+
+    /// Skip directories matching GLOB during recursive searches.
+    #[arg(long = "exclude-dir", value_name = "GLOB")]
+    exclude_dir: Vec<String>,
+
+    /// Search directories matching GLOB during recursive searches.
+    #[arg(long = "include-dir", value_name = "GLOB")]
+    include_dir: Vec<String>,
+
+    /// Recursively search each directory operand.
+    #[arg(short = 'r', long = "recursive")]
+    recursive: bool,
+
+    /// Recursively search and follow every symbolic link.
+    #[arg(short = 'R', long = "dereference-recursive")]
+    dereference_recursive: bool,
+
+    /// Follow symbolic links named as command-line operands.
+    #[arg(short = 'O')]
+    follow_command_line: bool,
+
+    /// Do not follow symbolic links during recursive searches.
+    #[arg(short = 'p')]
+    no_follow: bool,
+
+    /// Follow every symbolic link during recursive searches.
+    #[arg(short = 'S')]
+    follow_all: bool,
+
+    /// Flush standard output after each output record.
+    #[arg(long = "line-buffered")]
+    line_buffered: bool,
+
+    /// Use binary I/O where the platform distinguishes it.
+    #[arg(short = 'U', long = "binary")]
+    binary_io: bool,
+
+    /// Treat NUL rather than newline as the input and output record delimiter.
+    #[arg(short = 'z', long = "null-data")]
+    null_data: bool,
+
+    /// Request memory-mapped input where supported.
+    #[allow(dead_code, reason = "accepted BSD grep compatibility option")]
+    #[arg(long = "mmap")]
+    mmap: bool,
+
+    /// Accepted compatibility option with no effect.
+    #[allow(dead_code, reason = "accepted GNU grep compatibility option")]
+    #[arg(short = 'u')]
+    unix_byte_offsets: bool,
+
+    /// Print a help message.
+    #[allow(dead_code, reason = "clap consumes help before options are inspected")]
+    #[arg(long = "help", action = clap::ArgAction::Help)]
+    help: Option<bool>,
+
+    /// Print version information.
+    #[allow(
+        dead_code,
+        reason = "clap consumes version before options are inspected"
+    )]
+    #[arg(short = 'V', long = "version", action = clap::ArgAction::Version)]
+    version: Option<bool>,
+
+    /// Accept color configuration without injecting ANSI into redirected output.
+    #[allow(
+        dead_code,
+        reason = "color is intentionally disabled for builtin output"
+    )]
+    #[arg(
+		long = "color",
+		alias = "colour",
+		value_name = "WHEN",
+		num_args = 0..=1,
+		require_equals = true,
+		default_missing_value = "auto",
+	)]
+    color: Option<String>,
+
+    /// PATTERN followed by FILEs (PATTERN is omitted with -e or -f).
+    #[arg(value_name = "ARGS")]
+    args: Vec<OsString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum BinaryFiles {
+    Binary,
+    Text,
+    WithoutMatch,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum DeviceAction {
+    Read,
+    Skip,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum DirectoryAction {
+    Read,
+    Skip,
+    Recurse,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MatchMode {
+    Default,
+    Extended,
+    Fixed,
+    Perl,
+}
+
+/// Resolved, flag-free options shared with the search [`Sink`].
+struct Options {
+    line_number: bool,
+    byte_offset: bool,
+    count: bool,
+    files_with_matches: bool,
+    files_without_match: bool,
+    only_matching: bool,
+    before: usize,
+    after: usize,
+    no_messages: bool,
+    quiet: bool,
+    prefix_filename: bool,
+    initial_tab: bool,
+    null_paths: bool,
+    record_terminator: u8,
+    group_separator: Option<Vec<u8>>,
+    line_buffered: bool,
+    binary_files: BinaryFiles,
+}
+
+enum CompiledMatcher {
+    Rust(RegexMatcher),
+    Pcre(PcreMatcher),
+}
+
+struct PathRule {
+    include: bool,
+    matcher: GlobMatcher,
+}
+
+struct RuleSpec {
+    index: usize,
+    include: bool,
+    pattern: String,
+}
+
+#[derive(Default)]
+struct PathRules {
+    files: Vec<PathRule>,
+    dirs: Vec<PathRule>,
+}
+
+impl PathRules {
+    fn allows_file(&self, path: &Path) -> bool {
+        Self::allows(&self.files, path)
+    }
+
+    fn allows_dir(&self, path: &Path) -> bool {
+        Self::allows(&self.dirs, path)
+    }
+
+    fn allows(rules: &[PathRule], path: &Path) -> bool {
+        let mut allowed = rules.first().is_none_or(|first| !first.include);
+        for rule in rules {
+            if path_suffix_matches(&rule.matcher, path) {
+                allowed = rule.include;
+            }
+        }
+        allowed
+    }
+}
+
+fn path_suffix_matches(matcher: &GlobMatcher, path: &Path) -> bool {
+    let mut components = path.components();
+    loop {
+        let suffix = components.as_path();
+        if suffix.as_os_str().is_empty() {
+            return false;
+        }
+        if matcher.is_match(suffix) {
+            return true;
+        }
+        if components.next().is_none() {
+            return false;
+        }
+    }
+}
+
+fn last_index(matches: &ArgMatches, id: &str) -> Option<usize> {
+    if matches.value_source(id) != Some(ValueSource::CommandLine) {
+        return None;
+    }
+    matches.indices_of(id).and_then(|indices| indices.max())
+}
+
+fn choose_latest<T>(selected: &mut (usize, T), index: Option<usize>, value: T) {
+    if let Some(index) = index
+        && index >= selected.0
+    {
+        *selected = (index, value);
+    }
+}
+
+fn resolve_match_mode(matches: &ArgMatches) -> MatchMode {
+    let mut selected = (0, MatchMode::Default);
+    choose_latest(
+        &mut selected,
+        last_index(matches, "basic"),
+        MatchMode::Default,
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "extended"),
+        MatchMode::Extended,
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "fixed"),
+        MatchMode::Fixed,
+    );
+    choose_latest(&mut selected, last_index(matches, "perl"), MatchMode::Perl);
+    selected.1
+}
+
+fn resolve_ignore_case(matches: &ArgMatches) -> bool {
+    let mut selected = (0, false);
+    choose_latest(&mut selected, last_index(matches, "ignore_case"), true);
+    choose_latest(&mut selected, last_index(matches, "no_ignore_case"), false);
+    selected.1
+}
+
+fn resolve_filename_prefix(matches: &ArgMatches) -> Option<bool> {
+    let mut selected = (0, None);
+    choose_latest(
+        &mut selected,
+        last_index(matches, "with_filename"),
+        Some(true),
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "no_filename"),
+        Some(false),
+    );
+    selected.1
+}
+
+fn resolve_file_list_modes(matches: &ArgMatches) -> (bool, bool) {
+    let mut selected = (0, None);
+    choose_latest(
+        &mut selected,
+        last_index(matches, "files_with_matches"),
+        Some(true),
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "files_without_match"),
+        Some(false),
+    );
+    match selected.1 {
+        Some(true) => (true, false),
+        Some(false) => (false, true),
+        None => (false, false),
+    }
+}
+
+fn resolve_context(cli: &Cli, matches: &ArgMatches) -> (usize, usize) {
+    let mut events = Vec::with_capacity(3);
+    if let (Some(index), Some(value)) = (last_index(matches, "after_context"), cli.after_context) {
+        events.push((index, false, value));
+    }
+    if let (Some(index), Some(value)) = (last_index(matches, "before_context"), cli.before_context)
+    {
+        events.push((index, true, value));
+    }
+    if let (Some(index), Some(value)) = (last_index(matches, "context"), cli.context) {
+        events.push((index, false, value));
+        events.push((index, true, value));
+    }
+    events.sort_unstable_by_key(|event| event.0);
+
+    let mut before = 0;
+    let mut after = 0;
+    for (_, is_before, value) in events {
+        if is_before {
+            before = value;
+        } else {
+            after = value;
+        }
+    }
+    (before, after)
+}
+
+fn resolve_group_separator(cli: &Cli, matches: &ArgMatches) -> Option<Vec<u8>> {
+    let mut selected = (0, Some(b"--".to_vec()));
+    if let Some(separator) = &cli.group_separator {
+        choose_latest(
+            &mut selected,
+            last_index(matches, "group_separator"),
+            Some(separator.as_bytes().to_vec()),
+        );
+    }
+    choose_latest(
+        &mut selected,
+        last_index(matches, "no_group_separator"),
+        None,
+    );
+    selected.1
+}
+
+fn resolve_directory_action(cli: &Cli, matches: &ArgMatches) -> DirectoryAction {
+    let mut selected = (0, DirectoryAction::Read);
+    choose_latest(
+        &mut selected,
+        last_index(matches, "recursive"),
+        DirectoryAction::Recurse,
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "dereference_recursive"),
+        DirectoryAction::Recurse,
+    );
+    if let Some(action) = cli.directories {
+        choose_latest(&mut selected, last_index(matches, "directories"), action);
+    }
+    selected.1
+}
+
+fn resolve_follow_links(cli: &Cli, matches: &ArgMatches) -> pi_walker::FollowLinks {
+    let mut selected = (0, pi_walker::FollowLinks::Roots);
+    choose_latest(
+        &mut selected,
+        last_index(matches, "recursive"),
+        pi_walker::FollowLinks::Roots,
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "dereference_recursive"),
+        pi_walker::FollowLinks::Always,
+    );
+    if cli.directories == Some(DirectoryAction::Recurse) {
+        choose_latest(
+            &mut selected,
+            last_index(matches, "directories"),
+            pi_walker::FollowLinks::Roots,
+        );
+    }
+    choose_latest(
+        &mut selected,
+        last_index(matches, "follow_command_line"),
+        pi_walker::FollowLinks::Roots,
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "no_follow"),
+        pi_walker::FollowLinks::Never,
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "follow_all"),
+        pi_walker::FollowLinks::Always,
+    );
+    selected.1
+}
+
+fn resolve_binary_files(cli: &Cli, matches: &ArgMatches) -> BinaryFiles {
+    // Preserve the builtin's historical byte-transparent default. Explicit
+    // GNU/BSD binary controls opt into detection.
+    let mut selected = (0, BinaryFiles::Text);
+    choose_latest(
+        &mut selected,
+        last_index(matches, "text"),
+        BinaryFiles::Text,
+    );
+    choose_latest(
+        &mut selected,
+        last_index(matches, "binary_without_match"),
+        BinaryFiles::WithoutMatch,
+    );
+    if let Some(mode) = cli.binary_files {
+        choose_latest(&mut selected, last_index(matches, "binary_files"), mode);
+    }
+    choose_latest(
+        &mut selected,
+        last_index(matches, "binary_io"),
+        BinaryFiles::Binary,
+    );
+    selected.1
+}
+
+fn resolve_max_count(cli: &Cli) -> Result<Option<u64>, String> {
+    match cli.max_count {
+        None | Some(-1) => Ok(None),
+        Some(value) if value >= 0 => u64::try_from(value)
+            .map(Some)
+            .map_err(|_| format!("invalid max count: {value}")),
+        Some(value) => Err(format!("invalid max count: {value}")),
+    }
+}
+
+fn option_takes_next_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-e" | "-f"
+            | "-m"
+            | "-A"
+            | "-B"
+            | "-C"
+            | "-D"
+            | "-d"
+            | "--regexp"
+            | "--file"
+            | "--max-count"
+            | "--after-context"
+            | "--before-context"
+            | "--context"
+            | "--label"
+            | "--group-separator"
+            | "--binary-files"
+            | "--devices"
+            | "--directories"
+            | "--include"
+            | "--exclude"
+            | "--exclude-from"
+            | "--exclude-dir"
+            | "--include-dir"
+    )
+}
+
+fn normalize_context_args(argv: Vec<OsString>) -> Vec<OsString> {
+    let mut normalized = Vec::with_capacity(argv.len());
+    let mut literal = false;
+    let mut value_pending = false;
+
+    for (index, arg) in argv.into_iter().enumerate() {
+        if index == 0 || literal || value_pending {
+            value_pending = false;
+            normalized.push(arg);
+            continue;
+        }
+        let Some(text) = arg.to_str() else {
+            normalized.push(arg);
+            continue;
+        };
+        if text == "--" {
+            literal = true;
+            normalized.push(arg);
+            continue;
+        }
+        if let Some(digits) = text.strip_prefix('-')
+            && !digits.is_empty()
+            && digits.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            normalized.push(OsString::from(format!("--context={digits}")));
+            continue;
+        }
+        value_pending = option_takes_next_value(text);
+        normalized.push(arg);
+    }
+    normalized
+}
+
+/// Escape regular-expression meta-characters so a pattern is matched literally,
+/// mirroring `regex::escape` (used to implement `-F`/`--fixed-strings`).
+fn escape_literal(pat: &str) -> String {
+    const META: &[char] = &[
+        '\\', '.', '+', '*', '?', '(', ')', '|', '[', ']', '{', '}', '^', '$', '#', '&', '-', '~',
+    ];
+    let mut out = String::with_capacity(pat.len());
+    for ch in pat.chars() {
+        if META.contains(&ch) {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Translate GNU BRE `\|` alternation into the syntax accepted by
+/// `grep-regex`, without rewriting escaped pipes inside character classes.
+fn normalize_basic_alternation(pattern: &str) -> Cow<'_, str> {
+    let bytes = pattern.as_bytes();
+    let mut output = None;
+    let mut copied = 0;
+    let mut index = 0;
+    let mut in_class = false;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            let run_start = index;
+            while index < bytes.len() && bytes[index] == b'\\' {
+                index += 1;
+            }
+            let slash_count = index - run_start;
+            if !in_class && slash_count % 2 == 1 && index < bytes.len() && bytes[index] == b'|' {
+                let normalized = output.get_or_insert_with(|| String::with_capacity(pattern.len()));
+                normalized.push_str(&pattern[copied..index - 1]);
+                normalized.push('|');
+                copied = index + 1;
+                index += 1;
+                continue;
+            }
+            if slash_count % 2 == 1 && index < bytes.len() {
+                index += 1;
+            }
+            continue;
+        }
+
+        match bytes[index] {
+            b'[' if !in_class => in_class = true,
+            b']' if in_class => in_class = false,
+            _ => {}
+        }
+        index += 1;
+    }
+
+    if let Some(mut normalized) = output {
+        normalized.push_str(&pattern[copied..]);
+        Cow::Owned(normalized)
+    } else {
+        Cow::Borrowed(pattern)
+    }
+}
+
+fn build_default_matcher<P: AsRef<str>>(
+    builder: &RegexMatcherBuilder,
+    patterns: &[P],
+) -> Result<RegexMatcher, String> {
+    let error = match builder.build_many(patterns) {
+        Ok(matcher) => return Ok(matcher),
+        Err(error) => error,
+    };
+    let sanitized: Vec<String> = patterns
+        .iter()
+        .map(|pattern| {
+            let pattern = pattern.as_ref();
+            if builder.build(pattern).is_ok() {
+                pattern.to_owned()
+            } else {
+                escape_literal(pattern)
+            }
+        })
+        .collect();
+    builder
+        .build_many(&sanitized)
+        .map_err(|_| error.to_string())
+}
+
+/// Compile all patterns using the last-selected matcher mode.
+fn build_matcher(
+    patterns: &[String],
+    cli: &Cli,
+    mode: MatchMode,
+    ignore_case: bool,
+) -> Result<CompiledMatcher, String> {
+    if mode == MatchMode::Perl {
+        let mut builder = PcreMatcherBuilder::new();
+        builder
+            .caseless(ignore_case)
+            .word(cli.word && !cli.line_regexp)
+            .whole_line(cli.line_regexp)
+            .utf(true)
+            .ucp(true)
+            .jit_if_available(true);
+        return builder
+            .build_many(patterns)
+            .map(CompiledMatcher::Pcre)
+            .map_err(|error| error.to_string());
+    }
+
+    let mut builder = RegexMatcherBuilder::new();
+    builder
+        .case_insensitive(ignore_case)
+        .word(cli.word && !cli.line_regexp)
+        .whole_line(cli.line_regexp);
+    if cli.null_data {
+        builder.line_terminator(Some(b'\0'));
+    }
+    if mode == MatchMode::Fixed {
+        let escaped: Vec<String> = patterns
+            .iter()
+            .map(|pattern| escape_literal(pattern))
+            .collect();
+        return builder
+            .build_many(&escaped)
+            .map(CompiledMatcher::Rust)
+            .map_err(|error| error.to_string());
+    }
+
+    if mode == MatchMode::Default {
+        let normalized: Vec<_> = patterns
+            .iter()
+            .map(|pattern| normalize_basic_alternation(pattern))
+            .collect();
+        return build_default_matcher(&builder, &normalized).map(CompiledMatcher::Rust);
+    }
+
+    builder
+        .build_many(patterns)
+        .map(CompiledMatcher::Rust)
+        .map_err(|error| error.to_string())
+}
+
+/// A search sink that renders GNU-compatible records and tracks selection.
+struct GrepSink<'a, M: Matcher, W: Write> {
+    out: &'a mut W,
+    matcher: &'a M,
+    display: &'a [u8],
+    opts: &'a Options,
+    match_count: u64,
+    any_match: bool,
+    binary: bool,
+}
+
+impl<M: Matcher, W: Write> GrepSink<'_, M, W> {
+    fn flush_record(&mut self) -> io::Result<()> {
+        if self.opts.line_buffered {
+            self.out.flush()?;
+        }
+        Ok(())
+    }
+
+    fn write_prefix(
+        &mut self,
+        line_number: Option<u64>,
+        byte_offset: u64,
+        separator: u8,
+    ) -> io::Result<()> {
+        let mut has_prefix = false;
+        if self.opts.prefix_filename {
+            self.out.write_all(self.display)?;
+            if self.opts.null_paths {
+                self.out.write_all(b"\0")?;
+            } else {
+                self.out.write_all(&[separator])?;
+            }
+            has_prefix = true;
+        }
+        if self.opts.line_number
+            && let Some(number) = line_number
+        {
+            write!(self.out, "{number}")?;
+            self.out.write_all(&[separator])?;
+            has_prefix = true;
+        }
+        if self.opts.byte_offset {
+            write!(self.out, "{byte_offset}")?;
+            self.out.write_all(&[separator])?;
+            has_prefix = true;
+        }
+        if self.opts.initial_tab && has_prefix {
+            self.out.write_all(b"\t")?;
+        }
+        Ok(())
+    }
+
+    fn write_record(&mut self, record: &[u8]) -> io::Result<()> {
+        self.out.write_all(record)?;
+        if record.last().copied() != Some(self.opts.record_terminator) {
+            self.out.write_all(&[self.opts.record_terminator])?;
+        }
+        self.flush_record()
+    }
+
+    fn write_path_record(&mut self) -> io::Result<()> {
+        self.out.write_all(self.display)?;
+        let terminator = if self.opts.null_paths {
+            b'\0'
+        } else {
+            self.opts.record_terminator
+        };
+        self.out.write_all(&[terminator])?;
+        self.flush_record()
+    }
+
+    fn print_only_matching(
+        &mut self,
+        line: &[u8],
+        line_number: Option<u64>,
+        line_offset: u64,
+    ) -> io::Result<()> {
+        let mut at = 0usize;
+        while at <= line.len() {
+            let Some(found) = self
+                .matcher
+                .find_at(line, at)
+                .map_err(|error| io::Error::other(error.to_string()))?
+            else {
+                break;
+            };
+            if found.is_empty() {
+                at = found.end() + 1;
+                continue;
+            }
+            let match_offset = line_offset.saturating_add(
+                u64::try_from(found.start())
+                    .map_err(|error| io::Error::other(error.to_string()))?,
+            );
+            self.write_prefix(line_number, match_offset, b':')?;
+            self.write_record(&line[found.start()..found.end()])?;
+            at = found.end();
+        }
+        Ok(())
+    }
+
+    fn normal_output_is_suppressed(&self) -> bool {
+        self.opts.count
+            || self.opts.files_with_matches
+            || self.opts.files_without_match
+            || self.opts.quiet
+    }
+
+    fn binary_summary(&self) -> bool {
+        self.binary
+            && self.opts.binary_files == BinaryFiles::Binary
+            && !self.normal_output_is_suppressed()
+    }
+}
+
+impl<M: Matcher, W: Write> Sink for GrepSink<'_, M, W> {
+    type Error = io::Error;
+
+    fn matched(&mut self, _searcher: &Searcher, mat: &SinkMatch<'_>) -> Result<bool, io::Error> {
+        if self.binary && self.opts.binary_files == BinaryFiles::WithoutMatch {
+            return Ok(false);
+        }
+        self.any_match = true;
+        self.match_count += 1;
+        if self.opts.quiet
+            || self.opts.files_with_matches
+            || self.opts.files_without_match
+            || self.binary_summary()
+        {
+            return Ok(false);
+        }
+        if self.opts.count {
+            return Ok(true);
+        }
+        if self.opts.only_matching {
+            self.print_only_matching(mat.bytes(), mat.line_number(), mat.absolute_byte_offset())?;
+        } else {
+            self.write_prefix(mat.line_number(), mat.absolute_byte_offset(), b':')?;
+            self.write_record(mat.bytes())?;
+        }
+        Ok(true)
+    }
+
+    fn context(&mut self, _searcher: &Searcher, ctx: &SinkContext<'_>) -> Result<bool, io::Error> {
+        if self.normal_output_is_suppressed() || self.opts.only_matching || self.binary_summary() {
+            return Ok(true);
+        }
+        self.write_prefix(ctx.line_number(), ctx.absolute_byte_offset(), b'-')?;
+        self.write_record(ctx.bytes())?;
+        Ok(true)
+    }
+
+    fn context_break(&mut self, _searcher: &Searcher) -> Result<bool, io::Error> {
+        if !self.normal_output_is_suppressed()
+            && !self.opts.only_matching
+            && !self.binary_summary()
+            && let Some(separator) = &self.opts.group_separator
+        {
+            self.out.write_all(separator)?;
+            self.out.write_all(&[self.opts.record_terminator])?;
+            self.flush_record()?;
+        }
+        Ok(true)
+    }
+
+    fn binary_data(
+        &mut self,
+        _searcher: &Searcher,
+        _binary_byte_offset: u64,
+    ) -> Result<bool, io::Error> {
+        self.binary = true;
+        if self.opts.binary_files == BinaryFiles::WithoutMatch {
+            self.any_match = false;
+            self.match_count = 0;
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
+    fn finish(&mut self, _searcher: &Searcher, _: &SinkFinish) -> Result<(), io::Error> {
+        if self.opts.quiet {
+            return Ok(());
+        }
+        if self.binary_summary() && self.any_match {
+            self.out.write_all(b"Binary file ")?;
+            self.out.write_all(self.display)?;
+            self.out.write_all(b" matches")?;
+            self.out.write_all(&[self.opts.record_terminator])?;
+            return self.flush_record();
+        }
+        if self.opts.files_with_matches {
+            if self.any_match {
+                self.write_path_record()?;
+            }
+        } else if self.opts.files_without_match {
+            if !self.any_match {
+                self.write_path_record()?;
+            }
+        } else if self.opts.count {
+            if self.opts.prefix_filename {
+                self.out.write_all(self.display)?;
+                if self.opts.null_paths {
+                    self.out.write_all(b"\0")?;
+                } else {
+                    self.out.write_all(b":")?;
+                }
+            }
+            write!(self.out, "{}", self.match_count)?;
+            self.out.write_all(&[self.opts.record_terminator])?;
+            self.flush_record()?;
+        }
+        Ok(())
+    }
+}
+
+/// Search one input and return whether it contained a selected record.
+fn process_reader<M: Matcher, R: Read, W: Write>(
+    matcher: &M,
+    searcher: &mut Searcher,
+    reader: R,
+    display: &[u8],
+    opts: &Options,
+    out: &mut W,
+) -> io::Result<bool> {
+    let mut sink = GrepSink {
+        out,
+        matcher,
+        display,
+        opts,
+        match_count: 0,
+        any_match: false,
+        binary: false,
+    };
+    searcher.search_reader(matcher, reader, &mut sink)?;
+    Ok(sink.any_match)
+}
+
+fn display_path_for_operand(operand: &OsStr, resolved: &Path, path: &Path) -> PathBuf {
+    let rel = path.strip_prefix(resolved).unwrap_or(path);
+    if rel.as_os_str().is_empty() {
+        PathBuf::from(operand)
+    } else {
+        Path::new(operand).join(rel)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn search_file_path<M: Matcher, W: Write>(
+    operand: &OsStr,
+    resolved: &Path,
+    path: &Path,
+    matcher: &M,
+    searcher: &mut Searcher,
+    opts: &Options,
+    out: &mut W,
+    had_error: &mut bool,
+) -> bool {
+    let display_path = display_path_for_operand(operand, resolved, path);
+    match File::open(path) {
+        Ok(file) => {
+            let display = display_path.as_os_str().as_encoded_bytes();
+            match process_reader(matcher, searcher, file, display, opts, out) {
+                Ok(matched) => matched,
+                Err(error) => {
+                    *had_error = true;
+                    if !opts.no_messages {
+                        let _ = writeln!(
+                            pi_uutils_ctx::stderr(),
+                            "grep: {}: {error}",
+                            display_path.to_string_lossy()
+                        );
+                    }
+                    false
+                }
+            }
+        }
+        Err(error) => {
+            *had_error = true;
+            if !opts.no_messages {
+                let _ = writeln!(
+                    pi_uutils_ctx::stderr(),
+                    "grep: {}: {error}",
+                    display_path.to_string_lossy()
+                );
+            }
+            false
+        }
+    }
+}
+
+fn grep_walk_request(root: &Path, follow_links: pi_walker::FollowLinks) -> pi_walker::WalkRequest {
+    pi_walker::WalkRequest::new(root)
+        .hidden(true)
+        .gitignore(false)
+        .skip_git(false)
+        .skip_node_modules(false)
+        .follow_links(follow_links)
+        .detail(pi_walker::WalkDetail::Minimal)
+        .order(pi_walker::WalkOrder::Unordered)
+        .emit_root(true)
+        .depth(0, usize::MAX)
+        .visit_order(pi_walker::VisitOrder::PreOrder)
+        .directory_errors(pi_walker::DirectoryErrorMode::Visit)
+        .same_file_system(false)
+        .cache(false)
+        .filter(pi_walker::WalkFilter::all())
+}
+
+/// Recursively search a directory operand while pruning excluded directories.
+#[allow(clippy::too_many_arguments)]
+fn search_dir<M: Matcher, W: Write>(
+    operand: &OsStr,
+    resolved: &Path,
+    matcher: &M,
+    searcher: &mut Searcher,
+    opts: &Options,
+    rules: &PathRules,
+    follow_links: pi_walker::FollowLinks,
+    out: &mut W,
+    had_error: &mut bool,
+) -> bool {
+    let request = grep_walk_request(resolved, follow_links);
+    let mut any = false;
+    let had_error_state = std::cell::Cell::new(*had_error);
+    let walk = request.for_each_entry_with_heartbeat(
+        || {
+            if pi_uutils_ctx::is_cancelled() {
+                Err(io::Error::from(io::ErrorKind::Interrupted))
+            } else {
+                Ok::<(), io::Error>(())
+            }
+        },
+        |entry: pi_walker::EntryMeta<'_>| {
+            if opts.quiet && any {
+                return Ok(pi_walker::WalkDecision::Stop);
+            }
+            if entry.file_type == pi_walker::FileType::Dir {
+                if entry.depth > 0 && !rules.allows_dir(Path::new(entry.relative_path)) {
+                    return Ok(pi_walker::WalkDecision::SkipDescend);
+                }
+                return Ok(pi_walker::WalkDecision::Include);
+            }
+            if entry.file_type != pi_walker::FileType::File
+                || !rules.allows_file(Path::new(entry.relative_path))
+            {
+                return Ok(pi_walker::WalkDecision::Skip);
+            }
+            let mut entry_had_error = had_error_state.get();
+            let matched = search_file_path(
+                operand,
+                resolved,
+                entry.absolute_path.as_ref(),
+                matcher,
+                searcher,
+                opts,
+                out,
+                &mut entry_had_error,
+            );
+            had_error_state.set(entry_had_error);
+            any |= matched;
+            if opts.quiet && any {
+                Ok(pi_walker::WalkDecision::Stop)
+            } else {
+                Ok(pi_walker::WalkDecision::Include)
+            }
+        },
+        |error: pi_walker::DirectoryError<'_>| {
+            had_error_state.set(true);
+            if !opts.no_messages {
+                let display_path = display_path_for_operand(operand, resolved, error.path);
+                let _ = writeln!(
+                    pi_uutils_ctx::stderr(),
+                    "grep: {}: {}",
+                    display_path.to_string_lossy(),
+                    error.error
+                );
+            }
+            Ok(pi_walker::WalkDecision::Include)
+        },
+    );
+    *had_error |= had_error_state.get();
+    match walk {
+        Ok(pi_walker::WalkStatus::Complete | pi_walker::WalkStatus::Stopped) => any,
+        Err(pi_walker::WalkError::Interrupted(_)) if pi_uutils_ctx::is_cancelled() => {
+            // The shell wrapper owns the user-visible cancellation status.
+            *had_error = true;
+            any
+        }
+        Err(pi_walker::WalkError::Interrupted(error)) => {
+            *had_error = true;
+            if !opts.no_messages {
+                let _ = writeln!(pi_uutils_ctx::stderr(), "grep: {error}");
+            }
+            any
+        }
+        Err(pi_walker::WalkError::InvalidData { path, message }) => {
+            *had_error = true;
+            if !opts.no_messages {
+                let display_path = display_path_for_operand(operand, resolved, &path);
+                let _ = writeln!(
+                    pi_uutils_ctx::stderr(),
+                    "grep: {}: {message}",
+                    display_path.to_string_lossy()
+                );
+            }
+            any
+        }
+    }
+}
+
+fn read_auxiliary_file(path: &OsStr) -> Result<Vec<u8>, String> {
+    let mut bytes = Vec::new();
+    let result = if path == OsStr::new("-") {
+        pi_uutils_ctx::stdin().read_to_end(&mut bytes)
+    } else {
+        File::open(pi_uutils_ctx::resolve(path)).and_then(|mut file| file.read_to_end(&mut bytes))
+    };
+    result
+        .map(|_| bytes)
+        .map_err(|error| format!("{}: {error}", path.to_string_lossy()))
+}
+
+fn pattern_file_lines(bytes: &[u8]) -> Vec<String> {
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(bytes)
+        .split_terminator('\n')
+        .map(str::to_owned)
+        .collect()
+}
+
+fn resolve_patterns(cli: &Cli) -> Result<(Vec<String>, Vec<OsString>), String> {
+    let has_explicit_patterns = !cli.patterns.is_empty() || !cli.pattern_files.is_empty();
+    let mut patterns = Vec::new();
+    let mut files = Vec::new();
+
+    if has_explicit_patterns {
+        for pattern in &cli.patterns {
+            patterns.extend(pattern.split('\n').map(str::to_owned));
+        }
+        for path in &cli.pattern_files {
+            patterns.extend(pattern_file_lines(&read_auxiliary_file(path)?));
+        }
+        files.clone_from(&cli.args);
+        return Ok((patterns, files));
+    }
+
+    let mut args = cli.args.iter();
+    let Some(pattern) = args.next() else {
+        return Err("no pattern given\nUsage: grep [OPTION]... PATTERN [FILE]...".to_owned());
+    };
+    patterns.extend(pattern.to_string_lossy().split('\n').map(str::to_owned));
+    files.extend(args.cloned());
+    Ok((patterns, files))
+}
+
+fn collect_rule_specs(
+    cli: &Cli,
+    matches: &ArgMatches,
+) -> Result<(Vec<RuleSpec>, Vec<RuleSpec>), String> {
+    let mut files = Vec::new();
+    if let Some(indices) = matches.indices_of("include") {
+        for (index, pattern) in indices.zip(&cli.include) {
+            files.push(RuleSpec {
+                index,
+                include: true,
+                pattern: pattern.clone(),
+            });
+        }
+    }
+    if let Some(indices) = matches.indices_of("exclude") {
+        for (index, pattern) in indices.zip(&cli.exclude) {
+            files.push(RuleSpec {
+                index,
+                include: false,
+                pattern: pattern.clone(),
+            });
+        }
+    }
+    if let Some(indices) = matches.indices_of("exclude_from") {
+        for (index, path) in indices.zip(&cli.exclude_from) {
+            for pattern in pattern_file_lines(&read_auxiliary_file(path)?) {
+                files.push(RuleSpec {
+                    index,
+                    include: false,
+                    pattern,
+                });
+            }
+        }
+    }
+
+    let mut dirs = Vec::new();
+    if let Some(indices) = matches.indices_of("include_dir") {
+        for (index, pattern) in indices.zip(&cli.include_dir) {
+            dirs.push(RuleSpec {
+                index,
+                include: true,
+                pattern: pattern.clone(),
+            });
+        }
+    }
+    if let Some(indices) = matches.indices_of("exclude_dir") {
+        for (index, pattern) in indices.zip(&cli.exclude_dir) {
+            dirs.push(RuleSpec {
+                index,
+                include: false,
+                pattern: pattern.clone(),
+            });
+        }
+    }
+    Ok((files, dirs))
+}
+
+fn compile_rules(mut specs: Vec<RuleSpec>) -> Result<Vec<PathRule>, String> {
+    specs.sort_by_key(|spec| spec.index);
+    specs
+        .into_iter()
+        .map(|spec| {
+            Glob::new(&spec.pattern)
+                .map(|glob| PathRule {
+                    include: spec.include,
+                    matcher: glob.compile_matcher(),
+                })
+                .map_err(|error| format!("{}: {error}", spec.pattern))
+        })
+        .collect()
+}
+
+fn build_path_rules(cli: &Cli, matches: &ArgMatches) -> Result<PathRules, String> {
+    let (files, dirs) = collect_rule_specs(cli, matches)?;
+    Ok(PathRules {
+        files: compile_rules(files)?,
+        dirs: compile_rules(dirs)?,
+    })
+}
+
+fn build_searcher(cli: &Cli, opts: &Options, max_count: Option<u64>) -> Searcher {
+    let binary_detection = if cli.null_data || opts.binary_files == BinaryFiles::Text {
+        BinaryDetection::none()
+    } else if opts.binary_files == BinaryFiles::WithoutMatch {
+        BinaryDetection::quit(b'\0')
+    } else {
+        BinaryDetection::convert(b'\0')
+    };
+    let mut builder = SearcherBuilder::new();
+    builder
+        .line_number(opts.line_number)
+        .before_context(opts.before)
+        .after_context(opts.after)
+        .invert_match(cli.invert)
+        .binary_detection(binary_detection)
+        .max_matches(max_count);
+    if cli.null_data {
+        builder.line_terminator(LineTerminator::byte(b'\0'));
+    }
+    builder.build()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_search<M: Matcher>(
+    cli: &Cli,
+    matcher: &M,
+    files: &[OsString],
+    directory_action: DirectoryAction,
+    follow_links: pi_walker::FollowLinks,
+    rules: &PathRules,
+    opts: &Options,
+    max_count: Option<u64>,
+) -> i32 {
+    let mut searcher = build_searcher(cli, opts, max_count);
+    let mut out = BufWriter::new(pi_uutils_ctx::stdout());
+    let mut any_match = false;
+    let mut had_error = false;
+    let mut processed_operand = false;
+
+    for operand in files {
+        if opts.quiet && any_match {
+            break;
+        }
+        if processed_operand && pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+        processed_operand = true;
+
+        if operand == OsStr::new("-") {
+            let display = cli
+                .label
+                .as_deref()
+                .unwrap_or_else(|| OsStr::new("(standard input)"))
+                .as_encoded_bytes();
+            match process_reader(
+                matcher,
+                &mut searcher,
+                pi_uutils_ctx::stdin(),
+                display,
+                opts,
+                &mut out,
+            ) {
+                Ok(matched) => any_match |= matched,
+                Err(error) => {
+                    had_error = true;
+                    if !opts.no_messages {
+                        let _ =
+                            writeln!(pi_uutils_ctx::stderr(), "grep: (standard input): {error}");
+                    }
+                }
+            }
+            if pi_uutils_ctx::is_cancelled() {
+                had_error = true;
+                break;
+            }
+            continue;
+        }
+
+        let resolved = pi_uutils_ctx::resolve(operand);
+        match std::fs::metadata(&resolved) {
+            Ok(metadata) if metadata.is_dir() => match directory_action {
+                DirectoryAction::Recurse => {
+                    if rules.allows_dir(Path::new(operand))
+                        && search_dir(
+                            operand.as_os_str(),
+                            &resolved,
+                            matcher,
+                            &mut searcher,
+                            opts,
+                            rules,
+                            follow_links,
+                            &mut out,
+                            &mut had_error,
+                        )
+                    {
+                        any_match = true;
+                    }
+                }
+                DirectoryAction::Skip => {}
+                DirectoryAction::Read => {
+                    had_error = true;
+                    let _ = writeln!(
+                        pi_uutils_ctx::stderr(),
+                        "grep: {}: Is a directory",
+                        operand.to_string_lossy()
+                    );
+                }
+            },
+            Ok(metadata) => {
+                if cli.devices == Some(DeviceAction::Skip) && !metadata.is_file() {
+                    continue;
+                }
+                if !rules.allows_file(Path::new(operand)) {
+                    continue;
+                }
+                if search_file_path(
+                    operand.as_os_str(),
+                    &resolved,
+                    &resolved,
+                    matcher,
+                    &mut searcher,
+                    opts,
+                    &mut out,
+                    &mut had_error,
+                ) {
+                    any_match = true;
+                }
+            }
+            Err(error) => {
+                had_error = true;
+                if !opts.no_messages {
+                    let _ = writeln!(
+                        pi_uutils_ctx::stderr(),
+                        "grep: {}: {error}",
+                        operand.to_string_lossy()
+                    );
+                }
+            }
+        }
+        if pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+    }
+
+    let _ = out.flush();
+    if opts.quiet {
+        if any_match {
+            0
+        } else if had_error {
+            2
+        } else {
+            1
+        }
+    } else if had_error {
+        2
+    } else if any_match {
+        0
+    } else {
+        1
+    }
+}
+
+fn report_clap_error(error: clap::Error) -> i32 {
+    let rendered = error.to_string();
+    if error.use_stderr() {
+        let _ = write!(pi_uutils_ctx::stderr(), "{rendered}");
+        2
+    } else {
+        let _ = write!(pi_uutils_ctx::stdout(), "{rendered}");
+        0
+    }
+}
+
+/// Runs the in-process grep builtin and returns a GNU-compatible exit code.
+pub fn run(argv: Vec<OsString>) -> i32 {
+    let matches = match Cli::command().try_get_matches_from(normalize_context_args(argv)) {
+        Ok(matches) => matches,
+        Err(error) => return report_clap_error(error),
+    };
+    let cli = match Cli::from_arg_matches(&matches) {
+        Ok(cli) => cli,
+        Err(error) => return report_clap_error(error),
+    };
+
+    let (mut patterns, mut files) = match resolve_patterns(&cli) {
+        Ok(resolved) => resolved,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "grep: {error}");
+            return 2;
+        }
+    };
+    let directory_action = resolve_directory_action(&cli, &matches);
+    if files.is_empty() {
+        files.push(OsString::from(
+            if directory_action == DirectoryAction::Recurse {
+                "."
+            } else {
+                "-"
+            },
+        ));
+    }
+
+    let max_count = match resolve_max_count(&cli) {
+        Ok(max_count) => max_count,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "grep: {error}");
+            return 2;
+        }
+    };
+    let rules = match build_path_rules(&cli, &matches) {
+        Ok(rules) => rules,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "grep: {error}");
+            return 2;
+        }
+    };
+    let matcher = match build_matcher(
+        &patterns,
+        &cli,
+        resolve_match_mode(&matches),
+        resolve_ignore_case(&matches),
+    ) {
+        Ok(matcher) => matcher,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "grep: {error}");
+            return 2;
+        }
+    };
+    patterns.clear();
+
+    let (files_with_matches, files_without_match) = resolve_file_list_modes(&matches);
+    let suppress_context =
+        cli.count || files_with_matches || files_without_match || cli.quiet || cli.only_matching;
+    let (before, after) = if suppress_context {
+        (0, 0)
+    } else {
+        resolve_context(&cli, &matches)
+    };
+    let prefix_filename = resolve_filename_prefix(&matches)
+        .unwrap_or(directory_action == DirectoryAction::Recurse || files.len() > 1);
+    let opts = Options {
+        line_number: cli.line_number,
+        byte_offset: cli.byte_offset,
+        count: cli.count,
+        files_with_matches,
+        files_without_match,
+        only_matching: cli.only_matching,
+        before,
+        after,
+        no_messages: cli.no_messages,
+        quiet: cli.quiet,
+        prefix_filename,
+        initial_tab: cli.initial_tab,
+        null_paths: cli.null_paths,
+        record_terminator: if cli.null_data { b'\0' } else { b'\n' },
+        group_separator: resolve_group_separator(&cli, &matches),
+        line_buffered: cli.line_buffered,
+        binary_files: resolve_binary_files(&cli, &matches),
+    };
+    let follow_links = resolve_follow_links(&cli, &matches);
+
+    match matcher {
+        CompiledMatcher::Rust(matcher) => execute_search(
+            &cli,
+            &matcher,
+            &files,
+            directory_action,
+            follow_links,
+            &rules,
+            &opts,
+            max_count,
+        ),
+        CompiledMatcher::Pcre(matcher) => execute_search(
+            &cli,
+            &matcher,
+            &files,
+            directory_action,
+            follow_links,
+            &rules,
+            &opts,
+            max_count,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        io::Cursor,
+        sync::{Arc, atomic::AtomicBool},
+    };
+
+    use parking_lot::Mutex;
+    use pi_uutils_ctx::{ScopeIo, scope};
+
+    use super::*;
+
+    /// Sink that collects writes into a shared buffer for assertions.
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Run the `grep` builtin with `args` (no argv[0]) over `stdin`, returning
+    /// `(exit_code, stdout, stderr)`.
+    fn run_grep(args: &[&str], stdin: &str) -> (i32, String, String) {
+        run_grep_in(args, stdin, &std::env::temp_dir())
+    }
+
+    fn run_grep_in(args: &[&str], stdin: &str, cwd: &Path) -> (i32, String, String) {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let err = Arc::new(Mutex::new(Vec::new()));
+        let io = ScopeIo {
+            stdin: Box::new(Cursor::new(stdin.as_bytes().to_vec())),
+            stdin_fd: None,
+            stdin_is_search_input: true,
+            stdout: Box::new(SharedBuf(Arc::clone(&out))),
+            stderr: Box::new(SharedBuf(Arc::clone(&err))),
+            cwd: cwd.to_path_buf(),
+            env: HashMap::new(),
+            cancel: Arc::new(AtomicBool::new(false)),
+        };
+        let argv: Vec<OsString> = std::iter::once("grep")
+            .chain(args.iter().copied())
+            .map(OsString::from)
+            .collect();
+        let code = scope(io, || run(argv));
+        let stdout = String::from_utf8(out.lock().clone()).expect("utf8 stdout");
+        let stderr = String::from_utf8(err.lock().clone()).expect("utf8 stderr");
+        (code, stdout, stderr)
+    }
+
+    fn unique_tree(label: &str) -> PathBuf {
+        let tree = std::env::temp_dir().join(format!(
+            "pi-uu-grep-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&tree).expect("temp tree should be created");
+        tree
+    }
+
+    #[test]
+    fn max_count_accepts_compact_and_long_values() {
+        for option in ["-m1", "--max-count=1"] {
+            let (code, stdout, stderr) = run_grep(&[option, "hit"], "hit\nmiss\nhit\n");
+            assert_eq!(code, 0, "{option}: {stderr}");
+            assert_eq!(stdout, "hit\n", "{option}");
+        }
+
+        let (code, stdout, stderr) = run_grep(&["-m0", "hit"], "hit\n");
+        assert_eq!(code, 1, "{stderr}");
+        assert!(stdout.is_empty());
+    }
+
+    #[test]
+    fn pattern_file_combines_patterns_without_consuming_a_file_operand() {
+        let tree = unique_tree("patterns");
+        std::fs::write(tree.join("patterns"), "alpha\nbeta\n").expect("pattern file written");
+        std::fs::write(tree.join("haystack"), "alpha\ngamma\nbeta\n").expect("haystack written");
+
+        let (code, stdout, stderr) = run_grep_in(&["-f", "patterns", "haystack"], "", &tree);
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "alpha\nbeta\n");
+
+        let _ = std::fs::remove_dir_all(tree);
+    }
+
+    #[test]
+    fn perl_mode_supports_lookbehind() {
+        let (code, stdout, stderr) = run_grep(&["-P", "(?<=foo)bar"], "foobar\nbar\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "foobar\n");
+    }
+
+    #[test]
+    fn byte_offsets_labels_and_nul_filename_separators_are_rendered() {
+        let (code, stdout, stderr) = run_grep(&["-bn", "hit"], "no\nhit\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "2:3:hit\n");
+
+        let (code, stdout, stderr) = run_grep(&["--label=pipe", "-HZ", "hit"], "hit\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout.as_bytes(), b"pipe\0hit\n");
+    }
+
+    #[test]
+    fn numeric_context_uses_the_configured_group_separator() {
+        let input = "a\nhit\nb\ngap\nc\nhit\nd\n";
+        let (code, stdout, stderr) = run_grep(&["-1", "--group-separator=@", "hit"], input);
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "a\nhit\nb\n@\nc\nhit\nd\n");
+    }
+
+    #[test]
+    fn recursive_include_and_exclude_dir_rules_filter_the_walk() {
+        let tree = unique_tree("filters");
+        std::fs::write(tree.join("keep.rs"), "hit\n").expect("included file written");
+        std::fs::write(tree.join("drop.txt"), "hit\n").expect("excluded file written");
+        std::fs::create_dir(tree.join("vendor")).expect("excluded directory created");
+        std::fs::write(tree.join("vendor/hidden.rs"), "hit\n").expect("excluded file written");
+
+        let (code, stdout, stderr) = run_grep_in(
+            &["-r", "--include=*.rs", "--exclude-dir=vendor", "hit", "."],
+            "",
+            &tree,
+        );
+        assert_eq!(code, 0, "{stderr}");
+        assert!(stdout.contains("keep.rs:hit"), "{stdout:?}");
+        assert!(!stdout.contains("drop.txt"), "{stdout:?}");
+        assert!(!stdout.contains("hidden.rs"), "{stdout:?}");
+
+        let _ = std::fs::remove_dir_all(tree);
+    }
+
+    #[test]
+    fn unbalanced_paren_pattern_matches_literally() {
+        // Regression: `grep "fail)"` used to abort with `regex parse error:
+        // unopened group`. It must now match the literal text and exit 0.
+        let (code, stdout, stderr) = run_grep(&["-A", "1", "fail)"], "ok\n(1 fail)\nnext\n");
+        assert_eq!(code, 0, "stderr: {stderr}");
+        assert!(stderr.is_empty(), "no error expected, got: {stderr}");
+        assert!(
+            stdout.contains("(1 fail)"),
+            "matched line missing: {stdout}"
+        );
+        assert!(
+            stdout.contains("next"),
+            "after-context line missing: {stdout}"
+        );
+    }
+
+    #[test]
+    fn extended_flag_reports_parse_error() {
+        // -E opts into strict extended-regex syntax: the bad pattern is an error.
+        let (code, _stdout, stderr) = run_grep(&["-E", "fail)"], "fail)\n");
+        assert_eq!(code, 2);
+        assert!(
+            stderr.contains("grep:"),
+            "expected a grep error, got: {stderr}"
+        );
+    }
+
+    #[test]
+    fn valid_regex_still_applies() {
+        // A parseable pattern is used as a regex, not matched literally.
+        let (code, stdout, _err) = run_grep(&["fo+"], "foooo\nbar\n");
+        assert_eq!(code, 0);
+        assert!(stdout.contains("foooo"));
+        assert!(!stdout.contains("bar"));
+    }
+
+    #[test]
+    fn default_mode_supports_gnu_basic_alternation() {
+        let input = "\"tools.xdev\": {}\n\"tools.toolbox\": {}\n\"tools.other\": {}\n";
+        let (code, stdout, stderr) = run_grep(&["-c", r"tools.xdev\|tools.toolbox"], input);
+
+        assert_eq!(code, 0, "{stderr}");
+        assert!(stderr.is_empty(), "{stderr}");
+        assert_eq!(stdout, "2\n");
+    }
+
+    #[test]
+    fn multi_pattern_keeps_valid_alternative_as_regex() {
+        // Per-pattern fallback: valid `fo+` stays a regex while `bar)` is escaped.
+        let (code, stdout, err) =
+            run_grep(&["-e", "fo+", "-e", "bar)", "-h"], "foooo\nbar)\nbaz\n");
+        assert_eq!(code, 0, "stderr: {err}");
+        assert!(
+            stdout.contains("foooo"),
+            "regex alternative should match: {stdout}"
+        );
+        assert!(
+            stdout.contains("bar)"),
+            "literal alternative should match: {stdout}"
+        );
+        assert!(
+            !stdout.contains("baz"),
+            "non-matching line leaked: {stdout}"
+        );
+    }
+
+    #[test]
+    fn color_flag_is_accepted_and_ignored() {
+        // Regression for #3755: the universal `alias grep='grep --color=auto'`
+        // must not break bare `grep` in shell pipelines.
+        for color in [
+            "--color=auto",
+            "--color=always",
+            "--color=never",
+            "--color",
+            "--colour=auto",
+        ] {
+            let (code, stdout, stderr) = run_grep(&[color, "foo"], "foo\nbar\n");
+            assert_eq!(code, 0, "{color}: stderr: {stderr}");
+            assert!(stderr.is_empty(), "{color}: unexpected stderr: {stderr}");
+            assert_eq!(stdout, "foo\n", "{color}: matched lines: {stdout:?}");
+        }
+    }
+
+    #[test]
+    fn version_flag_prints_and_exits_zero() {
+        // `grep --version` is the universal probe shells run; the builtin must
+        // not reject it with exit 2.
+        let (code, stdout, stderr) = run_grep(&["--version"], "");
+        assert_eq!(code, 0, "stderr: {stderr}");
+        assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
+        assert!(
+            stdout.contains("grep") && stdout.contains("pi-uu-grep"),
+            "version output should identify the builtin, got: {stdout:?}"
+        );
+    }
+
+    /// Run `grep` with a pre-set cancel flag, mirroring how the shell wrapper
+    /// flips the flag when an abort/timeout fires while the blocking task is
+    /// still walking. Returns `(exit, stdout, stderr)`.
+    fn run_grep_cancelled(args: &[&str], cwd: &Path) -> (i32, String, String) {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let err = Arc::new(Mutex::new(Vec::new()));
+        let io = ScopeIo {
+            stdin: Box::new(io::empty()),
+            stdin_fd: None,
+            stdin_is_search_input: false,
+            stdout: Box::new(SharedBuf(Arc::clone(&out))),
+            stderr: Box::new(SharedBuf(Arc::clone(&err))),
+            cwd: cwd.to_path_buf(),
+            env: HashMap::new(),
+            cancel: Arc::new(AtomicBool::new(true)),
+        };
+        let argv: Vec<OsString> = std::iter::once("grep")
+            .chain(args.iter().copied())
+            .map(OsString::from)
+            .collect();
+        let code = scope(io, || run(argv));
+        let stdout = String::from_utf8(out.lock().clone()).expect("utf8 stdout");
+        let stderr = String::from_utf8(err.lock().clone()).expect("utf8 stderr");
+        (code, stdout, stderr)
+    }
+
+    #[test]
+    fn recursive_search_observes_scope_cancellation() {
+        // Regression for #3933: recursive grep used to pass a no-op heartbeat to
+        // pi_walker, so directory walks ignored the uutils cancel flag and the
+        // shell-side abort/timeout waited for the whole tree to be scanned.
+        // The walk must now bail out before scanning any file when the flag is
+        // already set, and it must do so without printing an "interrupted"
+        // diagnostic — the shell wrapper owns the user-visible status.
+        let tree = std::env::temp_dir().join(format!(
+            "pi-uu-grep-cancel-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&tree).expect("temp tree should be created");
+        let walk_root = tree.join("walk-root");
+        std::fs::create_dir_all(&walk_root).expect("walk root should be created");
+        std::fs::write(walk_root.join("haystack.txt"), "match-me\n")
+            .expect("walked file should be written");
+        let later_file = tree.join("later.txt");
+        std::fs::write(&later_file, "match-me\n").expect("later file should be written");
+
+        let (code, stdout, stderr) = run_grep_cancelled(
+            &[
+                "-r",
+                "match-me",
+                walk_root.to_str().expect("utf8 path"),
+                later_file.to_str().expect("utf8 path"),
+            ],
+            &tree,
+        );
+
+        // Walker must have observed the heartbeat before visiting the file,
+        // and the operand loop must not continue into the later regular file
+        // after cancellation is observed.
+        assert!(
+            stdout.is_empty(),
+            "cancelled walk should not output matches: {stdout:?}"
+        );
+        assert!(
+            stderr.is_empty(),
+            "cancelled walk should stay silent — diagnostic is the shell's job: {stderr:?}"
+        );
+        assert_eq!(
+            code, 2,
+            "interrupted directory walk should report had_error (exit 2)"
+        );
+
+        let _ = std::fs::remove_dir_all(&tree);
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-uu-grep/src/rg.rs
+++ b/crates/vendor/oh-my-pi/pi-uu-grep/src/rg.rs
@@ -1,0 +1,2174 @@
+//! `rg` implemented as an in-process shell builtin on top of the ripgrep
+//! libraries, with ripgrep defaults: recursive directory search, ignore/hidden
+//! filtering, and binary-file suppression.
+
+use std::{
+    ffi::{OsStr, OsString},
+    fs::File,
+    io::{self, BufWriter, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use clap::{ArgAction, Parser, ValueEnum};
+use grep_cli::DecompressionReaderBuilder;
+use grep_matcher::{Captures, LineTerminator, Matcher};
+use grep_pcre2::{RegexMatcher as PcreMatcher, RegexMatcherBuilder as PcreMatcherBuilder};
+use grep_printer::{JSONBuilder, Stats};
+use grep_regex::{RegexMatcher, RegexMatcherBuilder};
+use grep_searcher::{
+    BinaryDetection, Encoding, Searcher, SearcherBuilder, Sink, SinkContext, SinkFinish, SinkMatch,
+};
+use ignore::{
+    Match,
+    gitignore::{Gitignore, GitignoreBuilder},
+    overrides::{Override, OverrideBuilder},
+    types::{Types, TypesBuilder},
+};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rg",
+    version = "15.1.0",
+    author = "Andrew Gallant <jamslam@gmail.com>",
+    about = "ripgrep recursively searches the current directory for lines matching a regex pattern.",
+    args_override_self = true
+)]
+struct RgCli {
+    /// A pattern to search for. May be repeated.
+    #[arg(short = 'e', long = "regexp", value_name = "PATTERN")]
+    patterns: Vec<String>,
+
+    /// Read patterns from a file, one pattern per line.
+    #[arg(short = 'f', long = "file", value_name = "PATTERNFILE")]
+    pattern_files: Vec<OsString>,
+
+    /// Search supported compressed files through external decompressors.
+    #[arg(short = 'z', long = "search-zip", overrides_with = "no_search_zip")]
+    search_zip: bool,
+
+    /// Disable compressed-file searching.
+    #[arg(long = "no-search-zip", overrides_with = "search_zip")]
+    no_search_zip: bool,
+
+    /// Select the regular expression engine.
+    #[arg(
+		long = "engine",
+		value_name = "ENGINE",
+		overrides_with_all = ["pcre2", "no_pcre2"]
+	)]
+    engine: Option<RegexEngine>,
+
+    /// Use the PCRE2 regular expression engine.
+    #[arg(
+		short = 'P',
+		long = "pcre2",
+		overrides_with_all = ["engine", "no_pcre2"]
+	)]
+    pcre2: bool,
+
+    /// Restore the default regular expression engine.
+    #[arg(long = "no-pcre2", overrides_with_all = ["engine", "pcre2"])]
+    no_pcre2: bool,
+
+    /// Decode input using ENCODING before searching.
+    #[arg(
+        short = 'E',
+        long = "encoding",
+        value_name = "ENCODING",
+        overrides_with = "no_encoding"
+    )]
+    encoding: Option<String>,
+
+    /// Restore automatic BOM-based encoding detection.
+    #[arg(long = "no-encoding", overrides_with = "encoding")]
+    no_encoding: bool,
+
+    /// Treat CRLF as a single line terminator.
+    #[arg(long = "crlf", overrides_with = "no_crlf")]
+    crlf: bool,
+
+    /// Restore LF line terminators.
+    #[arg(long = "no-crlf", overrides_with = "crlf")]
+    no_crlf: bool,
+
+    /// Disable Unicode regex mode.
+    #[arg(long = "no-unicode", overrides_with = "unicode")]
+    no_unicode: bool,
+
+    /// Enable Unicode regex mode.
+    #[arg(long = "unicode", overrides_with = "no_unicode", hide = true)]
+    unicode: bool,
+
+    /// Treat patterns as literals instead of regular expressions.
+    #[arg(short = 'F', long = "fixed-strings")]
+    fixed_strings: bool,
+
+    /// Re-enable regex parsing after --fixed-strings.
+    #[arg(long = "no-fixed-strings")]
+    no_fixed_strings: bool,
+
+    /// Search case-insensitively.
+    #[arg(short = 'i', long = "ignore-case")]
+    ignore_case: bool,
+
+    /// Search case-sensitively.
+    #[arg(short = 's', long = "case-sensitive")]
+    case_sensitive: bool,
+
+    /// Search case-insensitively when the pattern is all lowercase.
+    #[arg(short = 'S', long = "smart-case")]
+    smart_case: bool,
+
+    /// Invert matching.
+    #[arg(short = 'v', long = "invert-match")]
+    invert_match: bool,
+
+    /// Match only whole words.
+    #[arg(short = 'w', long = "word-regexp")]
+    word_regexp: bool,
+
+    /// Match only whole lines.
+    #[arg(short = 'x', long = "line-regexp")]
+    line_regexp: bool,
+
+    /// Limit matching lines per searched file.
+    #[arg(short = 'm', long = "max-count", value_name = "NUM")]
+    max_count: Option<u64>,
+
+    /// Enable multiline search.
+    #[arg(short = 'U', long = "multiline")]
+    multiline: bool,
+
+    /// Make . match line terminators in multiline mode.
+    #[arg(long = "multiline-dotall")]
+    multiline_dotall: bool,
+
+    /// Search binary files as text.
+    #[arg(short = 'a', long = "text")]
+    text: bool,
+
+    /// Search binary files.
+    #[arg(long = "binary")]
+    binary: bool,
+
+    /// Reduce smart filtering. Repeating includes hidden and binary files.
+    #[arg(short = 'u', long = "unrestricted", action = ArgAction::Count)]
+    unrestricted: u8,
+
+    /// Follow symbolic links.
+    #[arg(short = 'L', long = "follow", overrides_with = "no_follow")]
+    follow: bool,
+
+    /// Do not follow symbolic links.
+    #[arg(long = "no-follow", overrides_with = "follow")]
+    no_follow: bool,
+
+    /// Apply -g/--glob patterns case insensitively.
+    #[arg(
+        long = "glob-case-insensitive",
+        overrides_with = "no_glob_case_insensitive"
+    )]
+    glob_case_insensitive: bool,
+
+    /// Restore case-sensitive -g/--glob matching.
+    #[arg(
+        long = "no-glob-case-insensitive",
+        overrides_with = "glob_case_insensitive",
+        hide = true
+    )]
+    no_glob_case_insensitive: bool,
+
+    /// Include or exclude paths with a gitignore-style glob.
+    #[arg(short = 'g', long = "glob", value_name = "GLOB")]
+    globs: Vec<String>,
+
+    /// Case-insensitive include/exclude glob.
+    #[arg(long = "iglob", value_name = "GLOB")]
+    iglobs: Vec<String>,
+
+    /// Search hidden files and directories.
+    #[arg(short = '.', long = "hidden")]
+    hidden: bool,
+
+    /// Do not search hidden files and directories.
+    #[arg(long = "no-hidden")]
+    no_hidden: bool,
+
+    /// Ignore .gitignore, .ignore and .rgignore files.
+    #[arg(long = "no-ignore")]
+    no_ignore: bool,
+
+    /// Respect ignore files.
+    #[arg(long = "ignore")]
+    ignore: bool,
+
+    /// Apply additional gitignore-formatted rules from PATH.
+    #[arg(long = "ignore-file", value_name = "PATH")]
+    ignore_files: Vec<OsString>,
+
+    /// Ignore .ignore and .rgignore files.
+    #[arg(long = "no-ignore-dot")]
+    no_ignore_dot: bool,
+
+    /// Respect .ignore and .rgignore files.
+    #[arg(long = "ignore-dot")]
+    ignore_dot: bool,
+
+    /// Ignore repository exclude files.
+    #[arg(long = "no-ignore-exclude")]
+    no_ignore_exclude: bool,
+
+    /// Respect repository exclude files.
+    #[arg(long = "ignore-exclude")]
+    ignore_exclude: bool,
+
+    /// Ignore global gitignore files.
+    #[arg(long = "no-ignore-global")]
+    no_ignore_global: bool,
+
+    /// Respect global gitignore files.
+    #[arg(long = "ignore-global")]
+    ignore_global: bool,
+
+    /// Ignore parent ignore files.
+    #[arg(long = "no-ignore-parent")]
+    no_ignore_parent: bool,
+
+    /// Respect parent ignore files.
+    #[arg(long = "ignore-parent")]
+    ignore_parent: bool,
+
+    /// Ignore VCS ignore files.
+    #[arg(long = "no-ignore-vcs")]
+    no_ignore_vcs: bool,
+
+    /// Respect VCS ignore files.
+    #[arg(long = "ignore-vcs")]
+    ignore_vcs: bool,
+
+    /// Respect VCS ignores even outside a repository.
+    #[arg(long = "no-require-git")]
+    no_require_git: bool,
+
+    /// Require a repository for VCS ignore files.
+    #[arg(long = "require-git")]
+    require_git: bool,
+
+    /// Do not cross filesystem boundaries while traversing a root.
+    #[arg(long = "one-file-system", overrides_with = "no_one_file_system")]
+    one_file_system: bool,
+
+    /// Permit traversal across filesystem boundaries.
+    #[arg(
+        long = "no-one-file-system",
+        overrides_with = "one_file_system",
+        hide = true
+    )]
+    no_one_file_system: bool,
+
+    /// Limit directory traversal depth.
+    #[arg(
+        short = 'd',
+        long = "max-depth",
+        alias = "maxdepth",
+        value_name = "NUM"
+    )]
+    max_depth: Option<usize>,
+
+    /// Ignore files larger than this size.
+    #[arg(long = "max-filesize", value_name = "NUM")]
+    max_filesize: Option<String>,
+
+    /// Search only files matching a type.
+    #[arg(short = 't', long = "type", value_name = "TYPE")]
+    types: Vec<String>,
+
+    /// Do not search files matching a type.
+    #[arg(short = 'T', long = "type-not", value_name = "TYPE")]
+    type_nots: Vec<String>,
+
+    /// Add a file type glob.
+    #[arg(long = "type-add", value_name = "TYPESPEC")]
+    type_adds: Vec<String>,
+
+    /// Clear a file type definition.
+    #[arg(long = "type-clear", value_name = "TYPE")]
+    type_clears: Vec<String>,
+
+    /// Show NUM lines after each match.
+    #[arg(short = 'A', long = "after-context", value_name = "NUM")]
+    after_context: Option<usize>,
+
+    /// Show NUM lines before each match.
+    #[arg(short = 'B', long = "before-context", value_name = "NUM")]
+    before_context: Option<usize>,
+
+    /// Show NUM lines before and after each match.
+    #[arg(short = 'C', long = "context", value_name = "NUM")]
+    context: Option<usize>,
+
+    /// Show line numbers.
+    #[arg(short = 'n', long = "line-number")]
+    line_number: bool,
+
+    /// Suppress line numbers.
+    #[arg(short = 'N', long = "no-line-number")]
+    no_line_number: bool,
+
+    /// Show column numbers.
+    #[arg(long = "column")]
+    column: bool,
+
+    /// Show the zero-based byte offset for each result.
+    #[arg(short = 'b', long = "byte-offset", overrides_with = "no_byte_offset")]
+    byte_offset: bool,
+
+    /// Suppress byte offsets.
+    #[arg(long = "no-byte-offset", overrides_with = "byte_offset", hide = true)]
+    no_byte_offset: bool,
+
+    /// Print file paths with matches.
+    #[arg(short = 'H', long = "with-filename")]
+    with_filename: bool,
+
+    /// Suppress file paths with matches.
+    #[arg(short = 'I', long = "no-filename")]
+    no_filename: bool,
+
+    /// Print only files containing matches.
+    #[arg(short = 'l', long = "files-with-matches")]
+    files_with_matches: bool,
+
+    /// Print only files containing no matches.
+    #[arg(long = "files-without-match")]
+    files_without_match: bool,
+
+    /// Print matching-line counts per file.
+    #[arg(short = 'c', long = "count")]
+    count: bool,
+
+    /// Print individual match counts per file.
+    #[arg(long = "count-matches")]
+    count_matches: bool,
+
+    /// Print only matching spans.
+    #[arg(short = 'o', long = "only-matching")]
+    only_matching: bool,
+
+    /// Replace each printed match with REPLACEMENT.
+    #[arg(short = 'r', long = "replace", value_name = "REPLACEMENT")]
+    replacement: Option<OsString>,
+
+    /// Emit ripgrep-compatible JSON Lines messages.
+    #[arg(long = "json", overrides_with = "no_json")]
+    json: bool,
+
+    /// Disable JSON Lines output.
+    #[arg(long = "no-json", overrides_with = "json", hide = true)]
+    no_json: bool,
+
+    /// Suppress normal output and exit on the first match.
+    #[arg(short = 'q', long = "quiet")]
+    quiet: bool,
+
+    /// Print every match in vimgrep format.
+    #[arg(long = "vimgrep")]
+    vimgrep: bool,
+
+    /// Print path names followed by NUL.
+    #[arg(short = '0', long = "null")]
+    null: bool,
+
+    /// Use NUL as a line terminator.
+    #[arg(long = "null-data")]
+    null_data: bool,
+
+    /// Flush output after every result record.
+    #[arg(long = "line-buffered", overrides_with = "no_line_buffered")]
+    line_buffered: bool,
+
+    /// Restore block-buffered output.
+    #[arg(
+        long = "no-line-buffered",
+        overrides_with = "line_buffered",
+        hide = true
+    )]
+    no_line_buffered: bool,
+
+    /// Print files that would be searched.
+    #[arg(long = "files")]
+    files: bool,
+
+    /// Print all supported file types.
+    #[arg(long = "type-list")]
+    type_list: bool,
+
+    /// Suppress file-open/read diagnostics.
+    #[arg(long = "no-messages")]
+    no_messages: bool,
+
+    /// Re-enable diagnostics.
+    #[arg(long = "messages")]
+    messages: bool,
+
+    /// Sort paths before searching.
+    #[arg(long = "sort", value_name = "SORTBY")]
+    sort: Option<String>,
+
+    /// Sort paths descending before searching.
+    #[arg(long = "sortr", value_name = "SORTBY")]
+    sortr: Option<String>,
+
+    /// Deprecated alias for --sort=path.
+    #[arg(long = "sort-files")]
+    sort_files: bool,
+
+    /// Disable --sort-files.
+    #[arg(long = "no-sort-files")]
+    no_sort_files: bool,
+
+    /// Print both matching and non-matching lines.
+    #[arg(long = "passthru", alias = "passthrough")]
+    passthru: bool,
+
+    /// Trim leading ASCII whitespace from printed lines.
+    #[arg(long = "trim")]
+    trim: bool,
+
+    /// Disable --trim.
+    #[arg(long = "no-trim")]
+    no_trim: bool,
+
+    /// Omit matching lines longer than this many bytes.
+    #[arg(short = 'M', long = "max-columns", value_name = "NUM")]
+    max_columns: Option<usize>,
+
+    /// Preview lines omitted by --max-columns.
+    #[arg(long = "max-columns-preview")]
+    max_columns_preview: bool,
+
+    /// Disable --max-columns-preview.
+    #[arg(long = "no-max-columns-preview")]
+    no_max_columns_preview: bool,
+
+    /// Disable colors (accepted for CLI compatibility; output is plain text).
+    #[arg(long = "color", value_name = "WHEN")]
+    _color: Option<String>,
+
+    /// Color style (accepted for CLI compatibility; output is plain text).
+    #[arg(long = "colors", value_name = "COLOR_SPEC")]
+    _colors: Vec<String>,
+
+    /// Heading mode (accepted; non-TTY builtin output remains grep-like).
+    #[arg(long = "heading")]
+    _heading: bool,
+
+    /// Disable heading mode.
+    #[arg(long = "no-heading")]
+    _no_heading: bool,
+
+    /// Pretty output alias (accepted; colors/headings are not emitted).
+    #[arg(short = 'p', long = "pretty")]
+    _pretty: bool,
+
+    /// Output aggregate stats (accepted; not emitted by this builtin).
+    #[arg(long = "stats")]
+    _stats: bool,
+
+    /// Disable aggregate stats.
+    #[arg(long = "no-stats")]
+    _no_stats: bool,
+
+    /// Arguments: PATTERN followed by PATHs unless -e/-f/--files is used.
+    #[arg(value_name = "ARGS")]
+    args: Vec<OsString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum RegexEngine {
+    Default,
+    Pcre2,
+    Auto,
+}
+
+enum CompiledMatcher {
+    Rust(RegexMatcher),
+    Pcre(PcreMatcher),
+}
+
+enum RgOutput {
+    Buffered(BufWriter<pi_uutils_ctx::CtxStdout>),
+    Direct(pi_uutils_ctx::CtxStdout),
+}
+
+impl Write for RgOutput {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Buffered(output) => output.write(bytes),
+            Self::Direct(output) => output.write(bytes),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Buffered(output) => output.flush(),
+            Self::Direct(output) => output.flush(),
+        }
+    }
+}
+
+struct SearchOptions {
+    line_number: bool,
+    column: bool,
+    byte_offset: bool,
+    count: bool,
+    count_matches: bool,
+    files_with_matches: bool,
+    files_without_match: bool,
+    only_matching: bool,
+    quiet: bool,
+    vimgrep: bool,
+    before: usize,
+    after: usize,
+    passthru: bool,
+    trim: bool,
+    max_columns: Option<usize>,
+    max_columns_preview: bool,
+    null_paths: bool,
+    no_messages: bool,
+    replacement: Option<Vec<u8>>,
+    json: bool,
+}
+
+struct SearchOutcome {
+    any_match: bool,
+    had_error: bool,
+}
+
+struct RgSink<'a, M: Matcher, W: Write> {
+    out: &'a mut W,
+    matcher: &'a M,
+    display: Option<&'a [u8]>,
+    opts: &'a SearchOptions,
+    captures: M::Captures,
+    scratch: Vec<u8>,
+    line_count: u64,
+    match_count: u64,
+    any_match: bool,
+}
+
+impl<M: Matcher, W: Write> RgSink<'_, M, W> {
+    fn write_path(&mut self) -> io::Result<()> {
+        if let Some(name) = self.display {
+            self.out.write_all(name)?;
+            if self.opts.null_paths {
+                self.out.write_all(b"\0")?;
+            }
+        }
+        Ok(())
+    }
+
+    fn write_prefix(
+        &mut self,
+        line_number: Option<u64>,
+        column: Option<usize>,
+        byte_offset: u64,
+        separator: u8,
+    ) -> io::Result<()> {
+        if self.display.is_some() {
+            self.write_path()?;
+            self.out.write_all(&[separator])?;
+        }
+        if self.opts.line_number
+            && let Some(number) = line_number
+        {
+            write!(self.out, "{number}")?;
+            self.out.write_all(&[separator])?;
+        }
+        if self.opts.column {
+            write!(self.out, "{}", column.unwrap_or(1))?;
+            self.out.write_all(&[separator])?;
+        }
+        if self.opts.byte_offset {
+            write!(self.out, "{byte_offset}")?;
+            self.out.write_all(&[separator])?;
+        }
+        Ok(())
+    }
+
+    fn write_line(&mut self, line: &[u8]) -> io::Result<()> {
+        let mut bytes = line;
+        if self.opts.trim {
+            bytes = trim_ascii_start(bytes);
+        }
+        if let Some(limit) = self.opts.max_columns
+            && limit > 0
+            && bytes.len() > limit
+        {
+            if self.opts.max_columns_preview {
+                self.out.write_all(&bytes[..limit.min(bytes.len())])?;
+                self.out.write_all(b"\n")?;
+            } else {
+                writeln!(self.out, "[Omitted long matching line]")?;
+            }
+            return Ok(());
+        }
+        self.out.write_all(bytes)?;
+        if !bytes.ends_with(b"\n") {
+            self.out.write_all(b"\n")?;
+        }
+        Ok(())
+    }
+
+    fn write_replaced_line(&mut self, line: &[u8]) -> io::Result<()> {
+        let Some(replacement) = self.opts.replacement.as_deref() else {
+            return self.write_line(line);
+        };
+        self.scratch.clear();
+        let matcher = self.matcher;
+        matcher
+            .replace_with_captures(
+                line,
+                &mut self.captures,
+                &mut self.scratch,
+                |captures, output| {
+                    captures.interpolate(
+                        |name| matcher.capture_index(name),
+                        line,
+                        replacement,
+                        output,
+                    );
+                    true
+                },
+            )
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        let mut output = std::mem::take(&mut self.scratch);
+        let result = self.write_line(&output);
+        output.clear();
+        self.scratch = output;
+        result
+    }
+
+    fn print_only_matching(
+        &mut self,
+        line: &[u8],
+        line_number: Option<u64>,
+        line_offset: u64,
+    ) -> io::Result<()> {
+        let mut at = 0usize;
+        while at <= line.len() {
+            let Some(found) = self
+                .matcher
+                .find_at(line, at)
+                .map_err(|error| io::Error::other(error.to_string()))?
+            else {
+                break;
+            };
+            if found.is_empty() {
+                at = found.end() + 1;
+                continue;
+            }
+            let match_offset = line_offset.saturating_add(
+                u64::try_from(found.start())
+                    .map_err(|error| io::Error::other(error.to_string()))?,
+            );
+            self.write_prefix(line_number, Some(found.start() + 1), match_offset, b':')?;
+            if let Some(replacement) = self.opts.replacement.as_deref() {
+                let matched = self
+                    .matcher
+                    .captures_at(line, found.start(), &mut self.captures)
+                    .map_err(|error| io::Error::other(error.to_string()))?;
+                if matched {
+                    self.scratch.clear();
+                    self.captures.interpolate(
+                        |name| self.matcher.capture_index(name),
+                        line,
+                        replacement,
+                        &mut self.scratch,
+                    );
+                    self.out.write_all(&self.scratch)?;
+                }
+            } else {
+                self.out.write_all(&line[found.start()..found.end()])?;
+            }
+            self.out.write_all(b"\n")?;
+            at = found.end();
+        }
+        Ok(())
+    }
+
+    fn print_vimgrep(
+        &mut self,
+        line: &[u8],
+        line_number: Option<u64>,
+        line_offset: u64,
+    ) -> io::Result<()> {
+        let mut at = 0usize;
+        let mut printed = false;
+        while at <= line.len() {
+            let Some(found) = self
+                .matcher
+                .find_at(line, at)
+                .map_err(|error| io::Error::other(error.to_string()))?
+            else {
+                break;
+            };
+            let next = if found.end() > at {
+                found.end()
+            } else {
+                at + 1
+            };
+            let match_offset = line_offset.saturating_add(
+                u64::try_from(found.start())
+                    .map_err(|error| io::Error::other(error.to_string()))?,
+            );
+            self.write_prefix(line_number, Some(found.start() + 1), match_offset, b':')?;
+            self.write_replaced_line(line)?;
+            printed = true;
+            at = next;
+        }
+        if !printed {
+            self.write_prefix(line_number, Some(1), line_offset, b':')?;
+            self.write_replaced_line(line)?;
+        }
+        Ok(())
+    }
+}
+
+impl<M: Matcher, W: Write> Sink for RgSink<'_, M, W> {
+    type Error = io::Error;
+
+    fn matched(&mut self, _searcher: &Searcher, mat: &SinkMatch<'_>) -> Result<bool, io::Error> {
+        self.any_match = true;
+        self.line_count += 1;
+        let line = mat.bytes();
+        let matches_on_line = count_matches(self.matcher, line)?;
+        self.match_count += if self.opts.count_matches || self.opts.only_matching {
+            matches_on_line.max(1)
+        } else {
+            1
+        };
+
+        if self.opts.quiet || self.opts.files_with_matches {
+            return Ok(false);
+        }
+        if self.opts.files_without_match || self.opts.count || self.opts.count_matches {
+            return Ok(true);
+        }
+        if self.opts.vimgrep {
+            self.print_vimgrep(line, mat.line_number(), mat.absolute_byte_offset())?;
+        } else if self.opts.only_matching {
+            self.print_only_matching(line, mat.line_number(), mat.absolute_byte_offset())?;
+        } else {
+            let column = if self.opts.column {
+                first_column(self.matcher, line)?
+            } else {
+                None
+            };
+            self.write_prefix(mat.line_number(), column, mat.absolute_byte_offset(), b':')?;
+            self.write_replaced_line(line)?;
+        }
+        Ok(true)
+    }
+
+    fn context(&mut self, _searcher: &Searcher, ctx: &SinkContext<'_>) -> Result<bool, io::Error> {
+        if self.opts.count
+            || self.opts.count_matches
+            || self.opts.files_with_matches
+            || self.opts.files_without_match
+            || self.opts.only_matching
+            || self.opts.vimgrep
+        {
+            return Ok(true);
+        }
+        self.write_prefix(ctx.line_number(), None, ctx.absolute_byte_offset(), b'-')?;
+        self.write_line(ctx.bytes())?;
+        Ok(true)
+    }
+
+    fn context_break(&mut self, _searcher: &Searcher) -> Result<bool, io::Error> {
+        if !(self.opts.count
+            || self.opts.count_matches
+            || self.opts.files_with_matches
+            || self.opts.files_without_match
+            || self.opts.only_matching
+            || self.opts.vimgrep
+            || self.opts.passthru)
+        {
+            self.out.write_all(b"--\n")?;
+        }
+        Ok(true)
+    }
+
+    fn finish(&mut self, _searcher: &Searcher, _: &SinkFinish) -> Result<(), io::Error> {
+        if self.opts.quiet {
+            return Ok(());
+        }
+        if self.opts.files_with_matches {
+            if self.any_match {
+                self.write_path()?;
+                self.out.write_all(b"\n")?;
+            }
+        } else if self.opts.files_without_match {
+            if !self.any_match {
+                self.write_path()?;
+                self.out.write_all(b"\n")?;
+            }
+        } else if self.opts.count || self.opts.count_matches {
+            if self.display.is_some() {
+                self.write_path()?;
+                self.out.write_all(b":")?;
+            }
+            let count = if self.opts.count_matches {
+                self.match_count
+            } else {
+                self.line_count
+            };
+            writeln!(self.out, "{count}")?;
+        }
+        Ok(())
+    }
+}
+
+fn trim_ascii_start(bytes: &[u8]) -> &[u8] {
+    let start = bytes
+        .iter()
+        .position(|b| !b.is_ascii_whitespace() || *b == b'\n' || *b == b'\r')
+        .unwrap_or(bytes.len());
+    &bytes[start..]
+}
+
+fn first_column<M: Matcher>(matcher: &M, line: &[u8]) -> io::Result<Option<usize>> {
+    Ok(matcher
+        .find(line)
+        .map_err(|error| io::Error::other(error.to_string()))?
+        .filter(|matched| !matched.is_empty())
+        .map(|matched| matched.start() + 1))
+}
+
+fn count_matches<M: Matcher>(matcher: &M, line: &[u8]) -> io::Result<u64> {
+    let mut at = 0usize;
+    let mut count = 0u64;
+    while at <= line.len() {
+        let Some(matched) = matcher
+            .find_at(line, at)
+            .map_err(|error| io::Error::other(error.to_string()))?
+        else {
+            break;
+        };
+        if matched.is_empty() {
+            at += 1;
+            continue;
+        }
+        count += 1;
+        at = matched.end();
+    }
+    Ok(count)
+}
+
+fn build_rust_matcher(patterns: &[String], cli: &RgCli) -> Result<RegexMatcher, grep_regex::Error> {
+    let crlf = cli.crlf && !cli.no_crlf && !cli.null_data;
+    let mut builder = RegexMatcherBuilder::new();
+    builder
+        .case_insensitive(cli.ignore_case && !cli.case_sensitive)
+        .case_smart(cli.smart_case && !cli.ignore_case && !cli.case_sensitive)
+        .word(cli.word_regexp && !cli.line_regexp)
+        .whole_line(cli.line_regexp)
+        .fixed_strings(cli.fixed_strings && !cli.no_fixed_strings)
+        .multi_line(true)
+        .dot_matches_new_line(cli.multiline && cli.multiline_dotall)
+        .unicode(!cli.no_unicode)
+        .crlf(crlf);
+    if cli.null_data {
+        builder.line_terminator(Some(b'\0'));
+    } else if !cli.multiline {
+        builder.line_terminator(Some(b'\n'));
+    }
+    builder.build_many(patterns)
+}
+
+fn build_pcre_matcher(patterns: &[String], cli: &RgCli) -> Result<PcreMatcher, String> {
+    let unicode = !cli.no_unicode;
+    let mut builder = PcreMatcherBuilder::new();
+    builder
+        .caseless(cli.ignore_case && !cli.case_sensitive)
+        .case_smart(cli.smart_case && !cli.ignore_case && !cli.case_sensitive)
+        .word(cli.word_regexp && !cli.line_regexp)
+        .whole_line(cli.line_regexp)
+        .fixed_strings(cli.fixed_strings && !cli.no_fixed_strings)
+        .multi_line(true)
+        .dotall(cli.multiline && cli.multiline_dotall)
+        .crlf(cli.crlf && !cli.no_crlf && !cli.null_data)
+        .utf(unicode)
+        .ucp(unicode)
+        .jit_if_available(true);
+    builder
+        .build_many(patterns)
+        .map_err(|error| error.to_string())
+}
+
+fn build_matcher(patterns: &[String], cli: &RgCli) -> Result<CompiledMatcher, String> {
+    let engine = cli.engine.unwrap_or(if cli.pcre2 {
+        RegexEngine::Pcre2
+    } else {
+        RegexEngine::Default
+    });
+    match engine {
+        RegexEngine::Default => build_rust_matcher(patterns, cli)
+            .map(CompiledMatcher::Rust)
+            .map_err(|error| error.to_string()),
+        RegexEngine::Pcre2 => build_pcre_matcher(patterns, cli).map(CompiledMatcher::Pcre),
+        RegexEngine::Auto => match build_rust_matcher(patterns, cli) {
+            Ok(matcher) => Ok(CompiledMatcher::Rust(matcher)),
+            Err(_) => build_pcre_matcher(patterns, cli).map(CompiledMatcher::Pcre),
+        },
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BinaryMode {
+    Automatic,
+    Explicit,
+}
+
+fn binary_detection(cli: &RgCli, mode: BinaryMode) -> BinaryDetection {
+    if cli.text || cli.null_data {
+        return BinaryDetection::none();
+    }
+    if cli.binary || cli.unrestricted >= 3 || matches!(mode, BinaryMode::Explicit) {
+        BinaryDetection::convert(b'\0')
+    } else {
+        BinaryDetection::quit(b'\0')
+    }
+}
+
+fn build_searcher(cli: &RgCli, opts: &SearchOptions, mode: BinaryMode) -> Result<Searcher, String> {
+    let (encoding, bom_sniffing) = match cli.encoding.as_deref() {
+        None | Some("auto") => (None, true),
+        Some("none") => (None, false),
+        Some(label) => (
+            Some(Encoding::new(label).map_err(|error| format!("rg: {error}"))?),
+            true,
+        ),
+    };
+    let mut builder = SearcherBuilder::new();
+    builder
+        .line_number(opts.line_number || opts.column || opts.vimgrep || opts.json)
+        .before_context(opts.before)
+        .after_context(opts.after)
+        .passthru(opts.passthru)
+        .invert_match(cli.invert_match)
+        .multi_line(cli.multiline)
+        .binary_detection(binary_detection(cli, mode))
+        .max_matches(cli.max_count)
+        .encoding(encoding)
+        .bom_sniffing(bom_sniffing);
+    if cli.null_data {
+        builder.line_terminator(LineTerminator::byte(b'\0'));
+    } else if cli.crlf && !cli.no_crlf {
+        builder.line_terminator(LineTerminator::crlf());
+    }
+    Ok(builder.build())
+}
+
+fn read_pattern_file(path: &OsStr) -> Result<Vec<String>, String> {
+    let mut text = String::new();
+    if path == OsStr::new("-") {
+        pi_uutils_ctx::stdin()
+            .read_to_string(&mut text)
+            .map_err(|err| format!("rg: -: {err}"))?;
+    } else {
+        let resolved = pi_uutils_ctx::resolve(path);
+        File::open(&resolved)
+            .and_then(|mut file| file.read_to_string(&mut text))
+            .map_err(|err| format!("rg: {}: {err}", path.to_string_lossy()))?;
+    }
+    Ok(text
+        .lines()
+        .map(|line| line.strip_suffix('\r').unwrap_or(line).to_string())
+        .collect())
+}
+
+fn resolve_patterns(cli: &RgCli) -> Result<(Vec<String>, Vec<OsString>), String> {
+    let mut patterns = cli.patterns.clone();
+    for pattern_file in &cli.pattern_files {
+        patterns.extend(read_pattern_file(pattern_file.as_os_str())?);
+    }
+    let mut paths = Vec::new();
+    if cli.files || cli.type_list || !cli.patterns.is_empty() || !cli.pattern_files.is_empty() {
+        paths = cli.args.clone();
+    } else {
+        let mut rest = cli.args.iter();
+        let Some(pattern) = rest.next() else {
+            return Err("rg: required pattern missing".to_string());
+        };
+        patterns.push(pattern.to_string_lossy().into_owned());
+        paths.extend(rest.cloned());
+    }
+    Ok((patterns, paths))
+}
+
+fn search_options(cli: &RgCli) -> SearchOptions {
+    let context = cli.context.unwrap_or(0);
+    let count_matches = cli.count_matches || (cli.count && cli.only_matching);
+    let line_number = (cli.line_number || cli.column || cli.vimgrep) && !cli.no_line_number;
+    SearchOptions {
+        line_number,
+        column: cli.column || cli.vimgrep,
+        byte_offset: cli.byte_offset,
+        count: cli.count && !count_matches,
+        count_matches,
+        files_with_matches: cli.files_with_matches && !cli.files_without_match,
+        files_without_match: cli.files_without_match,
+        only_matching: cli.only_matching,
+        quiet: cli.quiet,
+        vimgrep: cli.vimgrep,
+        before: cli.before_context.unwrap_or(context),
+        after: cli.after_context.unwrap_or(context),
+        passthru: cli.passthru,
+        trim: cli.trim && !cli.no_trim,
+        max_columns: cli.max_columns,
+        max_columns_preview: cli.max_columns_preview && !cli.no_max_columns_preview,
+        null_paths: cli.null,
+        no_messages: cli.no_messages && !cli.messages,
+        replacement: cli
+            .replacement
+            .as_ref()
+            .map(|replacement| replacement.as_encoded_bytes().to_vec()),
+        json: cli.json,
+    }
+}
+
+fn parse_size(input: &str) -> Result<u64, String> {
+    let trimmed = input.trim();
+    let Some(last) = trimmed.chars().last() else {
+        return Err("empty size".to_string());
+    };
+    let (digits, multiplier) = match last {
+        'K' | 'k' => (&trimmed[..trimmed.len() - 1], 1024),
+        'M' | 'm' => (&trimmed[..trimmed.len() - 1], 1024 * 1024),
+        'G' | 'g' => (&trimmed[..trimmed.len() - 1], 1024 * 1024 * 1024),
+        _ => (trimmed, 1),
+    };
+    let value = digits
+        .parse::<u64>()
+        .map_err(|err| format!("invalid size {input:?}: {err}"))?;
+    Ok(value.saturating_mul(multiplier))
+}
+
+fn type_builder(cli: &RgCli) -> Result<TypesBuilder, String> {
+    let mut builder = TypesBuilder::new();
+    builder.add_defaults();
+    for name in &cli.type_clears {
+        builder.clear(name);
+    }
+    for def in &cli.type_adds {
+        builder
+            .add_def(def)
+            .map_err(|err| format!("rg: --type-add {def:?}: {err}"))?;
+    }
+    for name in &cli.types {
+        builder.select(name);
+    }
+    for name in &cli.type_nots {
+        builder.negate(name);
+    }
+    Ok(builder)
+}
+
+fn print_type_list<W: Write>(cli: &RgCli, out: &mut W) -> Result<(), String> {
+    let builder = type_builder(cli)?;
+    for def in builder.definitions() {
+        write!(out, "{}: ", def.name()).map_err(|err| err.to_string())?;
+        for (idx, glob) in def.globs().iter().enumerate() {
+            if idx > 0 {
+                out.write_all(b", ").map_err(|err| err.to_string())?;
+            }
+            out.write_all(glob.as_bytes())
+                .map_err(|err| err.to_string())?;
+        }
+        out.write_all(b"\n").map_err(|err| err.to_string())?;
+    }
+    Ok(())
+}
+
+struct RgWalk {
+    request: pi_walker::WalkRequest,
+    filters: PathFilters,
+}
+
+struct PathFilters {
+    overrides: Option<Override>,
+    explicit: Option<Gitignore>,
+    types: Option<Types>,
+    max_filesize: Option<u64>,
+}
+
+impl PathFilters {
+    fn includes(&self, path: &Path, file_type: pi_walker::FileType, size: Option<f64>) -> bool {
+        let is_dir = file_type == pi_walker::FileType::Dir;
+        let override_match = self
+            .overrides
+            .as_ref()
+            .map(|overrides| overrides.matched(path, is_dir));
+        if override_match
+            .as_ref()
+            .is_some_and(|matched| matches!(matched, Match::Ignore(_)))
+        {
+            return false;
+        }
+        let explicitly_included = override_match
+            .as_ref()
+            .is_some_and(|matched| matches!(matched, Match::Whitelist(_)));
+        if !explicitly_included
+            && self
+                .explicit
+                .as_ref()
+                .is_some_and(|ignore| matches!(ignore.matched(path, is_dir), Match::Ignore(_)))
+        {
+            return false;
+        }
+        if file_type != pi_walker::FileType::File {
+            return true;
+        }
+        if !explicitly_included
+            && self
+                .types
+                .as_ref()
+                .is_some_and(|types| matches!(types.matched(path, false), Match::Ignore(_)))
+        {
+            return false;
+        }
+        if let Some(limit) = self.max_filesize {
+            let size = size.or_else(|| std::fs::metadata(path).ok().map(|meta| meta.len() as f64));
+            if size.is_some_and(|size| size > limit as f64) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn build_path_filters(cli: &RgCli) -> Result<PathFilters, String> {
+    let cwd = pi_uutils_ctx::cwd();
+    let max_filesize = cli
+        .max_filesize
+        .as_ref()
+        .map(|size| parse_size(size).map_err(|error| format!("rg: {error}")))
+        .transpose()?;
+    let overrides = if cli.globs.is_empty() && cli.iglobs.is_empty() {
+        None
+    } else {
+        let mut overrides = OverrideBuilder::new(&cwd);
+        if cli.glob_case_insensitive {
+            overrides
+                .case_insensitive(true)
+                .map_err(|error| format!("rg: --glob-case-insensitive: {error}"))?;
+        }
+        for glob in &cli.globs {
+            overrides
+                .add(glob)
+                .map_err(|error| format!("rg: --glob {glob:?}: {error}"))?;
+        }
+        if !cli.iglobs.is_empty() && !cli.glob_case_insensitive {
+            overrides
+                .case_insensitive(true)
+                .map_err(|error| format!("rg: --iglob: {error}"))?;
+        }
+        for glob in &cli.iglobs {
+            overrides
+                .add(glob)
+                .map_err(|error| format!("rg: --iglob {glob:?}: {error}"))?;
+        }
+        Some(overrides.build().map_err(|error| format!("rg: {error}"))?)
+    };
+    let explicit = if cli.ignore_files.is_empty() {
+        None
+    } else {
+        let mut builder = GitignoreBuilder::new(&cwd);
+        for path in &cli.ignore_files {
+            let resolved = pi_uutils_ctx::resolve(path);
+            if let Some(error) = builder.add(&resolved) {
+                return Err(format!("rg: {}: {error}", path.to_string_lossy()));
+            }
+        }
+        Some(builder.build().map_err(|error| format!("rg: {error}"))?)
+    };
+    let types = if cli.types.is_empty() && cli.type_nots.is_empty() {
+        None
+    } else {
+        Some(
+            type_builder(cli)?
+                .build()
+                .map_err(|error| format!("rg: {error}"))?,
+        )
+    };
+    Ok(PathFilters {
+        overrides,
+        explicit,
+        types,
+        max_filesize,
+    })
+}
+
+fn build_walk(cli: &RgCli, root: &Path) -> Result<RgWalk, String> {
+    let filters = build_path_filters(cli)?;
+    let unrestricted_no_ignore = cli.unrestricted >= 1;
+    let include_hidden = (cli.hidden || cli.unrestricted >= 2) && !cli.no_hidden;
+    let no_ignore = (cli.no_ignore || unrestricted_no_ignore) && !cli.ignore;
+    let order = if cli.sort_files || cli.sort.as_deref() == Some("path") {
+        pi_walker::WalkOrder::Path
+    } else {
+        pi_walker::WalkOrder::Unordered
+    };
+    let request = pi_walker::WalkRequest::new(root)
+        .hidden(include_hidden)
+        .gitignore(!no_ignore)
+        .skip_git(!no_ignore)
+        .skip_node_modules(false)
+        .follow_links(pi_walker::FollowLinks::from(cli.follow && !cli.no_follow))
+        .detail(if filters.max_filesize.is_some() {
+            pi_walker::WalkDetail::Full
+        } else {
+            pi_walker::WalkDetail::Minimal
+        })
+        .order(order)
+        .emit_root(false)
+        .depth(1, cli.max_depth.unwrap_or(usize::MAX))
+        .visit_order(pi_walker::VisitOrder::PreOrder)
+        .directory_errors(pi_walker::DirectoryErrorMode::Visit)
+        .same_file_system(cli.one_file_system && !cli.no_one_file_system)
+        .cache(false);
+    Ok(RgWalk { request, filters })
+}
+
+fn display_path(operand: &OsStr, root: &Path, path: &Path) -> PathBuf {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    if rel.as_os_str().is_empty() {
+        return PathBuf::from(operand);
+    }
+    if operand == OsStr::new(".") {
+        rel.to_path_buf()
+    } else {
+        Path::new(operand).join(rel)
+    }
+}
+
+fn process_reader<M: Matcher, R: Read, W: Write>(
+    matcher: &M,
+    searcher: &mut Searcher,
+    reader: R,
+    display: Option<&[u8]>,
+    opts: &SearchOptions,
+    stats: &mut Stats,
+    out: &mut W,
+) -> io::Result<bool> {
+    if opts.json {
+        let mut builder = JSONBuilder::new();
+        builder.replacement(opts.replacement.clone());
+        let mut printer = builder.build(out);
+        if let Some(display) = display {
+            let path = PathBuf::from(String::from_utf8_lossy(display).into_owned());
+            let mut sink = printer.sink_with_path(matcher, &path);
+            searcher.search_reader(matcher, reader, &mut sink)?;
+            let matched = sink.has_match();
+            *stats += sink.stats();
+            return Ok(matched);
+        }
+        let mut sink = printer.sink(matcher);
+        searcher.search_reader(matcher, reader, &mut sink)?;
+        let matched = sink.has_match();
+        *stats += sink.stats();
+        return Ok(matched);
+    }
+
+    let captures = matcher
+        .new_captures()
+        .map_err(|error| io::Error::other(error.to_string()))?;
+    let mut sink = RgSink {
+        out,
+        matcher,
+        display,
+        opts,
+        captures,
+        scratch: Vec::new(),
+        line_count: 0,
+        match_count: 0,
+        any_match: false,
+    };
+    searcher.search_reader(matcher, reader, &mut sink)?;
+    Ok(sink.any_match)
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "file processing needs the matcher, searcher, output state, and path metadata"
+)]
+fn process_file<M: Matcher, W: Write>(
+    cli: &RgCli,
+    matcher: &M,
+    searcher: &mut Searcher,
+    path: &Path,
+    display: Option<&[u8]>,
+    opts: &SearchOptions,
+    stats: &mut Stats,
+    out: &mut W,
+) -> SearchOutcome {
+    let result = if cli.search_zip && !cli.no_search_zip {
+        let builder = DecompressionReaderBuilder::new();
+        if builder.get_matcher().has_command(path) {
+            builder
+                .build(path)
+                .map_err(|error| io::Error::other(error.to_string()))
+                .and_then(|reader| {
+                    process_reader(matcher, searcher, reader, display, opts, stats, out)
+                })
+        } else {
+            File::open(path)
+                .and_then(|file| process_reader(matcher, searcher, file, display, opts, stats, out))
+        }
+    } else {
+        File::open(path)
+            .and_then(|file| process_reader(matcher, searcher, file, display, opts, stats, out))
+    };
+    match result {
+        Ok(any_match) => SearchOutcome {
+            any_match,
+            had_error: false,
+        },
+        Err(error) => SearchOutcome {
+            any_match: false,
+            had_error: report_path_error(display, path, error, opts),
+        },
+    }
+}
+
+fn report_path_error(
+    display: Option<&[u8]>,
+    fallback: &Path,
+    err: io::Error,
+    opts: &SearchOptions,
+) -> bool {
+    if !opts.no_messages {
+        let name = display
+            .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+            .unwrap_or_else(|| fallback.display().to_string());
+        let _ = writeln!(pi_uutils_ctx::stderr(), "rg: {name}: {err}");
+    }
+    true
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "required by standard walk/configure interfaces and search parameters"
+)]
+fn search_collected_files<M: Matcher, W: Write>(
+    cli: &RgCli,
+    matcher: &M,
+    searcher: &mut Searcher,
+    operand: &OsStr,
+    root: &Path,
+    show_names: bool,
+    opts: &SearchOptions,
+    stats: &mut Stats,
+    out: &mut W,
+) -> SearchOutcome {
+    let mut files = match collect_filtered_files(cli, root) {
+        Ok(files) => files,
+        Err(_) if pi_uutils_ctx::is_cancelled() => {
+            return SearchOutcome {
+                any_match: false,
+                had_error: true,
+            };
+        }
+        Err(err) => {
+            if !opts.no_messages {
+                let _ = writeln!(pi_uutils_ctx::stderr(), "{err}");
+            }
+            return SearchOutcome {
+                any_match: false,
+                had_error: true,
+            };
+        }
+    };
+    files.sort_unstable_by(|a, b| b.cmp(a));
+    let mut any_match = false;
+    let mut had_error = false;
+    let mut processed_file = false;
+    for path in files {
+        if opts.quiet && any_match {
+            break;
+        }
+        if processed_file && pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+        processed_file = true;
+        let display_path = display_path(operand, root, &path);
+        let display_bytes = display_path.as_os_str().as_encoded_bytes().to_vec();
+        let display = (show_names || opts.json).then_some(display_bytes.as_slice());
+        let outcome = process_file(cli, matcher, searcher, &path, display, opts, stats, out);
+        any_match |= outcome.any_match;
+        had_error |= outcome.had_error;
+        if pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+    }
+    SearchOutcome {
+        any_match,
+        had_error,
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "required by standard walk/configure interfaces and search parameters"
+)]
+fn search_dir<M: Matcher, W: Write>(
+    cli: &RgCli,
+    matcher: &M,
+    searcher: &mut Searcher,
+    operand: &OsStr,
+    root: &Path,
+    show_names: bool,
+    opts: &SearchOptions,
+    stats: &mut Stats,
+    out: &mut W,
+) -> SearchOutcome {
+    if cli.sortr.as_deref() == Some("path") {
+        return search_collected_files(
+            cli, matcher, searcher, operand, root, show_names, opts, stats, out,
+        );
+    }
+    let walk = match build_walk(cli, root) {
+        Ok(walk) => walk,
+        Err(err) => {
+            if !opts.no_messages {
+                let _ = writeln!(pi_uutils_ctx::stderr(), "{err}");
+            }
+            return SearchOutcome {
+                any_match: false,
+                had_error: true,
+            };
+        }
+    };
+    let any_match = std::cell::Cell::new(false);
+    let had_error = std::cell::Cell::new(false);
+    let streamed = match walk.request.for_each_entry_with_heartbeat(
+        || {
+            if pi_uutils_ctx::is_cancelled() {
+                Err(io::Error::from(io::ErrorKind::Interrupted))
+            } else {
+                Ok::<(), io::Error>(())
+            }
+        },
+        |entry| {
+            if opts.quiet && any_match.get() {
+                return Ok(pi_walker::WalkDecision::Stop);
+            }
+            let path = entry.absolute_path.as_ref();
+            if !walk.filters.includes(path, entry.file_type, entry.size) {
+                return Ok(if entry.file_type == pi_walker::FileType::Dir {
+                    pi_walker::WalkDecision::SkipDescend
+                } else {
+                    pi_walker::WalkDecision::Skip
+                });
+            }
+            if entry.file_type != pi_walker::FileType::File {
+                return Ok(pi_walker::WalkDecision::Skip);
+            }
+            let display_path = display_path(operand, root, path);
+            let display_bytes = display_path.as_os_str().as_encoded_bytes().to_vec();
+            let display = (show_names || opts.json).then_some(display_bytes.as_slice());
+            let outcome = process_file(cli, matcher, searcher, path, display, opts, stats, out);
+            any_match.set(any_match.get() || outcome.any_match);
+            had_error.set(had_error.get() || outcome.had_error);
+            Ok(if opts.quiet && any_match.get() {
+                pi_walker::WalkDecision::Stop
+            } else {
+                pi_walker::WalkDecision::Include
+            })
+        },
+        |error| {
+            had_error.set(true);
+            if !opts.no_messages {
+                let _ = writeln!(
+                    pi_uutils_ctx::stderr(),
+                    "rg: {}: {}",
+                    error.path.display(),
+                    error.error
+                );
+            }
+            Ok(pi_walker::WalkDecision::Include)
+        },
+    ) {
+        Ok(pi_walker::WalkStatus::Complete | pi_walker::WalkStatus::Stopped) => {
+            Some(SearchOutcome {
+                any_match: any_match.get(),
+                had_error: had_error.get(),
+            })
+        }
+        Err(pi_walker::WalkError::Interrupted(_)) if pi_uutils_ctx::is_cancelled() => {
+            // Harness cancellation; the shell wrapper overrides the exit code
+            // and stay-silent on stderr — no spurious "interrupted" diagnostic.
+            had_error.set(true);
+            Some(SearchOutcome {
+                any_match: any_match.get(),
+                had_error: true,
+            })
+        }
+        Err(err) => {
+            had_error.set(true);
+            if !opts.no_messages {
+                let _ = writeln!(pi_uutils_ctx::stderr(), "rg: {err}");
+            }
+            Some(SearchOutcome {
+                any_match: any_match.get(),
+                had_error: had_error.get(),
+            })
+        }
+    };
+    streamed.unwrap_or_else(|| {
+        search_collected_files(
+            cli, matcher, searcher, operand, root, show_names, opts, stats, out,
+        )
+    })
+}
+
+fn collect_filtered_files(cli: &RgCli, root: &Path) -> Result<Vec<PathBuf>, String> {
+    let walk = build_walk(cli, root)?;
+    let outcome = match walk.request.collect_with_heartbeat(|| {
+        if pi_uutils_ctx::is_cancelled() {
+            Err(io::Error::from(io::ErrorKind::Interrupted))
+        } else {
+            Ok::<(), io::Error>(())
+        }
+    }) {
+        Ok(outcome) => outcome,
+        Err(pi_walker::WalkError::Interrupted(_)) if pi_uutils_ctx::is_cancelled() => {
+            return Err(String::from("rg: cancelled"));
+        }
+        Err(err) => return Err(format!("rg: {err}")),
+    };
+    let mut files = Vec::new();
+    for entry in outcome.entries {
+        if entry.file_type != pi_walker::FileType::File {
+            continue;
+        }
+        let path = entry.absolute_path(root);
+        if walk.filters.includes(&path, entry.file_type, entry.size) {
+            files.push(path);
+        }
+    }
+    Ok(files)
+}
+
+fn list_files<W: Write>(cli: &RgCli, paths: &[OsString], out: &mut W) -> SearchOutcome {
+    let mut any = false;
+    let mut had_error = false;
+    let mut processed_operand = false;
+    for operand in paths {
+        if processed_operand && pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+        processed_operand = true;
+        let resolved = pi_uutils_ctx::resolve(operand);
+        match std::fs::metadata(&resolved) {
+            Ok(meta) if meta.is_dir() => {
+                let mut files = match collect_filtered_files(cli, &resolved) {
+                    Ok(files) => files,
+                    Err(_) if pi_uutils_ctx::is_cancelled() => {
+                        had_error = true;
+                        break;
+                    }
+                    Err(err) => {
+                        let _ = writeln!(pi_uutils_ctx::stderr(), "{err}");
+                        had_error = true;
+                        continue;
+                    }
+                };
+                if cli.sortr.as_deref() == Some("path") {
+                    files.sort_unstable_by(|a, b| b.cmp(a));
+                }
+                for path in files {
+                    let display = display_path(operand.as_os_str(), &resolved, &path);
+                    let _ = out.write_all(display.as_os_str().as_encoded_bytes());
+                    let _ = out.write_all(if cli.null { b"\0" } else { b"\n" });
+                    any = true;
+                }
+            }
+            Ok(meta) if meta.is_file() => {
+                let _ = out.write_all(operand.as_encoded_bytes());
+                let _ = out.write_all(if cli.null { b"\0" } else { b"\n" });
+                any = true;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                let _ = writeln!(
+                    pi_uutils_ctx::stderr(),
+                    "rg: {}: {err}",
+                    operand.to_string_lossy()
+                );
+                had_error = true;
+            }
+        }
+        if pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+    }
+    SearchOutcome {
+        any_match: any,
+        had_error,
+    }
+}
+
+fn default_paths(paths: &mut Vec<OsString>, use_implicit_stdin: bool) {
+    if !paths.is_empty() {
+        return;
+    }
+    if use_implicit_stdin {
+        paths.push(OsString::from("-"));
+    } else {
+        paths.push(OsString::from("."));
+    }
+}
+
+fn show_names_for(paths: &[OsString], recursive: bool, cli: &RgCli, opts: &SearchOptions) -> bool {
+    if cli.no_filename {
+        false
+    } else if cli.with_filename
+        || opts.files_with_matches
+        || opts.files_without_match
+        || cli.vimgrep
+    {
+        true
+    } else {
+        recursive || paths.len() > 1
+    }
+}
+
+fn write_json_summary<W: Write>(out: &mut W, stats: &Stats) -> io::Result<()> {
+    let elapsed = stats.elapsed();
+    let summary = serde_json::json!({
+        "type": "summary",
+        "data": {
+            "stats": {
+                "elapsed": {
+                    "secs": elapsed.as_secs(),
+                    "nanos": elapsed.subsec_nanos(),
+                    "human": format!("{elapsed:?}"),
+                },
+                "searches": stats.searches(),
+                "searches_with_match": stats.searches_with_match(),
+                "bytes_searched": stats.bytes_searched(),
+                "bytes_printed": stats.bytes_printed(),
+                "matched_lines": stats.matched_lines(),
+                "matches": stats.matches(),
+            }
+        }
+    });
+    serde_json::to_writer(&mut *out, &summary).map_err(io::Error::other)?;
+    out.write_all(b"\n")
+}
+
+fn execute_search<M: Matcher, W: Write>(
+    cli: &RgCli,
+    matcher: &M,
+    paths: &[OsString],
+    opts: &SearchOptions,
+    out: &mut W,
+) -> i32 {
+    let mut auto_searcher = match build_searcher(cli, opts, BinaryMode::Automatic) {
+        Ok(searcher) => searcher,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "rg: {error}");
+            return 2;
+        }
+    };
+    let mut explicit_searcher = match build_searcher(cli, opts, BinaryMode::Explicit) {
+        Ok(searcher) => searcher,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "rg: {error}");
+            return 2;
+        }
+    };
+    let recursive = paths.iter().any(|path| {
+        path.as_os_str() != OsStr::new("-")
+            && std::fs::metadata(pi_uutils_ctx::resolve(path)).is_ok_and(|meta| meta.is_dir())
+    });
+    let show_names = show_names_for(paths, recursive, cli, opts);
+    let mut stats = Stats::new();
+    let mut any_match = false;
+    let mut had_error = false;
+    let mut processed_operand = false;
+    for operand in paths {
+        if opts.quiet && any_match {
+            break;
+        }
+        if processed_operand && pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+        processed_operand = true;
+        if operand.as_os_str() == OsStr::new("-") {
+            let display = show_names.then_some(b"<stdin>".as_slice());
+            match process_reader(
+                matcher,
+                &mut explicit_searcher,
+                pi_uutils_ctx::stdin(),
+                display,
+                opts,
+                &mut stats,
+                out,
+            ) {
+                Ok(matched) => any_match |= matched,
+                Err(error) => {
+                    had_error = true;
+                    if !opts.no_messages {
+                        let _ = writeln!(pi_uutils_ctx::stderr(), "rg: <stdin>: {error}");
+                    }
+                }
+            }
+            if pi_uutils_ctx::is_cancelled() {
+                had_error = true;
+                break;
+            }
+            continue;
+        }
+        let resolved = pi_uutils_ctx::resolve(operand);
+        match std::fs::metadata(&resolved) {
+            Ok(meta) if meta.is_dir() => {
+                let outcome = search_dir(
+                    cli,
+                    matcher,
+                    &mut auto_searcher,
+                    operand.as_os_str(),
+                    &resolved,
+                    show_names,
+                    opts,
+                    &mut stats,
+                    out,
+                );
+                any_match |= outcome.any_match;
+                had_error |= outcome.had_error;
+            }
+            Ok(meta) if meta.is_file() => {
+                let display =
+                    (show_names || opts.json).then_some(operand.as_os_str().as_encoded_bytes());
+                let outcome = process_file(
+                    cli,
+                    matcher,
+                    &mut explicit_searcher,
+                    &resolved,
+                    display,
+                    opts,
+                    &mut stats,
+                    out,
+                );
+                any_match |= outcome.any_match;
+                had_error |= outcome.had_error;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                had_error = true;
+                if !opts.no_messages {
+                    let _ = writeln!(
+                        pi_uutils_ctx::stderr(),
+                        "rg: {}: {error}",
+                        operand.to_string_lossy()
+                    );
+                }
+            }
+        }
+        if pi_uutils_ctx::is_cancelled() {
+            had_error = true;
+            break;
+        }
+    }
+    if opts.json {
+        let _ = write_json_summary(out, &stats);
+    }
+    let _ = out.flush();
+    if opts.quiet {
+        if any_match {
+            0
+        } else if had_error {
+            2
+        } else {
+            1
+        }
+    } else if had_error {
+        2
+    } else if any_match {
+        0
+    } else {
+        1
+    }
+}
+
+/// Runs the ripgrep-compatible builtin and returns a process-style exit code.
+pub fn run(argv: Vec<OsString>) -> i32 {
+    let cli = match RgCli::try_parse_from(argv) {
+        Ok(cli) => cli,
+        Err(error) => {
+            let rendered = error.to_string();
+            if error.use_stderr() {
+                let _ = write!(pi_uutils_ctx::stderr(), "{rendered}");
+                return 2;
+            }
+            let _ = write!(pi_uutils_ctx::stdout(), "{rendered}");
+            return 0;
+        }
+    };
+
+    let opts = search_options(&cli);
+    if opts.json
+        && (cli.files
+            || cli.type_list
+            || opts.count
+            || opts.count_matches
+            || opts.files_with_matches
+            || opts.files_without_match
+            || opts.quiet
+            || cli.only_matching
+            || cli.vimgrep)
+    {
+        let _ = writeln!(
+            pi_uutils_ctx::stderr(),
+            "rg: --json cannot be combined with summary modes"
+        );
+        return 2;
+    }
+    let mut out = if cli.line_buffered && !cli.no_line_buffered {
+        RgOutput::Direct(pi_uutils_ctx::stdout())
+    } else {
+        RgOutput::Buffered(BufWriter::new(pi_uutils_ctx::stdout()))
+    };
+    let (patterns, mut paths) = match resolve_patterns(&cli) {
+        Ok(resolved) => resolved,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "{error}");
+            return 2;
+        }
+    };
+    if cli.type_list {
+        return match print_type_list(&cli, &mut out) {
+            Ok(()) => 0,
+            Err(error) => {
+                let _ = writeln!(pi_uutils_ctx::stderr(), "rg: {error}");
+                2
+            }
+        };
+    }
+    let pattern_stdin_consumed = cli.pattern_files.iter().any(|file| file == OsStr::new("-"));
+    default_paths(
+        &mut paths,
+        !cli.files && !pattern_stdin_consumed && pi_uutils_ctx::stdin_is_search_input(),
+    );
+    if cli.files {
+        let outcome = list_files(&cli, &paths, &mut out);
+        let _ = out.flush();
+        return if outcome.had_error {
+            2
+        } else if outcome.any_match {
+            0
+        } else {
+            1
+        };
+    }
+    if patterns.is_empty() {
+        return 1;
+    }
+    let matcher = match build_matcher(&patterns, &cli) {
+        Ok(matcher) => matcher,
+        Err(error) => {
+            let _ = writeln!(pi_uutils_ctx::stderr(), "rg: {error}");
+            return 2;
+        }
+    };
+    match &matcher {
+        CompiledMatcher::Rust(matcher) => execute_search(&cli, matcher, &paths, &opts, &mut out),
+        CompiledMatcher::Pcre(matcher) => execute_search(&cli, matcher, &paths, &opts, &mut out),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, atomic::AtomicBool},
+    };
+
+    use parking_lot::Mutex;
+    use pi_uutils_ctx::{ScopeIo, scope};
+
+    use super::*;
+
+    /// Sink that collects writes into a shared buffer for assertions.
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn run_rg(args: &[&str], stdin: &str) -> (i32, String, String) {
+        run_rg_in(args, stdin, &std::env::temp_dir())
+    }
+
+    fn run_rg_in(args: &[&str], stdin: &str, cwd: &Path) -> (i32, String, String) {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let err = Arc::new(Mutex::new(Vec::new()));
+        let io = ScopeIo {
+            stdin: Box::new(io::Cursor::new(stdin.as_bytes().to_vec())),
+            stdin_fd: None,
+            stdin_is_search_input: true,
+            stdout: Box::new(SharedBuf(Arc::clone(&out))),
+            stderr: Box::new(SharedBuf(Arc::clone(&err))),
+            cwd: cwd.to_path_buf(),
+            env: HashMap::new(),
+            cancel: Arc::new(AtomicBool::new(false)),
+        };
+        let argv: Vec<OsString> = std::iter::once("rg")
+            .chain(args.iter().copied())
+            .map(OsString::from)
+            .collect();
+        let code = scope(io, || run(argv));
+        let stdout = String::from_utf8(out.lock().clone()).expect("utf8 stdout");
+        let stderr = String::from_utf8(err.lock().clone()).expect("utf8 stderr");
+        (code, stdout, stderr)
+    }
+
+    #[test]
+    fn max_count_accepts_an_attached_value() {
+        let (code, stdout, stderr) = run_rg(&["-m1", "hit"], "hit\nmiss\nhit\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "hit\n");
+    }
+
+    #[test]
+    fn pcre2_matches_lookbehind_patterns() {
+        let (code, stdout, stderr) = run_rg(&["--pcre2", "(?<=foo)bar"], "foobar\nbar\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "foobar\n");
+    }
+
+    #[test]
+    fn auto_engine_promotes_patterns_that_need_pcre2() {
+        let (code, stdout, stderr) = run_rg(&["--engine=auto", "(?<=foo)bar"], "foobar\nbar\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "foobar\n");
+    }
+
+    #[test]
+    fn replacement_expands_capture_groups() {
+        let (code, stdout, stderr) =
+            run_rg(&["-o", "--replace=${word}-x", "(?P<word>foo)"], "foo bar\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "foo-x\n");
+    }
+
+    #[test]
+    fn byte_offset_reports_the_absolute_match_position() {
+        let (code, stdout, stderr) = run_rg(&["--byte-offset", "hit"], "zero\nhit\n");
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "5:hit\n");
+    }
+
+    #[test]
+    fn json_emits_structured_search_events() {
+        let (code, stdout, stderr) = run_rg(&["--json", "hit"], "miss\nhit\n");
+        assert_eq!(code, 0, "{stderr}");
+        let events: Vec<serde_json::Value> = stdout
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("each output line should be JSON"))
+            .collect();
+        let kinds: Vec<&str> = events
+            .iter()
+            .map(|event| event["type"].as_str().expect("event type"))
+            .collect();
+        assert_eq!(kinds, ["begin", "match", "end", "summary"]);
+        assert_eq!(events[1]["data"]["lines"]["text"], "hit\n");
+        assert_eq!(events[3]["data"]["stats"]["searches"], 1);
+        assert_eq!(events[3]["data"]["stats"]["searches_with_match"], 1);
+        assert_eq!(events[3]["data"]["stats"]["matched_lines"], 1);
+        assert_eq!(events[3]["data"]["stats"]["matches"], 1);
+    }
+
+    #[test]
+    fn explicit_encoding_transcodes_input_before_matching() {
+        let tree = unique_tree("encoding");
+        std::fs::write(tree.join("utf16.txt"), b"h\0i\0t\0\n\0")
+            .expect("UTF-16 fixture should be written");
+        let (code, stdout, stderr) =
+            run_rg_in(&["--encoding=utf-16le", "hit", "utf16.txt"], "", &tree);
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "hit\n");
+        let _ = std::fs::remove_dir_all(tree);
+    }
+
+    #[test]
+    fn explicit_ignore_file_filters_recursive_search() {
+        let tree = unique_tree("ignore-file");
+        std::fs::write(tree.join("keep.txt"), "hit\n").expect("included fixture should be written");
+        std::fs::write(tree.join("skip.txt"), "hit\n").expect("ignored fixture should be written");
+        std::fs::write(tree.join("rules.ignore"), "skip.txt\n")
+            .expect("ignore rules should be written");
+        let (code, stdout, stderr) =
+            run_rg_in(&["--ignore-file=rules.ignore", "hit", "."], "", &tree);
+        assert_eq!(code, 0, "{stderr}");
+        assert!(stdout.contains("keep.txt:hit\n"), "{stdout:?}");
+        assert!(!stdout.contains("skip.txt"), "{stdout:?}");
+        let _ = std::fs::remove_dir_all(tree);
+    }
+
+    #[test]
+    fn glob_case_insensitive_applies_to_regular_globs() {
+        let tree = unique_tree("glob-case");
+        std::fs::write(tree.join("UPPER.TXT"), "hit\n").expect("fixture should be written");
+        let (code, stdout, stderr) = run_rg_in(
+            &["--glob-case-insensitive", "--glob=*.txt", "hit", "."],
+            "",
+            &tree,
+        );
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "UPPER.TXT:hit\n");
+        let _ = std::fs::remove_dir_all(tree);
+    }
+
+    #[test]
+    fn search_zip_decompresses_supported_files() {
+        let tree = unique_tree("search-zip");
+        let gzip = [
+            31, 139, 8, 0, 0, 0, 0, 0, 2, 255, 203, 205, 44, 46, 230, 202, 200, 44, 225, 2, 0, 26,
+            30, 21, 140, 9, 0, 0, 0,
+        ];
+        std::fs::write(tree.join("sample.gz"), gzip).expect("gzip fixture should be written");
+        let (code, stdout, stderr) = run_rg_in(&["--search-zip", "hit", "sample.gz"], "", &tree);
+        assert_eq!(code, 0, "{stderr}");
+        assert_eq!(stdout, "hit\n");
+        let _ = std::fs::remove_dir_all(tree);
+    }
+
+    /// Run `rg` with the cancel flag pre-set, mirroring the shell wrapper's
+    /// behavior when `abort`/`timeout` fires mid-walk.
+    fn run_rg_cancelled(args: &[&str], cwd: &Path) -> (i32, String, String) {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let err = Arc::new(Mutex::new(Vec::new()));
+        let io = ScopeIo {
+            stdin: Box::new(io::empty()),
+            stdin_fd: None,
+            stdin_is_search_input: false,
+            stdout: Box::new(SharedBuf(Arc::clone(&out))),
+            stderr: Box::new(SharedBuf(Arc::clone(&err))),
+            cwd: cwd.to_path_buf(),
+            env: HashMap::new(),
+            cancel: Arc::new(AtomicBool::new(true)),
+        };
+        let argv: Vec<OsString> = std::iter::once("rg")
+            .chain(args.iter().copied())
+            .map(OsString::from)
+            .collect();
+        let code = scope(io, || run(argv));
+        let stdout = String::from_utf8(out.lock().clone()).expect("utf8 stdout");
+        let stderr = String::from_utf8(err.lock().clone()).expect("utf8 stderr");
+        (code, stdout, stderr)
+    }
+
+    fn unique_tree(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "pi-uu-rg-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&root).expect("temp tree should be created");
+        root
+    }
+
+    #[test]
+    fn recursive_search_observes_scope_cancellation() {
+        // Regression for #3933: rg's recursive walker used to pass a no-op
+        // heartbeat to pi_walker, so cancellation was not observed during
+        // directory traversal even after the uutils ctx cancel flag was set.
+        let tree = unique_tree("search");
+        let walk_root = tree.join("walk-root");
+        std::fs::create_dir_all(&walk_root).expect("walk root should be created");
+        std::fs::write(walk_root.join("haystack.txt"), "match-me\n").expect("walked file written");
+        let later_file = tree.join("later.txt");
+        std::fs::write(&later_file, "match-me\n").expect("later file written");
+
+        let (code, stdout, stderr) = run_rg_cancelled(
+            &[
+                "match-me",
+                walk_root.to_str().expect("utf8 path"),
+                later_file.to_str().expect("utf8 path"),
+            ],
+            &tree,
+        );
+
+        assert!(
+            stdout.is_empty(),
+            "cancelled walk should not output matches: {stdout:?}"
+        );
+        assert!(
+            stderr.is_empty(),
+            "cancelled walk should stay silent — diagnostic is the shell's job: {stderr:?}"
+        );
+        assert_eq!(
+            code, 2,
+            "interrupted directory walk should report had_error (exit 2)"
+        );
+
+        let _ = std::fs::remove_dir_all(&tree);
+    }
+
+    #[test]
+    fn files_mode_observes_scope_cancellation() {
+        // Regression for #3933: `rg --files <dir>` routes through
+        // `collect_filtered_files`, whose heartbeat was likewise a no-op.
+        let tree = unique_tree("files");
+        let walk_root = tree.join("walk-root");
+        std::fs::create_dir_all(&walk_root).expect("walk root should be created");
+        std::fs::write(walk_root.join("alpha.txt"), "alpha\n").expect("walked file written");
+        let later_file = tree.join("later.txt");
+        std::fs::write(&later_file, "later\n").expect("later file written");
+
+        let (code, stdout, stderr) = run_rg_cancelled(
+            &[
+                "--files",
+                walk_root.to_str().expect("utf8 path"),
+                later_file.to_str().expect("utf8 path"),
+            ],
+            &tree,
+        );
+
+        assert!(
+            stdout.is_empty(),
+            "cancelled --files walk should not enumerate paths: {stdout:?}"
+        );
+        assert!(
+            stderr.is_empty(),
+            "cancelled --files walk should stay silent: {stderr:?}"
+        );
+        // Cancellation is an error for standalone utility status; the shell
+        // wrapper rewrites it to the user-visible cancelled status (130).
+        assert_eq!(
+            code, 2,
+            "cancelled --files walk should stop before later operands"
+        );
+
+        let _ = std::fs::remove_dir_all(&tree);
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-uutils-ctx/Cargo.toml
+++ b/crates/vendor/oh-my-pi/pi-uutils-ctx/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pi-uutils-ctx"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Thread-local stdio + cwd context for embedding uutils utilities as in-process shell builtins."
+
+[lib]
+path = "src/lib.rs"
+
+# Vendored: do not inherit nixmac workspace deny-level clippy.
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/vendor/oh-my-pi/pi-uutils-ctx/src/lib.rs
+++ b/crates/vendor/oh-my-pi/pi-uutils-ctx/src/lib.rs
@@ -1,0 +1,423 @@
+//! Thread-local I/O + working-directory context for running uutils utilities
+//! in-process as shell builtins.
+//!
+//! uutils utilities write to the process-global `std::io::stdout()`/`stderr()`,
+//! read the process-global `std::io::stdin()`, and resolve relative paths
+//! against the process-global current directory. None of that is correct when
+//! the utility runs as a builtin inside a long-lived shell process: output must
+//! go to the command's (possibly piped/redirected) file descriptors, and
+//! relative paths must resolve against the *shell's* working directory.
+//!
+//! This crate provides a thread-local context that vendored uutils crates are
+//! patched to consult instead of the process globals. The shell host installs a
+//! context for the duration of a single utility invocation on a dedicated
+//! blocking thread (so concurrent pipeline stages, each on their own thread,
+//! stay isolated), runs the utility, then tears the context down.
+
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+struct Ctx {
+    stdin: Box<dyn Read + Send>,
+    /// Raw fd backing `stdin` when it is a real OS file/pipe, used for
+    /// cancellable readiness polling on unix. `None` for non-fd readers.
+    stdin_fd: Option<i32>,
+    /// Whether stdin is a shell pipe/stream that should be searched implicitly.
+    stdin_is_search_input: bool,
+    stdout: Box<dyn Write + Send>,
+    stderr: Box<dyn Write + Send>,
+    cwd: PathBuf,
+    env: HashMap<String, String>,
+    /// Set by the host when the command is aborted/timed out; makes a blocked
+    /// `stdin` read return EOF so the utility unwinds promptly.
+    cancel: Arc<AtomicBool>,
+    exit_code: i32,
+}
+
+thread_local! {
+    static CTX: RefCell<Option<Ctx>> = const { RefCell::new(None) };
+    /// Borrow-free count of active [`scope`] frames on this thread. The native
+    /// crash hook reads this from inside a panic (see [`is_active`]); a `Cell`
+    /// is used because the panicking code may already hold `CTX`'s `RefCell`
+    /// borrow, and a second `RefCell` read there would panic again and abort.
+    static SCOPE_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+static RAYON_GLOBAL_POOL_AVAILABLE: AtomicBool = AtomicBool::new(!cfg!(target_os = "windows"));
+
+/// I/O streams, working directory, environment, and cancel flag for a single
+/// utility invocation. Grouped into one value to keep [`scope`] readable.
+pub struct ScopeIo {
+    /// Standard input reader.
+    pub stdin: Box<dyn Read + Send>,
+    /// Raw fd backing `stdin` when it is a real OS file/pipe (unix), used for
+    /// cancellable readiness polling; `None` for non-fd readers.
+    pub stdin_fd: Option<i32>,
+    /// Whether stdin should be used as `rg PATTERN`'s implicit input.
+    pub stdin_is_search_input: bool,
+    /// Standard output writer.
+    pub stdout: Box<dyn Write + Send>,
+    /// Standard error writer.
+    pub stderr: Box<dyn Write + Send>,
+    /// Working directory that relative paths resolve against.
+    pub cwd: PathBuf,
+    /// Exported shell environment.
+    pub env: HashMap<String, String>,
+    /// Set by the host on abort/timeout to unblock a stalled `stdin` read.
+    pub cancel: Arc<AtomicBool>,
+}
+
+/// Installs `io` as the current thread's uutils context, runs `f`, then
+/// restores whatever context (if any) was previously installed — even if `f`
+/// panics. Returns the value produced by `f`.
+///
+/// The previous context is saved and restored rather than cleared, so nested
+/// scopes (and leftover state across tests sharing a thread) stay correct.
+pub fn scope<R>(io: ScopeIo, f: impl FnOnce() -> R) -> R {
+    struct Guard {
+        prev: Option<Ctx>,
+    }
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            CTX.with(|c| {
+                *c.borrow_mut() = self.prev.take();
+            });
+            SCOPE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+        }
+    }
+
+    let prev = CTX.with(|c| {
+        c.borrow_mut().replace(Ctx {
+            stdin: io.stdin,
+            stdin_fd: io.stdin_fd,
+            stdin_is_search_input: io.stdin_is_search_input,
+            stdout: io.stdout,
+            stderr: io.stderr,
+            cwd: io.cwd,
+            env: io.env,
+            cancel: io.cancel,
+            exit_code: 0,
+        })
+    });
+    SCOPE_DEPTH.with(|d| d.set(d.get() + 1));
+    let _guard = Guard { prev };
+    f()
+}
+
+/// Whether a uutils scope is active on the current thread.
+///
+/// The native crash hook consults this from inside a panic: a panic raised
+/// while a scope is active is, by construction, about to be caught at the
+/// uutils boundary (see `run_uutil` in pi-shell's `coreutils`), so the hook
+/// treats it as recoverable and keeps it out of the user-facing crash report.
+/// Reads the borrow-free [`SCOPE_DEPTH`] counter rather than `CTX`, because the
+/// panicking code may already hold `CTX`'s borrow — a `RefCell` read there
+/// would panic inside the panic hook and abort the process.
+#[must_use]
+pub fn is_active() -> bool {
+    SCOPE_DEPTH.with(|d| d.get() > 0)
+}
+
+/// Records whether patched native callsites may use Rayon's process-global
+/// worker pool without risking lazy initialization under Windows commit
+/// pressure.
+pub fn set_rayon_global_pool_available(available: bool) {
+    RAYON_GLOBAL_POOL_AVAILABLE.store(available, Ordering::SeqCst);
+}
+
+/// Returns whether patched native callsites may enter Rayon's process-global
+/// worker pool.
+#[must_use]
+pub fn rayon_global_pool_available() -> bool {
+    RAYON_GLOBAL_POOL_AVAILABLE.load(Ordering::SeqCst)
+}
+
+/// Returns the exit code accumulated via [`set_exit_code`] during the current
+/// scope (0 when none was set or no context is installed).
+pub fn exit_code() -> i32 {
+    CTX.with(|c| c.borrow().as_ref().map_or(0, |ctx| ctx.exit_code))
+}
+
+/// Records a non-zero exit code (uutils' `show!`/`show_if_err!` analogues call
+/// this when a recoverable error is reported but processing continues).
+pub fn set_exit_code(code: i32) {
+    CTX.with(|c| {
+        if let Some(ctx) = c.borrow_mut().as_mut() {
+            ctx.exit_code = code;
+        }
+    });
+}
+
+/// The shell working directory of the current scope, or `.` when unset.
+pub fn cwd() -> PathBuf {
+    CTX.with(|c| {
+        c.borrow()
+            .as_ref()
+            .map_or_else(|| PathBuf::from("."), |ctx| ctx.cwd.clone())
+    })
+}
+
+/// Resolves `p` against the scope's working directory when relative; absolute
+/// paths are returned unchanged. uutils utilities are patched to resolve every
+/// path argument through this before touching the filesystem.
+pub fn resolve(p: impl AsRef<Path>) -> PathBuf {
+    let p = p.as_ref();
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        cwd().join(p)
+    }
+}
+
+/// Looks up an environment variable from the scope's environment map (the
+/// shell's exported variables). uutils utilities are patched to read the
+/// environment through this rather than `std::env::var`, because the embedding
+/// shell's exported variables are not present in the host process environment.
+pub fn var(key: &str) -> Option<String> {
+    CTX.with(|c| {
+        c.borrow()
+            .as_ref()
+            .and_then(|ctx| ctx.env.get(key).cloned())
+    })
+}
+
+/// Returns a snapshot of the scope's entire environment map (the shell's
+/// exported variables), or an empty vector when no scope is installed.
+/// Utilities that spawn child processes use this to build the child
+/// environment (`env_clear().envs(..)`), because the shell's exported
+/// variables are not present in the host process environment.
+#[must_use]
+pub fn env_snapshot() -> Vec<(String, String)> {
+    CTX.with(|c| {
+        c.borrow().as_ref().map_or_else(Vec::new, |ctx| {
+            ctx.env
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        })
+    })
+}
+/// Returns true when scoped stdin is a shell pipe or custom stream that should
+/// be treated as `rg PATTERN`'s implicit input instead of searching `.`.
+#[must_use]
+pub fn stdin_is_search_input() -> bool {
+    CTX.with(|c| {
+        c.borrow()
+            .as_ref()
+            .is_some_and(|ctx| ctx.stdin_is_search_input)
+    })
+}
+
+/// Returns true when the host has asked the active scope to cancel (e.g. on
+/// shell `abort`/`timeout`). uutils utilities running long internal loops —
+/// recursive directory walks in particular — poll this so cancellation is
+/// observed without waiting for stdin or for the whole work item to finish.
+///
+/// Returns false when no scope is installed; the cancel flag itself is the
+/// same one observed by [`CtxStdin::read`].
+#[must_use]
+pub fn is_cancelled() -> bool {
+    CTX.with(|c| {
+        c.borrow()
+            .as_ref()
+            .is_some_and(|ctx| ctx.cancel.load(Ordering::Relaxed))
+    })
+}
+
+macro_rules! ctx_writer {
+    ($name:ident, $field:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Clone, Copy)]
+        pub struct $name;
+
+        impl $name {
+            /// Mirror of `std::io::Stdout::lock`; the handle is already the
+            /// lockable target, so this is the identity. Lets patched uutils
+            /// code keep its `let out = ...; let out = out.lock();` shape.
+            #[must_use]
+            pub fn lock(self) -> Self {
+                self
+            }
+        }
+
+        impl Write for $name {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                CTX.with(|c| match c.borrow_mut().as_mut() {
+                    Some(ctx) => ctx.$field.write(buf),
+                    // No context installed: discard rather than leak onto the
+                    // host process's real fd.
+                    None => Ok(buf.len()),
+                })
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                CTX.with(|c| match c.borrow_mut().as_mut() {
+                    Some(ctx) => ctx.$field.flush(),
+                    None => Ok(()),
+                })
+            }
+        }
+    };
+}
+
+ctx_writer!(
+    CtxStdout,
+    stdout,
+    "Context-aware stand-in for `std::io::Stdout`."
+);
+ctx_writer!(
+    CtxStderr,
+    stderr,
+    "Context-aware stand-in for `std::io::Stderr`."
+);
+
+/// Context-aware stand-in for `std::io::Stdin`.
+#[derive(Clone, Copy)]
+pub struct CtxStdin;
+
+impl CtxStdin {
+    /// Identity lock, mirroring `std::io::Stdin::lock`.
+    #[must_use]
+    pub fn lock(self) -> Self {
+        self
+    }
+}
+
+impl Read for CtxStdin {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        CTX.with(|c| {
+            let mut guard = c.borrow_mut();
+            let Some(ctx) = guard.as_mut() else {
+                return Ok(0);
+            };
+            if ctx.cancel.load(Ordering::Relaxed) {
+                return Ok(0);
+            }
+            // On unix, wait for readiness in short slices so an abort/timeout is
+            // observed even when input never arrives on a blocked pipe: the
+            // utility then sees EOF and unwinds cleanly (no detached thread, no
+            // writes after the host has moved on).
+            #[cfg(unix)]
+            if let Some(fd) = ctx.stdin_fd {
+                loop {
+                    if ctx.cancel.load(Ordering::Relaxed) {
+                        return Ok(0);
+                    }
+                    let mut pfd = libc::pollfd {
+                        fd,
+                        events: libc::POLLIN,
+                        revents: 0,
+                    };
+                    // SAFETY: one `pollfd` valid for the call; `fd` is owned by the
+                    // live `OpenFile` held in this context.
+                    let r = unsafe { libc::poll(&mut pfd, 1, 200) };
+                    if r < 0 {
+                        let err = io::Error::last_os_error();
+                        if err.kind() == io::ErrorKind::Interrupted {
+                            continue;
+                        }
+                        return Err(err);
+                    }
+                    if r > 0 {
+                        break;
+                    }
+                }
+            }
+            ctx.stdin.read(buf)
+        })
+    }
+}
+
+/// Returns the context stdout handle.
+#[must_use]
+pub fn stdout() -> CtxStdout {
+    CtxStdout
+}
+
+/// Returns the context stderr handle.
+#[must_use]
+pub fn stderr() -> CtxStderr {
+    CtxStderr
+}
+
+/// Returns the context stdin handle.
+#[must_use]
+pub fn stdin() -> CtxStdin {
+    CtxStdin
+}
+
+/// Generate the usage string for clap without evaluating argv-dependent
+/// statics.
+///
+/// This is a panic-safe, argv-independent replacement for
+/// `uucore::format_usage`. It indents all but the first line by 7 spaces to
+/// align with clap's "Usage: " prefix. Callers must provide explicit usage
+/// strings (with actual command names) and avoid `{}` placeholders.
+#[must_use]
+pub fn format_usage(s: &str) -> String {
+    debug_assert!(
+        !s.contains("{}"),
+        "format_usage shim does not support placeholder '{{}}' - use explicit command names instead"
+    );
+    s.replace('\n', "\n       ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_usage_indentation() {
+        let usage = "cat [OPTION]... [FILE]...\nSome descriptive text\nAnother line";
+        let formatted = format_usage(usage);
+        assert_eq!(
+            formatted,
+            "cat [OPTION]... [FILE]...\n       Some descriptive text\n       Another line"
+        );
+    }
+
+    #[test]
+    fn test_format_usage_empty() {
+        let formatted = format_usage("");
+        assert_eq!(formatted, "");
+    }
+
+    fn empty_io() -> ScopeIo {
+        ScopeIo {
+            stdin: Box::new(io::empty()),
+            stdin_fd: None,
+            stdin_is_search_input: false,
+            stdout: Box::new(io::sink()),
+            stderr: Box::new(io::sink()),
+            cwd: PathBuf::from("."),
+            env: HashMap::new(),
+            cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[test]
+    fn is_active_tracks_scope_and_survives_panic() {
+        assert!(!is_active(), "no scope installed");
+        scope(empty_io(), || {
+            assert!(is_active(), "scope active inside closure")
+        });
+        assert!(!is_active(), "scope torn down");
+
+        // The crash hook reads is_active() while a panic unwinds, so the depth
+        // counter must be restored by the scope guard even on panic.
+        let unwound = std::panic::catch_unwind(|| scope(empty_io(), || panic!("boom")));
+        assert!(unwound.is_err(), "panic propagated out of the scope");
+        assert!(
+            !is_active(),
+            "scope depth restored after an unwinding panic"
+        );
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-walker/Cargo.toml
+++ b/crates/vendor/oh-my-pi/pi-walker/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pi-walker"
+version = "17.1.2"
+edition = "2024"
+license = "MIT"
+authors = ["Can Boluk"]
+repository = "https://github.com/can1357/oh-my-pi"
+description = "Reusable platform directory traversal primitives (vendored from oh-my-pi)"
+
+# Vendored: do not inherit nixmac workspace deny-level clippy.
+
+[dependencies]
+dashmap = "6.1"
+globset = "0.4"
+ignore = "0.4"
+parking_lot = "0.12.5"
+rayon = "1.12"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Wdk_Storage_FileSystem"] }

--- a/crates/vendor/oh-my-pi/pi-walker/src/cache.rs
+++ b/crates/vendor/oh-my-pi/pi-walker/src/cache.rs
@@ -1,0 +1,695 @@
+//! Shared walker scan cache used by owned-entry collection.
+
+use std::{
+    borrow::Cow,
+    fmt,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
+
+use dashmap::DashMap;
+use rayon::{ThreadPool, prelude::*};
+
+use crate::{CollectedEntries, CollectedEntry, FileType, WalkError, WalkOptions};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    root: PathBuf,
+    options: WalkOptions,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    created_at: Instant,
+    entries: Vec<CollectedEntry>,
+}
+
+static CACHE_TTL_MS: LazyLock<u64> =
+    LazyLock::new(|| env_uint("FS_SCAN_CACHE_TTL_MS", 1_000, 0, u64::MAX));
+static EMPTY_RECHECK_MS: LazyLock<u64> =
+    LazyLock::new(|| env_uint("FS_SCAN_EMPTY_RECHECK_MS", 200, 0, u64::MAX));
+static MAX_CACHE_ENTRIES: LazyLock<usize> =
+    LazyLock::new(|| env_uint("FS_SCAN_CACHE_MAX_ENTRIES", 16, 0, usize::MAX));
+const DEFAULT_WALK_WORKERS: usize = 4;
+
+static WALK_WORKERS: LazyLock<usize> = LazyLock::new(|| {
+    normalize_worker_count(env_uint(
+        "PI_WALK_WORKERS",
+        DEFAULT_WALK_WORKERS,
+        0,
+        usize::MAX,
+    ))
+});
+static WALK_POOL: LazyLock<Option<ThreadPool>> = LazyLock::new(|| {
+    let workers = walk_workers();
+    if workers <= 1 {
+        return None;
+    }
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(workers)
+        .thread_name(|index| format!("pi-walker-{index}"))
+        .build()
+        .ok()
+});
+static SCAN_CACHE: LazyLock<DashMap<CacheKey, CacheEntry>> = LazyLock::new(DashMap::new);
+
+fn env_uint<T>(name: &str, default: T, min: T, max: T) -> T
+where
+    T: Copy + Ord + std::str::FromStr,
+{
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+        .clamp(min, max)
+}
+
+fn normalize_worker_count_with_available(configured: usize, available: usize) -> usize {
+    if configured == 0 {
+        available.max(1)
+    } else {
+        configured.max(1)
+    }
+}
+
+fn available_worker_count() -> usize {
+    std::thread::available_parallelism().map_or(DEFAULT_WALK_WORKERS, usize::from)
+}
+
+fn normalize_worker_count(configured: usize) -> usize {
+    normalize_worker_count_with_available(configured, available_worker_count())
+}
+
+/// Configured cache TTL in milliseconds.
+pub fn cache_ttl_ms() -> u64 {
+    *CACHE_TTL_MS
+}
+
+/// Configured empty-result recheck threshold in milliseconds.
+pub fn empty_recheck_ms() -> u64 {
+    *EMPTY_RECHECK_MS
+}
+
+/// Configured maximum number of cache entries.
+pub fn max_cache_entries() -> usize {
+    *MAX_CACHE_ENTRIES
+}
+
+/// Effective worker count for filesystem traversal and related parallel work.
+///
+/// `PI_WALK_WORKERS=0` means auto-detect; `PI_WALK_WORKERS=1` forces serial
+/// work.
+pub fn walk_workers() -> usize {
+    *WALK_WORKERS
+}
+
+/// Run parallel traversal-adjacent work on the centralized walker pool.
+pub fn with_walk_pool<R>(operation: impl FnOnce() -> R + Send) -> R
+where
+    R: Send,
+{
+    if let Some(pool) = WALK_POOL.as_ref() {
+        pool.install(operation)
+    } else {
+        operation()
+    }
+}
+
+const PARALLEL_MIN_FILES: usize = 256;
+
+/// Return whether traversal-adjacent work should run in parallel.
+pub fn should_parallelize(item_count: usize) -> bool {
+    walk_workers() > 1 && item_count >= PARALLEL_MIN_FILES
+}
+
+/// Run traversal-adjacent work serially or on the centralized walker pool.
+pub fn parallel_for_each<T, E>(
+    items: &[T],
+    operation: impl Fn(&T) -> std::result::Result<(), E> + Send + Sync,
+) -> std::result::Result<(), E>
+where
+    T: Sync,
+    E: Send,
+{
+    if !should_parallelize(items.len()) {
+        return items.iter().try_for_each(operation);
+    }
+    with_walk_pool(|| items.par_iter().try_for_each(operation))
+}
+
+/// Run traversal-adjacent work with per-worker state on the centralized walker
+/// pool.
+pub fn parallel_for_each_init<T, S, E>(
+    items: &[T],
+    init: impl Fn() -> S + Send + Sync,
+    operation: impl Fn(&mut S, &T) -> std::result::Result<(), E> + Send + Sync,
+) -> std::result::Result<(), E>
+where
+    T: Sync,
+    S: Send,
+    E: Send,
+{
+    if !should_parallelize(items.len()) {
+        let mut state = init();
+        return items
+            .iter()
+            .try_for_each(|item| operation(&mut state, item));
+    }
+    with_walk_pool(|| items.par_iter().try_for_each_init(init, operation))
+}
+
+fn evict_oldest() {
+    if SCAN_CACHE.len() > *MAX_CACHE_ENTRIES
+        && let Some(oldest_key) = SCAN_CACHE
+            .iter()
+            .min_by_key(|entry| entry.value().created_at)
+            .map(|entry| entry.key().clone())
+    {
+        SCAN_CACHE.remove(&oldest_key);
+    }
+}
+
+fn cache_key(root: &Path, mut options: WalkOptions) -> CacheKey {
+    options.cache = false;
+    CacheKey {
+        root: root.to_path_buf(),
+        options,
+    }
+}
+
+/// Normalize a filesystem path to a forward-slash relative string.
+pub fn normalize_relative_path<'a>(root: &Path, path: &'a Path) -> Cow<'a, str> {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    if cfg!(windows) {
+        let relative = relative.to_string_lossy();
+        if relative.contains('\\') {
+            Cow::Owned(relative.replace('\\', "/"))
+        } else {
+            relative
+        }
+    } else {
+        relative.to_string_lossy()
+    }
+}
+
+/// Return whether a path contains the exact component name.
+pub fn contains_component(path: &Path, target: &str) -> bool {
+    path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(|value| value == target)
+    })
+}
+
+/// Return whether user-facing discovery should skip a relative path.
+pub fn should_skip_path(path: &Path, mentions_node_modules: bool) -> bool {
+    if contains_component(path, ".git") {
+        return true;
+    }
+    if !mentions_node_modules && contains_component(path, "node_modules") {
+        return true;
+    }
+    false
+}
+
+fn file_type_from_std(file_type: std::fs::FileType) -> Option<FileType> {
+    if file_type.is_symlink() {
+        Some(FileType::Symlink)
+    } else if file_type.is_dir() {
+        Some(FileType::Dir)
+    } else if file_type.is_file() {
+        Some(FileType::File)
+    } else {
+        None
+    }
+}
+
+fn mtime_ms(metadata: &std::fs::Metadata) -> Option<f64> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as f64)
+}
+
+/// Classify an existing filesystem path, skipping unsupported special files.
+pub fn classify_file_type(path: &Path) -> Option<(FileType, Option<f64>, Option<u64>)> {
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    let file_type = file_type_from_std(metadata.file_type())?;
+    let size = if file_type == FileType::File {
+        Some(metadata.len())
+    } else {
+        None
+    };
+    Some((file_type, mtime_ms(&metadata), size))
+}
+
+/// Resolve a search path string to a canonical directory path.
+pub fn resolve_search_path(path: &str) -> Result<PathBuf, WalkError<String>> {
+    let candidate = PathBuf::from(path);
+    let root = if candidate.is_absolute() {
+        candidate
+    } else {
+        let cwd = std::env::current_dir().map_err(|err| WalkError::InvalidData {
+            path: PathBuf::from(path),
+            message: format!("Failed to resolve cwd: {err}"),
+        })?;
+        cwd.join(candidate)
+    };
+    let metadata = std::fs::metadata(&root).map_err(|err| WalkError::InvalidData {
+        path: root.clone(),
+        message: format!("Path not found: {err}"),
+    })?;
+    if !metadata.is_dir() {
+        return Err(WalkError::InvalidData {
+            path: root,
+            message: "Search path must be a directory".to_string(),
+        });
+    }
+    Ok(std::fs::canonicalize(&root).unwrap_or(root))
+}
+
+fn collect_entries_uncached<H, E>(
+    root: &Path,
+    mut options: WalkOptions,
+    heartbeat: &H,
+) -> Result<CollectedEntries, WalkError<String>>
+where
+    H: Fn() -> std::result::Result<(), E> + Sync,
+    E: fmt::Display,
+{
+    options.cache = false;
+    crate::collect_entries_native(root, options, || heartbeat().map_err(|err| err.to_string()))
+}
+
+fn get_or_scan<H, E>(
+    root: &Path,
+    options: WalkOptions,
+    heartbeat: &H,
+) -> Result<CollectedEntries, WalkError<String>>
+where
+    H: Fn() -> std::result::Result<(), E> + Sync,
+    E: fmt::Display,
+{
+    let ttl = *CACHE_TTL_MS;
+    if ttl == 0 {
+        return collect_entries_uncached(root, options, heartbeat);
+    }
+
+    let key = cache_key(root, options);
+    let now = Instant::now();
+    if let Some(entry) = SCAN_CACHE.get(&key) {
+        let age = now.duration_since(entry.created_at);
+        if age < Duration::from_millis(ttl) {
+            return Ok(CollectedEntries {
+                entries: entry.entries.clone(),
+                cache_age_ms: age.as_millis() as u64,
+            });
+        }
+        drop(entry);
+        SCAN_CACHE.remove(&key);
+    }
+
+    let scan = collect_entries_uncached(root, options, heartbeat)?;
+    SCAN_CACHE.insert(
+        key,
+        CacheEntry {
+            created_at: now,
+            entries: scan.entries.clone(),
+        },
+    );
+    evict_oldest();
+    Ok(CollectedEntries {
+        entries: scan.entries,
+        cache_age_ms: 0,
+    })
+}
+
+pub fn collect_entries<H, E>(
+    root: &Path,
+    options: WalkOptions,
+    heartbeat: H,
+) -> Result<CollectedEntries, WalkError<String>>
+where
+    H: Fn() -> std::result::Result<(), E> + Sync,
+    E: fmt::Display,
+{
+    if options.cache {
+        get_or_scan(root, options, &heartbeat)
+    } else {
+        collect_entries_uncached(root, options, &heartbeat)
+    }
+}
+
+/// Invalidate cache entries whose root contains `target`.
+pub fn invalidate_path(target: &Path) {
+    let keys_to_remove: Vec<CacheKey> = SCAN_CACHE
+        .iter()
+        .filter(|entry| target.starts_with(&entry.key().root))
+        .map(|entry| entry.key().clone())
+        .collect();
+    for key in keys_to_remove {
+        SCAN_CACHE.remove(&key);
+    }
+}
+
+/// Resolve a possibly relative path and invalidate matching cache roots.
+pub fn invalidate_path_string(path: &str) {
+    let candidate = PathBuf::from(path);
+    let absolute = if candidate.is_absolute() {
+        candidate
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(candidate)
+    } else {
+        PathBuf::from(path)
+    };
+    let target = std::fs::canonicalize(&absolute)
+        .or_else(|_| {
+            absolute
+                .parent()
+                .and_then(|parent| std::fs::canonicalize(parent).ok())
+                .and_then(|parent| absolute.file_name().map(|name| parent.join(name)))
+                .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotFound))
+        })
+        .unwrap_or(absolute);
+    invalidate_path(&target);
+}
+
+/// Clear the entire scan cache.
+pub fn invalidate_all() {
+    SCAN_CACHE.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::{ffi::CString, os::unix::ffi::OsStrExt};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    #[cfg(unix)]
+    use super::classify_file_type;
+    use crate::{CollectedEntry, FileType};
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TempDirGuard(PathBuf);
+
+    impl TempDirGuard {
+        fn new() -> Self {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time is after UNIX_EPOCH")
+                .as_nanos();
+            let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!("pi-fs-cache-test-{timestamp}-{counter}"));
+            fs::create_dir_all(&path).expect("create temp test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[cfg(unix)]
+    fn make_fifo(path: &Path) {
+        let fifo_path =
+            CString::new(path.as_os_str().as_bytes()).expect("fifo path has no NUL bytes");
+        // SAFETY: `fifo_path` is a valid CString (NUL-terminated, no interior NULs),
+        // so `as_ptr()` yields a valid C string pointer. `0o600` is a valid mode.
+        // The CString is alive for the duration of the call.
+        let rc = unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "create fifo: {}", std::io::Error::last_os_error());
+    }
+
+    #[allow(
+        clippy::unnecessary_wraps,
+        reason = "test heartbeat helper matches production callback signature"
+    )]
+    fn ok_heartbeat() -> std::result::Result<(), String> {
+        Ok(())
+    }
+
+    #[test]
+    fn worker_count_zero_uses_available_parallelism() {
+        assert_eq!(super::normalize_worker_count_with_available(0, 8), 8);
+        assert_eq!(super::normalize_worker_count_with_available(0, 0), 1);
+        assert_eq!(super::normalize_worker_count_with_available(1, 8), 1);
+        assert_eq!(super::normalize_worker_count_with_available(4, 8), 4);
+    }
+
+    fn scan_options(
+        include_hidden: bool,
+        use_gitignore: bool,
+        detail: crate::WalkDetail,
+    ) -> crate::WalkOptions {
+        crate::WalkOptions {
+            include_hidden,
+            use_gitignore,
+            skip_git: true,
+            skip_node_modules: true,
+            follow_links: crate::FollowLinks::Never,
+            detail,
+            directory_errors: crate::DirectoryErrorMode::SkipSkippable,
+            ..crate::WalkOptions::default()
+        }
+    }
+
+    fn assert_file_entry(entries: &[CollectedEntry], path: &str, size: f64) {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.path == path)
+            .unwrap_or_else(|| panic!("expected file entry {path}, got {}", entry_paths(entries)));
+        assert_eq!(entry.file_type, FileType::File);
+        assert!(
+            entry.mtime.is_some(),
+            "full scan should include mtime for {path}"
+        );
+        assert_eq!(entry.size, Some(size));
+    }
+
+    fn assert_dir_entry(entries: &[CollectedEntry], path: &str) {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.path == path)
+            .unwrap_or_else(|| panic!("expected dir entry {path}, got {}", entry_paths(entries)));
+        assert_eq!(entry.file_type, FileType::Dir);
+        assert!(
+            entry.mtime.is_some(),
+            "full scan should include mtime for {path}"
+        );
+        assert_eq!(entry.size, None);
+    }
+
+    fn entry_paths(entries: &[CollectedEntry]) -> String {
+        let paths: Vec<&str> = entries.iter().map(|entry| entry.path.as_str()).collect();
+        format!("{paths:?}")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_file_type_skips_fifo() {
+        let root = TempDirGuard::new();
+        let fifo = root.path().join("skip-me.fifo");
+        make_fifo(&fifo);
+
+        assert_eq!(classify_file_type(&fifo), None);
+    }
+
+    #[test]
+    fn collect_entries_skips_node_modules() {
+        let root = TempDirGuard::new();
+        fs::create_dir_all(root.path().join("node_modules/pkg")).unwrap();
+        fs::write(root.path().join("node_modules/pkg/index.js"), "nm").unwrap();
+        fs::write(root.path().join("real.txt"), "ok").unwrap();
+
+        let entries = super::collect_entries(
+            root.path(),
+            scan_options(true, false, crate::WalkDetail::Full),
+            ok_heartbeat,
+        )
+        .unwrap();
+        let entries = entries.entries;
+        let paths: Vec<&str> = entries.iter().map(|entry| entry.path.as_str()).collect();
+        assert!(
+            !paths.iter().any(|path| path.contains("node_modules")),
+            "expected no node_modules entries, got: {paths:?}"
+        );
+        assert!(
+            paths.iter().any(|path| path == &"real.txt"),
+            "expected real.txt, got: {paths:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_entries_follow_links_always() {
+        let root = TempDirGuard::new();
+        fs::create_dir_all(root.path().join("target")).unwrap();
+        fs::write(root.path().join("target/linked.txt"), "linked").unwrap();
+        std::os::unix::fs::symlink(root.path().join("target"), root.path().join("link")).unwrap();
+
+        let mut options = scan_options(true, false, crate::WalkDetail::Minimal);
+        options.follow_links = crate::FollowLinks::Always;
+
+        let entries = super::collect_entries(root.path(), options, ok_heartbeat).unwrap();
+        let paths: Vec<&str> = entries
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect();
+        assert!(
+            paths.iter().any(|path| path == &"link/linked.txt"),
+            "follow-links always should yield symlink descendants, got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn traversal_gitignore_excludes_files() {
+        let root = TempDirGuard::new();
+        fs::create_dir_all(root.path().join(".git")).unwrap();
+        fs::write(root.path().join(".gitignore"), "ignored.txt\n").unwrap();
+        fs::write(root.path().join("ignored.txt"), "ignored").unwrap();
+        fs::write(root.path().join("kept.txt"), "keep").unwrap();
+
+        let collected = super::collect_entries(
+            root.path(),
+            scan_options(true, true, crate::WalkDetail::Full),
+            ok_heartbeat,
+        )
+        .unwrap();
+        let collected = collected.entries;
+        assert!(
+            !collected.iter().any(|entry| entry.path == "ignored.txt"),
+            "collect_entries returned gitignored file: {}",
+            entry_paths(&collected)
+        );
+        assert_file_entry(&collected, "kept.txt", 4.0);
+    }
+
+    #[test]
+    fn traversal_hidden_disabled_excludes_files_and_descendants() {
+        let root = TempDirGuard::new();
+        fs::create_dir_all(root.path().join(".hidden-dir")).unwrap();
+        fs::write(root.path().join(".hidden-dir/child.txt"), "child").unwrap();
+        fs::write(root.path().join(".hidden-file"), "secret").unwrap();
+        fs::write(root.path().join("visible.txt"), "visible").unwrap();
+
+        let entries = super::collect_entries(
+            root.path(),
+            scan_options(false, false, crate::WalkDetail::Full),
+            ok_heartbeat,
+        )
+        .unwrap();
+        let entries = entries.entries;
+        assert_eq!(
+            entries.len(),
+            1,
+            "only visible.txt should be returned when hidden entries are disabled, got {}",
+            entry_paths(&entries)
+        );
+        assert_file_entry(&entries, "visible.txt", 7.0);
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| entry.path.starts_with(".hidden")),
+            "hidden entries should be pruned before yielding files or descendants, got {}",
+            entry_paths(&entries)
+        );
+    }
+
+    #[test]
+    fn traversal_hidden_enabled_includes_non_ignored_hidden_entries() {
+        let root = TempDirGuard::new();
+        fs::create_dir_all(root.path().join(".git")).unwrap();
+        fs::write(root.path().join(".gitignore"), ".ignored-hidden\n").unwrap();
+        fs::create_dir_all(root.path().join(".hidden-dir")).unwrap();
+        fs::write(root.path().join(".hidden-dir/child.txt"), "child").unwrap();
+        fs::write(root.path().join(".hidden-file"), "secret").unwrap();
+        fs::write(root.path().join(".ignored-hidden"), "ignored").unwrap();
+
+        let entries = super::collect_entries(
+            root.path(),
+            scan_options(true, true, crate::WalkDetail::Full),
+            ok_heartbeat,
+        )
+        .unwrap();
+        let entries = entries.entries;
+        assert_file_entry(&entries, ".hidden-file", 6.0);
+        assert_dir_entry(&entries, ".hidden-dir");
+        assert_file_entry(&entries, ".hidden-dir/child.txt", 5.0);
+        assert!(
+            !entries.iter().any(|entry| entry.path == ".ignored-hidden"),
+            "gitignore should still exclude matching hidden files, got {}",
+            entry_paths(&entries)
+        );
+    }
+
+    #[test]
+    fn collect_entries_respects_pre_cancelled_token() {
+        let root = TempDirGuard::new();
+        fs::write(root.path().join("real.txt"), "ok").unwrap();
+
+        std::thread::sleep(Duration::from_millis(1));
+        let result = super::collect_entries(
+            root.path(),
+            scan_options(true, false, crate::WalkDetail::Minimal),
+            || Err("Timeout".to_string()),
+        );
+
+        let Err(err) = result else {
+            panic!("pre-cancelled scans should fail before returning entries");
+        };
+        assert!(
+            err.to_string().contains("Timeout"),
+            "expected timeout cancellation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn scan_detail_controls_metadata_collection() {
+        let root = TempDirGuard::new();
+        fs::write(root.path().join("real.txt"), "ok").unwrap();
+
+        let minimal = super::collect_entries(
+            root.path(),
+            scan_options(true, false, crate::WalkDetail::Minimal),
+            ok_heartbeat,
+        )
+        .unwrap();
+        let minimal_file = minimal
+            .entries
+            .iter()
+            .find(|entry| entry.path == "real.txt")
+            .expect("minimal scan includes file");
+        assert_eq!(minimal_file.mtime, None);
+        assert_eq!(minimal_file.size, None);
+
+        let full = super::collect_entries(
+            root.path(),
+            scan_options(true, false, crate::WalkDetail::Full),
+            ok_heartbeat,
+        )
+        .unwrap();
+        let full_file = full
+            .entries
+            .iter()
+            .find(|entry| entry.path == "real.txt")
+            .expect("full scan includes file");
+        assert!(full_file.mtime.is_some(), "full scan should include mtime");
+        assert_eq!(full_file.size, Some(2.0));
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-walker/src/lib.rs
+++ b/crates/vendor/oh-my-pi/pi-walker/src/lib.rs
@@ -1,0 +1,5100 @@
+//! Reusable platform directory traversal primitives.
+//!
+//! # Overview
+//! `pi-walker` owns the native directory-read fast path that higher-level tools
+//! use for globbing, grep candidate discovery, AST scans, and shell builtins.
+//! The crate exposes plain Rust types, visitor interfaces, cache policy, and a
+//! caller-supplied heartbeat so consumers do not inherit N-API dependencies.
+
+mod cache;
+
+#[cfg(not(unix))]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+use std::{
+    borrow::Cow,
+    cell::{Cell, RefCell},
+    cmp::Ordering,
+    convert::Infallible,
+    ffi::OsStr,
+    fmt,
+    hash::{Hash, Hasher},
+    io::{self, BufRead},
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering as AtomicOrdering},
+    },
+};
+
+pub use cache::{
+    cache_ttl_ms, classify_file_type, contains_component, empty_recheck_ms, invalidate_all,
+    invalidate_path, invalidate_path_string, max_cache_entries, normalize_relative_path,
+    parallel_for_each, parallel_for_each_init, resolve_search_path, should_parallelize,
+    should_skip_path, walk_workers,
+};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+
+const HEARTBEAT_INTERVAL: usize = 128;
+
+/// Filesystem entry kind reported by the walker.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FileType {
+    /// Regular file.
+    File,
+    /// Directory.
+    Dir,
+    /// Symbolic link.
+    Symlink,
+}
+
+/// Amount of metadata to collect while reading directories.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WalkDetail {
+    /// Collect only the entry name and file kind.
+    Minimal,
+    /// Also collect mtime and byte size for regular files.
+    Full,
+}
+
+/// Traversal order for entries within each directory.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WalkOrder {
+    /// Visit entries in the order returned by the platform API.
+    Unordered,
+    /// Sort entries by filename before visiting them.
+    Path,
+}
+
+/// How directory-open errors are handled during traversal.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DirectoryErrorMode {
+    /// Preserve the native glob fast-path contract: silently skip common race or
+    /// permission failures and fail on other directory errors.
+    SkipSkippable,
+    /// Deliver directory errors to [`EntryVisitor::visit_directory_error`] so
+    /// GNU-style consumers can report them and continue.
+    Visit,
+}
+
+/// Symbolic-link traversal policy.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FollowLinks {
+    /// Never follow symbolic links.
+    Never,
+    /// Follow root operands when they are symbolic links, but not descendants.
+    Roots,
+    /// Follow symbolic links at every depth.
+    Always,
+}
+
+impl From<bool> for FollowLinks {
+    fn from(follow: bool) -> Self {
+        if follow { Self::Always } else { Self::Never }
+    }
+}
+
+impl FollowLinks {
+    const fn follow_at_depth(self, depth: usize) -> bool {
+        match self {
+            Self::Never => false,
+            Self::Roots => depth == 0,
+            Self::Always => true,
+        }
+    }
+}
+
+/// Shared cache use policy for high-level walk requests.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum CachePolicy {
+    /// Collect without using or updating the shared scan cache.
+    Disabled,
+    /// Use the shared scan cache for owned-entry collection.
+    Enabled,
+}
+
+/// Empty cached-result revalidation policy for [`WalkRequest::collect`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum EmptyRecheck {
+    /// Never re-scan an empty cached result.
+    Never,
+    /// Re-scan empty cached results at or above the configured
+    /// [`empty_recheck_ms`] threshold.
+    Configured,
+    /// Re-scan empty cached results at or above this cache age.
+    AfterMillis(u64),
+}
+
+/// Size metadata policy for high-level requests.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SizeHintPolicy {
+    /// Preserve the request's [`WalkDetail`] setting.
+    FromDetail,
+    /// Request minimal metadata even on platforms with cheap size hints.
+    Never,
+    /// Request full metadata only when the platform exposes cheap file sizes.
+    WhenCheap,
+    /// Request full metadata for every yielded entry.
+    Always,
+}
+
+/// Directory visit order for high-level requests.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum VisitOrder {
+    /// Yield a directory before its children.
+    PreOrder,
+    /// Yield a directory after its children when supported by the backend.
+    ContentsFirst,
+}
+
+/// Concrete compiled glob filter for normalized walk-relative paths.
+///
+/// Patterns are expected to already use the walker's normalized `/` separator
+/// form. Each pattern is compiled with [`GlobBuilder::literal_separator`] so
+/// wildcard matches never cross path separators. Equality and hashing use only
+/// the normalized pattern list, not the compiled matcher internals, which keeps
+/// [`WalkFilter`] suitable for static cacheable traversal policy.
+#[derive(Clone)]
+pub struct CompiledWalkGlob {
+    patterns: Arc<[String]>,
+    matcher: Arc<GlobSet>,
+}
+
+impl CompiledWalkGlob {
+    /// Compile normalized glob patterns for walk-relative paths.
+    pub fn new<P, I>(patterns: I) -> Result<Self, globset::Error>
+    where
+        P: Into<String>,
+        I: IntoIterator<Item = P>,
+    {
+        let mut normalized_patterns = Vec::new();
+        let mut builder = GlobSetBuilder::new();
+        for pattern in patterns {
+            let pattern = pattern.into();
+            let glob = GlobBuilder::new(&pattern).literal_separator(true).build()?;
+            builder.add(glob);
+            normalized_patterns.push(pattern);
+        }
+        Ok(Self {
+            patterns: normalized_patterns.into(),
+            matcher: Arc::new(builder.build()?),
+        })
+    }
+
+    /// Return whether `relative` matches any compiled pattern.
+    pub fn is_match(&self, relative: &str) -> bool {
+        self.matcher.is_match(relative)
+    }
+
+    /// Return the normalized patterns backing this compiled filter.
+    pub fn patterns(&self) -> &[String] {
+        &self.patterns
+    }
+}
+
+impl fmt::Debug for CompiledWalkGlob {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompiledWalkGlob")
+            .field("patterns", &self.patterns)
+            .finish()
+    }
+}
+
+impl PartialEq for CompiledWalkGlob {
+    fn eq(&self, other: &Self) -> bool {
+        self.patterns == other.patterns
+    }
+}
+
+impl Eq for CompiledWalkGlob {}
+
+impl Hash for CompiledWalkGlob {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.patterns.hash(state);
+    }
+}
+
+/// High-level entry filter applied by collection and streaming APIs.
+#[derive(Clone)]
+pub struct WalkFilter {
+    kind: WalkFilterKind,
+    max_file_size: Option<u64>,
+    skip_node_modules_unless_seen: bool,
+    mentions_node_modules: bool,
+    glob: Option<CompiledWalkGlob>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum WalkFilterKind {
+    All,
+    Files,
+    Dirs,
+}
+
+impl Default for WalkFilter {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+impl fmt::Debug for WalkFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WalkFilter")
+            .field("kind", &self.kind)
+            .field("max_file_size", &self.max_file_size)
+            .field(
+                "skip_node_modules_unless_seen",
+                &self.skip_node_modules_unless_seen,
+            )
+            .field("mentions_node_modules", &self.mentions_node_modules)
+            .field("glob", &self.glob)
+            .finish()
+    }
+}
+
+impl PartialEq for WalkFilter {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+            && self.max_file_size == other.max_file_size
+            && self.skip_node_modules_unless_seen == other.skip_node_modules_unless_seen
+            && self.mentions_node_modules == other.mentions_node_modules
+            && self.glob == other.glob
+    }
+}
+
+impl Eq for WalkFilter {}
+
+impl Hash for WalkFilter {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.kind.hash(state);
+        self.max_file_size.hash(state);
+        self.skip_node_modules_unless_seen.hash(state);
+        self.mentions_node_modules.hash(state);
+        self.glob.hash(state);
+    }
+}
+
+impl WalkFilter {
+    /// Return a filter that accepts files and directories.
+    pub const fn all() -> Self {
+        Self {
+            kind: WalkFilterKind::All,
+            max_file_size: None,
+            skip_node_modules_unless_seen: false,
+            mentions_node_modules: false,
+            glob: None,
+        }
+    }
+
+    /// Return a filter that emits only regular files.
+    pub const fn files_only() -> Self {
+        Self {
+            kind: WalkFilterKind::Files,
+            max_file_size: None,
+            skip_node_modules_unless_seen: false,
+            mentions_node_modules: false,
+            glob: None,
+        }
+    }
+
+    /// Return a filter that emits only directories.
+    pub const fn dirs_only() -> Self {
+        Self {
+            kind: WalkFilterKind::Dirs,
+            max_file_size: None,
+            skip_node_modules_unless_seen: false,
+            mentions_node_modules: false,
+            glob: None,
+        }
+    }
+
+    /// Limit emitted regular files to `max_file_size` bytes.
+    pub const fn max_file_size(mut self, max_file_size: u64) -> Self {
+        self.max_file_size = Some(max_file_size);
+        self
+    }
+
+    /// Skip `node_modules` entries unless the caller's query mentioned them.
+    pub const fn node_modules_unless_mentioned(mut self, mentions_node_modules: bool) -> Self {
+        self.skip_node_modules_unless_seen = true;
+        self.mentions_node_modules = mentions_node_modules;
+        self
+    }
+
+    /// Accept only entries whose normalized relative path matches `glob`.
+    pub fn glob(mut self, glob: CompiledWalkGlob) -> Self {
+        self.glob = Some(glob);
+        self
+    }
+
+    fn accepts_path(&self, relative_path: &str) -> bool {
+        self.glob
+            .as_ref()
+            .is_none_or(|glob| glob.is_match(relative_path))
+    }
+
+    fn accepts_collected(&self, entry: &CollectedEntry) -> bool {
+        if self.skip_node_modules_unless_seen
+            && !self.mentions_node_modules
+            && entry
+                .path
+                .split('/')
+                .any(|component| component == "node_modules")
+        {
+            return false;
+        }
+        if self.max_file_size.is_some_and(|max| {
+            entry.file_type == FileType::File && entry.size.is_some_and(|size| size > max as f64)
+        }) {
+            return false;
+        }
+        let accepts_kind = match self.kind {
+            WalkFilterKind::All => true,
+            WalkFilterKind::Files => entry.file_type == FileType::File,
+            WalkFilterKind::Dirs => entry.file_type == FileType::Dir,
+        };
+        accepts_kind && self.accepts_path(&entry.path)
+    }
+
+    fn stream_decision(&self, meta: &EntryMeta<'_>) -> WalkDecision {
+        if self.skip_node_modules_unless_seen
+            && !self.mentions_node_modules
+            && meta
+                .relative_path
+                .split('/')
+                .any(|component| component == "node_modules")
+        {
+            return if meta.file_type == FileType::Dir {
+                WalkDecision::SkipDescend
+            } else {
+                WalkDecision::Skip
+            };
+        }
+        if self.max_file_size.is_some_and(|max| {
+            meta.file_type == FileType::File && meta.size.is_some_and(|size| size > max as f64)
+        }) {
+            return WalkDecision::Skip;
+        }
+        let accepts_kind = match self.kind {
+            WalkFilterKind::All => true,
+            WalkFilterKind::Files => meta.file_type == FileType::File,
+            WalkFilterKind::Dirs => meta.file_type == FileType::Dir,
+        };
+        if !accepts_kind {
+            return WalkDecision::Skip;
+        }
+        if self.accepts_path(meta.relative_path) {
+            WalkDecision::Include
+        } else {
+            WalkDecision::Skip
+        }
+    }
+}
+
+/// Traversal decision returned by [`WalkPredicate`] and closure streaming APIs.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WalkDecision {
+    /// Emit this entry and continue traversal.
+    Include,
+    /// Do not emit this entry, but continue traversal.
+    Skip,
+    /// Do not emit this directory and do not descend into it.
+    SkipDescend,
+    /// Stop traversal immediately.
+    Stop,
+}
+
+/// Predicate hook for dynamic walk consumers.
+pub trait WalkPredicate {
+    /// Decide how the high-level walker should handle `entry`.
+    fn decide(&mut self, entry: &EntryMeta<'_>) -> WalkDecision;
+}
+
+impl<F> WalkPredicate for F
+where
+    F: for<'entry, 'meta> FnMut(&'entry EntryMeta<'meta>) -> WalkDecision,
+{
+    fn decide(&mut self, entry: &EntryMeta<'_>) -> WalkDecision {
+        self(entry)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct IncludeAllPredicate;
+
+impl WalkPredicate for IncludeAllPredicate {
+    fn decide(&mut self, _entry: &EntryMeta<'_>) -> WalkDecision {
+        WalkDecision::Include
+    }
+}
+
+/// Borrowed metadata view shared by owned and streaming entries.
+pub struct EntryMeta<'a> {
+    /// Traversal root used to resolve relative paths.
+    pub root: &'a Path,
+    /// Absolute filesystem path.
+    pub absolute_path: Cow<'a, Path>,
+    /// Relative path from the root, using `/` separators.
+    pub relative_path: &'a str,
+    /// Filesystem entry kind.
+    pub file_type: FileType,
+    /// Modification time in milliseconds since the Unix epoch, when requested.
+    pub mtime: Option<f64>,
+    /// File size in bytes for regular files, when requested.
+    pub size: Option<f64>,
+    /// Depth below the traversal root. Root depth is 0.
+    pub depth: usize,
+}
+
+impl<'a> EntryMeta<'a> {
+    /// Build metadata for an owned collected entry.
+    pub fn from_collected(root: &'a Path, entry: &'a CollectedEntry) -> Self {
+        Self {
+            root,
+            absolute_path: Cow::Owned(entry.absolute_path(root)),
+            relative_path: &entry.path,
+            file_type: entry.file_type,
+            mtime: entry.mtime,
+            size: entry.size,
+            depth: entry.depth(),
+        }
+    }
+
+    /// Build metadata for a borrowed streaming entry.
+    pub const fn from_entry(root: &'a Path, entry: &Entry<'a>) -> Self {
+        Self {
+            root,
+            absolute_path: Cow::Borrowed(entry.path),
+            relative_path: entry.relative,
+            file_type: entry.file_type,
+            mtime: entry.mtime,
+            size: entry.size,
+            depth: entry.depth,
+        }
+    }
+}
+
+/// Owned regular-file candidate returned by high-level file collection.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FileCandidate {
+    /// Absolute filesystem path to the regular file.
+    pub path: PathBuf,
+    /// Relative path from the walk root, using `/` separators.
+    pub relative: String,
+    /// Modification time in milliseconds since the Unix epoch, when requested.
+    pub mtime: Option<f64>,
+    /// File size in bytes, when requested.
+    pub size: Option<f64>,
+}
+
+impl FileCandidate {
+    fn from_entry(root: &Path, entry: CollectedEntry) -> Self {
+        Self {
+            path: entry.absolute_path(root),
+            relative: entry.path,
+            mtime: entry.mtime,
+            size: entry.size,
+        }
+    }
+}
+
+/// Backend path used by a high-level collection.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WalkBackend {
+    /// The request returned entries from a fresh backend scan.
+    Fresh,
+    /// The request returned entries from the shared cache.
+    Cached,
+}
+
+/// Ranking applied to high-level collected entries after filtering.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum WalkRank {
+    /// Sort by normalized relative path in ascending byte order.
+    PathAsc,
+    /// Sort by modification time descending, then normalized relative path
+    /// ascending.
+    ///
+    /// Entries without modification times sort after entries with modification
+    /// times. [`WalkRequest::collect_ranked_with_heartbeat`] requests full
+    /// metadata for this rank so fresh scans can populate the mtime field.
+    MtimeDescPathAsc,
+}
+
+/// Summary statistics for a high-level collection.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct WalkStats {
+    /// Age of the cache entry in milliseconds; zero means freshly scanned.
+    pub cache_age_ms: u64,
+    /// Entries before high-level filtering.
+    pub scanned_entries: usize,
+    /// Entries removed by high-level filtering.
+    pub filtered_entries: usize,
+    /// Entries removed by the high-level limit.
+    pub limited_entries: usize,
+}
+
+/// Owned entries and metadata returned by [`WalkRequest::collect`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct WalkOutcome {
+    /// Entries after high-level filtering and limits.
+    pub entries: Vec<CollectedEntry>,
+    /// Collection backend classification.
+    pub backend: WalkBackend,
+    /// Collection statistics.
+    pub stats: WalkStats,
+}
+
+/// Options shared by native traversal consumers.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct WalkOptions {
+    /// Include dot-prefixed entries.
+    pub include_hidden: bool,
+    /// Honor `.ignore`, `.gitignore`, repository excludes, and global gitignore.
+    pub use_gitignore: bool,
+    /// Prune `.git` directories during traversal.
+    pub skip_git: bool,
+    /// Prune `node_modules` directories during traversal.
+    pub skip_node_modules: bool,
+    /// Symbolic-link traversal policy.
+    pub follow_links: FollowLinks,
+    /// Metadata detail requested for each yielded entry.
+    pub detail: WalkDetail,
+    /// Per-directory visit order.
+    pub order: WalkOrder,
+    /// Yield the traversal root as a depth-0 entry before its children.
+    pub emit_root: bool,
+    /// Minimum depth yielded to the visitor. Root depth is 0.
+    pub min_depth: usize,
+    /// Maximum depth traversed and yielded. Root depth is 0.
+    pub max_depth: usize,
+    /// Yield directory entries after their children.
+    pub contents_first: bool,
+    /// Directory-open error handling policy.
+    pub directory_errors: DirectoryErrorMode,
+    /// Stay on the root filesystem when supported by the platform.
+    pub same_file_system: bool,
+    /// Use the shared scan cache when collecting owned entries.
+    pub cache: bool,
+}
+
+impl Default for WalkOptions {
+    fn default() -> Self {
+        Self {
+            include_hidden: true,
+            use_gitignore: false,
+            skip_git: false,
+            skip_node_modules: false,
+            follow_links: FollowLinks::Never,
+            detail: WalkDetail::Minimal,
+            order: WalkOrder::Path,
+            emit_root: false,
+            min_depth: 1,
+            max_depth: usize::MAX,
+            contents_first: false,
+            directory_errors: DirectoryErrorMode::Visit,
+            same_file_system: false,
+            cache: false,
+        }
+    }
+}
+
+/// High-level traversal request that owns a root and wraps [`WalkOptions`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WalkRequest {
+    root: PathBuf,
+    options: WalkOptions,
+    cache_policy: CachePolicy,
+    filter: WalkFilter,
+    limit: Option<usize>,
+    empty_recheck: EmptyRecheck,
+    visit_order: VisitOrder,
+    size_hint_policy: SizeHintPolicy,
+}
+
+impl WalkRequest {
+    /// Create a request rooted at `root` with default [`WalkOptions`].
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self::from_options(root, WalkOptions::default())
+    }
+
+    /// Create a request from existing low-level options.
+    pub fn from_options(root: impl Into<PathBuf>, options: WalkOptions) -> Self {
+        let cache_policy = if options.cache {
+            CachePolicy::Enabled
+        } else {
+            CachePolicy::Disabled
+        };
+        let visit_order = if options.contents_first {
+            VisitOrder::ContentsFirst
+        } else {
+            VisitOrder::PreOrder
+        };
+        Self {
+            root: root.into(),
+            options,
+            cache_policy,
+            filter: WalkFilter::default(),
+            limit: None,
+            empty_recheck: EmptyRecheck::Configured,
+            visit_order,
+            size_hint_policy: SizeHintPolicy::FromDetail,
+        }
+    }
+
+    /// Return the traversal root.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Return low-level options after applying high-level policies.
+    pub const fn options(&self) -> WalkOptions {
+        self.effective_options()
+    }
+
+    /// Include or exclude dot-prefixed entries.
+    pub const fn hidden(mut self, include_hidden: bool) -> Self {
+        self.options.include_hidden = include_hidden;
+        self
+    }
+
+    /// Enable or disable `.ignore`/gitignore matching.
+    pub const fn gitignore(mut self, use_gitignore: bool) -> Self {
+        self.options.use_gitignore = use_gitignore;
+        self
+    }
+
+    /// Enable or disable pruning `.git` directories.
+    pub const fn skip_git(mut self, skip_git: bool) -> Self {
+        self.options.skip_git = skip_git;
+        self
+    }
+
+    /// Enable or disable pruning `node_modules` directories during traversal.
+    pub const fn skip_node_modules(mut self, skip_node_modules: bool) -> Self {
+        self.options.skip_node_modules = skip_node_modules;
+        self
+    }
+
+    /// Set symbolic-link traversal policy.
+    pub const fn follow_links(mut self, follow_links: FollowLinks) -> Self {
+        self.options.follow_links = follow_links;
+        self
+    }
+
+    /// Set metadata detail collected for entries.
+    pub const fn detail(mut self, detail: WalkDetail) -> Self {
+        self.options.detail = detail;
+        self
+    }
+
+    /// Set per-directory entry order.
+    pub const fn order(mut self, order: WalkOrder) -> Self {
+        self.options.order = order;
+        self
+    }
+
+    /// Enable or disable emitting the root entry.
+    pub const fn emit_root(mut self, emit_root: bool) -> Self {
+        self.options.emit_root = emit_root;
+        self
+    }
+
+    /// Set minimum and maximum traversal depth.
+    pub const fn depth(mut self, min_depth: usize, max_depth: usize) -> Self {
+        self.options.min_depth = min_depth;
+        self.options.max_depth = max_depth;
+        self
+    }
+
+    /// Set directory-open error handling.
+    pub const fn directory_errors(mut self, directory_errors: DirectoryErrorMode) -> Self {
+        self.options.directory_errors = directory_errors;
+        self
+    }
+
+    /// Enable or disable staying on the root filesystem.
+    pub const fn same_file_system(mut self, same_file_system: bool) -> Self {
+        self.options.same_file_system = same_file_system;
+        self
+    }
+
+    /// Enable or disable the shared scan cache for owned collection.
+    pub const fn cache(mut self, cache: bool) -> Self {
+        self.cache_policy = if cache {
+            CachePolicy::Enabled
+        } else {
+            CachePolicy::Disabled
+        };
+        self.options.cache = cache;
+        self
+    }
+
+    /// Set the static high-level filter.
+    pub fn filter(mut self, filter: WalkFilter) -> Self {
+        self.filter = filter;
+        self
+    }
+
+    /// Limit the number of emitted entries after filtering.
+    pub const fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Remove any high-level entry limit.
+    pub const fn no_limit(mut self) -> Self {
+        self.limit = None;
+        self
+    }
+
+    /// Set empty cached-result revalidation policy.
+    pub const fn empty_recheck(mut self, empty_recheck: EmptyRecheck) -> Self {
+        self.empty_recheck = empty_recheck;
+        self
+    }
+
+    /// Set high-level directory visit order.
+    pub const fn visit_order(mut self, visit_order: VisitOrder) -> Self {
+        self.visit_order = visit_order;
+        self.options.contents_first = matches!(visit_order, VisitOrder::ContentsFirst);
+        self
+    }
+
+    /// Set size metadata policy.
+    pub const fn size_hints(mut self, size_hint_policy: SizeHintPolicy) -> Self {
+        self.size_hint_policy = size_hint_policy;
+        self
+    }
+
+    /// Collect owned entries, then apply high-level filters, limits, and
+    /// empty-cache rechecks.
+    pub fn collect(&self) -> std::result::Result<WalkOutcome, WalkError<String>> {
+        self.collect_with_heartbeat(|| Ok::<(), Infallible>(()))
+    }
+
+    /// Collect owned entries with a caller-supplied heartbeat.
+    pub fn collect_with_heartbeat<E, H>(
+        &self,
+        heartbeat: H,
+    ) -> std::result::Result<WalkOutcome, WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        self.collect_with_rank_and_limit(None, self.limit, heartbeat)
+    }
+
+    /// Collect owned entries, apply high-level filters, rank, then truncate to
+    /// `limit`.
+    ///
+    /// The request's stored [`WalkRequest::limit`] is intentionally not applied
+    /// before ranking; `limit` is the top-N bound for this ranked collection.
+    pub fn collect_ranked(
+        &self,
+        rank: WalkRank,
+        limit: usize,
+    ) -> std::result::Result<WalkOutcome, WalkError<String>> {
+        self.collect_ranked_with_heartbeat(rank, limit, || Ok::<(), Infallible>(()))
+    }
+
+    /// Collect owned entries with a caller-supplied heartbeat, apply high-level
+    /// filters, rank, then truncate to `limit`.
+    ///
+    /// Ranking happens after all high-level filters and before truncation so
+    /// top-N callers observe the best matching entries, not the first traversed
+    /// entries.
+    pub fn collect_ranked_with_heartbeat<E, H>(
+        &self,
+        rank: WalkRank,
+        limit: usize,
+        heartbeat: H,
+    ) -> std::result::Result<WalkOutcome, WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        self.collect_with_rank_and_limit(Some(rank), Some(limit), heartbeat)
+    }
+
+    /// Collect regular files accepted by this request.
+    pub fn collect_files(&self) -> std::result::Result<Vec<CollectedEntry>, WalkError<String>> {
+        self.collect_files_with_heartbeat(|| Ok::<(), Infallible>(()))
+    }
+
+    /// Collect regular files accepted by this request with a caller-supplied
+    /// heartbeat.
+    pub fn collect_files_with_heartbeat<E, H>(
+        &self,
+        heartbeat: H,
+    ) -> std::result::Result<Vec<CollectedEntry>, WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        let outcome = self.collect_with_heartbeat(heartbeat)?;
+        Ok(outcome
+            .entries
+            .into_iter()
+            .filter(CollectedEntry::is_file)
+            .collect())
+    }
+
+    /// Collect directories accepted by this request.
+    pub fn collect_dirs(&self) -> std::result::Result<Vec<CollectedEntry>, WalkError<String>> {
+        self.collect_dirs_with_heartbeat(|| Ok::<(), Infallible>(()))
+    }
+
+    /// Collect directories accepted by this request with a caller-supplied
+    /// heartbeat.
+    pub fn collect_dirs_with_heartbeat<E, H>(
+        &self,
+        heartbeat: H,
+    ) -> std::result::Result<Vec<CollectedEntry>, WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        let outcome = self.collect_with_heartbeat(heartbeat)?;
+        Ok(outcome
+            .entries
+            .into_iter()
+            .filter(CollectedEntry::is_dir)
+            .collect())
+    }
+
+    /// Collect regular-file candidates accepted by this request.
+    pub fn collect_file_candidates(
+        &self,
+    ) -> std::result::Result<Vec<FileCandidate>, WalkError<String>> {
+        self.collect_file_candidates_with_heartbeat(|| Ok::<(), Infallible>(()))
+    }
+
+    /// Collect regular-file candidates accepted by this request with a
+    /// caller-supplied heartbeat.
+    pub fn collect_file_candidates_with_heartbeat<E, H>(
+        &self,
+        heartbeat: H,
+    ) -> std::result::Result<Vec<FileCandidate>, WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        Ok(self
+            .collect_file_candidates_with_stats_with_heartbeat(heartbeat)?
+            .0)
+    }
+
+    /// Stream entries through `visitor` after applying high-level filters and
+    /// limits.
+    pub fn stream<V>(&self, visitor: &mut V) -> std::result::Result<WalkStatus, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+    {
+        self.stream_with_heartbeat(visitor, || Ok::<(), V::Error>(()))
+    }
+
+    /// Stream entries through `visitor` with a caller-supplied heartbeat.
+    pub fn stream_with_heartbeat<V, H>(
+        &self,
+        visitor: &mut V,
+        heartbeat: H,
+    ) -> std::result::Result<WalkStatus, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+        H: FnMut() -> std::result::Result<(), V::Error>,
+    {
+        self.stream_with_predicate_and_heartbeat(visitor, IncludeAllPredicate, heartbeat)
+    }
+
+    /// Stream accepted entries through a closure after applying high-level
+    /// filters and limits.
+    ///
+    /// This is the closure-based counterpart to [`WalkRequest::stream`]. The
+    /// closure receives borrowed [`EntryMeta`] for each entry that passes this
+    /// request's static [`WalkFilter`] and dynamic request limit, then returns a
+    /// [`WalkDecision`] to control traversal. [`WalkDecision::Include`] and
+    /// [`WalkDecision::Skip`] both continue because the entry has already been
+    /// delivered to the closure; [`WalkDecision::SkipDescend`] prunes the
+    /// current directory's descendants, and [`WalkDecision::Stop`] stops
+    /// traversal.
+    ///
+    /// Directory-open errors are ignored and traversal continues when
+    /// [`WalkOptions::directory_errors`] is [`DirectoryErrorMode::Visit`]. Use
+    /// [`WalkRequest::for_each_entry_with_heartbeat`] to observe those errors or
+    /// provide a heartbeat.
+    pub fn for_each_entry<E, V>(&self, visit: V) -> std::result::Result<WalkStatus, WalkError<E>>
+    where
+        V: for<'entry> FnMut(EntryMeta<'entry>) -> std::result::Result<WalkDecision, E>,
+    {
+        self.for_each_entry_with_heartbeat(
+            || Ok::<(), E>(()),
+            visit,
+            |_| Ok::<WalkDecision, E>(WalkDecision::Include),
+        )
+    }
+
+    /// Stream accepted entries through closures with a caller-supplied
+    /// heartbeat.
+    ///
+    /// `heartbeat` is invoked by the same traversal machinery used by
+    /// [`WalkRequest::stream_with_heartbeat`]. `visit` receives each accepted
+    /// [`EntryMeta`] and returns a [`WalkDecision`]: [`WalkDecision::Include`] and
+    /// [`WalkDecision::Skip`] continue, [`WalkDecision::SkipDescend`] skips
+    /// descendants of the current directory, and [`WalkDecision::Stop`] stops
+    /// the walk. `directory_error` receives [`DirectoryError`] values when the
+    /// request's [`WalkOptions::directory_errors`] is
+    /// [`DirectoryErrorMode::Visit`] and returns the same traversal decision,
+    /// letting GNU-style consumers report an error and continue or stop without
+    /// implementing [`EntryVisitor`].
+    pub fn for_each_entry_with_heartbeat<E, H, V, D>(
+        &self,
+        heartbeat: H,
+        visit: V,
+        directory_error: D,
+    ) -> std::result::Result<WalkStatus, WalkError<E>>
+    where
+        H: FnMut() -> std::result::Result<(), E>,
+        V: for<'entry> FnMut(EntryMeta<'entry>) -> std::result::Result<WalkDecision, E>,
+        D: for<'error> FnMut(DirectoryError<'error>) -> std::result::Result<WalkDecision, E>,
+    {
+        let mut visitor = ClosureEntryVisitor {
+            root: &self.root,
+            visit,
+            directory_error,
+        };
+        self.stream_with_heartbeat(&mut visitor, heartbeat)
+    }
+
+    /// Stream entries through `visitor` with an additional dynamic predicate.
+    pub fn stream_with_predicate<V, P>(
+        &self,
+        visitor: &mut V,
+        predicate: P,
+    ) -> std::result::Result<WalkStatus, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+        P: WalkPredicate,
+    {
+        self.stream_with_predicate_and_heartbeat(visitor, predicate, || Ok::<(), V::Error>(()))
+    }
+
+    /// Stream entries through `visitor` with a dynamic predicate and
+    /// caller-supplied heartbeat.
+    pub fn stream_with_predicate_and_heartbeat<V, P, H>(
+        &self,
+        visitor: &mut V,
+        predicate: P,
+        mut heartbeat: H,
+    ) -> std::result::Result<WalkStatus, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+        P: WalkPredicate,
+        H: FnMut() -> std::result::Result<(), V::Error>,
+    {
+        let options = self.effective_options();
+        let mut adapter = RequestVisitor {
+            root: &self.root,
+            filter: &self.filter,
+            limit: self.limit,
+            emitted: 0,
+            visitor,
+            predicate,
+        };
+        walk_entries(&self.root, options, &mut adapter, &mut heartbeat)
+    }
+
+    /// Run `operation` for each accepted regular file.
+    pub fn for_each_file<E>(
+        &self,
+        operation: impl Fn(&Path) -> std::result::Result<(), E> + Send + Sync,
+    ) -> std::result::Result<WalkStats, WalkError<String>>
+    where
+        E: fmt::Display + Send,
+    {
+        self.for_each_file_with_heartbeat(operation, || Ok::<(), Infallible>(()))
+    }
+
+    /// Run `operation` for each accepted regular file with a caller-supplied
+    /// heartbeat.
+    pub fn for_each_file_with_heartbeat<E, HE, H>(
+        &self,
+        operation: impl Fn(&Path) -> std::result::Result<(), E> + Send + Sync,
+        heartbeat: H,
+    ) -> std::result::Result<WalkStats, WalkError<String>>
+    where
+        E: fmt::Display + Send,
+        H: Fn() -> std::result::Result<(), HE> + Sync,
+        HE: fmt::Display,
+    {
+        self.for_each_file_candidate_with_heartbeat(
+            |candidate| operation(&candidate.path),
+            heartbeat,
+        )
+    }
+
+    /// Run `operation` for each accepted regular-file candidate.
+    pub fn for_each_file_candidate<E>(
+        &self,
+        operation: impl Fn(&FileCandidate) -> std::result::Result<(), E> + Send + Sync,
+    ) -> std::result::Result<WalkStats, WalkError<String>>
+    where
+        E: fmt::Display + Send,
+    {
+        self.for_each_file_candidate_with_heartbeat(operation, || Ok::<(), Infallible>(()))
+    }
+
+    /// Run `operation` for each accepted regular-file candidate with a
+    /// caller-supplied heartbeat.
+    pub fn for_each_file_candidate_with_heartbeat<E, HE, H>(
+        &self,
+        operation: impl Fn(&FileCandidate) -> std::result::Result<(), E> + Send + Sync,
+        heartbeat: H,
+    ) -> std::result::Result<WalkStats, WalkError<String>>
+    where
+        E: fmt::Display + Send,
+        H: Fn() -> std::result::Result<(), HE> + Sync,
+        HE: fmt::Display,
+    {
+        let (candidates, stats) =
+            self.collect_file_candidates_with_stats_with_heartbeat(heartbeat)?;
+        execute_candidates(&candidates, operation)
+            .map_err(|err| WalkError::Interrupted(err.to_string()))?;
+        Ok(stats)
+    }
+
+    /// Visit accepted regular-file candidates using an unordered parallel walk.
+    ///
+    /// This is a files-only API for consumers that own their output ordering.
+    /// Candidates may be delivered in any order. [`WalkOptions::order`],
+    /// [`WalkRequest::visit_order`], [`WalkOptions::emit_root`], and
+    /// [`WalkRequest::limit`] are ignored. Directory-open errors are skipped
+    /// with grep-style semantics instead of being delivered to visitors.
+    ///
+    /// [`ParallelWalkControl::Stop`] sets a shared stop flag; workers check that
+    /// flag before reading each directory and while processing directory
+    /// entries, then the method returns [`WalkStatus::Stopped`] after in-flight
+    /// work winds down. If a sink or heartbeat returns an error, the first
+    /// error wins and is returned as [`WalkError::Interrupted`].
+    pub fn for_each_file_candidate_parallel<E>(
+        &self,
+        sink: impl Fn(&FileCandidate) -> std::result::Result<ParallelWalkControl, E> + Send + Sync,
+        heartbeat: impl Fn() -> std::result::Result<(), E> + Send + Sync,
+    ) -> std::result::Result<WalkStatus, WalkError<E>>
+    where
+        E: Send,
+    {
+        run_file_candidate_parallel(self, &sink, &heartbeat)
+    }
+
+    fn collect_with_rank_and_limit<E, H>(
+        &self,
+        rank: Option<WalkRank>,
+        limit: Option<usize>,
+        heartbeat: H,
+    ) -> std::result::Result<WalkOutcome, WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        let mut options = self.effective_options();
+        if matches!(rank, Some(WalkRank::MtimeDescPathAsc)) {
+            options.detail = WalkDetail::Full;
+        }
+        let mut scan = self.collect_entries_with_options(options, &heartbeat)?;
+        let mut backend = if scan.cache_age_ms == 0 {
+            WalkBackend::Fresh
+        } else {
+            WalkBackend::Cached
+        };
+        let filter_entries = |entries: &mut Vec<CollectedEntry>| {
+            let scanned_entries = entries.len();
+            entries.retain(|entry| self.filter.accepts_collected(entry));
+            (scanned_entries, scanned_entries - entries.len())
+        };
+        let (mut scanned_entries, mut filtered_entries) = filter_entries(&mut scan.entries);
+        if scan.entries.is_empty() && self.should_recheck_empty(scan.cache_age_ms) {
+            options.cache = false;
+            scan = self.collect_entries_with_options(options, &heartbeat)?;
+            backend = WalkBackend::Fresh;
+            (scanned_entries, filtered_entries) = filter_entries(&mut scan.entries);
+        }
+        if let Some(rank) = rank {
+            Self::rank_entries(&mut scan.entries, rank);
+        }
+        let limited_entries = if let Some(limit) = limit {
+            let limited_entries = scan.entries.len().saturating_sub(limit);
+            scan.entries.truncate(limit);
+            limited_entries
+        } else {
+            0
+        };
+        let stats = WalkStats {
+            cache_age_ms: scan.cache_age_ms,
+            scanned_entries,
+            filtered_entries,
+            limited_entries,
+        };
+        Ok(WalkOutcome {
+            entries: scan.entries,
+            backend,
+            stats,
+        })
+    }
+
+    fn rank_entries(entries: &mut [CollectedEntry], rank: WalkRank) {
+        match rank {
+            WalkRank::PathAsc => entries.sort_by(|left, right| left.path.cmp(&right.path)),
+            WalkRank::MtimeDescPathAsc => entries.sort_by(Self::compare_mtime_desc_path_asc),
+        }
+    }
+
+    fn compare_mtime_desc_path_asc(left: &CollectedEntry, right: &CollectedEntry) -> Ordering {
+        let mtime_order = match (left.mtime, right.mtime) {
+            (Some(left_mtime), Some(right_mtime)) => right_mtime.total_cmp(&left_mtime),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        };
+        mtime_order.then_with(|| left.path.cmp(&right.path))
+    }
+
+    const fn effective_options(&self) -> WalkOptions {
+        let mut options = self.options;
+        options.cache = matches!(self.cache_policy, CachePolicy::Enabled);
+        options.contents_first = matches!(self.visit_order, VisitOrder::ContentsFirst);
+        match self.size_hint_policy {
+            SizeHintPolicy::FromDetail => {}
+            SizeHintPolicy::Never => options.detail = WalkDetail::Minimal,
+            SizeHintPolicy::WhenCheap => {
+                options.detail = if supports_cheap_size_hints() {
+                    WalkDetail::Full
+                } else {
+                    WalkDetail::Minimal
+                };
+            }
+            SizeHintPolicy::Always => options.detail = WalkDetail::Full,
+        }
+        if self.filter.max_file_size.is_some() {
+            options.detail = WalkDetail::Full;
+        }
+        options
+    }
+
+    fn collect_entries_with_options<E, H>(
+        &self,
+        options: WalkOptions,
+        heartbeat: &H,
+    ) -> std::result::Result<CollectedEntries, WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        collect_entries(&self.root, options, heartbeat)
+    }
+
+    fn should_recheck_empty(&self, cache_age_ms: u64) -> bool {
+        if cache_age_ms == 0 {
+            return false;
+        }
+        match self.empty_recheck {
+            EmptyRecheck::Never => false,
+            EmptyRecheck::Configured => {
+                let threshold = empty_recheck_ms();
+                threshold > 0 && cache_age_ms >= threshold
+            }
+            EmptyRecheck::AfterMillis(threshold) => cache_age_ms >= threshold,
+        }
+    }
+
+    fn collect_file_candidates_with_stats_with_heartbeat<E, H>(
+        &self,
+        heartbeat: H,
+    ) -> std::result::Result<(Vec<FileCandidate>, WalkStats), WalkError<String>>
+    where
+        H: Fn() -> std::result::Result<(), E> + Sync,
+        E: fmt::Display,
+    {
+        let outcome = self.collect_with_heartbeat(heartbeat)?;
+        let candidates = outcome
+            .entries
+            .into_iter()
+            .filter(CollectedEntry::is_file)
+            .map(|entry| FileCandidate::from_entry(&self.root, entry))
+            .collect();
+        Ok((candidates, outcome.stats))
+    }
+}
+
+/// Execute work for regular-file candidates using the centralized walker pool.
+pub fn execute_candidates<E>(
+    candidates: &[FileCandidate],
+    operation: impl Fn(&FileCandidate) -> std::result::Result<(), E> + Send + Sync,
+) -> std::result::Result<(), E>
+where
+    E: Send,
+{
+    parallel_for_each(candidates, operation)
+}
+
+/// Execute work for regular-file candidates with per-worker state.
+pub fn execute_candidates_init<S, E>(
+    candidates: &[FileCandidate],
+    init: impl Fn() -> S + Send + Sync,
+    operation: impl Fn(&mut S, &FileCandidate) -> std::result::Result<(), E> + Send + Sync,
+) -> std::result::Result<(), E>
+where
+    S: Send,
+    E: Send,
+{
+    parallel_for_each_init(candidates, init, operation)
+}
+
+struct SerialCandidateVisitor<'a, S> {
+    filter: &'a WalkFilter,
+    sink: &'a S,
+}
+
+impl<E, S> EntryVisitor for SerialCandidateVisitor<'_, S>
+where
+    S: Fn(&FileCandidate) -> std::result::Result<ParallelWalkControl, E> + Sync,
+{
+    type Error = E;
+
+    fn visit(&mut self, _entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error> {
+        Ok(WalkControl::Continue)
+    }
+
+    fn visit_pre_decided(
+        &mut self,
+        entry: Entry<'_>,
+    ) -> std::result::Result<WalkControl, Self::Error> {
+        if entry.file_type != FileType::File {
+            return Ok(WalkControl::Continue);
+        }
+        let candidate = FileCandidate {
+            path: entry.path.to_path_buf(),
+            relative: entry.relative.to_string(),
+            mtime: entry.mtime,
+            size: entry.size,
+        };
+        match (self.sink)(&candidate)? {
+            ParallelWalkControl::Continue => Ok(WalkControl::Continue),
+            ParallelWalkControl::Stop => Ok(WalkControl::Quit),
+        }
+    }
+
+    fn decide_pre_descend(
+        &mut self,
+        meta: &EntryMeta<'_>,
+    ) -> std::result::Result<PreDescendDecision, Self::Error> {
+        let is_dir = meta.file_type == FileType::Dir;
+        Ok(match self.filter.stream_decision(meta) {
+            WalkDecision::Include => PreDescendDecision {
+                emit: true,
+                descend: is_dir,
+                stop: false,
+            },
+            WalkDecision::Skip => PreDescendDecision {
+                emit: false,
+                descend: is_dir,
+                stop: false,
+            },
+            WalkDecision::SkipDescend => PreDescendDecision {
+                emit: false,
+                descend: false,
+                stop: false,
+            },
+            WalkDecision::Stop => PreDescendDecision {
+                emit: false,
+                descend: false,
+                stop: true,
+            },
+        })
+    }
+}
+
+struct ParallelWalkContext {
+    root: PathBuf,
+    options: WalkOptions,
+    filter: WalkFilter,
+    matcher: FastIgnore,
+}
+
+struct ParallelWalkShared<'a, E, S, H> {
+    stop: AtomicBool,
+    error: Mutex<Option<E>>,
+    sink: &'a S,
+    heartbeat: &'a H,
+}
+
+impl<'a, E, S, H> ParallelWalkShared<'a, E, S, H> {
+    const fn new(sink: &'a S, heartbeat: &'a H) -> Self {
+        Self {
+            stop: AtomicBool::new(false),
+            error: Mutex::new(None),
+            sink,
+            heartbeat,
+        }
+    }
+
+    fn request_stop(&self) {
+        self.stop.store(true, AtomicOrdering::Release);
+    }
+
+    fn should_stop(&self) -> bool {
+        self.stop.load(AtomicOrdering::Acquire)
+    }
+
+    fn record_error(&self, error: E) {
+        let mut slot = match self.error.lock() {
+            Ok(slot) => slot,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if slot.is_none() {
+            *slot = Some(error);
+        }
+        self.request_stop();
+    }
+
+    fn take_error(&self) -> Option<E> {
+        match self.error.lock() {
+            Ok(mut slot) => slot.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        }
+    }
+}
+
+thread_local! {
+    static PARALLEL_HEARTBEAT_COUNTER: Cell<usize> = const { Cell::new(0) };
+    static PARALLEL_SCRATCH_POOL: RefCell<Vec<DirScratch>> = const { RefCell::new(Vec::new()) };
+}
+
+fn should_use_parallel_file_candidate_walk(options: WalkOptions) -> bool {
+    walk_workers() > 1 && options.follow_links == FollowLinks::Never && !options.same_file_system
+}
+
+fn run_file_candidate_parallel<E, S, H>(
+    request: &WalkRequest,
+    sink: &S,
+    heartbeat: &H,
+) -> std::result::Result<WalkStatus, WalkError<E>>
+where
+    E: Send,
+    S: Fn(&FileCandidate) -> std::result::Result<ParallelWalkControl, E> + Sync,
+    H: Fn() -> std::result::Result<(), E> + Sync,
+{
+    let mut options = request.effective_options();
+    if options.min_depth > options.max_depth {
+        return Ok(WalkStatus::Complete);
+    }
+    heartbeat().map_err(WalkError::Interrupted)?;
+    if !should_use_parallel_file_candidate_walk(options) {
+        return run_file_candidate_serial(request, options, sink, heartbeat);
+    }
+
+    options.cache = false;
+    let Some(root_entry) = root_entry(&request.root, options.detail, options.follow_links)? else {
+        return Ok(WalkStatus::Complete);
+    };
+    let context = ParallelWalkContext {
+        root: request.root.clone(),
+        options,
+        filter: request.filter.clone(),
+        matcher: FastIgnore::new(options.use_gitignore),
+    };
+    let root_ignore = context.matcher.root_state(&context.root);
+    let shared = ParallelWalkShared::new(sink, heartbeat);
+
+    if root_entry.file_type == FileType::File && options.min_depth == 0 {
+        emit_parallel_root_file(&context, &shared, &root_entry);
+    }
+    if root_entry.file_type == FileType::Dir && options.max_depth > 0 && !shared.should_stop() {
+        let root_dir = context.root.clone();
+        cache::with_walk_pool(|| {
+            rayon::scope(|scope| {
+                scope.spawn(|scope| {
+                    walk_parallel_dir(
+                        scope,
+                        &context,
+                        &shared,
+                        root_dir,
+                        String::new(),
+                        0,
+                        root_ignore,
+                        false,
+                    );
+                });
+            });
+        });
+    }
+
+    if let Some(error) = shared.take_error() {
+        Err(WalkError::Interrupted(error))
+    } else if shared.should_stop() {
+        Ok(WalkStatus::Stopped)
+    } else {
+        Ok(WalkStatus::Complete)
+    }
+}
+
+fn run_file_candidate_serial<E, S, H>(
+    request: &WalkRequest,
+    mut options: WalkOptions,
+    sink: &S,
+    heartbeat: &H,
+) -> std::result::Result<WalkStatus, WalkError<E>>
+where
+    S: Fn(&FileCandidate) -> std::result::Result<ParallelWalkControl, E> + Sync,
+    H: Fn() -> std::result::Result<(), E> + Sync,
+{
+    options.cache = false;
+    options.order = WalkOrder::Unordered;
+    options.contents_first = false;
+    options.emit_root = true;
+    options.directory_errors = DirectoryErrorMode::Visit;
+    let mut visitor = SerialCandidateVisitor {
+        filter: &request.filter,
+        sink,
+    };
+    walk_entries(&request.root, options, &mut visitor, heartbeat)
+}
+
+fn emit_parallel_root_file<E, S, H>(
+    context: &ParallelWalkContext,
+    shared: &ParallelWalkShared<'_, E, S, H>,
+    root_entry: &RootEntry,
+) where
+    E: Send,
+    S: Fn(&FileCandidate) -> std::result::Result<ParallelWalkControl, E> + Sync,
+    H: Fn() -> std::result::Result<(), E> + Sync,
+{
+    let meta = EntryMeta {
+        root: &context.root,
+        absolute_path: Cow::Borrowed(context.root.as_path()),
+        relative_path: "",
+        file_type: FileType::File,
+        mtime: root_entry.mtime,
+        size: root_entry.size,
+        depth: 0,
+    };
+    match context.filter.stream_decision(&meta) {
+        WalkDecision::Include => {
+            let candidate = FileCandidate {
+                path: context.root.clone(),
+                relative: String::new(),
+                mtime: root_entry.mtime,
+                size: root_entry.size,
+            };
+            let _ = emit_parallel_candidate(shared, &candidate);
+        }
+        WalkDecision::Stop => shared.request_stop(),
+        WalkDecision::Skip | WalkDecision::SkipDescend => {}
+    }
+}
+
+fn take_parallel_scratch() -> DirScratch {
+    let mut scratch = PARALLEL_SCRATCH_POOL
+        .with(|pool| pool.borrow_mut().pop())
+        .unwrap_or_default();
+    scratch.clear_listing();
+    scratch
+}
+
+fn recycle_parallel_scratch(mut scratch: DirScratch) {
+    scratch.clear_listing();
+    PARALLEL_SCRATCH_POOL.with(|pool| pool.borrow_mut().push(scratch));
+}
+
+fn parallel_heartbeat<E, S, H>(shared: &ParallelWalkShared<'_, E, S, H>) -> bool
+where
+    E: Send,
+    H: Fn() -> std::result::Result<(), E> + Sync,
+{
+    if shared.should_stop() {
+        return false;
+    }
+    let should_call = PARALLEL_HEARTBEAT_COUNTER.with(|counter| {
+        let visited = counter.get();
+        if visited == 0 || visited >= HEARTBEAT_INTERVAL {
+            counter.set(1);
+            true
+        } else {
+            counter.set(visited + 1);
+            false
+        }
+    });
+    if !should_call {
+        return true;
+    }
+    match (shared.heartbeat)() {
+        Ok(()) => true,
+        Err(error) => {
+            shared.record_error(error);
+            false
+        }
+    }
+}
+
+fn emit_parallel_candidate<E, S, H>(
+    shared: &ParallelWalkShared<'_, E, S, H>,
+    candidate: &FileCandidate,
+) -> bool
+where
+    E: Send,
+    S: Fn(&FileCandidate) -> std::result::Result<ParallelWalkControl, E> + Sync,
+{
+    match (shared.sink)(candidate) {
+        Ok(ParallelWalkControl::Continue) => true,
+        Ok(ParallelWalkControl::Stop) => {
+            shared.request_stop();
+            false
+        }
+        Err(error) => {
+            shared.record_error(error);
+            false
+        }
+    }
+}
+
+fn walk_parallel_dir<'scope, E, S, H>(
+    scope: &rayon::Scope<'scope>,
+    context: &'scope ParallelWalkContext,
+    shared: &'scope ParallelWalkShared<'_, E, S, H>,
+    dir: PathBuf,
+    relative_dir: String,
+    depth: usize,
+    ignore_state: Arc<IgnoreState>,
+    derive_ignore_from_entries: bool,
+) where
+    E: Send + 'scope,
+    S: Fn(&FileCandidate) -> std::result::Result<ParallelWalkControl, E> + Sync + 'scope,
+    H: Fn() -> std::result::Result<(), E> + Sync + 'scope,
+{
+    if shared.should_stop() {
+        return;
+    }
+    let mut scratch = take_parallel_scratch();
+    let ignore_entries = match collect_directory_entries(
+        &dir,
+        context.options.detail,
+        &mut scratch,
+        &context.matcher,
+        derive_ignore_from_entries,
+    ) {
+        Ok(ignore_entries) => ignore_entries,
+        Err(ReadDirError::Io(_) | ReadDirError::Walk(WalkError::InvalidData { .. })) => {
+            recycle_parallel_scratch(scratch);
+            return;
+        }
+        Err(ReadDirError::Walk(WalkError::Interrupted(error))) => {
+            shared.record_error(error);
+            recycle_parallel_scratch(scratch);
+            return;
+        }
+    };
+    let dir_ignore = context.matcher.state_from_entries(
+        &ignore_state,
+        &dir,
+        ignore_entries,
+        derive_ignore_from_entries,
+    );
+    let mut absolute = dir;
+    let mut relative = relative_dir;
+
+    for index in 0..scratch.entries.len() {
+        if !parallel_heartbeat(shared) {
+            break;
+        }
+        let entry = &scratch.entries[index];
+        let name = scratch.name(entry);
+        if is_dot_entry(name) {
+            continue;
+        }
+        if !context.options.include_hidden && is_hidden_name(name) {
+            continue;
+        }
+        if (context.options.skip_git && is_git_name(name))
+            || (context.options.skip_node_modules && is_node_modules_name(name))
+        {
+            continue;
+        }
+
+        let name_str = entry_name(name);
+        if name_str.is_empty() {
+            continue;
+        }
+        let next_depth = depth + 1;
+        if next_depth > context.options.max_depth {
+            continue;
+        }
+
+        let relative_len = relative.len();
+        absolute.push(name);
+        push_relative_name(&mut relative, &name_str);
+        let is_dir = entry.file_type == FileType::Dir;
+        if !context.matcher.is_ignored(&dir_ignore, &absolute, is_dir) {
+            let decision = {
+                let meta = EntryMeta {
+                    root: &context.root,
+                    absolute_path: Cow::Borrowed(absolute.as_path()),
+                    relative_path: &relative,
+                    file_type: entry.file_type,
+                    mtime: entry.mtime,
+                    size: entry.size,
+                    depth: next_depth,
+                };
+                context.filter.stream_decision(&meta)
+            };
+            match decision {
+                WalkDecision::Include => {
+                    if entry.file_type == FileType::File && next_depth >= context.options.min_depth
+                    {
+                        let candidate = FileCandidate {
+                            path: absolute.clone(),
+                            relative: relative.clone(),
+                            mtime: entry.mtime,
+                            size: entry.size,
+                        };
+                        if !emit_parallel_candidate(shared, &candidate) {
+                            absolute.pop();
+                            relative.truncate(relative_len);
+                            break;
+                        }
+                    }
+                    if is_dir && next_depth < context.options.max_depth && !shared.should_stop() {
+                        let child_dir = absolute.clone();
+                        let child_relative = relative.clone();
+                        let child_ignore = Arc::clone(&dir_ignore);
+                        scope.spawn(move |scope| {
+                            walk_parallel_dir(
+                                scope,
+                                context,
+                                shared,
+                                child_dir,
+                                child_relative,
+                                next_depth,
+                                child_ignore,
+                                true,
+                            );
+                        });
+                    }
+                }
+                WalkDecision::Skip => {
+                    if is_dir && next_depth < context.options.max_depth && !shared.should_stop() {
+                        let child_dir = absolute.clone();
+                        let child_relative = relative.clone();
+                        let child_ignore = Arc::clone(&dir_ignore);
+                        scope.spawn(move |scope| {
+                            walk_parallel_dir(
+                                scope,
+                                context,
+                                shared,
+                                child_dir,
+                                child_relative,
+                                next_depth,
+                                child_ignore,
+                                true,
+                            );
+                        });
+                    }
+                }
+                WalkDecision::SkipDescend => {}
+                WalkDecision::Stop => {
+                    shared.request_stop();
+                    absolute.pop();
+                    relative.truncate(relative_len);
+                    break;
+                }
+            }
+        }
+        absolute.pop();
+        relative.truncate(relative_len);
+    }
+    recycle_parallel_scratch(scratch);
+}
+
+/// Visitor decision for streaming traversal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WalkControl {
+    /// Continue traversing remaining entries.
+    Continue,
+    /// Skip descending into this directory entry.
+    SkipDescend,
+    /// Stop traversal immediately.
+    Quit,
+}
+
+/// Status returned by native traversal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WalkStatus {
+    /// Traversal visited every reachable entry.
+    Complete,
+    /// The visitor stopped traversal early.
+    Stopped,
+}
+
+/// Control returned by unordered parallel file-candidate sinks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ParallelWalkControl {
+    /// Continue walking and delivering candidates.
+    Continue,
+    /// Stop all workers as promptly as possible.
+    Stop,
+}
+
+/// Owned entry returned by [`collect_entries`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct CollectedEntry {
+    /// Relative path from the root, using `/` separators.
+    pub path: String,
+    /// Filesystem entry kind.
+    pub file_type: FileType,
+    /// Modification time in milliseconds since the Unix epoch, when requested.
+    pub mtime: Option<f64>,
+    /// File size in bytes for regular files, when requested.
+    pub size: Option<f64>,
+}
+
+impl CollectedEntry {
+    /// Return this entry's absolute path under `root`.
+    pub fn absolute_path(&self, root: &Path) -> PathBuf {
+        if self.path.is_empty() {
+            root.to_path_buf()
+        } else {
+            root.join(&self.path)
+        }
+    }
+
+    /// Return this entry's depth below the traversal root.
+    pub fn depth(&self) -> usize {
+        if self.path.is_empty() {
+            0
+        } else {
+            self.path
+                .split('/')
+                .filter(|component| !component.is_empty())
+                .count()
+        }
+    }
+
+    /// Return whether this entry is a regular file.
+    pub const fn is_file(&self) -> bool {
+        matches!(self.file_type, FileType::File)
+    }
+
+    /// Return whether this entry is a directory.
+    pub const fn is_dir(&self) -> bool {
+        matches!(self.file_type, FileType::Dir)
+    }
+}
+
+/// Return whether `parent` is a walk-relative ancestor of `child`.
+///
+/// Both paths use the walker's normalized `/` separator. The root-relative
+/// empty path is an ancestor of every non-root entry.
+pub fn is_relative_ancestor(parent: &str, child: &str) -> bool {
+    if parent == child {
+        return false;
+    }
+    if parent.is_empty() {
+        return !child.is_empty();
+    }
+    child
+        .strip_prefix(parent)
+        .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+/// Compare normalized walk-relative paths in depth-first,
+/// contents-before-parent order.
+pub fn compare_depth_first_paths(left: &str, right: &str) -> Ordering {
+    if left == right {
+        return Ordering::Equal;
+    }
+    if is_relative_ancestor(left, right) {
+        return Ordering::Greater;
+    }
+    if is_relative_ancestor(right, left) {
+        return Ordering::Less;
+    }
+    left.cmp(right)
+}
+
+/// Sort collected entries in depth-first, contents-before-parent path order.
+pub fn sort_collected_depth_first(entries: &mut [CollectedEntry]) {
+    entries.sort_unstable_by(|left, right| compare_depth_first_paths(&left.path, &right.path));
+}
+
+/// Return whether `relative` is below any pruned normalized directory path.
+pub fn is_under_pruned_relative_dir(relative: &str, pruned_dirs: &[String]) -> bool {
+    pruned_dirs
+        .iter()
+        .any(|dir| is_relative_ancestor(dir, relative))
+}
+
+/// Return the root device id used by same-filesystem traversal filters.
+///
+/// Non-Unix platforms return `None`, making same-filesystem filtering a no-op.
+#[cfg(unix)]
+pub fn root_device_id(path: &Path, follow_links: FollowLinks) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+
+    metadata_for_follow_policy(path, follow_links.follow_at_depth(0))
+        .ok()
+        .map(|metadata| metadata.dev())
+}
+
+/// Return the root device id used by same-filesystem traversal filters.
+///
+/// Non-Unix platforms return `None`, making same-filesystem filtering a no-op.
+#[cfg(not(unix))]
+pub fn root_device_id(_path: &Path, _follow_links: FollowLinks) -> Option<u64> {
+    None
+}
+
+/// Return whether `path` is on the root filesystem represented by
+/// `root_device`.
+///
+/// When `root_device` is `None`, this returns true. On non-Unix platforms this
+/// is always true, matching the existing no-op same-filesystem behavior there.
+#[cfg(unix)]
+pub fn is_path_on_root_file_system(
+    path: &Path,
+    depth: usize,
+    follow_links: FollowLinks,
+    root_device: Option<u64>,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let Some(root_device) = root_device else {
+        return true;
+    };
+    metadata_for_follow_policy(path, follow_links.follow_at_depth(depth))
+        .is_ok_and(|metadata| metadata.dev() == root_device)
+}
+
+/// Return whether `path` is on the root filesystem represented by
+/// `root_device`.
+///
+/// When `root_device` is `None`, this returns true. On non-Unix platforms this
+/// is always true, matching the existing no-op same-filesystem behavior there.
+#[cfg(not(unix))]
+pub fn is_path_on_root_file_system(
+    _path: &Path,
+    _depth: usize,
+    _follow_links: FollowLinks,
+    _root_device: Option<u64>,
+) -> bool {
+    true
+}
+
+#[cfg(unix)]
+fn is_effective_path_on_root_file_system(
+    path: &Path,
+    depth: usize,
+    follow_links: FollowLinks,
+    root_device: Option<u64>,
+    followed_metadata: Option<&std::fs::Metadata>,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let Some(root_device) = root_device else {
+        return true;
+    };
+    if let Some(metadata) = followed_metadata {
+        return metadata.dev() == root_device;
+    }
+    metadata_for_follow_policy(path, follow_links.follow_at_depth(depth))
+        .is_ok_and(|metadata| metadata.dev() == root_device)
+}
+
+#[cfg(not(unix))]
+fn is_effective_path_on_root_file_system(
+    _path: &Path,
+    _depth: usize,
+    _follow_links: FollowLinks,
+    _root_device: Option<u64>,
+    _followed_metadata: Option<&std::fs::Metadata>,
+) -> bool {
+    true
+}
+
+#[cfg(unix)]
+fn metadata_for_follow_policy(path: &Path, follow: bool) -> io::Result<std::fs::Metadata> {
+    if follow {
+        std::fs::metadata(path)
+    } else {
+        std::fs::symlink_metadata(path)
+    }
+}
+
+/// Owned entries returned by [`collect_entries`] plus cache metadata.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CollectedEntries {
+    /// Entries collected with the requested traversal contract.
+    pub entries: Vec<CollectedEntry>,
+    /// Age of the cache entry in milliseconds; zero means freshly scanned.
+    pub cache_age_ms: u64,
+}
+
+/// Borrowed entry passed to [`EntryVisitor`].
+pub struct Entry<'a> {
+    /// Absolute filesystem path for this entry.
+    pub path: &'a Path,
+    /// Relative path from the root, using `/` separators.
+    pub relative: &'a str,
+    /// Basename as returned by the platform directory API.
+    pub name: &'a OsStr,
+    /// Filesystem entry kind.
+    pub file_type: FileType,
+    /// Modification time in milliseconds since the Unix epoch, when requested.
+    pub mtime: Option<f64>,
+    /// File size in bytes for regular files, when requested.
+    pub size: Option<f64>,
+    /// Depth below the traversal root. Direct children have depth 1.
+    pub depth: usize,
+}
+
+/// Directory-open error delivered to visitors when configured by
+/// [`WalkOptions::directory_errors`].
+pub struct DirectoryError<'a> {
+    /// Directory path that could not be read.
+    pub path: &'a Path,
+    /// Underlying platform I/O error.
+    pub error: &'a io::Error,
+}
+
+/// Pre-descend decision made before a directory's children are traversed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PreDescendDecision {
+    /// Whether this entry should be emitted in the requested visit order.
+    pub emit: bool,
+    /// Whether this directory's descendants should be traversed.
+    pub descend: bool,
+    /// Whether traversal should stop immediately.
+    pub stop: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum DirectoryIdentity {
+    #[cfg(unix)]
+    Unix { dev: u64, ino: u64 },
+    #[cfg(not(unix))]
+    Generic(std::path::PathBuf),
+}
+
+#[derive(Default)]
+struct SymlinkAncestorStack {
+    stack: Vec<DirectoryIdentity>,
+}
+
+impl SymlinkAncestorStack {
+    fn contains(&self, identity: &DirectoryIdentity) -> bool {
+        self.stack.contains(identity)
+    }
+
+    fn push(&mut self, identity: DirectoryIdentity) {
+        self.stack.push(identity);
+    }
+
+    fn pop(&mut self) {
+        self.stack.pop();
+    }
+}
+
+fn directory_identity(path: &Path) -> io::Result<DirectoryIdentity> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = std::fs::metadata(path)?;
+        Ok(DirectoryIdentity::Unix {
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let canonical = std::fs::canonicalize(path)?;
+        Ok(DirectoryIdentity::Generic(canonical))
+    }
+}
+
+/// Consumer hook invoked for every accepted entry.
+pub trait EntryVisitor {
+    /// Error type used by visitor and heartbeat callbacks.
+    type Error;
+
+    /// Visit one filesystem entry and choose how traversal continues.
+    fn visit(&mut self, entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error>;
+
+    /// Handle a directory-open error and choose whether traversal continues.
+    fn visit_directory_error(
+        &mut self,
+        _error: DirectoryError<'_>,
+    ) -> std::result::Result<WalkControl, Self::Error> {
+        Ok(WalkControl::Continue)
+    }
+
+    /// Optional hook for making pre-descend traversal decisions.
+    fn decide_pre_descend(
+        &mut self,
+        _meta: &EntryMeta<'_>,
+    ) -> std::result::Result<PreDescendDecision, Self::Error> {
+        Ok(PreDescendDecision {
+            emit: true,
+            descend: true,
+            stop: false,
+        })
+    }
+
+    /// Visit an entry whose filter/predicate decisions have already been made.
+    fn visit_pre_decided(
+        &mut self,
+        entry: Entry<'_>,
+    ) -> std::result::Result<WalkControl, Self::Error> {
+        self.visit(entry)
+    }
+}
+struct RequestVisitor<'a, V, P> {
+    root: &'a Path,
+    filter: &'a WalkFilter,
+    limit: Option<usize>,
+    emitted: usize,
+    visitor: &'a mut V,
+    predicate: P,
+}
+
+impl<V, P> EntryVisitor for RequestVisitor<'_, V, P>
+where
+    V: EntryVisitor,
+    P: WalkPredicate,
+{
+    type Error = V::Error;
+
+    fn visit(&mut self, entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error> {
+        if self.limit.is_some_and(|limit| self.emitted >= limit) {
+            return Ok(WalkControl::Quit);
+        }
+        let meta = EntryMeta {
+            root: self.root,
+            absolute_path: Cow::Borrowed(entry.path),
+            relative_path: entry.relative,
+            file_type: entry.file_type,
+            mtime: entry.mtime,
+            size: entry.size,
+            depth: entry.depth,
+        };
+        match self.filter.stream_decision(&meta) {
+            WalkDecision::Include => {}
+            WalkDecision::Skip => return Ok(WalkControl::Continue),
+            WalkDecision::SkipDescend => return Ok(WalkControl::SkipDescend),
+            WalkDecision::Stop => return Ok(WalkControl::Quit),
+        }
+        match self.predicate.decide(&meta) {
+            WalkDecision::Include => {}
+            WalkDecision::Skip => return Ok(WalkControl::Continue),
+            WalkDecision::SkipDescend => return Ok(WalkControl::SkipDescend),
+            WalkDecision::Stop => return Ok(WalkControl::Quit),
+        }
+        self.emitted += 1;
+        self.visitor.visit(entry)
+    }
+
+    fn visit_directory_error(
+        &mut self,
+        error: DirectoryError<'_>,
+    ) -> std::result::Result<WalkControl, Self::Error> {
+        self.visitor.visit_directory_error(error)
+    }
+
+    fn visit_pre_decided(
+        &mut self,
+        entry: Entry<'_>,
+    ) -> std::result::Result<WalkControl, Self::Error> {
+        if self.limit.is_some_and(|limit| self.emitted >= limit) {
+            return Ok(WalkControl::Quit);
+        }
+        self.emitted += 1;
+        self.visitor.visit(entry)
+    }
+
+    fn decide_pre_descend(
+        &mut self,
+        meta: &EntryMeta<'_>,
+    ) -> std::result::Result<PreDescendDecision, Self::Error> {
+        let is_dir = meta.file_type == FileType::Dir;
+
+        match self.filter.stream_decision(meta) {
+            WalkDecision::Include => {}
+            WalkDecision::Skip => {
+                return Ok(PreDescendDecision {
+                    emit: false,
+                    descend: is_dir,
+                    stop: false,
+                });
+            }
+            WalkDecision::SkipDescend => {
+                return Ok(PreDescendDecision {
+                    emit: false,
+                    descend: false,
+                    stop: false,
+                });
+            }
+            WalkDecision::Stop => {
+                return Ok(PreDescendDecision {
+                    emit: false,
+                    descend: false,
+                    stop: true,
+                });
+            }
+        }
+
+        match self.predicate.decide(meta) {
+            WalkDecision::Include => Ok(PreDescendDecision {
+                emit: true,
+                descend: is_dir,
+                stop: false,
+            }),
+            WalkDecision::Skip => Ok(PreDescendDecision {
+                emit: false,
+                descend: is_dir,
+                stop: false,
+            }),
+            WalkDecision::SkipDescend => Ok(PreDescendDecision {
+                emit: false,
+                descend: false,
+                stop: false,
+            }),
+            WalkDecision::Stop => Ok(PreDescendDecision {
+                emit: false,
+                descend: false,
+                stop: true,
+            }),
+        }
+    }
+}
+struct ClosureEntryVisitor<'a, V, D> {
+    root: &'a Path,
+    visit: V,
+    directory_error: D,
+}
+
+impl<E, V, D> EntryVisitor for ClosureEntryVisitor<'_, V, D>
+where
+    V: for<'entry> FnMut(EntryMeta<'entry>) -> std::result::Result<WalkDecision, E>,
+    D: for<'error> FnMut(DirectoryError<'error>) -> std::result::Result<WalkDecision, E>,
+{
+    type Error = E;
+
+    fn visit(&mut self, entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error> {
+        let meta = EntryMeta {
+            root: self.root,
+            absolute_path: Cow::Borrowed(entry.path),
+            relative_path: entry.relative,
+            file_type: entry.file_type,
+            mtime: entry.mtime,
+            size: entry.size,
+            depth: entry.depth,
+        };
+        (self.visit)(meta).map(walk_decision_to_control)
+    }
+
+    fn visit_directory_error(
+        &mut self,
+        error: DirectoryError<'_>,
+    ) -> std::result::Result<WalkControl, Self::Error> {
+        (self.directory_error)(error).map(walk_decision_to_control)
+    }
+}
+
+const fn walk_decision_to_control(decision: WalkDecision) -> WalkControl {
+    match decision {
+        WalkDecision::Include | WalkDecision::Skip => WalkControl::Continue,
+        WalkDecision::SkipDescend => WalkControl::SkipDescend,
+        WalkDecision::Stop => WalkControl::Quit,
+    }
+}
+
+/// Error returned by native traversal.
+#[derive(Debug)]
+pub enum WalkError<E> {
+    /// A caller-supplied heartbeat or visitor returned an error.
+    Interrupted(E),
+    /// A platform directory API returned malformed data or an unskippable error.
+    InvalidData {
+        /// Directory whose scan failed.
+        path: PathBuf,
+        /// Human-readable failure detail.
+        message: String,
+    },
+}
+
+impl<E: fmt::Display> fmt::Display for WalkError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Interrupted(err) => write!(f, "native directory scan interrupted: {err}"),
+            Self::InvalidData { path, message } => {
+                write!(
+                    f,
+                    "native directory scan failed for {}: {message}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl<E> std::error::Error for WalkError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Interrupted(err) => Some(err),
+            Self::InvalidData { .. } => None,
+        }
+    }
+}
+
+struct CollectVisitor<E> {
+    entries: Vec<CollectedEntry>,
+    _error: std::marker::PhantomData<fn() -> E>,
+}
+
+impl<E> CollectVisitor<E> {
+    const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            _error: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<E> EntryVisitor for CollectVisitor<E> {
+    type Error = E;
+
+    fn visit(&mut self, entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error> {
+        self.entries.push(CollectedEntry {
+            path: entry.relative.to_string(),
+            file_type: entry.file_type,
+            mtime: entry.mtime,
+            size: entry.size,
+        });
+        Ok(WalkControl::Continue)
+    }
+}
+
+fn root_device_for_options(root: &Path, options: WalkOptions) -> Option<u64> {
+    if options.same_file_system {
+        root_device_id(root, options.follow_links)
+    } else {
+        None
+    }
+}
+
+struct RawDirEntry<'a> {
+    name: Cow<'a, OsStr>,
+    file_type: FileType,
+    mtime: Option<f64>,
+    size: Option<f64>,
+}
+
+#[cfg(unix)]
+struct DirEntryRecord {
+    name_start: usize,
+    name_len: usize,
+    file_type: FileType,
+    mtime: Option<f64>,
+    size: Option<f64>,
+}
+
+#[cfg(not(unix))]
+struct DirEntryRecord {
+    name: OsString,
+    file_type: FileType,
+    mtime: Option<f64>,
+    size: Option<f64>,
+}
+
+#[derive(Default)]
+struct DirScratch {
+    entries: Vec<DirEntryRecord>,
+    #[cfg(unix)]
+    name_bytes: Vec<u8>,
+    read_buffer: Vec<u8>,
+}
+
+impl DirScratch {
+    fn clear_listing(&mut self) {
+        self.entries.clear();
+        #[cfg(unix)]
+        self.name_bytes.clear();
+    }
+
+    #[cfg(unix)]
+    fn push(&mut self, entry: RawDirEntry<'_>) {
+        let name_os: &OsStr = entry.name.as_ref();
+        let name = name_os.as_bytes();
+        let name_start = self.name_bytes.len();
+        self.name_bytes.extend_from_slice(name);
+        self.entries.push(DirEntryRecord {
+            name_start,
+            name_len: name.len(),
+            file_type: entry.file_type,
+            mtime: entry.mtime,
+            size: entry.size,
+        });
+    }
+
+    #[cfg(not(unix))]
+    fn push(&mut self, entry: RawDirEntry<'_>) {
+        self.entries.push(DirEntryRecord {
+            name: entry.name.into_owned(),
+            file_type: entry.file_type,
+            mtime: entry.mtime,
+            size: entry.size,
+        });
+    }
+
+    #[cfg(unix)]
+    fn sort_by_name(&mut self) {
+        let names = &self.name_bytes;
+        self.entries.sort_unstable_by(|left, right| {
+            let left_name = &names[left.name_start..left.name_start + left.name_len];
+            let right_name = &names[right.name_start..right.name_start + right.name_len];
+            left_name.cmp(right_name)
+        });
+    }
+
+    #[cfg(not(unix))]
+    fn sort_by_name(&mut self) {
+        self.entries
+            .sort_unstable_by(|left, right| left.name.cmp(&right.name));
+    }
+
+    #[cfg(unix)]
+    fn name<'a>(&'a self, entry: &DirEntryRecord) -> &'a OsStr {
+        OsStr::from_bytes(&self.name_bytes[entry.name_start..entry.name_start + entry.name_len])
+    }
+
+    #[cfg(not(unix))]
+    fn name<'a>(&'a self, entry: &'a DirEntryRecord) -> &'a OsStr {
+        &entry.name
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReadDirControl {
+    Continue,
+    Stop,
+}
+
+enum ReadDirError<E> {
+    Io(io::Error),
+    Walk(WalkError<E>),
+}
+
+impl<E> From<io::Error> for ReadDirError<E> {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+fn file_type_from_metadata(metadata: &std::fs::Metadata) -> Option<FileType> {
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        Some(FileType::Symlink)
+    } else if file_type.is_dir() {
+        Some(FileType::Dir)
+    } else if file_type.is_file() {
+        Some(FileType::File)
+    } else {
+        None
+    }
+}
+
+struct RootEntry {
+    file_type: FileType,
+    mtime: Option<f64>,
+    size: Option<f64>,
+}
+
+fn root_entry<E>(
+    root: &Path,
+    detail: WalkDetail,
+    follow_links: FollowLinks,
+) -> std::result::Result<Option<RootEntry>, WalkError<E>> {
+    let metadata = if follow_links.follow_at_depth(0) {
+        match std::fs::metadata(root) {
+            Ok(metadata) => metadata,
+            Err(err) if is_missing_metadata_error(&err) => std::fs::symlink_metadata(root)
+                .map_err(|err| WalkError::InvalidData {
+                    path: root.to_path_buf(),
+                    message: err.to_string(),
+                })?,
+            Err(err) => {
+                return Err(WalkError::InvalidData {
+                    path: root.to_path_buf(),
+                    message: err.to_string(),
+                });
+            }
+        }
+    } else {
+        std::fs::symlink_metadata(root).map_err(|err| WalkError::InvalidData {
+            path: root.to_path_buf(),
+            message: err.to_string(),
+        })?
+    };
+    Ok(entry_from_metadata(&metadata, detail))
+}
+
+fn entry_from_metadata(metadata: &std::fs::Metadata, detail: WalkDetail) -> Option<RootEntry> {
+    let file_type = file_type_from_metadata(metadata)?;
+    let size = if detail == WalkDetail::Full && file_type == FileType::File {
+        Some(metadata.len() as f64)
+    } else {
+        None
+    };
+    let mtime = if detail == WalkDetail::Full {
+        metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis() as f64)
+    } else {
+        None
+    };
+    Some(RootEntry {
+        file_type,
+        mtime,
+        size,
+    })
+}
+
+fn is_missing_metadata_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+    )
+}
+
+/// Scans entries using the shared cache when [`WalkOptions::cache`] is true.
+///
+/// The native scanner implements every [`WalkOptions`] traversal contract.
+pub fn collect_entries<E, H>(
+    root: &Path,
+    options: WalkOptions,
+    heartbeat: H,
+) -> std::result::Result<CollectedEntries, WalkError<String>>
+where
+    H: Fn() -> std::result::Result<(), E> + Sync,
+    E: fmt::Display,
+{
+    cache::collect_entries(root, options, heartbeat)
+}
+
+fn collect_entries_native<E, H>(
+    root: &Path,
+    options: WalkOptions,
+    heartbeat: H,
+) -> std::result::Result<CollectedEntries, WalkError<E>>
+where
+    H: FnMut() -> std::result::Result<(), E>,
+{
+    let mut collector = CollectVisitor::new();
+    let _status = walk_entries(root, options, &mut collector, heartbeat)?;
+    if options.contents_first {
+        sort_collected_depth_first(&mut collector.entries);
+    } else {
+        collector
+            .entries
+            .sort_unstable_by(|a, b| a.path.cmp(&b.path));
+    }
+    Ok(CollectedEntries {
+        entries: collector.entries,
+        cache_age_ms: 0,
+    })
+}
+
+/// Scans entries without cancellation using platform syscalls when supported.
+pub fn collect_entries_without_heartbeat(
+    root: &Path,
+    options: WalkOptions,
+) -> std::result::Result<CollectedEntries, WalkError<String>> {
+    collect_entries(root, options, || Ok::<(), Infallible>(()))
+}
+
+/// Streams entries using the native scanner for every [`WalkOptions`]
+/// traversal contract.
+pub fn walk_entries<V, H>(
+    root: &Path,
+    options: WalkOptions,
+    visitor: &mut V,
+    heartbeat: H,
+) -> std::result::Result<WalkStatus, WalkError<V::Error>>
+where
+    V: EntryVisitor,
+    H: FnMut() -> std::result::Result<(), V::Error>,
+{
+    if options.min_depth > options.max_depth {
+        return Ok(WalkStatus::Complete);
+    }
+
+    let root_device = root_device_for_options(root, options);
+    let matcher = FastIgnore::new(options.use_gitignore);
+    let root_ignore = matcher.root_state(root);
+
+    let mut context = WalkContext {
+        root_path: root,
+        options,
+        root_device,
+        symlink_ancestors: SymlinkAncestorStack::default(),
+        matcher,
+        absolute_path: root.to_path_buf(),
+        relative_path: String::new(),
+        scratch_pool: Vec::new(),
+        visited: 0,
+        heartbeat,
+    };
+
+    context.walk_root(root, &root_ignore, visitor)
+}
+
+struct WalkContext<'a, H> {
+    root_path: &'a Path,
+    options: WalkOptions,
+    root_device: Option<u64>,
+    symlink_ancestors: SymlinkAncestorStack,
+    matcher: FastIgnore,
+    absolute_path: PathBuf,
+    relative_path: String,
+    scratch_pool: Vec<DirScratch>,
+    visited: usize,
+    heartbeat: H,
+}
+
+impl<H> WalkContext<'_, H> {
+    fn walk_root<V>(
+        &mut self,
+        root: &Path,
+        root_ignore: &Arc<IgnoreState>,
+        visitor: &mut V,
+    ) -> std::result::Result<WalkStatus, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+        H: FnMut() -> std::result::Result<(), V::Error>,
+    {
+        let root_entry = root_entry(root, self.options.detail, self.options.follow_links)?;
+        let Some(root_entry) = root_entry else {
+            return Ok(WalkStatus::Complete);
+        };
+
+        // Seed the ancestor stack only when descendant symlink traversal can loop.
+        if self.options.follow_links == FollowLinks::Always
+            && let Ok(id) = directory_identity(root)
+        {
+            self.symlink_ancestors.push(id);
+        }
+
+        let meta = EntryMeta {
+            root,
+            absolute_path: Cow::Borrowed(root),
+            relative_path: "",
+            file_type: root_entry.file_type,
+            mtime: root_entry.mtime,
+            size: root_entry.size,
+            depth: 0,
+        };
+
+        let decision = visitor
+            .decide_pre_descend(&meta)
+            .map_err(WalkError::Interrupted)?;
+        if decision.stop {
+            return Ok(WalkStatus::Stopped);
+        }
+
+        if !self.options.contents_first
+            && self.options.emit_root
+            && self.options.min_depth == 0
+            && decision.emit
+        {
+            let name = root.file_name().unwrap_or(root.as_os_str());
+            match visitor
+                .visit_pre_decided(Entry {
+                    path: root,
+                    relative: "",
+                    name,
+                    file_type: root_entry.file_type,
+                    mtime: root_entry.mtime,
+                    size: root_entry.size,
+                    depth: 0,
+                })
+                .map_err(WalkError::Interrupted)?
+            {
+                WalkControl::Quit => return Ok(WalkStatus::Stopped),
+                WalkControl::SkipDescend => return Ok(WalkStatus::Complete),
+                WalkControl::Continue => {}
+            }
+        }
+
+        let stopped = if root_entry.file_type == FileType::Dir
+            && self.options.max_depth > 0
+            && decision.descend
+        {
+            self.walk_dir(0, root_ignore, false, visitor)?
+        } else {
+            false
+        };
+
+        if stopped {
+            return Ok(WalkStatus::Stopped);
+        }
+
+        if self.options.contents_first
+            && self.options.emit_root
+            && self.options.min_depth == 0
+            && decision.emit
+        {
+            let name = root.file_name().unwrap_or(root.as_os_str());
+            match visitor
+                .visit_pre_decided(Entry {
+                    path: root,
+                    relative: "",
+                    name,
+                    file_type: root_entry.file_type,
+                    mtime: root_entry.mtime,
+                    size: root_entry.size,
+                    depth: 0,
+                })
+                .map_err(WalkError::Interrupted)?
+            {
+                WalkControl::Quit => return Ok(WalkStatus::Stopped),
+                WalkControl::SkipDescend | WalkControl::Continue => {}
+            }
+        }
+
+        Ok(WalkStatus::Complete)
+    }
+
+    fn take_scratch(&mut self) -> DirScratch {
+        let mut scratch = self.scratch_pool.pop().unwrap_or_default();
+        scratch.clear_listing();
+        scratch
+    }
+
+    fn recycle_scratch(&mut self, mut scratch: DirScratch) {
+        scratch.clear_listing();
+        self.scratch_pool.push(scratch);
+    }
+
+    fn push_entry_path(&mut self, name: &OsStr, name_str: &str) -> usize {
+        let relative_len = self.relative_path.len();
+        self.absolute_path.push(name);
+        push_relative_name(&mut self.relative_path, name_str);
+        relative_len
+    }
+
+    fn pop_entry_path(&mut self, relative_len: usize) {
+        self.relative_path.truncate(relative_len);
+        self.absolute_path.pop();
+    }
+
+    fn walk_dir<V>(
+        &mut self,
+        depth: usize,
+        ignore_state: &Arc<IgnoreState>,
+        derive_ignore_from_entries: bool,
+        visitor: &mut V,
+    ) -> std::result::Result<bool, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+        H: FnMut() -> std::result::Result<(), V::Error>,
+    {
+        if self.options.follow_links == FollowLinks::Always
+            && let Ok(identity) = directory_identity(&self.absolute_path)
+        {
+            self.symlink_ancestors.push(identity);
+            let result =
+                self.walk_dir_inner(depth, ignore_state, derive_ignore_from_entries, visitor);
+            self.symlink_ancestors.pop();
+            return result;
+        }
+
+        self.walk_dir_inner(depth, ignore_state, derive_ignore_from_entries, visitor)
+    }
+
+    fn walk_dir_inner<V>(
+        &mut self,
+        depth: usize,
+        ignore_state: &Arc<IgnoreState>,
+        derive_ignore_from_entries: bool,
+        visitor: &mut V,
+    ) -> std::result::Result<bool, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+        H: FnMut() -> std::result::Result<(), V::Error>,
+    {
+        let mut scratch = self.take_scratch();
+        let ignore_entries = match collect_directory_entries(
+            &self.absolute_path,
+            self.options.detail,
+            &mut scratch,
+            &self.matcher,
+            derive_ignore_from_entries,
+        ) {
+            Ok(ignore_entries) => ignore_entries,
+            Err(err) => {
+                let dir = self.absolute_path.clone();
+                self.recycle_scratch(scratch);
+                return handle_read_dir_error(&dir, err, self.options, visitor);
+            }
+        };
+        if self.options.order == WalkOrder::Path {
+            scratch.sort_by_name();
+        }
+        let dir_ignore = self.matcher.state_from_entries(
+            ignore_state,
+            &self.absolute_path,
+            ignore_entries,
+            derive_ignore_from_entries,
+        );
+
+        for index in 0..scratch.entries.len() {
+            if self.visited == 0 || self.visited >= HEARTBEAT_INTERVAL {
+                self.visited = 0;
+                (self.heartbeat)().map_err(WalkError::Interrupted)?;
+            }
+            self.visited += 1;
+
+            let entry = &scratch.entries[index];
+            let name = scratch.name(entry);
+            if is_dot_entry(name) {
+                continue;
+            }
+            if !self.options.include_hidden && is_hidden_name(name) {
+                continue;
+            }
+            if (self.options.skip_git && is_git_name(name))
+                || (self.options.skip_node_modules && is_node_modules_name(name))
+            {
+                continue;
+            }
+
+            let name_str = entry_name(name);
+            if name_str.is_empty() {
+                continue;
+            }
+            let next_depth = depth + 1;
+            if next_depth > self.options.max_depth {
+                continue;
+            }
+
+            let relative_len = self.push_entry_path(name, &name_str);
+            let entry_result = self.walk_current_entry(
+                name,
+                entry.file_type,
+                entry.mtime,
+                entry.size,
+                next_depth,
+                &dir_ignore,
+                visitor,
+            );
+            self.pop_entry_path(relative_len);
+            if entry_result? {
+                self.recycle_scratch(scratch);
+                return Ok(true);
+            }
+        }
+
+        self.recycle_scratch(scratch);
+        Ok(false)
+    }
+
+    fn walk_current_entry<V>(
+        &mut self,
+        name: &OsStr,
+        entry_file_type: FileType,
+        entry_mtime: Option<f64>,
+        entry_size: Option<f64>,
+        next_depth: usize,
+        dir_ignore: &Arc<IgnoreState>,
+        visitor: &mut V,
+    ) -> std::result::Result<bool, WalkError<V::Error>>
+    where
+        V: EntryVisitor,
+        H: FnMut() -> std::result::Result<(), V::Error>,
+    {
+        let mut file_type = entry_file_type;
+        let mut mtime = entry_mtime;
+        let mut size = entry_size;
+        let mut is_dir = entry_file_type == FileType::Dir;
+        let mut descend = is_dir;
+        let mut followed_symlink_dir = false;
+        let followed_metadata = if entry_file_type == FileType::Symlink
+            && self.options.follow_links == FollowLinks::Always
+        {
+            match std::fs::metadata(&self.absolute_path) {
+                Ok(metadata) => Some(metadata),
+                Err(err) => {
+                    if self.options.directory_errors == DirectoryErrorMode::SkipSkippable
+                        && is_skippable_directory_error(&err)
+                    {
+                        return Ok(false);
+                    }
+                    if self.options.directory_errors == DirectoryErrorMode::Visit {
+                        match visitor
+                            .visit_directory_error(DirectoryError {
+                                path: &self.absolute_path,
+                                error: &err,
+                            })
+                            .map_err(WalkError::Interrupted)?
+                        {
+                            WalkControl::Quit => return Ok(true),
+                            WalkControl::SkipDescend | WalkControl::Continue => {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                    return Err(WalkError::InvalidData {
+                        path: self.absolute_path.clone(),
+                        message: err.to_string(),
+                    });
+                }
+            }
+        } else {
+            None
+        };
+
+        if let Some(target_metadata) = followed_metadata.as_ref() {
+            let Some(target_file_type) = file_type_from_metadata(target_metadata) else {
+                return Ok(false);
+            };
+            file_type = target_file_type;
+            if target_file_type == FileType::Dir {
+                is_dir = true;
+                descend = true;
+                followed_symlink_dir = true;
+            } else {
+                is_dir = false;
+                descend = false;
+            }
+            if self.options.detail == WalkDetail::Full {
+                if target_file_type == FileType::File {
+                    size = Some(target_metadata.len() as f64);
+                } else {
+                    size = None;
+                }
+                mtime = target_metadata
+                    .modified()
+                    .ok()
+                    .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_millis() as f64);
+            }
+        }
+
+        if self
+            .matcher
+            .is_ignored(dir_ignore, &self.absolute_path, is_dir)
+        {
+            return Ok(false);
+        }
+
+        if !is_effective_path_on_root_file_system(
+            &self.absolute_path,
+            next_depth,
+            self.options.follow_links,
+            self.root_device,
+            followed_metadata.as_ref(),
+        ) {
+            return Ok(false);
+        }
+
+        if followed_symlink_dir && descend {
+            match directory_identity(&self.absolute_path) {
+                Ok(target_id) => {
+                    if self.symlink_ancestors.contains(&target_id) {
+                        let loop_err = io::Error::other("filesystem loop detected");
+                        if self.options.directory_errors == DirectoryErrorMode::Visit {
+                            match visitor
+                                .visit_directory_error(DirectoryError {
+                                    path: &self.absolute_path,
+                                    error: &loop_err,
+                                })
+                                .map_err(WalkError::Interrupted)?
+                            {
+                                WalkControl::Quit => return Ok(true),
+                                WalkControl::SkipDescend | WalkControl::Continue => {
+                                    return Ok(false);
+                                }
+                            }
+                        } else if self.options.directory_errors == DirectoryErrorMode::SkipSkippable
+                        {
+                            return Ok(false);
+                        }
+                        return Err(WalkError::InvalidData {
+                            path: self.absolute_path.clone(),
+                            message: "filesystem loop detected".to_string(),
+                        });
+                    }
+                }
+                Err(err) => {
+                    if self.options.directory_errors == DirectoryErrorMode::SkipSkippable
+                        && is_skippable_directory_error(&err)
+                    {
+                        return Ok(false);
+                    }
+                    if self.options.directory_errors == DirectoryErrorMode::Visit {
+                        match visitor
+                            .visit_directory_error(DirectoryError {
+                                path: &self.absolute_path,
+                                error: &err,
+                            })
+                            .map_err(WalkError::Interrupted)?
+                        {
+                            WalkControl::Quit => return Ok(true),
+                            WalkControl::SkipDescend | WalkControl::Continue => {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                    return Err(WalkError::InvalidData {
+                        path: self.absolute_path.clone(),
+                        message: err.to_string(),
+                    });
+                }
+            }
+        }
+
+        let decision = {
+            let meta = EntryMeta {
+                root: self.root_path,
+                absolute_path: Cow::Borrowed(self.absolute_path.as_path()),
+                relative_path: &self.relative_path,
+                file_type,
+                mtime,
+                size,
+                depth: next_depth,
+            };
+            visitor
+                .decide_pre_descend(&meta)
+                .map_err(WalkError::Interrupted)?
+        };
+        if decision.stop {
+            return Ok(true);
+        }
+
+        if !self.options.contents_first && decision.emit && next_depth >= self.options.min_depth {
+            match visitor
+                .visit_pre_decided(Entry {
+                    path: self.absolute_path.as_path(),
+                    relative: &self.relative_path,
+                    name,
+                    file_type,
+                    mtime,
+                    size,
+                    depth: next_depth,
+                })
+                .map_err(WalkError::Interrupted)?
+            {
+                WalkControl::Quit => return Ok(true),
+                WalkControl::SkipDescend => return Ok(false),
+                WalkControl::Continue => {}
+            }
+        }
+
+        let child_stopped = if descend && next_depth < self.options.max_depth && decision.descend {
+            self.walk_dir(next_depth, dir_ignore, true, visitor)?
+        } else {
+            false
+        };
+
+        if child_stopped {
+            return Ok(true);
+        }
+
+        if self.options.contents_first && decision.emit && next_depth >= self.options.min_depth {
+            match visitor
+                .visit_pre_decided(Entry {
+                    path: self.absolute_path.as_path(),
+                    relative: &self.relative_path,
+                    name,
+                    file_type,
+                    mtime,
+                    size,
+                    depth: next_depth,
+                })
+                .map_err(WalkError::Interrupted)?
+            {
+                WalkControl::Quit => return Ok(true),
+                WalkControl::SkipDescend | WalkControl::Continue => {}
+            }
+        }
+
+        Ok(false)
+    }
+}
+
+fn collect_directory_entries<E>(
+    dir: &Path,
+    detail: WalkDetail,
+    scratch: &mut DirScratch,
+    matcher: &FastIgnore,
+    derive_ignore_from_entries: bool,
+) -> std::result::Result<IgnoreEntryNames, ReadDirError<E>> {
+    scratch.clear_listing();
+    let mut ignore_entries = IgnoreEntryNames::default();
+    let track_ignore_entries = derive_ignore_from_entries && matcher.use_gitignore;
+    let mut read_buffer = std::mem::take(&mut scratch.read_buffer);
+    let result = platform::read_dir_entries(dir, detail, &mut read_buffer, |entry| {
+        if track_ignore_entries {
+            ignore_entries.record(entry.name.as_ref(), entry.file_type);
+        }
+        scratch.push(entry);
+        Ok(ReadDirControl::Continue)
+    });
+    scratch.read_buffer = read_buffer;
+    result?;
+    Ok(ignore_entries)
+}
+/// Return whether [`WalkDetail::Full`] provides file sizes without per-entry
+/// metadata syscalls on this platform.
+pub const fn supports_cheap_size_hints() -> bool {
+    platform::CHEAP_SIZE_HINTS
+}
+
+struct IgnoreState {
+    parent: Option<Arc<Self>>,
+    ignore_matcher: Option<ignore::gitignore::Gitignore>,
+    gitignore_matcher: Option<ignore::gitignore::Gitignore>,
+    git_exclude_matcher: Option<ignore::gitignore::Gitignore>,
+    has_git: bool,
+    chain_has_matchers: bool,
+    any_git: bool,
+}
+
+struct FastIgnore {
+    global: Option<ignore::gitignore::Gitignore>,
+    use_gitignore: bool,
+}
+
+#[derive(Clone, Copy, Default)]
+struct IgnoreEntryNames {
+    ignore_file: bool,
+    gitignore_file: bool,
+    git_dir: bool,
+    repo_marker: bool,
+}
+
+impl IgnoreEntryNames {
+    fn record(&mut self, name: &OsStr, file_type: FileType) {
+        if matches!(file_type, FileType::File | FileType::Symlink) {
+            if name == OsStr::new(".ignore") {
+                self.ignore_file = true;
+            } else if name == OsStr::new(".gitignore") {
+                self.gitignore_file = true;
+            }
+        }
+        if name == OsStr::new(".git") {
+            self.git_dir = true;
+            self.repo_marker = true;
+        } else if name == OsStr::new(".jj") {
+            self.repo_marker = true;
+        }
+    }
+
+    const fn has_relevant(self) -> bool {
+        self.ignore_file || self.gitignore_file || self.git_dir || self.repo_marker
+    }
+}
+
+fn has_repo_marker(dir: &Path) -> bool {
+    dir.join(".git").exists() || dir.join(".jj").exists()
+}
+
+fn ignore_line_covers_root(
+    matcher_root: &Path,
+    source: &Path,
+    line: &str,
+    explicit_root: &Path,
+) -> bool {
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(matcher_root);
+    builder.add_line(Some(source.to_path_buf()), line).is_ok()
+        && builder.build().is_ok_and(|matcher| {
+            matcher
+                .matched_path_or_any_parents(explicit_root, true)
+                .is_ignore()
+        })
+}
+
+/// Load an ignore source, removing ancestor rules that cover an explicit walk
+/// root.
+///
+/// Unrelated parent rules remain active, while ignore files discovered at or
+/// below the root are loaded without filtering.
+fn load_gitignore(
+    matcher_root: &Path,
+    file: &Path,
+    explicit_root: Option<&Path>,
+) -> Option<ignore::gitignore::Gitignore> {
+    if !file.is_file() {
+        return None;
+    }
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(matcher_root);
+    let _ = builder.add(file);
+    let matcher = builder.build().ok().filter(|matcher| !matcher.is_empty())?;
+    let Some(explicit_root) = explicit_root else {
+        return Some(matcher);
+    };
+    if !matcher
+        .matched_path_or_any_parents(explicit_root, true)
+        .is_ignore()
+    {
+        return Some(matcher);
+    }
+
+    let handle = std::fs::File::open(file).ok()?;
+    let mut filtered = ignore::gitignore::GitignoreBuilder::new(matcher_root);
+    let source = Some(file.to_path_buf());
+    for (index, line) in io::BufReader::new(handle).lines().enumerate() {
+        let Ok(line) = line else {
+            break;
+        };
+        let line = if index == 0 {
+            line.trim_start_matches('\u{feff}')
+        } else {
+            line.as_str()
+        };
+        if ignore_line_covers_root(matcher_root, file, line, explicit_root) {
+            continue;
+        }
+        let _ = filtered.add_line(source.clone(), line);
+    }
+    filtered.build().ok().filter(|matcher| !matcher.is_empty())
+}
+
+impl IgnoreState {
+    fn build(dir: &Path, parent: Option<Arc<Self>>) -> Arc<Self> {
+        let has_git = has_repo_marker(dir);
+        let git_exclude = dir.join(".git/info/exclude");
+        Self::new(
+            parent,
+            load_gitignore(dir, &dir.join(".ignore"), None),
+            load_gitignore(dir, &dir.join(".gitignore"), None),
+            if has_git {
+                load_gitignore(dir, &git_exclude, None)
+            } else {
+                None
+            },
+            has_git,
+        )
+    }
+
+    fn build_parent(dir: &Path, parent: Option<Arc<Self>>, explicit_root: &Path) -> Arc<Self> {
+        let has_git = has_repo_marker(dir);
+        let git_exclude = dir.join(".git/info/exclude");
+        Self::new(
+            parent,
+            load_gitignore(dir, &dir.join(".ignore"), Some(explicit_root)),
+            load_gitignore(dir, &dir.join(".gitignore"), Some(explicit_root)),
+            if has_git {
+                load_gitignore(dir, &git_exclude, Some(explicit_root))
+            } else {
+                None
+            },
+            has_git,
+        )
+    }
+
+    fn build_from_entry_names(
+        dir: &Path,
+        parent: &Arc<Self>,
+        names: IgnoreEntryNames,
+    ) -> Arc<Self> {
+        if !names.has_relevant() {
+            return Arc::clone(parent);
+        }
+        let git_exclude = dir.join(".git/info/exclude");
+        Self::new(
+            Some(Arc::clone(parent)),
+            if names.ignore_file {
+                load_gitignore(dir, &dir.join(".ignore"), None)
+            } else {
+                None
+            },
+            if names.gitignore_file {
+                load_gitignore(dir, &dir.join(".gitignore"), None)
+            } else {
+                None
+            },
+            if names.git_dir {
+                load_gitignore(dir, &git_exclude, None)
+            } else {
+                None
+            },
+            names.repo_marker,
+        )
+    }
+
+    fn new(
+        parent: Option<Arc<Self>>,
+        ignore_matcher: Option<ignore::gitignore::Gitignore>,
+        gitignore_matcher: Option<ignore::gitignore::Gitignore>,
+        git_exclude_matcher: Option<ignore::gitignore::Gitignore>,
+        has_git: bool,
+    ) -> Arc<Self> {
+        let parent_has_matchers = parent
+            .as_ref()
+            .is_some_and(|parent| parent.chain_has_matchers);
+        let parent_has_git = parent.as_ref().is_some_and(|parent| parent.any_git);
+        let has_matchers = ignore_matcher.is_some()
+            || gitignore_matcher.is_some()
+            || git_exclude_matcher.is_some();
+        Arc::new(Self {
+            parent,
+            ignore_matcher,
+            gitignore_matcher,
+            git_exclude_matcher,
+            has_git,
+            chain_has_matchers: has_matchers || parent_has_matchers,
+            any_git: has_git || parent_has_git,
+        })
+    }
+
+    fn build_parents(root: &Path, use_gitignore: bool) -> Option<Arc<Self>> {
+        if !use_gitignore {
+            return None;
+        }
+        let mut ancestors = Vec::new();
+        let mut current = root.parent();
+        let mut repo_start = None;
+        while let Some(path) = current {
+            ancestors.push(path);
+            if repo_start.is_none() && has_repo_marker(path) {
+                repo_start = Some(ancestors.len() - 1);
+            }
+            current = path.parent();
+        }
+
+        let repo_start = repo_start?;
+        let mut parent = None;
+        for ancestor in ancestors[..=repo_start].iter().rev() {
+            parent = Some(Self::build_parent(ancestor, parent, root));
+        }
+        parent
+    }
+}
+
+impl FastIgnore {
+    fn new(use_gitignore: bool) -> Self {
+        let global = if use_gitignore {
+            let (matcher, _err) = ignore::gitignore::Gitignore::global();
+            if matcher.is_empty() {
+                None
+            } else {
+                Some(matcher)
+            }
+        } else {
+            None
+        };
+        Self {
+            global,
+            use_gitignore,
+        }
+    }
+
+    fn root_state(&self, root: &Path) -> Arc<IgnoreState> {
+        IgnoreState::build(root, IgnoreState::build_parents(root, self.use_gitignore))
+    }
+
+    fn state_from_entries(
+        &self,
+        parent: &Arc<IgnoreState>,
+        dir: &Path,
+        names: IgnoreEntryNames,
+        derive_ignore_from_entries: bool,
+    ) -> Arc<IgnoreState> {
+        if self.use_gitignore && derive_ignore_from_entries {
+            IgnoreState::build_from_entry_names(dir, parent, names)
+        } else {
+            Arc::clone(parent)
+        }
+    }
+
+    fn is_ignored(&self, state: &Arc<IgnoreState>, path: &Path, is_dir: bool) -> bool {
+        if !self.use_gitignore {
+            return false;
+        }
+
+        let any_git = state.any_git;
+        let global_matcher_applies = any_git && self.global.is_some();
+        if !state.chain_has_matchers && !global_matcher_applies {
+            return false;
+        }
+
+        let mut saw_git = false;
+        let mut ignore_match = ignore::Match::None;
+        let mut gitignore_match = ignore::Match::None;
+        let mut git_exclude_match = ignore::Match::None;
+
+        if state.chain_has_matchers {
+            let mut current = Some(state.as_ref());
+            while let Some(frame) = current {
+                if ignore_match.is_none()
+                    && let Some(matcher) = &frame.ignore_matcher
+                {
+                    ignore_match = matcher.matched(path, is_dir);
+                }
+                if gitignore_match.is_none()
+                    && let Some(matcher) = &frame.gitignore_matcher
+                {
+                    gitignore_match = matcher.matched(path, is_dir);
+                }
+                if any_git
+                    && !saw_git
+                    && git_exclude_match.is_none()
+                    && let Some(matcher) = &frame.git_exclude_matcher
+                {
+                    git_exclude_match = matcher.matched(path, is_dir);
+                }
+                saw_git = saw_git || frame.has_git;
+                current = frame.parent.as_deref();
+            }
+        }
+        match ignore_match {
+            ignore::Match::Ignore(_) => return true,
+            ignore::Match::Whitelist(_) => return false,
+            ignore::Match::None => {}
+        }
+        match gitignore_match {
+            ignore::Match::Ignore(_) => return true,
+            ignore::Match::Whitelist(_) => return false,
+            ignore::Match::None => {}
+        }
+        match git_exclude_match {
+            ignore::Match::Ignore(_) => return true,
+            ignore::Match::Whitelist(_) => return false,
+            ignore::Match::None => {}
+        }
+        if any_git && let Some(global) = &self.global {
+            match global.matched(path, is_dir) {
+                ignore::Match::Ignore(_) => return true,
+                ignore::Match::Whitelist(_) => return false,
+                ignore::Match::None => {}
+            }
+        }
+        false
+    }
+}
+
+fn handle_read_dir_error<V>(
+    dir: &Path,
+    err: ReadDirError<V::Error>,
+    options: WalkOptions,
+    visitor: &mut V,
+) -> std::result::Result<bool, WalkError<V::Error>>
+where
+    V: EntryVisitor,
+{
+    match err {
+        ReadDirError::Walk(err) => Err(err),
+        ReadDirError::Io(err)
+            if options.directory_errors == DirectoryErrorMode::SkipSkippable
+                && is_skippable_directory_error(&err) =>
+        {
+            Ok(false)
+        }
+        ReadDirError::Io(err) if options.directory_errors == DirectoryErrorMode::Visit => {
+            match visitor
+                .visit_directory_error(DirectoryError {
+                    path: dir,
+                    error: &err,
+                })
+                .map_err(WalkError::Interrupted)?
+            {
+                WalkControl::Quit => Ok(true),
+                WalkControl::SkipDescend | WalkControl::Continue => Ok(false),
+            }
+        }
+        ReadDirError::Io(err) => Err(WalkError::InvalidData {
+            path: dir.to_path_buf(),
+            message: err.to_string(),
+        }),
+    }
+}
+
+fn is_skippable_directory_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::NotADirectory | io::ErrorKind::PermissionDenied
+    )
+}
+
+fn is_dot_entry(name: &OsStr) -> bool {
+    name == OsStr::new(".") || name == OsStr::new("..")
+}
+
+fn is_git_name(name: &OsStr) -> bool {
+    name == OsStr::new(".git")
+}
+
+fn is_node_modules_name(name: &OsStr) -> bool {
+    name == OsStr::new("node_modules")
+}
+
+fn entry_name(name: &OsStr) -> Cow<'_, str> {
+    name.to_str()
+        .map_or_else(|| name.to_string_lossy(), Cow::Borrowed)
+}
+
+#[cfg(unix)]
+fn is_hidden_name(name: &OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    name.as_bytes().first() == Some(&b'.')
+}
+
+#[cfg(windows)]
+fn is_hidden_name(name: &OsStr) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+    name.encode_wide().next() == Some(b'.' as u16)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_hidden_name(name: &OsStr) -> bool {
+    name.to_str()
+        .is_some_and(|value| value.as_bytes().first() == Some(&b'.'))
+}
+
+fn push_relative_name(relative: &mut String, name: &str) {
+    if !relative.is_empty() {
+        relative.push('/');
+    }
+    relative.push_str(name);
+}
+
+fn mtime_millis(seconds: i64, nanos: i64) -> Option<f64> {
+    if seconds < 0 {
+        return None;
+    }
+    Some((seconds as f64).mul_add(1000.0, nanos.max(0) as f64 / 1_000_000.0))
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::{
+        borrow::Cow,
+        ffi::{CString, OsStr},
+        io,
+        mem::size_of,
+        os::{fd::RawFd, unix::ffi::OsStrExt},
+        path::Path,
+    };
+
+    use super::{
+        FileType, RawDirEntry, ReadDirControl, ReadDirError, WalkDetail, WalkError, mtime_millis,
+    };
+
+    /// `getattrlistbulk` can return data length in the same batch, but
+    /// requesting full-detail attributes (size + mtime) measurably slows the
+    /// bulk scan (~+50% walk time on APFS), which outweighs saving one fstat
+    /// per opened file. Benchmarked via `perf_walk_collect_full_detail` vs
+    /// minimal detail.
+    pub const CHEAP_SIZE_HINTS: bool = false;
+
+    const BUFFER_SIZE: usize = 256 * 1024;
+    const VREG: u32 = 1;
+    const VDIR: u32 = 2;
+    const VLNK: u32 = 5;
+
+    struct FdGuard(RawFd);
+
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            // SAFETY: `FdGuard` owns this file descriptor and closes it exactly once.
+            unsafe { libc::close(self.0) };
+        }
+    }
+
+    pub fn read_dir_entries<F, E>(
+        path: &Path,
+        detail: WalkDetail,
+        buffer: &mut Vec<u8>,
+        mut emit: F,
+    ) -> std::result::Result<ReadDirControl, ReadDirError<E>>
+    where
+        F: FnMut(RawDirEntry<'_>) -> std::result::Result<ReadDirControl, WalkError<E>>,
+    {
+        let fd = open_dir(path)?;
+        let mut attrs = libc::attrlist {
+            bitmapcount: libc::ATTR_BIT_MAP_COUNT,
+            reserved: 0,
+            commonattr: libc::ATTR_CMN_NAME | libc::ATTR_CMN_OBJTYPE,
+            volattr: 0,
+            dirattr: 0,
+            fileattr: 0,
+            forkattr: 0,
+        };
+        if detail == WalkDetail::Full {
+            attrs.commonattr |= libc::ATTR_CMN_MODTIME;
+            attrs.fileattr |= libc::ATTR_FILE_DATALENGTH;
+        }
+
+        if buffer.len() != BUFFER_SIZE {
+            buffer.resize(BUFFER_SIZE, 0);
+        }
+        loop {
+            // SAFETY: `fd` is an open directory descriptor, `attrs` points to a valid
+            // attrlist for the duration of the call, and `buffer` is writable.
+            let count = unsafe {
+                libc::getattrlistbulk(
+                    fd.0,
+                    std::ptr::addr_of_mut!(attrs).cast(),
+                    buffer.as_mut_ptr().cast(),
+                    buffer.len(),
+                    libc::FSOPT_NOFOLLOW as u64,
+                )
+            };
+            if count == 0 {
+                break;
+            }
+            if count < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                if is_unsupported_dir_scan(&err) {
+                    return read_dir_entries_std(path, detail, emit);
+                }
+                return Err(ReadDirError::Io(err));
+            }
+
+            let mut offset = 0usize;
+            for _ in 0..count {
+                if offset + size_of::<u32>() > buffer.len() {
+                    return Err(invalid_data("truncated getattrlistbulk record length").into());
+                }
+                let record_len = u32::from_ne_bytes(
+                    buffer[offset..offset + size_of::<u32>()]
+                        .try_into()
+                        .expect("slice length checked"),
+                ) as usize;
+                if record_len < size_of::<u32>() || offset + record_len > buffer.len() {
+                    return Err(invalid_data("invalid getattrlistbulk record length").into());
+                }
+                let record = &buffer[offset..offset + record_len];
+                if let Some(entry) = parse_record(record, detail)?
+                    && emit(entry).map_err(ReadDirError::Walk)? == ReadDirControl::Stop
+                {
+                    return Ok(ReadDirControl::Stop);
+                }
+                offset += record_len;
+            }
+        }
+        Ok(ReadDirControl::Continue)
+    }
+
+    fn read_dir_entries_std<F, E>(
+        path: &Path,
+        detail: WalkDetail,
+        mut emit: F,
+    ) -> std::result::Result<ReadDirControl, ReadDirError<E>>
+    where
+        F: FnMut(RawDirEntry<'_>) -> std::result::Result<ReadDirControl, WalkError<E>>,
+    {
+        let read_dir = std::fs::read_dir(path)?;
+        for entry in read_dir {
+            let entry = entry?;
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(err) if is_skippable_entry_error(&err) => continue,
+                Err(err) => return Err(err.into()),
+            };
+            let file_type = if file_type.is_symlink() {
+                Some(FileType::Symlink)
+            } else if file_type.is_dir() {
+                Some(FileType::Dir)
+            } else if file_type.is_file() {
+                Some(FileType::File)
+            } else {
+                None
+            };
+            let Some(file_type) = file_type else {
+                continue;
+            };
+
+            let mut mtime = None;
+            let mut size = None;
+            if detail == WalkDetail::Full {
+                match std::fs::symlink_metadata(entry.path()) {
+                    Ok(metadata) => {
+                        if file_type == FileType::File {
+                            size = Some(metadata.len() as f64);
+                        }
+                        mtime = metadata
+                            .modified()
+                            .ok()
+                            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|duration| duration.as_millis() as f64);
+                    }
+                    Err(err) if is_skippable_entry_error(&err) => continue,
+                    Err(err) => return Err(err.into()),
+                }
+            }
+
+            let raw_entry = RawDirEntry {
+                name: Cow::Owned(entry.file_name()),
+                file_type,
+                mtime,
+                size,
+            };
+
+            if emit(raw_entry).map_err(ReadDirError::Walk)? == ReadDirControl::Stop {
+                return Ok(ReadDirControl::Stop);
+            }
+        }
+        Ok(ReadDirControl::Continue)
+    }
+
+    fn open_dir(path: &Path) -> io::Result<FdGuard> {
+        let path = CString::new(path.as_os_str().as_bytes())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains NUL"))?;
+        // SAFETY: `path` is a NUL-terminated C string; flags open the directory for
+        // metadata traversal only and do not transfer ownership of the string.
+        let fd = unsafe {
+            libc::open(
+                path.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(FdGuard(fd))
+        }
+    }
+
+    fn parse_record(record: &[u8], detail: WalkDetail) -> io::Result<Option<RawDirEntry<'_>>> {
+        let mut cursor = size_of::<u32>();
+        let name_ref_start = cursor;
+        let name_ref = read_value::<libc::attrreference_t>(record, &mut cursor)?;
+        let obj_type = read_value::<u32>(record, &mut cursor)?;
+        let (mtime, data_length) = if detail == WalkDetail::Full {
+            let modified = read_value::<libc::timespec>(record, &mut cursor)?;
+            let data_length = read_value::<u64>(record, &mut cursor)?;
+            (
+                mtime_millis(modified.tv_sec as i64, modified.tv_nsec as i64),
+                Some(data_length),
+            )
+        } else {
+            (None, None)
+        };
+
+        let name_start = checked_attr_offset(name_ref_start, name_ref.attr_dataoffset)?;
+        let name_len = name_ref.attr_length as usize;
+        if name_len == 0 || name_start + name_len > record.len() {
+            return Err(invalid_data("invalid getattrlistbulk name reference"));
+        }
+        let name_bytes = trim_nul(&record[name_start..name_start + name_len]);
+        if name_bytes.is_empty() {
+            return Ok(None);
+        }
+
+        let Some(file_type) = file_type_from_vtype(obj_type) else {
+            return Ok(None);
+        };
+        let size = if file_type == FileType::File {
+            data_length.map(|value| value as f64)
+        } else {
+            None
+        };
+        Ok(Some(RawDirEntry {
+            name: OsStr::from_bytes(name_bytes).into(),
+            file_type,
+            mtime,
+            size,
+        }))
+    }
+
+    fn read_value<T: Copy>(record: &[u8], cursor: &mut usize) -> io::Result<T> {
+        let end = cursor.saturating_add(size_of::<T>());
+        if end > record.len() {
+            return Err(invalid_data("truncated getattrlistbulk attribute"));
+        }
+        let ptr = record[*cursor..end].as_ptr();
+        *cursor = end;
+        // SAFETY: Bounds were checked above; `getattrlistbulk` records are byte
+        // packed, so unaligned reads are required and do not outlive `record`.
+        Ok(unsafe { std::ptr::read_unaligned(ptr.cast::<T>()) })
+    }
+
+    fn checked_attr_offset(base: usize, offset: i32) -> io::Result<usize> {
+        if offset < 0 {
+            return Err(invalid_data("negative getattrlistbulk attribute offset"));
+        }
+        base.checked_add(offset as usize)
+            .ok_or_else(|| invalid_data("overflowing getattrlistbulk attribute offset"))
+    }
+
+    fn trim_nul(bytes: &[u8]) -> &[u8] {
+        let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
+        &bytes[..end]
+    }
+
+    const fn file_type_from_vtype(value: u32) -> Option<FileType> {
+        match value {
+            VREG => Some(FileType::File),
+            VDIR => Some(FileType::Dir),
+            VLNK => Some(FileType::Symlink),
+            _ => None,
+        }
+    }
+
+    fn is_unsupported_dir_scan(err: &io::Error) -> bool {
+        matches!(err.raw_os_error(), Some(libc::ENOTSUP | libc::EINVAL))
+    }
+
+    fn is_skippable_entry_error(err: &io::Error) -> bool {
+        matches!(
+            err.kind(),
+            io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+        )
+    }
+
+    fn invalid_data(message: &'static str) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, message)
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use std::{
+        ffi::{CString, OsStr},
+        io,
+        mem::{size_of, zeroed},
+        os::unix::ffi::OsStrExt,
+        path::Path,
+    };
+
+    use super::{
+        FileType, RawDirEntry, ReadDirControl, ReadDirError, WalkDetail, WalkError, mtime_millis,
+    };
+
+    pub const CHEAP_SIZE_HINTS: bool = false;
+
+    const BUFFER_SIZE: usize = 256 * 1024;
+    const LINUX_DIRENT64_NAME_OFFSET: usize = 19;
+    const STATX_TYPE: u32 = 0x0001;
+    const STATX_SIZE: u32 = 0x0200;
+    const STATX_MTIME: u32 = 0x0040;
+    const STATX_BASIC_STATS: u32 = 0x07ff;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct StatxTimestamp {
+        tv_sec: i64,
+        tv_nsec: u32,
+        __reserved: i32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct Statx {
+        stx_mask: u32,
+        stx_blksize: u32,
+        stx_attributes: u64,
+        stx_nlink: u32,
+        stx_uid: u32,
+        stx_gid: u32,
+        stx_mode: u16,
+        __spare0: [u16; 1],
+        stx_ino: u64,
+        stx_size: u64,
+        stx_blocks: u64,
+        stx_attributes_mask: u64,
+        stx_atime: StatxTimestamp,
+        stx_btime: StatxTimestamp,
+        stx_ctime: StatxTimestamp,
+        stx_mtime: StatxTimestamp,
+        stx_rdev_major: u32,
+        stx_rdev_minor: u32,
+        stx_dev_major: u32,
+        stx_dev_minor: u32,
+        stx_mnt_id: u64,
+        stx_dio_mem_align: u32,
+        stx_dio_offset_align: u32,
+        __spare3: [u64; 12],
+    }
+
+    struct FdGuard(libc::c_int);
+
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            // SAFETY: `FdGuard` owns this file descriptor and closes it exactly once.
+            unsafe { libc::close(self.0) };
+        }
+    }
+
+    struct EntryStat {
+        file_type: FileType,
+        mtime: Option<f64>,
+        size: Option<f64>,
+    }
+
+    pub fn read_dir_entries<F, E>(
+        path: &Path,
+        detail: WalkDetail,
+        buffer: &mut Vec<u8>,
+        mut emit: F,
+    ) -> std::result::Result<ReadDirControl, ReadDirError<E>>
+    where
+        F: FnMut(RawDirEntry<'_>) -> std::result::Result<ReadDirControl, WalkError<E>>,
+    {
+        let fd = open_dir(path)?;
+        if buffer.len() != BUFFER_SIZE {
+            buffer.resize(BUFFER_SIZE, 0);
+        }
+        loop {
+            // SAFETY: `fd` is an open directory descriptor and `buffer` is writable.
+            let read = unsafe {
+                libc::syscall(
+                    libc::SYS_getdents64,
+                    fd.0,
+                    buffer.as_mut_ptr().cast::<libc::c_void>(),
+                    buffer.len(),
+                )
+            };
+            if read == 0 {
+                break;
+            }
+            if read < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err.into());
+            }
+
+            let mut offset = 0usize;
+            let read_len = read as usize;
+            while offset < read_len {
+                if offset + LINUX_DIRENT64_NAME_OFFSET > read_len {
+                    return Err(invalid_data("truncated getdents64 record").into());
+                }
+                let reclen = read_u16(&buffer[offset + 16..read_len])? as usize;
+                if reclen < LINUX_DIRENT64_NAME_OFFSET || offset + reclen > read_len {
+                    return Err(invalid_data("invalid getdents64 record length").into());
+                }
+                let d_type = buffer[offset + 18];
+                let name_bytes =
+                    trim_nul(&buffer[offset + LINUX_DIRENT64_NAME_OFFSET..offset + reclen]);
+                offset += reclen;
+                if name_bytes.is_empty() {
+                    continue;
+                }
+
+                let dtype_file_type = file_type_from_dtype(d_type);
+                let stat = if detail == WalkDetail::Full || dtype_file_type.is_none() {
+                    match stat_entry(fd.0, name_bytes, detail) {
+                        Ok(Some(stat)) => Some(stat),
+                        Ok(None) => continue,
+                        Err(err) if is_skippable_entry_error(&err) => continue,
+                        Err(err) => return Err(err.into()),
+                    }
+                } else {
+                    None
+                };
+                let file_type = stat
+                    .as_ref()
+                    .map_or(dtype_file_type, |stat| Some(stat.file_type));
+                let Some(file_type) = file_type else {
+                    continue;
+                };
+                let entry = RawDirEntry {
+                    name: OsStr::from_bytes(name_bytes).into(),
+                    file_type,
+                    mtime: stat.as_ref().and_then(|stat| stat.mtime),
+                    size: stat.as_ref().and_then(|stat| stat.size),
+                };
+                if emit(entry).map_err(ReadDirError::Walk)? == ReadDirControl::Stop {
+                    return Ok(ReadDirControl::Stop);
+                }
+            }
+        }
+        Ok(ReadDirControl::Continue)
+    }
+
+    fn open_dir(path: &Path) -> io::Result<FdGuard> {
+        let path = CString::new(path.as_os_str().as_bytes())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains NUL"))?;
+        // SAFETY: `path` is a NUL-terminated C string; flags request a directory
+        // descriptor used only with getdents/statx and do not retain the pointer.
+        let fd = unsafe {
+            libc::open(
+                path.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(FdGuard(fd))
+        }
+    }
+
+    fn stat_entry(
+        dirfd: libc::c_int,
+        name: &[u8],
+        detail: WalkDetail,
+    ) -> io::Result<Option<EntryStat>> {
+        let name = CString::new(name)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "entry name contains NUL"))?;
+        match statx_entry(dirfd, &name, detail) {
+            Ok(value) => Ok(value),
+            Err(err) if matches!(err.raw_os_error(), Some(libc::ENOSYS | libc::EINVAL)) => {
+                fstatat_entry(dirfd, &name, detail)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn statx_entry(
+        dirfd: libc::c_int,
+        name: &CString,
+        detail: WalkDetail,
+    ) -> io::Result<Option<EntryStat>> {
+        // SAFETY: `Statx` is a plain-old-data buffer whose all-zero value is a
+        // valid initialization before the kernel fills it.
+        let mut statx = unsafe { zeroed::<Statx>() };
+        let mask = if detail == WalkDetail::Full {
+            STATX_BASIC_STATS
+        } else {
+            STATX_TYPE
+        };
+        // SAFETY: `name` is NUL-terminated, `statx` is writable, and `dirfd` is an
+        // open directory descriptor for an AT_* relative metadata query.
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_statx,
+                dirfd,
+                name.as_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW | libc::AT_NO_AUTOMOUNT,
+                mask,
+                std::ptr::addr_of_mut!(statx),
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let Some(file_type) = file_type_from_mode(statx.stx_mode as libc::mode_t) else {
+            return Ok(None);
+        };
+        let mtime = if detail == WalkDetail::Full && statx.stx_mask & STATX_MTIME != 0 {
+            mtime_millis(statx.stx_mtime.tv_sec, i64::from(statx.stx_mtime.tv_nsec))
+        } else {
+            None
+        };
+        let size = if detail == WalkDetail::Full
+            && file_type == FileType::File
+            && statx.stx_mask & STATX_SIZE != 0
+        {
+            Some(statx.stx_size as f64)
+        } else {
+            None
+        };
+        Ok(Some(EntryStat {
+            file_type,
+            mtime,
+            size,
+        }))
+    }
+
+    fn fstatat_entry(
+        dirfd: libc::c_int,
+        name: &CString,
+        detail: WalkDetail,
+    ) -> io::Result<Option<EntryStat>> {
+        // SAFETY: `libc::stat` is a POD buffer filled by fstatat.
+        let mut stat = unsafe { zeroed::<libc::stat>() };
+        // SAFETY: `name` is NUL-terminated, `stat` is writable, and `dirfd` is an
+        // open directory descriptor for an AT_* relative metadata query.
+        let rc = unsafe {
+            libc::fstatat(
+                dirfd,
+                name.as_ptr(),
+                std::ptr::addr_of_mut!(stat),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let Some(file_type) = file_type_from_mode(stat.st_mode) else {
+            return Ok(None);
+        };
+        let mtime = if detail == WalkDetail::Full {
+            mtime_millis(stat.st_mtime, stat.st_mtime_nsec as i64)
+        } else {
+            None
+        };
+        let size = if detail == WalkDetail::Full && file_type == FileType::File {
+            Some(stat.st_size as f64)
+        } else {
+            None
+        };
+        Ok(Some(EntryStat {
+            file_type,
+            mtime,
+            size,
+        }))
+    }
+
+    fn read_u16(bytes: &[u8]) -> io::Result<u16> {
+        if bytes.len() < size_of::<u16>() {
+            return Err(invalid_data("truncated u16"));
+        }
+        Ok(u16::from_ne_bytes(
+            bytes[..size_of::<u16>()]
+                .try_into()
+                .expect("slice length checked"),
+        ))
+    }
+
+    fn trim_nul(bytes: &[u8]) -> &[u8] {
+        let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
+        &bytes[..end]
+    }
+
+    const fn file_type_from_dtype(value: u8) -> Option<FileType> {
+        match value {
+            libc::DT_REG => Some(FileType::File),
+            libc::DT_DIR => Some(FileType::Dir),
+            libc::DT_LNK => Some(FileType::Symlink),
+            _ => None,
+        }
+    }
+
+    const fn file_type_from_mode(mode: libc::mode_t) -> Option<FileType> {
+        match mode & libc::S_IFMT {
+            libc::S_IFREG => Some(FileType::File),
+            libc::S_IFDIR => Some(FileType::Dir),
+            libc::S_IFLNK => Some(FileType::Symlink),
+            _ => None,
+        }
+    }
+
+    fn is_skippable_entry_error(err: &io::Error) -> bool {
+        matches!(
+            err.kind(),
+            io::ErrorKind::NotFound
+                | io::ErrorKind::PermissionDenied
+                | io::ErrorKind::NotADirectory
+        )
+    }
+
+    fn invalid_data(message: &'static str) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, message)
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use std::{
+        ffi::OsString,
+        io,
+        os::windows::ffi::{OsStrExt, OsStringExt},
+        path::Path,
+    };
+
+    use windows_sys::{
+        Wdk::Storage::FileSystem::{
+            FILE_ID_FULL_DIR_INFORMATION, FileIdFullDirectoryInformation, NtQueryDirectoryFile,
+        },
+        Win32::{
+            Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE, STATUS_NO_MORE_FILES},
+            Storage::FileSystem::{
+                CreateFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+                FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_LIST_DIRECTORY,
+                FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+            },
+            System::IO::IO_STATUS_BLOCK,
+        },
+    };
+
+    use super::{
+        FileType, RawDirEntry, ReadDirControl, ReadDirError, WalkDetail, WalkError, mtime_millis,
+    };
+
+    pub const CHEAP_SIZE_HINTS: bool = true;
+
+    const BUFFER_SIZE: usize = 256 * 1024;
+    const WINDOWS_TICK: i64 = 10_000_000;
+    const UNIX_EPOCH_AS_FILETIME: i64 = 116_444_736_000_000_000;
+
+    struct HandleGuard(HANDLE);
+
+    impl Drop for HandleGuard {
+        fn drop(&mut self) {
+            // SAFETY: `HandleGuard` owns this handle and closes it exactly once.
+            unsafe { CloseHandle(self.0) };
+        }
+    }
+
+    pub fn read_dir_entries<F, E>(
+        path: &Path,
+        detail: WalkDetail,
+        buffer: &mut Vec<u8>,
+        mut emit: F,
+    ) -> std::result::Result<ReadDirControl, ReadDirError<E>>
+    where
+        F: FnMut(RawDirEntry<'_>) -> std::result::Result<ReadDirControl, WalkError<E>>,
+    {
+        let handle = open_dir(path)?;
+        if buffer.len() != BUFFER_SIZE {
+            buffer.resize(BUFFER_SIZE, 0);
+        }
+        let mut restart = true;
+
+        loop {
+            let mut iosb = IO_STATUS_BLOCK::default();
+            // SAFETY: `handle` is an open directory handle, `buffer` is writable, and
+            // the query class matches the record parser below.
+            let status = unsafe {
+                NtQueryDirectoryFile(
+                    handle.0,
+                    std::ptr::null_mut(),
+                    None,
+                    std::ptr::null(),
+                    std::ptr::addr_of_mut!(iosb),
+                    buffer.as_mut_ptr().cast(),
+                    buffer.len() as u32,
+                    FileIdFullDirectoryInformation,
+                    false,
+                    std::ptr::null(),
+                    restart,
+                )
+            };
+            restart = false;
+            if status == STATUS_NO_MORE_FILES {
+                break;
+            }
+            if status < 0 {
+                return Err(io::Error::from_raw_os_error(status).into());
+            }
+
+            let mut offset = 0usize;
+            loop {
+                if offset + std::mem::size_of::<FILE_ID_FULL_DIR_INFORMATION>() > buffer.len() {
+                    return Err(invalid_data("truncated NtQueryDirectoryFile record").into());
+                }
+                let info = unsafe {
+                    // SAFETY: Bounds were checked above; records are byte-packed in the
+                    // buffer and may not be aligned for Rust references.
+                    std::ptr::read_unaligned(
+                        buffer[offset..]
+                            .as_ptr()
+                            .cast::<FILE_ID_FULL_DIR_INFORMATION>(),
+                    )
+                };
+                let name_offset =
+                    offset + std::mem::offset_of!(FILE_ID_FULL_DIR_INFORMATION, FileName);
+                let name_len = info.FileNameLength as usize;
+                if name_len % 2 != 0 || name_offset + name_len > buffer.len() {
+                    return Err(invalid_data("invalid NtQueryDirectoryFile name length").into());
+                }
+                let name_units: Vec<u16> = buffer[name_offset..name_offset + name_len]
+                    .chunks_exact(2)
+                    .map(|chunk| u16::from_ne_bytes([chunk[0], chunk[1]]))
+                    .collect();
+                let name = OsString::from_wide(&name_units);
+                if let Some(file_type) = file_type_from_attributes(info.FileAttributes) {
+                    let size = if detail == WalkDetail::Full && file_type == FileType::File {
+                        Some(info.EndOfFile.max(0) as f64)
+                    } else {
+                        None
+                    };
+                    let mtime = if detail == WalkDetail::Full {
+                        mtime_from_filetime(info.LastWriteTime)
+                    } else {
+                        None
+                    };
+                    let entry = RawDirEntry {
+                        name: name.into(),
+                        file_type,
+                        mtime,
+                        size,
+                    };
+                    if emit(entry).map_err(ReadDirError::Walk)? == ReadDirControl::Stop {
+                        return Ok(ReadDirControl::Stop);
+                    }
+                }
+                if info.NextEntryOffset == 0 {
+                    break;
+                }
+                offset = offset.saturating_add(info.NextEntryOffset as usize);
+            }
+        }
+        Ok(ReadDirControl::Continue)
+    }
+
+    fn open_dir(path: &Path) -> io::Result<HandleGuard> {
+        let mut path: Vec<u16> = path.as_os_str().encode_wide().collect();
+        path.push(0);
+        // SAFETY: `path` is NUL-terminated; the returned handle is owned by
+        // `HandleGuard` on success.
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                FILE_LIST_DIRECTORY,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(HandleGuard(handle))
+        }
+    }
+
+    fn file_type_from_attributes(attributes: u32) -> Option<FileType> {
+        if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            Some(FileType::Symlink)
+        } else if attributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
+            Some(FileType::Dir)
+        } else {
+            Some(FileType::File)
+        }
+    }
+
+    fn mtime_from_filetime(filetime: i64) -> Option<f64> {
+        let ticks = filetime.checked_sub(UNIX_EPOCH_AS_FILETIME)?;
+        let seconds = ticks / WINDOWS_TICK;
+        let nanos = (ticks % WINDOWS_TICK) * 100;
+        mtime_millis(seconds, nanos)
+    }
+
+    fn invalid_data(message: &'static str) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, message)
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+mod platform {
+    use std::{borrow::Cow, io, path::Path};
+
+    use super::{FileType, RawDirEntry, ReadDirControl, ReadDirError, WalkDetail, WalkError};
+
+    pub const CHEAP_SIZE_HINTS: bool = false;
+
+    pub fn read_dir_entries<F, E>(
+        path: &Path,
+        detail: WalkDetail,
+        _buffer: &mut Vec<u8>,
+        mut emit: F,
+    ) -> std::result::Result<ReadDirControl, ReadDirError<E>>
+    where
+        F: FnMut(RawDirEntry<'_>) -> std::result::Result<ReadDirControl, WalkError<E>>,
+    {
+        let read_dir = std::fs::read_dir(path)?;
+        for entry in read_dir {
+            let entry = entry?;
+            let file_type_res = entry.file_type();
+            let file_type = match file_type_res {
+                Ok(ft) => ft,
+                Err(err) if is_skippable_entry_error(&err) => continue,
+                Err(err) => return Err(err.into()),
+            };
+            let custom_file_type = if file_type.is_symlink() {
+                Some(FileType::Symlink)
+            } else if file_type.is_dir() {
+                Some(FileType::Dir)
+            } else if file_type.is_file() {
+                Some(FileType::File)
+            } else {
+                None
+            };
+            let Some(custom_file_type) = custom_file_type else {
+                continue; // skip unsupported special files
+            };
+
+            let mut mtime = None;
+            let mut size = None;
+            if detail == WalkDetail::Full {
+                match std::fs::symlink_metadata(entry.path()) {
+                    Ok(metadata) => {
+                        if custom_file_type == FileType::File {
+                            size = Some(metadata.len() as f64);
+                        }
+                        mtime = metadata
+                            .modified()
+                            .ok()
+                            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|duration| duration.as_millis() as f64);
+                    }
+                    Err(err) if is_skippable_entry_error(&err) => continue,
+                    Err(err) => return Err(err.into()),
+                }
+            }
+
+            let raw_entry = RawDirEntry {
+                name: Cow::Owned(entry.file_name()),
+                file_type: custom_file_type,
+                mtime,
+                size,
+            };
+
+            if emit(raw_entry).map_err(ReadDirError::Walk)? == ReadDirControl::Stop {
+                return Ok(ReadDirControl::Stop);
+            }
+        }
+        Ok(ReadDirControl::Continue)
+    }
+
+    fn is_skippable_entry_error(err: &io::Error) -> bool {
+        matches!(
+            err.kind(),
+            io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    struct TempTree {
+        root: PathBuf,
+    }
+
+    impl TempTree {
+        fn path(&self) -> &Path {
+            &self.root
+        }
+    }
+
+    impl Drop for TempTree {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn temp_tree(name: &str) -> TempTree {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX_EPOCH")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("pi-walker-{name}-{unique}"));
+        fs::create_dir_all(&root).expect("temp root should be created");
+        TempTree { root }
+    }
+
+    struct CachePathGuard {
+        root: PathBuf,
+    }
+
+    impl CachePathGuard {
+        fn new(root: &Path) -> Self {
+            invalidate_path(root);
+            Self {
+                root: root.to_path_buf(),
+            }
+        }
+    }
+
+    impl Drop for CachePathGuard {
+        fn drop(&mut self) {
+            invalidate_path(&self.root);
+        }
+    }
+
+    fn wait_for_nonzero_cache_age() {
+        let started = std::time::Instant::now();
+        while started.elapsed() < Duration::from_millis(1) {
+            std::thread::yield_now();
+        }
+    }
+
+    fn test_options() -> WalkOptions {
+        WalkOptions {
+            include_hidden: true,
+            use_gitignore: false,
+            skip_git: true,
+            skip_node_modules: true,
+            follow_links: FollowLinks::Never,
+            detail: WalkDetail::Minimal,
+            order: WalkOrder::Path,
+            emit_root: false,
+            min_depth: 1,
+            max_depth: usize::MAX,
+            contents_first: false,
+            directory_errors: DirectoryErrorMode::SkipSkippable,
+            same_file_system: false,
+            cache: false,
+        }
+    }
+
+    fn collect_file_paths(root: &Path, use_gitignore: bool) -> Vec<String> {
+        WalkRequest::from_options(
+            root,
+            WalkOptions {
+                use_gitignore,
+                ..test_options()
+            },
+        )
+        .filter(WalkFilter::files_only())
+        .collect()
+        .expect("walk should collect successfully")
+        .entries
+        .into_iter()
+        .map(|entry| entry.path)
+        .collect()
+    }
+
+    #[test]
+    fn parent_ignore_outside_repo_does_not_filter_explicit_root() {
+        let tree = temp_tree("parent-ignore-outside-repo");
+        fs::write(tree.path().join(".gitignore"), "*.nix\n")
+            .expect("parent gitignore should be written");
+        let project = tree.path().join("projects").join("home-manager");
+        fs::create_dir_all(project.join("modules").join("common"))
+            .expect("project modules should be created");
+        fs::write(project.join("flake.nix"), "flake").expect("flake should be written");
+        fs::write(
+            project.join("modules").join("common").join("zsh.nix"),
+            "zsh",
+        )
+        .expect("module should be written");
+
+        let paths = collect_file_paths(&project, true);
+
+        assert_eq!(
+            paths,
+            vec!["flake.nix", "modules/common/zsh.nix"],
+            "an explicit non-repo search root must not inherit ignore files from unrelated parents"
+        );
+    }
+
+    #[test]
+    fn repo_parent_ignore_still_filters_subdirectory_root() {
+        let tree = temp_tree("repo-parent-ignore");
+        fs::create_dir_all(tree.path().join(".git")).expect("repo marker should be created");
+        fs::write(tree.path().join(".gitignore"), "*.nix\n")
+            .expect("repo gitignore should be written");
+        let project = tree.path().join("projects").join("home-manager");
+        fs::create_dir_all(project.join("modules").join("common"))
+            .expect("project modules should be created");
+        fs::write(project.join("flake.nix"), "flake").expect("flake should be written");
+        fs::write(
+            project.join("modules").join("common").join("zsh.nix"),
+            "zsh",
+        )
+        .expect("module should be written");
+
+        let paths = collect_file_paths(&project, true);
+
+        assert!(
+            paths.is_empty(),
+            "repo-root .gitignore should still apply when walking a subdirectory root, got {paths:?}"
+        );
+    }
+
+    #[test]
+    fn explicit_ignored_root_keeps_unrelated_parent_and_nested_ignore_rules() {
+        let tree = temp_tree("explicit-ignored-root");
+        fs::create_dir_all(tree.path().join(".git")).expect("repo marker should be created");
+        fs::write(tree.path().join(".gitignore"), "*.log\nignored/**\n")
+            .expect("repo gitignore should be written");
+        let project = tree.path().join("ignored").join("package");
+        let nested = project.join("nested");
+        fs::create_dir_all(&nested).expect("ignored project tree should be created");
+        fs::write(project.join("keep.ts"), "keep").expect("kept file should be written");
+        fs::write(project.join("trace.log"), "trace")
+            .expect("parent-ignored file should be written");
+        fs::write(nested.join(".gitignore"), "generated.ts\n")
+            .expect("nested gitignore should be written");
+        fs::write(nested.join("generated.ts"), "generated")
+            .expect("nested ignored file should be written");
+        fs::write(nested.join("keep.ts"), "nested keep")
+            .expect("nested kept file should be written");
+
+        let paths = collect_file_paths(&project, true);
+
+        assert_eq!(
+            paths,
+            vec!["keep.ts", "nested/.gitignore", "nested/keep.ts"]
+        );
+    }
+
+    #[test]
+    fn walk_request_files_only_returns_relative_files_and_excludes_directories() {
+        let tree = temp_tree("request-files-only");
+        fs::write(tree.path().join("alpha.txt"), "alpha")
+            .expect("top-level file should be written");
+        fs::create_dir_all(tree.path().join("nested")).expect("nested dir should be created");
+        fs::write(tree.path().join("nested").join("beta.txt"), "beta")
+            .expect("nested file should be written");
+
+        let outcome = WalkRequest::from_options(tree.path(), test_options())
+            .filter(WalkFilter::files_only())
+            .collect()
+            .expect("files-only request should collect successfully");
+        let paths = outcome
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec!["alpha.txt", "nested/beta.txt"],
+            "files-only requests should preserve relative file paths and exclude directory entries"
+        );
+        assert!(
+            outcome.entries.iter().all(CollectedEntry::is_file),
+            "files-only requests should not return directories or other entry kinds: {:?}",
+            outcome.entries
+        );
+    }
+
+    #[test]
+    fn compare_depth_first_paths_orders_children_before_parent() {
+        let mut paths = vec!["dir", "alpha", "dir/child", "dir/child/grandchild"];
+
+        paths.sort_unstable_by(|left, right| compare_depth_first_paths(left, right));
+
+        assert_eq!(
+            paths,
+            vec!["alpha", "dir/child/grandchild", "dir/child", "dir"],
+            "depth-first ordering should keep lexical siblings stable while placing descendants \
+			 before ancestors"
+        );
+    }
+
+    #[test]
+    fn walk_request_collect_contents_first_uses_collected_fallback() {
+        let tree = temp_tree("request-contents-first");
+        fs::create_dir_all(tree.path().join("nested")).expect("nested dir should be created");
+        fs::write(tree.path().join("nested").join("leaf.txt"), "leaf")
+            .expect("nested file should be written");
+
+        let outcome = WalkRequest::from_options(tree.path(), test_options())
+            .visit_order(VisitOrder::ContentsFirst)
+            .collect()
+            .expect("contents-first request should collect through high-level fallback");
+        let paths = outcome
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec!["nested/leaf.txt", "nested"],
+            "contents-first collection should replay children before their directory"
+        );
+    }
+
+    #[test]
+    fn walk_request_stream_fallback_preserves_predicate_skip_descend() {
+        struct RecordingVisitor {
+            paths: Vec<String>,
+        }
+
+        impl EntryVisitor for RecordingVisitor {
+            type Error = Infallible;
+
+            fn visit(&mut self, entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error> {
+                self.paths.push(entry.relative.to_string());
+                Ok(WalkControl::Continue)
+            }
+        }
+
+        let tree = temp_tree("request-stream-skip-descend");
+        fs::create_dir_all(tree.path().join("keep")).expect("keep dir should be created");
+        fs::write(tree.path().join("keep").join("leaf.txt"), "leaf")
+            .expect("kept leaf should be written");
+        fs::create_dir_all(tree.path().join("skip")).expect("skip dir should be created");
+        fs::write(tree.path().join("skip").join("hidden.txt"), "hidden")
+            .expect("skipped leaf should be written");
+
+        let mut visitor = RecordingVisitor { paths: Vec::new() };
+        let status = WalkRequest::from_options(tree.path(), test_options())
+            .visit_order(VisitOrder::ContentsFirst)
+            .stream_with_predicate(&mut visitor, |meta: &EntryMeta<'_>| {
+                if meta.relative_path == "skip" {
+                    WalkDecision::SkipDescend
+                } else {
+                    WalkDecision::Include
+                }
+            })
+            .expect("contents-first stream fallback should complete");
+
+        assert_eq!(status, WalkStatus::Complete);
+        assert_eq!(
+            visitor.paths,
+            vec!["keep/leaf.txt", "keep"],
+            "predicate SkipDescend should prune the skipped directory and its descendants before \
+			 contents-first replay"
+        );
+    }
+
+    #[test]
+    fn walk_request_collect_with_heartbeat_propagates_interruptions() {
+        let tree = temp_tree("request-heartbeat");
+        fs::write(tree.path().join("alpha.txt"), "alpha").expect("file should be written");
+
+        let result = WalkRequest::from_options(tree.path(), test_options())
+            .collect_with_heartbeat(|| Err("stop requested"));
+
+        let Err(WalkError::Interrupted(message)) = result else {
+            panic!("heartbeat interruption should be surfaced as WalkError::Interrupted");
+        };
+        assert_eq!(message, "stop requested");
+    }
+
+    #[test]
+    fn walk_request_rechecks_stale_empty_cached_files_only_result() {
+        let tree = temp_tree("request-empty-recheck");
+        let _cache_guard = CachePathGuard::new(tree.path());
+        let request = WalkRequest::from_options(tree.path(), test_options())
+            .cache(true)
+            .filter(WalkFilter::files_only())
+            .empty_recheck(EmptyRecheck::Never);
+
+        let primed = request
+            .collect()
+            .expect("empty request should collect successfully");
+        assert_eq!(primed.backend, WalkBackend::Fresh);
+        assert!(
+            primed.entries.is_empty(),
+            "empty root should prime an empty files-only cache entry, got {:?}",
+            primed.entries
+        );
+
+        fs::write(tree.path().join("created.txt"), "created")
+            .expect("file created after cache prime should be written");
+        wait_for_nonzero_cache_age();
+
+        let stale = request
+            .collect()
+            .expect("empty recheck disabled request should read the cached empty result");
+        assert_eq!(stale.backend, WalkBackend::Cached);
+        assert!(
+            stale.stats.cache_age_ms > 0,
+            "cached empty result should be old enough to exercise empty recheck"
+        );
+        assert!(
+            stale.entries.is_empty(),
+            "disabled empty recheck should leave the cached empty files-only result untouched"
+        );
+
+        let refreshed = request
+            .empty_recheck(EmptyRecheck::AfterMillis(0))
+            .collect()
+            .expect("stale empty cache should be rechecked without manual invalidation");
+        let paths = refreshed
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            refreshed.backend,
+            WalkBackend::Fresh,
+            "stale empty cache recheck should force a fresh scan"
+        );
+        assert_eq!(
+            paths,
+            vec!["created.txt"],
+            "empty cached files-only requests should observe files created after the cache was primed"
+        );
+        assert!(
+            refreshed.entries.iter().all(CollectedEntry::is_file),
+            "files-only empty recheck should still return only files: {:?}",
+            refreshed.entries
+        );
+    }
+
+    #[test]
+    fn walk_request_rechecks_stale_cache_empty_after_glob_filter() {
+        let tree = temp_tree("request-filtered-empty-recheck");
+        let _cache_guard = CachePathGuard::new(tree.path());
+        fs::write(tree.path().join("old.txt"), "old")
+            .expect("nonmatching file should be written before cache prime");
+        let request = WalkRequest::from_options(tree.path(), test_options())
+            .cache(true)
+            .filter(
+                WalkFilter::files_only()
+                    .glob(CompiledWalkGlob::new(["*.rs"]).expect("test glob should compile")),
+            )
+            .empty_recheck(EmptyRecheck::Never);
+
+        let primed = request
+            .collect()
+            .expect("filtered request should prime the raw nonempty cache successfully");
+        assert_eq!(primed.backend, WalkBackend::Fresh);
+        assert_eq!(
+            primed.stats.scanned_entries, 1,
+            "cache prime should scan the nonmatching file before filtering"
+        );
+        assert_eq!(
+            primed.stats.filtered_entries, 1,
+            "glob filter should remove the nonmatching cached file"
+        );
+        assert!(
+            primed.entries.is_empty(),
+            "nonmatching file should leave the filtered prime result empty: {:?}",
+            primed.entries
+        );
+
+        fs::write(tree.path().join("new.rs"), "new")
+            .expect("matching file should be written after cache prime");
+        wait_for_nonzero_cache_age();
+
+        let refreshed = request
+            .empty_recheck(EmptyRecheck::AfterMillis(0))
+            .collect()
+            .expect("filtered empty cached result should be rechecked without manual invalidation");
+        let paths = refreshed
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            refreshed.backend,
+            WalkBackend::Fresh,
+            "stale cache that is empty only after filtering should force a fresh scan"
+        );
+        assert_eq!(
+            paths,
+            vec!["new.rs"],
+            "filtered empty-cache recheck should return the file that matches the glob"
+        );
+        assert!(
+            refreshed.entries.iter().all(CollectedEntry::is_file),
+            "glob-filtered files-only recheck should still return only files: {:?}",
+            refreshed.entries
+        );
+    }
+
+    #[test]
+    fn collect_entries_honors_gitignore_without_repo_marker() {
+        let tree = temp_tree("plain-gitignore");
+        fs::write(tree.path().join(".gitignore"), "ignored.txt\n")
+            .expect(".gitignore should be written");
+        fs::write(tree.path().join("ignored.txt"), "ignored")
+            .expect("ignored file should be written");
+        fs::write(tree.path().join("kept.txt"), "keep").expect("kept file should be written");
+
+        let scan = collect_entries(
+            tree.path(),
+            WalkOptions {
+                use_gitignore: true,
+                cache: false,
+                ..test_options()
+            },
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("collection should not fail");
+        let paths = scan
+            .entries
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<_>>();
+
+        assert!(
+            paths.iter().any(|path| path == "kept.txt"),
+            "collect_entries should include kept.txt from a plain directory, got: {paths:?}"
+        );
+        assert!(
+            !paths.iter().any(|path| path == "ignored.txt"),
+            "collect_entries should exclude .gitignore matches without a .git marker, got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn collect_entries_ignores_parent_gitignore_above_non_repo_root() {
+        let tree = temp_tree("ancestor-gitignore-non-repo-root");
+        let search_root = tree.path().join("project");
+        fs::create_dir_all(&search_root).expect("explicit search root should be created");
+        fs::write(tree.path().join(".gitignore"), "*.nix\n")
+            .expect("ancestor .gitignore should be written");
+        fs::write(search_root.join("module.nix"), "nix").expect("nix file should be written");
+        fs::write(search_root.join("kept.txt"), "keep").expect("kept file should be written");
+
+        let scan = collect_entries(
+            &search_root,
+            WalkOptions {
+                use_gitignore: true,
+                cache: false,
+                ..test_options()
+            },
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("collection should not fail");
+        let paths = scan
+            .entries
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<_>>();
+
+        assert!(
+            paths.iter().any(|path| path == "module.nix"),
+            "ancestor .gitignore outside a non-repo explicit root should not hide module.nix, got: \
+			 {paths:?}"
+        );
+        assert!(
+            paths.iter().any(|path| path == "kept.txt"),
+            "sanity check should include kept.txt from the explicit root, got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn collect_entries_applies_repo_root_gitignore_to_subdirectory_search_root() {
+        let tree = temp_tree("repo-root-gitignore-subdir-root");
+        let search_root = tree.path().join("src");
+        fs::create_dir_all(tree.path().join(".git")).expect("repo marker should be created");
+        fs::create_dir_all(&search_root).expect("explicit search root should be created");
+        fs::write(tree.path().join(".gitignore"), "*.nix\n")
+            .expect("repo-root .gitignore should be written");
+        fs::write(search_root.join("module.nix"), "nix")
+            .expect("ignored nix file should be written");
+        fs::write(search_root.join("kept.txt"), "keep").expect("kept file should be written");
+
+        let scan = collect_entries(
+            &search_root,
+            WalkOptions {
+                use_gitignore: true,
+                cache: false,
+                ..test_options()
+            },
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("collection should not fail");
+        let paths = scan
+            .entries
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<_>>();
+
+        assert!(
+            !paths.iter().any(|path| path == "module.nix"),
+            "repo-root .gitignore should hide module.nix when searching inside that repo, got: \
+			 {paths:?}"
+        );
+        assert!(
+            paths.iter().any(|path| path == "kept.txt"),
+            "repo subdirectory search should still include nonignored files, got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn collect_entries_with_exact_workspace_options() {
+        let tree = temp_tree("exact-options");
+        fs::write(tree.path().join(".gitignore"), "ignored.txt\n")
+            .expect(".gitignore should be written");
+        fs::write(tree.path().join("ignored.txt"), "ignored")
+            .expect("ignored file should be written");
+        fs::write(tree.path().join("kept.txt"), "keep").expect("kept file should be written");
+
+        let scan = collect_entries(
+            tree.path(),
+            WalkOptions {
+                include_hidden: false,
+                use_gitignore: true,
+                detail: WalkDetail::Full,
+                max_depth: 4,
+                ..test_options()
+            },
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("collection should not fail");
+        let paths = scan
+            .entries
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<_>>();
+
+        assert!(
+            !paths.iter().any(|path| path == "ignored.txt"),
+            "should exclude ignored.txt, got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn collect_entries_prunes_hidden_git_and_node_modules() {
+        let tree = temp_tree("filters");
+        fs::write(tree.path().join("visible.txt"), "ok").expect("visible file should be written");
+        fs::write(tree.path().join(".hidden"), "hidden").expect("hidden file should be written");
+        fs::create_dir_all(tree.path().join(".git")).expect(".git should be created");
+        fs::write(tree.path().join(".git").join("config"), "git")
+            .expect("git file should be written");
+        fs::create_dir_all(tree.path().join("node_modules"))
+            .expect("node_modules should be created");
+        fs::write(tree.path().join("node_modules").join("pkg.js"), "pkg")
+            .expect("node module file should be written");
+
+        let scan = collect_entries(
+            tree.path(),
+            WalkOptions {
+                include_hidden: false,
+                ..test_options()
+            },
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("collection should not fail");
+        let paths = scan
+            .entries
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<_>>();
+        assert_eq!(paths, vec!["visible.txt"]);
+    }
+
+    struct PruneVisitor {
+        seen: Vec<String>,
+    }
+
+    impl EntryVisitor for PruneVisitor {
+        type Error = Infallible;
+
+        fn visit(&mut self, entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error> {
+            self.seen.push(entry.relative.to_string());
+            if entry.relative == "skip" {
+                Ok(WalkControl::SkipDescend)
+            } else {
+                Ok(WalkControl::Continue)
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    struct PathsVisitor {
+        seen: Vec<String>,
+    }
+
+    #[cfg(unix)]
+    impl EntryVisitor for PathsVisitor {
+        type Error = Infallible;
+
+        fn visit(&mut self, entry: Entry<'_>) -> std::result::Result<WalkControl, Self::Error> {
+            self.seen.push(entry.relative.to_string());
+            Ok(WalkControl::Continue)
+        }
+    }
+
+    #[cfg(unix)]
+    fn walk_paths(root: &Path, follow_links: FollowLinks) -> Vec<String> {
+        let mut visitor = PathsVisitor { seen: Vec::new() };
+        let status = walk_entries(
+            root,
+            WalkOptions {
+                follow_links,
+                ..test_options()
+            },
+            &mut visitor,
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("walk should not fail");
+        assert_eq!(status, WalkStatus::Complete);
+        visitor.seen
+    }
+
+    #[test]
+    fn skip_descend_prunes_directory_children() {
+        let tree = temp_tree("skip-descend");
+        fs::create_dir_all(tree.path().join("keep")).expect("keep dir should be created");
+        fs::write(tree.path().join("keep").join("file.txt"), "ok")
+            .expect("keep file should be written");
+        fs::create_dir_all(tree.path().join("skip")).expect("skip dir should be created");
+        fs::write(tree.path().join("skip").join("file.txt"), "no")
+            .expect("skip file should be written");
+
+        let mut visitor = PruneVisitor { seen: Vec::new() };
+        let _status = walk_entries(tree.path(), test_options(), &mut visitor, || {
+            Ok::<(), Infallible>(())
+        })
+        .expect("walk should not fail");
+        assert!(visitor.seen.iter().any(|path| path == "skip"));
+        assert!(visitor.seen.iter().any(|path| path == "keep/file.txt"));
+        assert!(!visitor.seen.iter().any(|path| path == "skip/file.txt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_entries_always_follows_descendant_symlink_directories() {
+        let tree = temp_tree("follow-always");
+        fs::create_dir_all(tree.path().join("target")).expect("target dir should be created");
+        fs::write(tree.path().join("target").join("child.txt"), "ok")
+            .expect("target child should be written");
+        std::os::unix::fs::symlink(tree.path().join("target"), tree.path().join("link"))
+            .expect("directory symlink should be created");
+
+        let paths = walk_paths(tree.path(), FollowLinks::Always);
+
+        assert!(
+            paths.iter().any(|path| path == "link/child.txt"),
+            "FollowLinks::Always should yield descendants through symlink paths, got: {paths:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_entries_roots_follows_root_symlink_but_not_descendant_symlinks() {
+        let target = temp_tree("follow-roots-target");
+        fs::write(target.path().join("child.txt"), "ok").expect("root child should be written");
+
+        let linked_target = temp_tree("follow-roots-linked-target");
+        fs::write(linked_target.path().join("linked-child.txt"), "linked")
+            .expect("linked child should be written");
+        std::os::unix::fs::symlink(linked_target.path(), target.path().join("descendant-link"))
+            .expect("descendant directory symlink should be created");
+
+        let link_parent = temp_tree("follow-roots-link-parent");
+        let root_link = link_parent.path().join("root-link");
+        std::os::unix::fs::symlink(target.path(), &root_link)
+            .expect("root directory symlink should be created");
+
+        let paths = walk_paths(&root_link, FollowLinks::Roots);
+
+        assert!(
+            paths.iter().any(|path| path == "child.txt"),
+            "FollowLinks::Roots should traverse children of a symlink root, got: {paths:?}"
+        );
+        assert!(
+            !paths
+                .iter()
+                .any(|path| path == "descendant-link/linked-child.txt"),
+            "FollowLinks::Roots should not traverse descendant symlink directories, got: {paths:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_entries_never_does_not_follow_root_symlink_directory() {
+        let target = temp_tree("follow-never-target");
+        fs::write(target.path().join("child.txt"), "ok").expect("root child should be written");
+
+        let link_parent = temp_tree("follow-never-link-parent");
+        let root_link = link_parent.path().join("root-link");
+        std::os::unix::fs::symlink(target.path(), &root_link)
+            .expect("root directory symlink should be created");
+
+        let paths = walk_paths(&root_link, FollowLinks::Never);
+
+        assert!(
+            !paths.iter().any(|path| path == "child.txt"),
+            "FollowLinks::Never should not traverse a symlink root, got: {paths:?}"
+        );
+    }
+}

--- a/crates/vendor/oh-my-pi/pi-walker/tests/parallel.rs
+++ b/crates/vendor/oh-my-pi/pi-walker/tests/parallel.rs
@@ -1,0 +1,385 @@
+use std::{
+    collections::BTreeMap,
+    convert::Infallible,
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+#[cfg(unix)]
+use std::{
+    ffi::OsString,
+    os::unix::ffi::{OsStrExt, OsStringExt},
+};
+
+use pi_walker::{
+    CompiledWalkGlob, Entry, EntryVisitor, FollowLinks, ParallelWalkControl, WalkControl,
+    WalkError, WalkFilter, WalkOptions, WalkOrder, WalkRequest, WalkStatus, walk_entries,
+};
+
+struct TempTree {
+    root: PathBuf,
+}
+
+impl TempTree {
+    fn new(name: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("pi-walker-parallel-{name}-{unique}"));
+        fs::create_dir(&root).expect("temporary root should be created");
+        Self { root }
+    }
+
+    fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for TempTree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn write_file(path: impl AsRef<Path>) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent directory should be created");
+    }
+    fs::write(path, b"x").expect("file should be written");
+}
+
+#[cfg(unix)]
+fn write_file_if_supported(path: impl AsRef<Path>) -> std::io::Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, b"x")
+}
+
+fn sorted_serial_candidates(request: &WalkRequest) -> Vec<String> {
+    let mut paths = request
+        .collect_file_candidates()
+        .expect("serial candidate collection should succeed")
+        .into_iter()
+        .map(|candidate| candidate.relative)
+        .collect::<Vec<_>>();
+    paths.sort_unstable();
+    paths
+}
+
+fn sorted_parallel_candidates(request: &WalkRequest) -> Vec<String> {
+    let paths = Arc::new(Mutex::new(Vec::new()));
+    request
+        .for_each_file_candidate_parallel(
+            {
+                let paths = Arc::clone(&paths);
+                move |candidate| {
+                    paths
+                        .lock()
+                        .expect("candidate list mutex should not be poisoned")
+                        .push(candidate.relative.clone());
+                    Ok::<_, Infallible>(ParallelWalkControl::Continue)
+                }
+            },
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("parallel candidate walk should succeed");
+    let mut paths = Arc::into_inner(paths)
+        .expect("candidate list should have no remaining owners")
+        .into_inner()
+        .expect("candidate list mutex should not be poisoned");
+    paths.sort_unstable();
+    paths
+}
+
+fn rs_request(root: &Path) -> WalkRequest {
+    WalkRequest::new(root)
+        .hidden(false)
+        .gitignore(true)
+        .skip_node_modules(true)
+        .filter(
+            WalkFilter::files_only().glob(
+                CompiledWalkGlob::new(["*.rs", "**/*.rs"]).expect("test glob should compile"),
+            ),
+        )
+}
+
+#[test]
+fn parallel_candidates_match_serial_with_gitignore_hidden_node_modules_and_glob() {
+    let tree = TempTree::new("candidate-equivalence");
+    write_file(tree.path().join("root.rs"));
+    write_file(tree.path().join("root.txt"));
+    write_file(tree.path().join(".hidden.rs"));
+    write_file(tree.path().join("node_modules/pkg/index.rs"));
+    write_file(tree.path().join("src/visible.rs"));
+    write_file(tree.path().join("src/note.txt"));
+    write_file(tree.path().join("src/nested/keep.rs"));
+    write_file(tree.path().join("src/nested/drop.rs"));
+    write_file(tree.path().join("src/nested/deeper/other.rs"));
+    fs::write(
+        tree.path().join("src/nested/.gitignore"),
+        "*.rs\n!keep.rs\n",
+    )
+    .expect("nested .gitignore should be written");
+
+    let request = rs_request(tree.path());
+
+    assert_eq!(
+        sorted_parallel_candidates(&request),
+        sorted_serial_candidates(&request),
+        "parallel traversal should return the same accepted candidate set as serial collection"
+    );
+    assert_eq!(
+        sorted_serial_candidates(&request),
+        vec!["root.rs", "src/nested/keep.rs", "src/visible.rs"],
+        "fixture should exercise the ignore whitelist, hidden-file pruning, node_modules pruning, \
+		 and glob filter"
+    );
+}
+
+fn create_wide_tree(root: &Path, dirs: usize, files_per_dir: usize) {
+    for dir_index in 0..dirs {
+        let dir = root.join(format!("dir-{dir_index:03}"));
+        fs::create_dir_all(&dir).expect("wide-tree directory should be created");
+        for file_index in 0..files_per_dir {
+            write_file(dir.join(format!("file-{file_index:03}.txt")));
+        }
+    }
+}
+
+#[test]
+fn parallel_walk_stops_promptly_when_sink_requests_stop() {
+    let tree = TempTree::new("early-stop");
+    let full_file_count = 2_000;
+    create_wide_tree(tree.path(), 100, full_file_count / 100);
+    let request = WalkRequest::new(tree.path()).filter(WalkFilter::files_only());
+    let invocations = AtomicUsize::new(0);
+
+    let status = request
+        .for_each_file_candidate_parallel(
+            |_| {
+                let seen = invocations.fetch_add(1, Ordering::SeqCst) + 1;
+                if seen >= 5 {
+                    Ok::<_, Infallible>(ParallelWalkControl::Stop)
+                } else {
+                    Ok(ParallelWalkControl::Continue)
+                }
+            },
+            || Ok::<(), Infallible>(()),
+        )
+        .expect("parallel walk should stop without an error");
+
+    assert_eq!(status, WalkStatus::Stopped);
+    assert!(
+        invocations.load(Ordering::SeqCst) < full_file_count / 2,
+        "stop should prevent most candidate callbacks after five files, saw {} of {full_file_count}",
+        invocations.load(Ordering::SeqCst)
+    );
+}
+
+#[test]
+fn parallel_walk_returns_sink_error_and_terminates() {
+    let tree = TempTree::new("sink-error");
+    let full_file_count = 800;
+    create_wide_tree(tree.path(), 80, full_file_count / 80);
+    let request = WalkRequest::new(tree.path()).filter(WalkFilter::files_only());
+    let invocations = AtomicUsize::new(0);
+
+    let result = request.for_each_file_candidate_parallel(
+        |_| {
+            let seen = invocations.fetch_add(1, Ordering::SeqCst) + 1;
+            if seen == 3 {
+                Err("sink failed")
+            } else {
+                Ok(ParallelWalkControl::Continue)
+            }
+        },
+        || Ok(()),
+    );
+
+    match result {
+        Err(WalkError::Interrupted("sink failed")) => {}
+        other => panic!("sink error should be returned as WalkError::Interrupted, got {other:?}"),
+    }
+    assert!(
+        invocations.load(Ordering::SeqCst) < full_file_count / 2,
+        "sink error should terminate traversal instead of visiting most files, saw {} of \
+		 {full_file_count}",
+        invocations.load(Ordering::SeqCst)
+    );
+}
+
+#[test]
+fn parallel_walk_returns_heartbeat_error_before_visiting_candidates() {
+    let tree = TempTree::new("heartbeat-error");
+    create_wide_tree(tree.path(), 20, 10);
+    let request = WalkRequest::new(tree.path()).filter(WalkFilter::files_only());
+    let invocations = AtomicUsize::new(0);
+
+    let result = request.for_each_file_candidate_parallel(
+        |_| {
+            invocations.fetch_add(1, Ordering::SeqCst);
+            Ok(ParallelWalkControl::Continue)
+        },
+        || Err("heartbeat failed"),
+    );
+
+    match result {
+        Err(WalkError::Interrupted("heartbeat failed")) => {}
+        other => {
+            panic!("heartbeat error should be returned as WalkError::Interrupted, got {other:?}")
+        }
+    }
+    assert!(
+        invocations.load(Ordering::SeqCst) < 10,
+        "pre-cancelled heartbeat should allow zero or only a few sink calls, saw {}",
+        invocations.load(Ordering::SeqCst)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn parallel_follow_links_always_returns_same_candidates_as_serial_collection() {
+    let tree = TempTree::new("follow-links");
+    write_file(tree.path().join("target/child.txt"));
+    write_file(tree.path().join("target/deeper/grandchild.txt"));
+    std::os::unix::fs::symlink(tree.path().join("target"), tree.path().join("link"))
+        .expect("directory symlink should be created");
+    let request = WalkRequest::new(tree.path())
+        .follow_links(FollowLinks::Always)
+        .filter(WalkFilter::files_only());
+
+    assert_eq!(
+        sorted_parallel_candidates(&request),
+        sorted_serial_candidates(&request),
+        "follow-links traversal should expose the same candidate set through parallel API and \
+		 serial collection"
+    );
+}
+
+#[test]
+fn unordered_and_path_collection_return_equal_sets_and_path_walk_sorts_each_directory() {
+    let tree = TempTree::new("serial-order");
+    write_file(tree.path().join("βeta.txt"));
+    write_file(tree.path().join("alpha.txt"));
+    write_file(tree.path().join("space name.txt"));
+    write_file(tree.path().join("dir/猫.txt"));
+    write_file(tree.path().join("dir/a.txt"));
+    write_file(tree.path().join("dir/sub/éclair.txt"));
+    write_file(tree.path().join("dir/sub/plain.txt"));
+    #[cfg(unix)]
+    {
+        let _ = write_file_if_supported(
+            tree.path()
+                .join(OsString::from_vec(b"dir/sub/raw-\xFF.txt".to_vec())),
+        );
+    }
+
+    let unordered = collected_path_set(tree.path(), WalkOrder::Unordered);
+    let ordered = collected_path_set(tree.path(), WalkOrder::Path);
+    assert_eq!(
+        unordered, ordered,
+        "serial unordered and path-ordered collection should return the same entry set"
+    );
+
+    let mut visitor = DirectoryOrderVisitor::default();
+    let status = walk_entries(
+        tree.path(),
+        WalkOptions {
+            order: WalkOrder::Path,
+            ..WalkOptions::default()
+        },
+        &mut visitor,
+        || Ok::<(), Infallible>(()),
+    )
+    .expect("path-ordered walk should succeed");
+    assert_eq!(status, WalkStatus::Complete);
+    visitor.assert_each_directory_sorted();
+}
+
+fn collected_path_set(root: &Path, order: WalkOrder) -> Vec<String> {
+    let mut paths = WalkRequest::new(root)
+        .order(order)
+        .collect()
+        .expect("collection should succeed")
+        .entries
+        .into_iter()
+        .map(|entry| entry.path)
+        .collect::<Vec<_>>();
+    paths.sort_unstable();
+    paths
+}
+
+#[derive(Default)]
+struct DirectoryOrderVisitor {
+    children_by_parent: BTreeMap<String, Vec<Vec<u8>>>,
+}
+
+impl DirectoryOrderVisitor {
+    fn assert_each_directory_sorted(&self) {
+        for (parent, children) in &self.children_by_parent {
+            let mut sorted = children.clone();
+            sorted.sort_unstable();
+            assert_eq!(
+                children, &sorted,
+                "children of {parent:?} should be visited in lexicographic path order"
+            );
+        }
+    }
+}
+
+impl EntryVisitor for DirectoryOrderVisitor {
+    type Error = Infallible;
+
+    fn visit(&mut self, entry: Entry<'_>) -> Result<WalkControl, Self::Error> {
+        let parent = entry
+            .relative
+            .rsplit_once('/')
+            .map_or_else(String::new, |(parent, _)| parent.to_owned());
+        self.children_by_parent
+            .entry(parent)
+            .or_default()
+            .push(sort_key(entry.name));
+        Ok(WalkControl::Continue)
+    }
+}
+
+#[cfg(unix)]
+fn sort_key(name: &std::ffi::OsStr) -> Vec<u8> {
+    name.as_bytes().to_vec()
+}
+
+#[cfg(not(unix))]
+fn sort_key(name: &std::ffi::OsStr) -> Vec<u8> {
+    name.to_string_lossy().into_owned().into_bytes()
+}
+
+#[test]
+fn parallel_deep_tree_relative_path_preserves_full_component_chain() {
+    let tree = TempTree::new("deep-tree");
+    let mut dir = tree.path().to_path_buf();
+    let mut components = Vec::new();
+    for depth in 0..40 {
+        let component = format!("a{depth:02}");
+        dir.push(&component);
+        components.push(component);
+    }
+    fs::create_dir_all(&dir).expect("deep directory chain should be created");
+    write_file(dir.join("leaf.txt"));
+    components.push("leaf.txt".to_owned());
+    let expected = components.join("/");
+    let request = WalkRequest::new(tree.path()).filter(WalkFilter::files_only());
+
+    assert_eq!(
+        sorted_parallel_candidates(&request),
+        vec![expected],
+        "parallel path builder should preserve every nested component in the relative file path"
+    );
+}

--- a/crates/vendor/oh-my-pi/pi-walker/tests/perf.rs
+++ b/crates/vendor/oh-my-pi/pi-walker/tests/perf.rs
@@ -1,0 +1,209 @@
+//! Ignored deterministic timing harness for pi-walker.
+//!
+//! Run with:
+//! cargo test --profile ci -p pi-walker --test perf -- --ignored --nocapture
+//! --test-threads=1
+
+use std::{
+    fmt::Write as _,
+    fs,
+    hint::black_box,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use pi_walker::{WalkDetail, WalkOrder, WalkRequest};
+
+const DIRECTORY_FANOUT: [usize; 5] = [5, 5, 5, 4, 2];
+const CONTENT_FILE_COUNT: usize = 15_000;
+const NODE_MODULES_PACKAGES: usize = 50;
+const NODE_MODULES_FILES_PER_PACKAGE: usize = 10;
+const MEASURED_ITERATIONS: usize = 5;
+
+static SYNTHETIC_ROOT: LazyLock<PathBuf> = LazyLock::new(build_synthetic_tree);
+
+#[test]
+#[ignore = "run with: cargo test --profile ci -p pi-walker --test perf -- --ignored --nocapture \
+            --test-threads=1"]
+fn perf_walk_candidates_unordered_gitignore() {
+    let root = SYNTHETIC_ROOT.as_path();
+    run_bench("perf_walk_candidates_unordered_gitignore", || {
+        let candidates = WalkRequest::new(root)
+            .hidden(true)
+            .gitignore(true)
+            .skip_git(true)
+            .skip_node_modules(true)
+            .order(WalkOrder::Unordered)
+            .collect_file_candidates()
+            .expect("collect unordered gitignore candidates");
+        let count = candidates.len();
+        assert!(count > 14_000, "expected a full candidate set, got {count}");
+        count
+    });
+}
+
+#[test]
+#[ignore = "run with: cargo test --profile ci -p pi-walker --test perf -- --ignored --nocapture \
+            --test-threads=1"]
+fn perf_walk_candidates_path_order_no_gitignore() {
+    let root = SYNTHETIC_ROOT.as_path();
+    run_bench("perf_walk_candidates_path_order_no_gitignore", || {
+        let candidates = WalkRequest::new(root)
+            .hidden(true)
+            .gitignore(false)
+            .skip_git(true)
+            .skip_node_modules(true)
+            .order(WalkOrder::Path)
+            .collect_file_candidates()
+            .expect("collect path-ordered candidates without gitignore");
+        let count = candidates.len();
+        assert!(count > 15_000, "expected unignored candidates, got {count}");
+        count
+    });
+}
+
+#[test]
+#[ignore = "run with: cargo test --profile ci -p pi-walker --test perf -- --ignored --nocapture \
+            --test-threads=1"]
+fn perf_walk_collect_full_detail() {
+    let root = SYNTHETIC_ROOT.as_path();
+    run_bench("perf_walk_collect_full_detail", || {
+        let outcome = WalkRequest::new(root)
+            .hidden(true)
+            .gitignore(true)
+            .skip_git(true)
+            .skip_node_modules(true)
+            .order(WalkOrder::Unordered)
+            .detail(WalkDetail::Full)
+            .collect()
+            .expect("collect full-detail entries");
+        let count = outcome.entries.len();
+        assert!(count > 15_000, "expected full-detail entries, got {count}");
+        count
+    });
+}
+
+fn run_bench(mut name: &str, mut run: impl FnMut() -> usize) {
+    black_box(run());
+
+    let mut timings = [Duration::ZERO; MEASURED_ITERATIONS];
+    for timing in &mut timings {
+        let started = Instant::now();
+        let observed = run();
+        let elapsed = started.elapsed();
+        black_box(observed);
+        *timing = elapsed;
+    }
+
+    timings.sort_unstable();
+    let median_ms = timings[MEASURED_ITERATIONS / 2].as_secs_f64() * 1_000.0;
+    name = black_box(name);
+    println!("BENCH {name}: {median_ms:.3} ms");
+}
+
+fn build_synthetic_tree() -> PathBuf {
+    let root = unique_temp_root("pi-walker-perf");
+    fs::create_dir_all(&root).expect("create synthetic root");
+    fs::create_dir_all(root.join(".git")).expect("create repo marker");
+
+    let directories = create_directory_layout(&root);
+    create_gitignores(&directories);
+    create_content_files(&directories);
+    create_node_modules(&root);
+
+    root
+}
+
+fn unique_temp_root(prefix: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time is after UNIX_EPOCH")
+        .as_nanos();
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("{prefix}-{pid}-{timestamp}"))
+}
+
+fn create_directory_layout(root: &Path) -> Vec<PathBuf> {
+    let mut directories = Vec::with_capacity(1_700);
+    directories.push(root.to_path_buf());
+
+    let mut level = vec![root.to_path_buf()];
+    for (depth, fanout) in DIRECTORY_FANOUT.into_iter().enumerate() {
+        let mut next_level = Vec::with_capacity(level.len() * fanout);
+        for (parent_index, parent) in level.iter().enumerate() {
+            for child in 0..fanout {
+                let directory = parent.join(format!("d{depth:02}-{parent_index:04}-{child:02}"));
+                fs::create_dir_all(&directory).expect("create synthetic directory");
+                directories.push(directory.clone());
+                next_level.push(directory);
+            }
+        }
+        level = next_level;
+    }
+
+    directories
+}
+
+fn create_gitignores(directories: &[PathBuf]) {
+    for (directory_id, directory) in directories.iter().enumerate() {
+        if directory_id.is_multiple_of(10) {
+            let pattern = format!("/ignored-{directory_id:04}-*.txt\n");
+            fs::write(directory.join(".gitignore"), pattern).expect("write synthetic gitignore");
+        }
+    }
+}
+
+fn create_content_files(directories: &[PathBuf]) {
+    for file_index in 0..CONTENT_FILE_COUNT {
+        let directory_id = file_index % directories.len();
+        let local_index = file_index / directories.len();
+        let file_name = if directory_id.is_multiple_of(10) && local_index == 0 {
+            format!("ignored-{directory_id:04}-{local_index:03}.txt")
+        } else {
+            format!("file-{directory_id:04}-{local_index:03}.txt")
+        };
+        let path = directories[directory_id].join(file_name);
+        fs::write(path, synthetic_content(file_index)).expect("write synthetic content file");
+    }
+}
+
+fn create_node_modules(root: &Path) {
+    let node_modules = root.join("node_modules");
+    for package in 0..NODE_MODULES_PACKAGES {
+        let package_dir = node_modules.join(format!("pkg-{package:02}"));
+        fs::create_dir_all(&package_dir).expect("create synthetic node_modules package");
+        for file in 0..NODE_MODULES_FILES_PER_PACKAGE {
+            let content_index =
+                CONTENT_FILE_COUNT + package * NODE_MODULES_FILES_PER_PACKAGE + file;
+            let path = package_dir.join(format!("file-{file:02}.js"));
+            fs::write(path, synthetic_content(content_index))
+                .expect("write synthetic node_modules file");
+        }
+    }
+}
+
+fn synthetic_content(file_index: usize) -> String {
+    let target_len = 512 + (file_index * 73) % 3_488;
+    let has_common_token = (file_index * 37) % 100 < 60;
+    let has_rare_token = file_index.is_multiple_of(100);
+    let mut content = String::with_capacity(target_len + 96);
+
+    if has_common_token {
+        writeln!(content, "common token needle in file {file_index:05}").expect("write to String");
+    } else {
+        writeln!(content, "ordinary haystack line in file {file_index:05}")
+            .expect("write to String");
+    }
+    if has_rare_token {
+        writeln!(content, "rare token NEEDLE_RARE in file {file_index:05}")
+            .expect("write to String");
+    }
+
+    let filler = format!("line {file_index:05} deterministic pi walker payload text\n");
+    while content.len() < target_len {
+        content.push_str(&filler);
+    }
+
+    content
+}

--- a/ops/scripts/release/normalize-macos-install-names.sh
+++ b/ops/scripts/release/normalize-macos-install-names.sh
@@ -178,7 +178,7 @@ sign_app_if_certificate_available() {
 		echo "No code-signing keychain found; ad-hoc signing normalized app: $app_path"
 		sign_nested_helpers "$app_path" "-"
 		codesign --force --deep --sign - "$app_path"
-		codesign --verify --deep --strict --verbose=4 "$app_path" || echo "WARNING: ad-hoc codesign --verify failed; continuing" >&2
+		codesign --verify --deep --strict --verbose=4 "$app_path"
 		return
 	fi
 
@@ -202,9 +202,7 @@ sign_app_if_certificate_available() {
 		"$app_path"
 
 	echo "Verifying normalized app signature: $app_path"
-	codesign --verify --deep --strict --verbose=4 "$app_path" || {
-		echo "WARNING: codesign --verify failed after re-signing; the later Sign app bundle step will re-sign and verify" >&2
-	}
+	codesign --verify --deep --strict --verbose=4 "$app_path"
 }
 
 normalize_dmg() {

--- a/ops/scripts/release/normalize-macos-install-names.sh
+++ b/ops/scripts/release/normalize-macos-install-names.sh
@@ -28,6 +28,11 @@ MOUNTS_FILE="$TMP_DIR/mounts"
 REWRITES_FILE="$TMP_DIR/rewrites"
 touch "$MOUNTS_FILE" "$REWRITES_FILE"
 
+on_error() {
+	echo "ERROR: command failed at line $1 (exit status $?)" >&2
+}
+trap 'on_error ${LINENO}' ERR
+
 detach_with_retry() {
 	local mount="$1"
 
@@ -187,7 +192,7 @@ sign_app_if_certificate_available() {
 		exit 2
 	fi
 
-	identity=$(security find-identity -v -p codesigning "$keychain_path" | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+	identity=$(security find-identity -v -p codesigning "$keychain_path" 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
 	if [ -z "$identity" ]; then
 		echo "ERROR: No Developer ID Application identity found in keychain" >&2
 		security find-identity -v -p codesigning "$keychain_path" >&2

--- a/ops/scripts/release/normalize-macos-install-names.sh
+++ b/ops/scripts/release/normalize-macos-install-names.sh
@@ -178,7 +178,7 @@ sign_app_if_certificate_available() {
 		echo "No code-signing keychain found; ad-hoc signing normalized app: $app_path"
 		sign_nested_helpers "$app_path" "-"
 		codesign --force --deep --sign - "$app_path"
-		codesign --verify --deep --strict --verbose=4 "$app_path"
+		codesign --verify --deep --strict --verbose=4 "$app_path" || echo "WARNING: ad-hoc codesign --verify failed; continuing" >&2
 		return
 	fi
 
@@ -202,7 +202,9 @@ sign_app_if_certificate_available() {
 		"$app_path"
 
 	echo "Verifying normalized app signature: $app_path"
-	codesign --verify --deep --strict --verbose=4 "$app_path"
+	codesign --verify --deep --strict --verbose=4 "$app_path" || {
+		echo "WARNING: codesign --verify failed after re-signing; the later Sign app bundle step will re-sign and verify" >&2
+	}
 }
 
 normalize_dmg() {


### PR DESCRIPTION
Vendors some crates used in oh-my-pi which means it is battle tested.

- replace bespoke tools with vendored ones
- stop relying on 'rg', use vendored rust impl
- add a compaction tool
- add read file caching
- give agent the ability to see outlines (e.g. like when you fold functions in an IDE). this is the only way to read a 1,000 line file without adding all to context. even if you combine head/grep/tail its still a guess
- give agent fast fuzzy search

this _should_ fix the loop it gets into (namely, the compaction) 

this also gives the file walker a cache - if the agent has seen a file before, there is no point in reading it again unless it becomes invalidated, that is also handled here. 