### PR TITLE
fix(helper): canonicalize activation path as root

### DIFF
--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -3,10 +3,10 @@ use crate::privileged_helper::protocol::{
     ActivateStorePathRequest, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HELPER_WARNING_PREFIX,
     HelperRequest, HelperResponse, UNAUTHORIZED_CLIENT_ERROR, validate_canonical_activate_path,
 };
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::process::Command;
@@ -148,23 +148,18 @@ fn activate_store_path(
     peer: &PeerIdentity,
     request: &ActivateStorePathRequest,
 ) -> Result<HelperResponse> {
-    validate_canonical_activate_path(&request.activate_path)?;
+    let activate_path = canonical_activation_target(&request.activate_path)?;
     // Account values are derived from the socket peer credentials; the
     // request's `user_name`/`user_id`/`home` are never trusted here.
     let account = user_account(peer.euid)?;
-    let argv = activation_argv(
-        peer.euid,
-        &account,
-        &request.activate_path,
-        request.ssh_auth_sock.as_deref(),
-    );
+    let argv = activation_argv(peer.euid, &account, &activate_path);
     let (status, mut stdout) = run_activation_command(&argv)?;
 
     // Profile maintenance runs only after a successful activation and is
     // best-effort: the system switch already happened, so its failures
     // surface as warnings instead of failing the apply.
     if status.success() {
-        for warning in post_activation_maintenance(&request.activate_path) {
+        for warning in post_activation_maintenance(&activate_path) {
             stdout.push_str(&format!("\n{HELPER_WARNING_PREFIX} {warning}"));
         }
     }
@@ -176,6 +171,91 @@ fn activate_store_path(
         stderr: String::new(),
         error: None,
     })
+}
+
+/// Resolves and authorizes the activation target at the privileged boundary,
+/// immediately before execution. The client's own canonicalization is a
+/// convenience, never a security input: a lexically valid request path can
+/// still contain symlinked or requester-writable components. The path is
+/// canonicalized here, revalidated, and every component is proved immutable
+/// to the (non-root) requester before root executes it. Shared by the helper
+/// daemon and the interactive fallback's root re-entry
+/// (`privileged_helper::root_activation`).
+pub(crate) fn canonical_activation_target(activate_path: &str) -> Result<String> {
+    // Lexical shape first, so a relative or non-store request never reaches
+    // the filesystem (`canonicalize` would resolve it against the daemon's
+    // cwd).
+    validate_canonical_activate_path(activate_path)?;
+    let canonical = fs::canonicalize(activate_path)
+        .with_context(|| format!("failed to resolve activation path {activate_path}"))?;
+    let canonical = validate_canonical_activate_path(canonical)?;
+    check_activation_path_unwritable(&canonical)?;
+    canonical
+        .into_os_string()
+        .into_string()
+        .map_err(|path| anyhow!("canonical activation path is not valid UTF-8: {path:?}"))
+}
+
+/// Walks every component of the canonical activation path — `/`, `/nix`,
+/// `/nix/store`, the store item, and the activate executable — and rejects
+/// any the requester could retarget. Root ownership plus no group/other
+/// write access is what makes check-then-exec sound here: once the walk
+/// passes, a non-root requester cannot swap any component between this walk
+/// and the exec.
+fn check_activation_path_unwritable(canonical: &Path) -> Result<()> {
+    let mut chain: Vec<&Path> = canonical.ancestors().collect();
+    chain.reverse();
+    for path in &chain {
+        let metadata = fs::symlink_metadata(path)
+            .with_context(|| format!("failed to inspect {}", path.display()))?;
+        check_component_metadata(path, &metadata, *path == canonical)?;
+    }
+    Ok(())
+}
+
+fn check_component_metadata(
+    path: &Path,
+    metadata: &fs::Metadata,
+    is_activation_target: bool,
+) -> Result<()> {
+    // The path was resolved a moment ago, so a symlink here means the tree
+    // changed underneath us.
+    if metadata.file_type().is_symlink() {
+        bail!("{} is a symlink", path.display());
+    }
+    if is_activation_target {
+        if !metadata.is_file() {
+            bail!("activation target {} is not a regular file", path.display());
+        }
+        if metadata.mode() & 0o111 == 0 {
+            bail!("activation target {} is not executable", path.display());
+        }
+    } else if !metadata.is_dir() {
+        bail!("{} is not a directory", path.display());
+    }
+    check_component_policy(path, metadata.uid(), metadata.mode(), metadata.is_dir())
+}
+
+/// Ownership/mode policy for one path component: root-owned, never
+/// world-writable, and never group-writable — except the store root itself,
+/// which is 1775 root:nixbld in the standard multi-user layout. The sticky
+/// bit stops group members from replacing or removing the resolved store
+/// item, and creating unrelated siblings gains them nothing. That is not
+/// true anywhere else on the path: entries created *inside* a store item
+/// sit next to the activation executable, so the exception must never
+/// extend past `/nix/store`.
+fn check_component_policy(path: &Path, owner_uid: u32, mode: u32, is_dir: bool) -> Result<()> {
+    if owner_uid != 0 {
+        bail!("{} is owned by uid {owner_uid}, not root", path.display());
+    }
+    if mode & 0o002 != 0 {
+        bail!("{} is world-writable", path.display());
+    }
+    let sticky_store_root = is_dir && mode & 0o1000 != 0 && path == Path::new("/nix/store");
+    if mode & 0o020 != 0 && !sticky_store_root {
+        bail!("{} is group-writable", path.display());
+    }
+    Ok(())
 }
 
 /// Runs a prepared activation argv with stderr merged into stdout (the old
@@ -209,13 +289,11 @@ pub(crate) fn run_activation_command(
 
 /// Direct-exec activation command: no shell, absolute programs only, a fixed
 /// root-owned PATH, and an otherwise empty environment (`env -i`).
-pub(crate) fn activation_argv(
-    uid: u32,
-    account: &UserAccount,
-    activate_path: &str,
-    ssh_auth_sock: Option<&str>,
-) -> Vec<String> {
-    let mut argv = vec![
+/// SSH_AUTH_SOCK is deliberately absent: builds and fetches already ran as
+/// the user, so privileged activation receives no capability to reach a
+/// user's SSH agent.
+pub(crate) fn activation_argv(uid: u32, account: &UserAccount, activate_path: &str) -> Vec<String> {
+    vec![
         "/bin/launchctl".to_string(),
         "asuser".to_string(),
         uid.to_string(),
@@ -225,12 +303,8 @@ pub(crate) fn activation_argv(
         format!("HOME={}", account.home),
         format!("USER={}", account.name),
         format!("LOGNAME={}", account.name),
-    ];
-    if let Some(sock) = ssh_auth_sock.filter(|sock| !sock.is_empty()) {
-        argv.push(format!("SSH_AUTH_SOCK={sock}"));
-    }
-    argv.push(activate_path.to_string());
-    argv
+        activate_path.to_string(),
+    ]
 }
 
 pub(crate) fn post_activation_maintenance(activate_path: &str) -> Vec<String> {
@@ -317,7 +391,6 @@ mod tests {
             user_name: "alice".to_string(),
             user_id: 501,
             home: "/Users/alice".to_string(),
-            ssh_auth_sock: Some("/tmp/ssh.sock".to_string()),
             nix_path: "/tmp/attacker-bin:/usr/bin".to_string(),
         }
     }
@@ -335,7 +408,6 @@ mod tests {
             501,
             &account(),
             "/nix/store/abc123-darwin-system-25.05.20260629/activate",
-            Some("/tmp/ssh.sock"),
         );
 
         assert_eq!(argv[0], "/bin/launchctl");
@@ -354,31 +426,19 @@ mod tests {
     }
 
     #[test]
-    fn activation_argv_never_builds_shell_or_sudoers() {
+    fn activation_argv_never_builds_shell_sudoers_or_agent_access() {
         let argv = activation_argv(
             501,
             &account(),
             "/nix/store/abc123-darwin-system-25.05.20260629/activate",
-            Some("/tmp/ssh.sock"),
         );
 
         assert!(!argv.iter().any(|arg| arg.contains("/bin/sh")));
         assert!(!argv.iter().any(|arg| arg.contains("sudo")));
         assert!(!argv.iter().any(|arg| arg.contains("sudoers")));
-    }
-
-    #[test]
-    fn activation_argv_omits_ssh_sock_when_absent_or_empty() {
-        for sock in [None, Some("")] {
-            let argv = activation_argv(
-                501,
-                &account(),
-                "/nix/store/abc123-darwin-system-25.05.20260629/activate",
-                sock,
-            );
-
-            assert!(!argv.iter().any(|arg| arg.starts_with("SSH_AUTH_SOCK=")));
-        }
+        // The privileged activation deliberately receives no capability to
+        // reach a user's SSH agent.
+        assert!(!argv.iter().any(|arg| arg.starts_with("SSH_AUTH_SOCK=")));
     }
 
     #[cfg(target_os = "macos")]
@@ -411,6 +471,108 @@ mod tests {
     #[test]
     fn peer_policy_accepts_console_user_peer() {
         assert!(check_peer_policy(501, Some(501)).is_ok());
+    }
+
+    #[test]
+    fn component_policy_accepts_root_owned_unwritable_components() {
+        let path = Path::new("/nix");
+        assert!(check_component_policy(path, 0, 0o755, true).is_ok());
+        assert!(check_component_policy(path, 0, 0o555, false).is_ok());
+    }
+
+    #[test]
+    fn component_policy_accepts_sticky_group_writable_store_dir() {
+        // The standard multi-user store: drwxrwxr-t root:nixbld.
+        assert!(check_component_policy(Path::new("/nix/store"), 0, 0o1775, true).is_ok());
+    }
+
+    #[test]
+    fn component_policy_rejects_non_root_owner() {
+        let error =
+            check_component_policy(Path::new("/nix/store/item"), 501, 0o755, true).unwrap_err();
+
+        assert!(error.to_string().contains("not root"));
+    }
+
+    #[test]
+    fn component_policy_rejects_group_writable_without_sticky() {
+        assert!(check_component_policy(Path::new("/nix"), 0, 0o775, true).is_err());
+        // The sticky exception applies to directories only, never to the
+        // activate executable itself.
+        let file = Path::new("/nix/store/item/activate");
+        assert!(check_component_policy(file, 0, 0o1775, false).is_err());
+    }
+
+    #[test]
+    fn component_policy_limits_sticky_exception_to_the_store_root() {
+        // Group members can create entries in any sticky group-writable
+        // directory, so a 1775 store *item* is not immutable — only the
+        // store root itself gets the exception.
+        let item = Path::new("/nix/store/item");
+        assert!(check_component_policy(item, 0, 0o1775, true).is_err());
+    }
+
+    #[test]
+    fn component_policy_rejects_world_writable_even_with_sticky() {
+        // A /tmp-shaped directory (drwxrwxrwt) must never pass.
+        assert!(check_component_policy(Path::new("/tmp"), 0, 0o1777, true).is_err());
+    }
+
+    #[test]
+    fn component_metadata_rejects_symlinks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("target");
+        fs::create_dir(&target).expect("create target dir");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let metadata = fs::symlink_metadata(&link).expect("lstat link");
+        let error = check_component_metadata(&link, &metadata, false).unwrap_err();
+
+        assert!(error.to_string().contains("symlink"));
+    }
+
+    #[test]
+    fn component_metadata_rejects_non_executable_or_non_file_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("activate");
+        fs::write(&file, "#!/bin/sh\n").expect("write file");
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).expect("chmod");
+
+        let metadata = fs::symlink_metadata(&file).expect("lstat file");
+        let error = check_component_metadata(&file, &metadata, true).unwrap_err();
+        assert!(error.to_string().contains("not executable"));
+
+        let dir_metadata = fs::symlink_metadata(dir.path()).expect("lstat dir");
+        let error = check_component_metadata(dir.path(), &dir_metadata, true).unwrap_err();
+        assert!(error.to_string().contains("not a regular file"));
+    }
+
+    #[test]
+    fn activation_walk_rejects_requester_writable_tree() {
+        // A tempdir tree is owned by the (non-root) test user — exactly what
+        // the walk exists to reject. Canonicalized first so the macOS /var
+        // symlink does not short-circuit the walk before the ownership check.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let item = dir
+            .path()
+            .canonicalize()
+            .expect("canonicalize")
+            .join("item");
+        fs::create_dir(&item).expect("create item dir");
+        let activate = item.join("activate");
+        fs::write(&activate, "#!/bin/sh\n").expect("write activate");
+        fs::set_permissions(&activate, fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let error = check_activation_path_unwritable(&activate).unwrap_err();
+
+        assert!(error.to_string().contains("not root"));
+    }
+
+    #[test]
+    fn canonical_target_rejects_non_store_and_missing_paths() {
+        assert!(canonical_activation_target("/tmp/activate").is_err());
+        assert!(canonical_activation_target("/nix/store/no-such-item-c1-test/activate").is_err());
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/protocol.rs
+++ b/apps/native/src-tauri/src/privileged_helper/protocol.rs
@@ -54,7 +54,6 @@ pub struct ActivateStorePathRequest {
     pub user_name: String,
     pub user_id: u32,
     pub home: String,
-    pub ssh_auth_sock: Option<String>,
     pub nix_path: String,
 }
 
@@ -182,9 +181,6 @@ pub fn current_user_activation_request(activate_path: &Path) -> Result<ActivateS
     let user_name = whoami::username().unwrap_or_else(|_| "root".to_string());
     let user_id = current_user_id();
     let home = std::env::var("HOME").unwrap_or_default();
-    let ssh_auth_sock = std::env::var("SSH_AUTH_SOCK")
-        .ok()
-        .filter(|value| !value.is_empty());
     let nix_path = crate::system::nix::get_nix_path();
 
     Ok(ActivateStorePathRequest {
@@ -192,7 +188,6 @@ pub fn current_user_activation_request(activate_path: &Path) -> Result<ActivateS
         user_name,
         user_id,
         home,
-        ssh_auth_sock,
         nix_path,
     })
 }
@@ -359,10 +354,10 @@ mod tests {
     }
 
     #[test]
-    fn activation_request_json_ignores_removed_link_field() {
-        // Wire compat with apps that still send canonicalLinkTarget: unknown
-        // fields are ignored on deserialization.
-        let json = r#"{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","sshAuthSock":null,"nixPath":"/bin","canonicalLinkTarget":"/Users/alice/.darwin"}"#;
+    fn activation_request_json_ignores_removed_fields() {
+        // Wire compat with apps that still send canonicalLinkTarget or
+        // sshAuthSock: unknown fields are ignored on deserialization.
+        let json = r#"{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","sshAuthSock":"/tmp/ssh.sock","nixPath":"/bin","canonicalLinkTarget":"/Users/alice/.darwin"}"#;
         let request: ActivateStorePathRequest = serde_json::from_str(json).expect("deserializes");
         assert_eq!(request.user_id, 501);
     }

--- a/apps/native/src-tauri/src/privileged_helper/root_activation.rs
+++ b/apps/native/src-tauri/src/privileged_helper/root_activation.rs
@@ -6,10 +6,11 @@
 //! NOPASSWD rule to `/etc/sudoers.d/nixmac-activate-temp` and cleaned it up
 //! with an EXIT trap. That mechanism is gone: the unprivileged app now
 //! re-executes its own binary with [`ROOT_ACTIVATE_ARG`], and this mode
-//! applies the same hardening rules as the helper daemon — direct exec with
-//! absolute programs, a fixed root-owned PATH and otherwise empty environment
-//! (`env -i`), and account values derived from the target uid (no sudoers,
-//! no shell logic as root).
+//! applies the same hardening rules as the helper daemon — the activation
+//! target canonicalized and proved unwritable by the requester on the
+//! privileged side, direct exec with absolute programs, a fixed root-owned
+//! PATH and otherwise empty environment (`env -i`), and account values
+//! derived from the target uid (no sudoers, no shell logic as root).
 
 use crate::privileged_helper::helper_runtime;
 use crate::privileged_helper::protocol::validate_canonical_activate_path;
@@ -36,7 +37,6 @@ const WARNING_PREFIX: &str = "nixmac: warning:";
 pub struct RootActivationArgs {
     pub uid: u32,
     pub activate_path: String,
-    pub ssh_auth_sock: Option<String>,
 }
 
 /// The exact command line handed to `osascript ... with administrator
@@ -45,7 +45,7 @@ pub struct RootActivationArgs {
 /// and the leading `exec` makes the elevated shell replace itself with this
 /// argv instead of staying alive as its parent.
 pub fn shell_command(exe: &str, args: &RootActivationArgs) -> String {
-    let mut argv = vec![
+    let argv = [
         exe.to_string(),
         ROOT_ACTIVATE_ARG.to_string(),
         "--uid".to_string(),
@@ -53,14 +53,6 @@ pub fn shell_command(exe: &str, args: &RootActivationArgs) -> String {
         "--activate".to_string(),
         args.activate_path.clone(),
     ];
-    if let Some(sock) = args
-        .ssh_auth_sock
-        .as_deref()
-        .filter(|sock| !sock.is_empty())
-    {
-        argv.push("--ssh-auth-sock".to_string());
-        argv.push(sock.to_string());
-    }
     let quoted = argv
         .iter()
         .map(|arg| shell_quote(arg))
@@ -82,7 +74,6 @@ fn shell_quote(value: &str) -> String {
 pub fn parse_args(args: impl IntoIterator<Item = String>) -> Result<RootActivationArgs> {
     let mut uid = None;
     let mut activate_path = None;
-    let mut ssh_auth_sock = None;
 
     let mut args = args.into_iter();
     while let Some(flag) = args.next() {
@@ -94,7 +85,6 @@ pub fn parse_args(args: impl IntoIterator<Item = String>) -> Result<RootActivati
                 uid = Some(value.parse::<u32>().context("--uid must be an integer")?);
             }
             "--activate" => activate_path = Some(value),
-            "--ssh-auth-sock" => ssh_auth_sock = Some(value),
             other => bail!("unknown root-activation argument: {other}"),
         }
     }
@@ -106,11 +96,7 @@ pub fn parse_args(args: impl IntoIterator<Item = String>) -> Result<RootActivati
     let activate_path = activate_path.context("--activate is required")?;
     validate_canonical_activate_path(&activate_path)?;
 
-    Ok(RootActivationArgs {
-        uid,
-        activate_path,
-        ssh_auth_sock,
-    })
+    Ok(RootActivationArgs { uid, activate_path })
 }
 
 /// Entry point for the root-activation dispatch in `main()`. Returns the
@@ -142,16 +128,15 @@ fn run_root_activation(args: impl IntoIterator<Item = String>) -> Result<i32> {
         eprintln!("{WARNING_PREFIX} {warning}");
     }
 
-    // Mirror the helper daemon: account values come from the uid lookup, and
-    // the activation is a direct exec of absolute programs with a fixed
-    // environment — the caller's environment never reaches root.
+    // Mirror the helper daemon: the target is resolved and proved immutable
+    // to the requester right here, immediately before root executes it;
+    // account values come from the uid lookup; and the activation is a
+    // direct exec of absolute programs with a fixed environment — the
+    // caller's environment (including any SSH agent socket) never reaches
+    // root.
+    let activate_path = helper_runtime::canonical_activation_target(&args.activate_path)?;
     let account = helper_runtime::user_account(args.uid)?;
-    let argv = helper_runtime::activation_argv(
-        args.uid,
-        &account,
-        &args.activate_path,
-        args.ssh_auth_sock.as_deref(),
-    );
+    let argv = helper_runtime::activation_argv(args.uid, &account, &activate_path);
     let (status, output) = helper_runtime::run_activation_command(&argv)?;
 
     if status.success() {
@@ -169,7 +154,7 @@ fn run_root_activation(args: impl IntoIterator<Item = String>) -> Result<i32> {
         }
         // Best-effort, same as the helper: the system switch already
         // happened, so maintenance failures are warnings, not errors.
-        for warning in helper_runtime::post_activation_maintenance(&args.activate_path) {
+        for warning in helper_runtime::post_activation_maintenance(&activate_path) {
             println!("{WARNING_PREFIX} {warning}");
         }
     } else {
@@ -207,19 +192,10 @@ mod tests {
 
     #[test]
     fn parse_accepts_full_argument_set() {
-        let parsed = args(&[
-            "--uid",
-            "501",
-            "--activate",
-            ACTIVATE,
-            "--ssh-auth-sock",
-            "/tmp/ssh.sock",
-        ])
-        .expect("valid args");
+        let parsed = args(&["--uid", "501", "--activate", ACTIVATE]).expect("valid args");
 
         assert_eq!(parsed.uid, 501);
         assert_eq!(parsed.activate_path, ACTIVATE);
-        assert_eq!(parsed.ssh_auth_sock.as_deref(), Some("/tmp/ssh.sock"));
     }
 
     #[test]
@@ -248,11 +224,26 @@ mod tests {
         assert!(error.to_string().contains("unknown root-activation"));
     }
 
+    #[test]
+    fn parse_rejects_removed_ssh_auth_sock_argument() {
+        // The agent socket was removed from privileged activation; the flag
+        // must not silently come back.
+        let flags = [
+            "--uid",
+            "501",
+            "--activate",
+            ACTIVATE,
+            "--ssh-auth-sock",
+            "/tmp/ssh.sock",
+        ];
+
+        assert!(args(&flags).is_err());
+    }
+
     fn full_args() -> RootActivationArgs {
         RootActivationArgs {
             uid: 501,
             activate_path: ACTIVATE.to_string(),
-            ssh_auth_sock: Some("/tmp/ssh.sock".to_string()),
         }
     }
 
@@ -282,16 +273,6 @@ mod tests {
                 "shell command must not contain {forbidden:?}: {command}"
             );
         }
-    }
-
-    #[test]
-    fn shell_command_omits_empty_ssh_sock() {
-        let mut args = full_args();
-        args.ssh_auth_sock = Some(String::new());
-
-        let command = shell_command("/Applications/nixmac.app/Contents/MacOS/nixmac", &args);
-
-        assert!(!command.contains("--ssh-auth-sock"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -786,9 +786,6 @@ fn run_activate_with_path(
         // SAFETY: `getuid` is thread-safe, has no preconditions, and cannot fail.
         uid: unsafe { libc::getuid() },
         activate_path: real_activate,
-        ssh_auth_sock: std::env::var("SSH_AUTH_SOCK")
-            .ok()
-            .filter(|sock| !sock.is_empty()),
     };
     let exe = std::env::current_exe()
         .map_err(|e| anyhow::anyhow!("Failed to resolve current executable: {}", e))?;


### PR DESCRIPTION
## Summary

- enforce the path helper is about to execute as root is fully root-owned (not user-level writable)

internal code `C1`

## Test Plan

- [ ] Manual testing

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
