### PR TITLE
test(release): fake stat for DMG apparent-size resize

### DIFF
--- a/ops/scripts/release/normalize-macos-install-names.sh
+++ b/ops/scripts/release/normalize-macos-install-names.sh
@@ -212,6 +212,10 @@ normalize_dmg() {
 	local normalized_dmg
 	local app_count
 	local current_kb
+	local file
+	local file_bytes
+	local file_kb
+	local largest_file_kb
 	local resized_kb
 
 	mount_point="$TMP_DIR/mnt-$(basename "$dmg_path" .dmg)"
@@ -232,14 +236,11 @@ normalize_dmg() {
 	hdiutil convert "$dmg_path" -format UDRW -o "$rw_dmg" >/dev/null
 
 	# install_name_tool writes a temporary replacement next to each Mach-O file.
-	# Tauri's compressed DMG can be exactly full, so grow the RW image before
-	# mounting it or the in-place rewrite can fail with "No space left on device".
-	current_kb=$(du -k "$rw_dmg" | awk '{print $1}')
-	resized_kb=$((current_kb + 102400))
-	hdiutil resize -size "${resized_kb}k" "$rw_dmg" >/dev/null
-
+	# Tauri's compressed DMG can be exactly full. Inspect it read-only first,
+	# then add enough filesystem headroom for a temporary copy of its largest
+	# file plus metadata/signing overhead.
 	mkdir -p "$mount_point"
-	hdiutil attach -readwrite -nobrowse -noautoopen -mountpoint "$mount_point" "$rw_dmg" >/dev/null
+	hdiutil attach -readonly -nobrowse -noautoopen -mountpoint "$mount_point" "$rw_dmg" >/dev/null
 	printf '%s\n' "$mount_point" >>"$MOUNTS_FILE"
 
 	app_count=$(find "$mount_point" -maxdepth 2 -name "*.app" -type d | wc -l | tr -d '[:space:]')
@@ -247,6 +248,24 @@ normalize_dmg() {
 		echo "ERROR: no .app bundle found in $dmg_path" >&2
 		exit 2
 	fi
+
+	largest_file_kb=0
+	while IFS= read -r -d '' file; do
+		file_bytes=$(wc -c <"$file" | tr -d '[:space:]')
+		file_kb=$(((file_bytes + 1023) / 1024))
+		if [ "$file_kb" -gt "$largest_file_kb" ]; then
+			largest_file_kb="$file_kb"
+		fi
+	done < <(find "$mount_point" -type f -print0)
+
+	detach_with_retry "$mount_point"
+
+	current_kb=$(du -k "$rw_dmg" | awk '{print $1}')
+	resized_kb=$((current_kb + largest_file_kb + 65536))
+	echo "Growing RW DMG to ${resized_kb}KB (${largest_file_kb}KB largest file + 64MB overhead)"
+	hdiutil resize -size "${resized_kb}k" "$rw_dmg" >/dev/null
+
+	hdiutil attach -readwrite -nobrowse -noautoopen -mountpoint "$mount_point" "$rw_dmg" >/dev/null
 
 	while IFS= read -r app_path; do
 		normalize_app "$app_path"

--- a/ops/scripts/release/normalize-macos-install-names.sh
+++ b/ops/scripts/release/normalize-macos-install-names.sh
@@ -260,7 +260,11 @@ normalize_dmg() {
 
 	detach_with_retry "$mount_point"
 
-	current_kb=$(du -k "$rw_dmg" | awk '{print $1}')
+	# Use the DMG's apparent (logical) size, not host-allocated blocks.
+	# du -k on a sparse UDRW image measures allocated sectors on the host
+	# filesystem, not the DMG's internal logical capacity. stat gives the
+	# apparent size which tracks what hdiutil resize operates on.
+	current_kb=$(stat -f "%z" "$rw_dmg" | awk '{printf "%d", ($1 + 1023) / 1024}')
 	resized_kb=$((current_kb + largest_file_kb + 65536))
 	echo "Growing RW DMG to ${resized_kb}KB (${largest_file_kb}KB largest file + 64MB overhead)"
 	hdiutil resize -size "${resized_kb}k" "$rw_dmg" >/dev/null

--- a/ops/scripts/release/normalize-macos-install-names.test.sh
+++ b/ops/scripts/release/normalize-macos-install-names.test.sh
@@ -22,6 +22,7 @@ FAKE_BIN="$TMP_DIR/bin"
 INSTALL_NAME_TOOL_LOG="$TMP_DIR/install-name-tool.log"
 TAURI_SIGNER_LOG="$TMP_DIR/tauri-signer.log"
 CODESIGN_LOG="$TMP_DIR/codesign.log"
+HDIUTIL_LOG="$TMP_DIR/hdiutil.log"
 TAURI_SHIM="$SCRIPT_DIR/../../../apps/native/node_modules/.bin/tauri"
 TAURI_BIN_DIR=$(dirname "$TAURI_SHIM")
 TAURI_NODE_MODULES_DIR=$(dirname "$TAURI_BIN_DIR")
@@ -33,6 +34,7 @@ touch "$INSTALL_NAME_TOOL_LOG"
 export INSTALL_NAME_TOOL_LOG
 export TAURI_SIGNER_LOG
 export CODESIGN_LOG
+export HDIUTIL_LOG
 
 if [ ! -x "$TAURI_SHIM" ]; then
 	if [ ! -d "$TAURI_NODE_MODULES_DIR" ]; then
@@ -125,6 +127,69 @@ set -euo pipefail
 printf '%s\n' "$*" >>"$CODESIGN_LOG"
 SH
 chmod +x "$FAKE_BIN/codesign"
+
+cat >"$FAKE_BIN/hdiutil" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$HDIUTIL_LOG"
+
+case "$1" in
+	convert)
+		output=""
+		while [ "$#" -gt 0 ]; do
+			if [ "$1" = "-o" ]; then
+				output="$2"
+				break
+			fi
+			shift
+		done
+		if [ -z "$output" ]; then
+			echo "missing hdiutil convert output" >&2
+			exit 2
+		fi
+		touch "$output"
+		;;
+	attach)
+		mount_point=""
+		while [ "$#" -gt 0 ]; do
+			if [ "$1" = "-mountpoint" ]; then
+				mount_point="$2"
+				break
+			fi
+			shift
+		done
+		if [ -z "$mount_point" ]; then
+			echo "missing hdiutil attach mount point" >&2
+			exit 2
+		fi
+		mkdir -p "$mount_point/NixIconvDmg.app/Contents/MacOS"
+		dd if=/dev/zero of="$mount_point/NixIconvDmg.app/Contents/MacOS/nix-iconv-dmg" bs=1 count=0 seek=157286400 2>/dev/null
+		;;
+	detach | resize)
+		;;
+	*)
+		echo "unexpected hdiutil invocation: $*" >&2
+		exit 2
+		;;
+esac
+SH
+chmod +x "$FAKE_BIN/hdiutil"
+
+cat >"$FAKE_BIN/du" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${!#}" in
+	*.rw.dmg)
+		printf '200000\t%s\n' "${!#}"
+		;;
+	*)
+		/usr/bin/du "$@"
+		;;
+esac
+SH
+chmod +x "$FAKE_BIN/du"
 
 make_app() {
 	local app="$1"
@@ -257,6 +322,33 @@ fi
 if ! grep -F -- "--sign -" "$CODESIGN_LOG" >/dev/null; then
 	echo "expected fallback signing to use an ad-hoc identity" >&2
 	cat "$CODESIGN_LOG" >&2
+	exit 1
+fi
+
+touch "$TMP_DIR/nixmac.dmg"
+RUNNER_TEMP="$TMP_DIR/dmg-runner" PATH="$FAKE_BIN:$PATH" "$SCRIPT" "$TMP_DIR/nixmac.dmg" >"$TMP_DIR/dmg-normalizer.out" 2>&1
+
+if ! grep -F "attach -readonly" "$HDIUTIL_LOG" >/dev/null; then
+	echo "expected DMG sizing inspection to mount read-only" >&2
+	cat "$HDIUTIL_LOG" >&2
+	exit 1
+fi
+
+if ! grep -F "resize -size 419136k" "$HDIUTIL_LOG" >/dev/null; then
+	echo "expected DMG resize to include its largest file plus 64MB overhead" >&2
+	cat "$HDIUTIL_LOG" >&2
+	exit 1
+fi
+
+READONLY_ATTACH_LINE=$(grep -n -F "attach -readonly" "$HDIUTIL_LOG" | head -1 | cut -d: -f1)
+FIRST_DETACH_LINE=$(grep -n -F "detach " "$HDIUTIL_LOG" | head -1 | cut -d: -f1)
+RESIZE_LINE=$(grep -n -F "resize -size 419136k" "$HDIUTIL_LOG" | head -1 | cut -d: -f1)
+READWRITE_ATTACH_LINE=$(grep -n -F "attach -readwrite" "$HDIUTIL_LOG" | head -1 | cut -d: -f1)
+if ! ((READONLY_ATTACH_LINE < FIRST_DETACH_LINE &&
+	FIRST_DETACH_LINE < RESIZE_LINE &&
+	RESIZE_LINE < READWRITE_ATTACH_LINE)); then
+	echo "expected read-only inspect, detach, resize, then read-write attach ordering" >&2
+	cat "$HDIUTIL_LOG" >&2
 	exit 1
 fi
 

--- a/ops/scripts/release/normalize-macos-install-names.test.sh
+++ b/ops/scripts/release/normalize-macos-install-names.test.sh
@@ -176,20 +176,25 @@ esac
 SH
 chmod +x "$FAKE_BIN/hdiutil"
 
-cat >"$FAKE_BIN/du" <<'SH'
+cat >"$FAKE_BIN/stat" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 
-case "${!#}" in
-	*.rw.dmg)
-		printf '200000\t%s\n' "${!#}"
-		;;
-	*)
-		/usr/bin/du "$@"
-		;;
-esac
+# Script uses: stat -f "%z" "$rw_dmg"
+# Return apparent logical size in bytes for the fake UDRW image.
+if [ "${1:-}" = "-f" ] && [ "${2:-}" = "%z" ]; then
+	case "${3:-}" in
+		*.rw.dmg)
+			# 200000 KiB apparent size (matches previous du fake)
+			printf '204800000\n'
+			exit 0
+			;;
+	esac
+fi
+
+exec /usr/bin/stat "$@"
 SH
-chmod +x "$FAKE_BIN/du"
+chmod +x "$FAKE_BIN/stat"
 
 make_app() {
 	local app="$1"


### PR DESCRIPTION
Follow-up to #609: the production script sizes via `stat -f %z`, but the test still faked `du`. Swap to a `stat` stub so the fixture matches and keeps expecting `419136k`.