### PR TITLE
fix(release): restore Developer ID identities on minimal Macly images

### DIFF
--- a/ops/scripts/release/cleanup-keychain.sh
+++ b/ops/scripts/release/cleanup-keychain.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Delete the temporary signing keychain created by import-certificate.sh.
+# Delete the temporary signing keychain created by import-certificate.sh and
+# restore the user keychain search list saved at import time.
 #
 # Optional env vars:
 #   RUNNER_TEMP  - GitHub Actions temp directory
 
 KEYCHAIN_PATH="${RUNNER_TEMP:-/tmp}/app-signing.keychain-db"
+KEYCHAINS_BEFORE_PATH="${RUNNER_TEMP:-/tmp}/app-signing-keychains-before.txt"
+
 if [ -f "$KEYCHAIN_PATH" ]; then
 	security delete-keychain "$KEYCHAIN_PATH" || true
 fi
+
+if [ -f "$KEYCHAINS_BEFORE_PATH" ]; then
+	# shellcheck disable=SC2046
+	security list-keychains -d user -s $(tr '\n' ' ' <"$KEYCHAINS_BEFORE_PATH") || true
+	rm -f "$KEYCHAINS_BEFORE_PATH"
+fi
+
+rm -f "${RUNNER_TEMP:-/tmp}/certificate.p12"
+rm -rf "${RUNNER_TEMP:-/tmp}/apple-intermediates"

--- a/ops/scripts/release/import-certificate.sh
+++ b/ops/scripts/release/import-certificate.sh
@@ -8,19 +8,61 @@ set -euo pipefail
 #   APPLE_CERTIFICATE_PASSWORD - Password for the P12
 #   KEYCHAIN_PASSWORD          - Password for the temporary keychain
 #   RUNNER_TEMP                - GitHub Actions temp directory
+#
+# Custom Macly Tahoe images omit Apple's Developer ID intermediate CAs from
+# System.keychain. Importing the P12 alone yields a private key but
+# "0 valid identities". Even with the intermediate in the temp keychain,
+# `find-identity` scoped to that path still returns 0 — the temp keychain must
+# sit on the user search list and identity lookup must be unscoped (see
+# sign-app.sh / normalize-macos-install-names.sh).
 
 KEYCHAIN_PATH="${RUNNER_TEMP}/app-signing.keychain-db"
+KEYCHAINS_BEFORE_PATH="${RUNNER_TEMP}/app-signing-keychains-before.txt"
+P12_PATH="${RUNNER_TEMP}/certificate.p12"
+INTERMEDIATE_DIR="${RUNNER_TEMP}/apple-intermediates"
+
+# Preserve the prior search list for cleanup-keychain.sh.
+security list-keychains -d user | tr -d '"' >"$KEYCHAINS_BEFORE_PATH"
 
 security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
 security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-echo "$APPLE_CERTIFICATE" | base64 --decode >"$RUNNER_TEMP/certificate.p12"
-security import "$RUNNER_TEMP/certificate.p12" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+echo "$APPLE_CERTIFICATE" | base64 --decode >"$P12_PATH"
+security import "$P12_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
 security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-# shellcheck disable=SC2046
-security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
 
-echo "=== Available signing identities ==="
-security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+# Install Apple Developer ID intermediates. Our leaf is G2-issued; import G1 too
+# for completeness. Minimal CI images do not ship these in System.keychain.
+mkdir -p "$INTERMEDIATE_DIR"
+for url in \
+	"https://www.apple.com/certificateauthority/DeveloperIDCA.cer" \
+	"https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer"; do
+	name=$(basename "$url")
+	curl -fsSL "$url" -o "$INTERMEDIATE_DIR/$name"
+	if ! security import "$INTERMEDIATE_DIR/$name" -k "$KEYCHAIN_PATH" \
+		-T /usr/bin/codesign -T /usr/bin/security >/dev/null 2>&1; then
+		openssl x509 -inform DER -in "$INTERMEDIATE_DIR/$name" -out "$INTERMEDIATE_DIR/${name}.pem"
+		security import "$INTERMEDIATE_DIR/${name}.pem" -k "$KEYCHAIN_PATH" \
+			-T /usr/bin/codesign -T /usr/bin/security >/dev/null
+	fi
+	echo "Imported intermediate: $name"
+done
+
+# Put the temp keychain first so unscoped find-identity can complete the chain.
+# shellcheck disable=SC2046
+security list-keychains -d user -s "$KEYCHAIN_PATH" $(tr '\n' ' ' <"$KEYCHAINS_BEFORE_PATH")
+
+echo "=== Available signing identities (unscoped search list) ==="
+# Unscoped on purpose: scoped find-identity to $KEYCHAIN_PATH returns 0 on Macly
+# even when the intermediate lives in that same keychain.
+IDENTITIES_OUT=$(security find-identity -v -p codesigning)
+printf '%s\n' "$IDENTITIES_OUT"
 echo "=== End identities ==="
+
+if ! printf '%s\n' "$IDENTITIES_OUT" | grep -q "Developer ID Application"; then
+	echo "ERROR: No Developer ID Application identity found after import" >&2
+	echo "Scoped temp keychain identities:" >&2
+	security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
+	exit 1
+fi

--- a/ops/scripts/release/normalize-macos-install-names.sh
+++ b/ops/scripts/release/normalize-macos-install-names.sh
@@ -192,10 +192,18 @@ sign_app_if_certificate_available() {
 		exit 2
 	fi
 
-	identity=$(security find-identity -v -p codesigning "$keychain_path" 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+	# Unscoped lookup: scoped find-identity to $keychain_path returns 0 on Macly
+	# even when leaf + intermediate are both in that keychain. import-certificate.sh
+	# already put the temp keychain first on the user search list.
+	# awk (not grepheal) so multiple matching identities cannot SIGPIPE under pipefail,
+	# and empty output is a normal empty string rather than a pipeline failure.
+	identity=$(
+		security find-identity -v -p codesigning 2>/dev/null \
+			| awk -F'"' '/Developer ID Application/ { print $2; exit }'
+	)
 	if [ -z "$identity" ]; then
-		echo "ERROR: No Developer ID Application identity found in keychain" >&2
-		security find-identity -v -p codesigning "$keychain_path" >&2
+		echo "ERROR: No Developer ID Application identity found in keychain search list" >&2
+		security find-identity -v -p codesigning >&2 || true
 		exit 1
 	fi
 
@@ -209,6 +217,7 @@ sign_app_if_certificate_available() {
 	echo "Verifying normalized app signature: $app_path"
 	codesign --verify --deep --strict --verbose=4 "$app_path"
 }
+
 
 normalize_dmg() {
 	local dmg_path="$1"

--- a/ops/scripts/release/normalize-macos-install-names.test.sh
+++ b/ops/scripts/release/normalize-macos-install-names.test.sh
@@ -116,6 +116,12 @@ if [ "$1" != "find-identity" ]; then
 	exit 2
 fi
 
+# Unscoped lookup: last arg must be the policy, not a keychain path.
+if [ "${!#}" != "codesigning" ]; then
+	echo "expected unscoped find-identity, got: $*" >&2
+	exit 2
+fi
+
 printf '%s\n' '  1) ABCDEF1234567890 "Developer ID Application: Test Signing (TEAMID)"'
 SH
 chmod +x "$FAKE_BIN/security"
@@ -283,6 +289,12 @@ fi
 
 if ! grep -F -- "--options runtime" "$CODESIGN_LOG" >/dev/null; then
 	echo "expected updater tarball app signing to use Developer ID options when a signing keychain exists" >&2
+	cat "$CODESIGN_LOG" >&2
+	exit 1
+fi
+
+if ! grep -F -- '--sign Developer ID Application: Test Signing (TEAMID)' "$CODESIGN_LOG" >/dev/null; then
+	echo "expected normalize to sign with Developer ID Application identity name" >&2
 	cat "$CODESIGN_LOG" >&2
 	exit 1
 fi

--- a/ops/scripts/release/sign-app.sh
+++ b/ops/scripts/release/sign-app.sh
@@ -14,12 +14,17 @@ fi
 
 echo "Signing $APP_PATH..."
 
-KEYCHAIN_PATH="${RUNNER_TEMP}/app-signing.keychain-db"
-IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+# Unscoped lookup: scoped find-identity to the temp keychain returns 0 on Macly
+# even when the leaf + intermediate are both present there. import-certificate.sh
+# already put the temp keychain first on the user search list.
+IDENTITY=$(
+	security find-identity -v -p codesigning 2>/dev/null \
+		| awk -F'"' '/Developer ID Application/ { print $2; exit }'
+)
 
 if [ -z "$IDENTITY" ]; then
-	echo "ERROR: No Developer ID Application identity found in keychain"
-	security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+	echo "ERROR: No Developer ID Application identity found in keychain search list" >&2
+	security find-identity -v -p codesigning >&2 || true
 	exit 1
 fi
 

--- a/ops/scripts/release/sign-app.test.sh
+++ b/ops/scripts/release/sign-app.test.sh
@@ -25,6 +25,12 @@ if [ "$1" != "find-identity" ]; then
 	exit 2
 fi
 
+# Unscoped lookup: last arg must be the policy, not a keychain path.
+if [ "${!#}" != "codesigning" ]; then
+	echo "expected unscoped find-identity, got: $*" >&2
+	exit 2
+fi
+
 printf '%s\n' '  1) ABCDEF1234567890 "Developer ID Application: Test Signing (TEAMID)"'
 SH
 chmod +x "$FAKE_BIN/security"
@@ -52,6 +58,12 @@ fi
 
 if ! grep -F -- "--entitlements apps/native/src-tauri/entitlements.plist" "$CODESIGN_LOG" >/dev/null; then
 	echo "expected sign-app to sign app with entitlements" >&2
+	cat "$CODESIGN_LOG" >&2
+	exit 1
+fi
+
+if ! grep -F -- '--sign Developer ID Application: Test Signing (TEAMID)' "$CODESIGN_LOG" >/dev/null; then
+	echo "expected sign-app to sign with Developer ID Application identity name" >&2
 	cat "$CODESIGN_LOG" >&2
 	exit 1
 fi


### PR DESCRIPTION
Custom Tahoe runners omit Apple Developer ID intermediate CAs, so a P12-only import left the leaf with 0 valid identities. Import G1/G2 intermediates into the temp keychain and switch find-identity to unscoped search-list lookup in import, sign-app, and normalize — scoped lookup to the temp keychain still returns 0 on Macly even with the intermediate present. Restore the prior keychain search list on cleanup.

## Summary

<!-- What does this PR do? Why? -->

## Test Plan

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [ ] No docs update needed
