### PR TITLE
fix(helper)!: drop claimed identity, version the protocol

### DIFF
--- a/apps/native/src-tauri/src/bin/nixmac-helper.rs
+++ b/apps/native/src-tauri/src/bin/nixmac-helper.rs
@@ -1,15 +1,5 @@
 #![allow(dead_code)]
 
-mod system {
-    pub mod nix {
-        pub fn get_nix_path() -> String {
-            std::env::var("PATH").unwrap_or_else(|_| {
-                "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin".to_string()
-            })
-        }
-    }
-}
-
 mod privileged_helper {
     pub mod protocol {
         include!(concat!(

--- a/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
+++ b/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
@@ -90,8 +90,8 @@ fn run_once() -> anyhow::Result<()> {
     }
 
     let activate_path = store_path.join("activate");
-    let request = privileged_helper::protocol::current_user_activation_request(&activate_path)?;
-    let response = privileged_helper::client::activate_store_path(request)?;
+    let request = privileged_helper::protocol::activation_request(&activate_path)?;
+    let response = privileged_helper::client::activate_store_path(&request)?;
     if !response.ok {
         // Leave the out-link in place: it keeps the built closure GC-rooted
         // for the next attempt, and that attempt's --out-link replaces it.

--- a/apps/native/src-tauri/src/privileged_helper/client.rs
+++ b/apps/native/src-tauri/src/privileged_helper/client.rs
@@ -1,6 +1,6 @@
 use crate::privileged_helper::peer_auth;
 use crate::privileged_helper::protocol::{
-    ActivateStorePathRequest, HELPER_SOCKET_PATH, HelperRequest, HelperResponse,
+    ActivationRequest, HELPER_SOCKET_PATH, HelperOp, HelperRequest, HelperResponse,
 };
 use anyhow::{Context, Result, bail};
 use std::io::{BufRead, BufReader, Write};
@@ -38,18 +38,19 @@ fn request_with_timeout(request: &HelperRequest, timeout: Duration) -> Result<He
         bail!("helper returned an empty response");
     }
 
-    Ok(serde_json::from_str(&line)?)
+    // The response's protocol version is checked before any of its fields
+    // are used; a missing or different version fails as a classified
+    // protocol skew for callers to act on.
+    HelperResponse::parse(&line)
 }
 
 pub fn status() -> Result<HelperResponse> {
-    request_with_timeout(&HelperRequest::Status, STATUS_PROBE_TIMEOUT)
+    request_with_timeout(&HelperRequest::new(HelperOp::Status), STATUS_PROBE_TIMEOUT)
 }
 
-pub fn activate_store_path(request_body: ActivateStorePathRequest) -> Result<HelperResponse> {
-    request_with_timeout(
-        &HelperRequest::ActivateStorePath {
-            request: request_body,
-        },
-        ACTIVATION_TIMEOUT,
-    )
+/// Sends an activation envelope. `ActivationRequest` is only constructible
+/// through `protocol::activation_request`, so this entry point cannot be
+/// handed a status operation or a hand-assembled version.
+pub fn activate_store_path(request: &ActivationRequest) -> Result<HelperResponse> {
+    request_with_timeout(&request.0, ACTIVATION_TIMEOUT)
 }

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -1,7 +1,8 @@
 use crate::privileged_helper::peer_auth::{self, PeerIdentity};
 use crate::privileged_helper::protocol::{
     ActivateStorePathRequest, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HELPER_WARNING_PREFIX,
-    HelperRequest, HelperResponse, UNAUTHORIZED_CLIENT_ERROR, validate_canonical_activate_path,
+    HelperOp, HelperRequest, HelperResponse, UNAUTHORIZED_CLIENT_ERROR,
+    validate_canonical_activate_path,
 };
 use anyhow::{Context, Result, anyhow, bail};
 use std::fs;
@@ -15,8 +16,8 @@ use std::process::Command;
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
 
 /// Fixed PATH for the privileged activation: root-owned system and Nix
-/// profile directories only. The requester's `nix_path` never reaches root
-/// command lookup.
+/// profile directories only. The protocol has no field for a requester to
+/// offer a PATH, so nothing requester-supplied reaches root command lookup.
 const ACTIVATION_PATH_ENV: &str =
     "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
@@ -90,19 +91,24 @@ fn handle_stream(mut stream: UnixStream) -> Result<()> {
     // body is touched: an unauthorized peer must never reach the reader or
     // the JSON parser.
     let response = match authorize_peer(&stream) {
-        Ok(peer) => match read_request(stream.try_clone()?) {
-            Ok(request) => match authorize_request(&peer, &request) {
-                Ok(()) => handle_request(&peer, request),
-                Err(error) => HelperResponse::error(-1, error.to_string()),
-            },
-            Err(error) => HelperResponse::error(-1, error.to_string()),
-        },
+        Ok(peer) => respond_authorized(&peer, &stream)?,
         Err(error) => HelperResponse::error(-1, format!("{UNAUTHORIZED_CLIENT_ERROR}: {error:#}")),
     };
     serde_json::to_writer(&mut stream, &response)?;
     stream.write_all(b"\n")?;
     stream.flush()?;
     Ok(())
+}
+
+/// Post-authorization request handling: only a request that clears the
+/// version gate reaches an operation handler; anything else — version skew,
+/// a v1 shape, unknown fields, framing violations — becomes a versioned
+/// protocol-error response without an operation being derived.
+fn respond_authorized(peer: &PeerIdentity, stream: &UnixStream) -> Result<HelperResponse> {
+    Ok(match read_request(stream.try_clone()?) {
+        Ok(op) => handle_request(peer, op),
+        Err(error) => HelperResponse::error(-1, error.to_string()),
+    })
 }
 
 fn authorize_peer(stream: &UnixStream) -> Result<PeerIdentity> {
@@ -127,7 +133,11 @@ fn check_peer_policy(peer_euid: u32, console_uid: Option<u32>) -> Result<()> {
     Ok(())
 }
 
-fn read_request(stream: impl Read) -> Result<HelperRequest> {
+/// Reads one framed request and returns the operation only if the sender
+/// speaks this daemon's protocol version. A version mismatch and an
+/// unrecognized field are both hard errors here, so no operation is derived
+/// from a request the daemon does not fully understand.
+fn read_request(stream: impl Read) -> Result<HelperOp> {
     let mut line = String::new();
     BufReader::new(stream)
         .take(MAX_REQUEST_BYTES)
@@ -135,13 +145,13 @@ fn read_request(stream: impl Read) -> Result<HelperRequest> {
     if !line.ends_with('\n') && line.len() as u64 >= MAX_REQUEST_BYTES {
         bail!("request exceeds {MAX_REQUEST_BYTES} bytes");
     }
-    Ok(serde_json::from_str(&line)?)
+    HelperRequest::parse(&line)
 }
 
-fn handle_request(peer: &PeerIdentity, request: HelperRequest) -> HelperResponse {
-    match request {
-        HelperRequest::Status => HelperResponse::ok("nixmac helper ready"),
-        HelperRequest::ActivateStorePath { request } => match activate_store_path(peer, &request) {
+fn handle_request(peer: &PeerIdentity, op: HelperOp) -> HelperResponse {
+    match op {
+        HelperOp::Status => HelperResponse::ok("nixmac helper ready"),
+        HelperOp::ActivateStorePath(request) => match activate_store_path(peer, &request) {
             Ok(response) => response,
             Err(error) => HelperResponse::error(-1, error.to_string()),
         },
@@ -153,10 +163,7 @@ fn activate_store_path(
     request: &ActivateStorePathRequest,
 ) -> Result<HelperResponse> {
     let activate_path = canonical_activation_target(&request.activate_path)?;
-    // Account values are derived from the socket peer credentials; the
-    // request's `user_name`/`user_id`/`home` are never trusted here.
-    let account = user_account(peer.euid)?;
-    let argv = activation_argv(peer.euid, &account, &activate_path);
+    let argv = activation_argv_for_peer(peer, &activate_path)?;
     let (status, mut stdout) = run_activation_command(&argv)?;
 
     // Profile maintenance runs only after a successful activation and is
@@ -168,13 +175,11 @@ fn activate_store_path(
         }
     }
 
-    Ok(HelperResponse {
-        ok: status.success(),
-        code: status.code().unwrap_or(-1),
+    Ok(HelperResponse::from_exit(
+        status.success(),
+        status.code().unwrap_or(-1),
         stdout,
-        stderr: String::new(),
-        error: None,
-    })
+    ))
 }
 
 /// Resolves and authorizes the activation target at the privileged boundary,
@@ -311,6 +316,16 @@ pub(crate) fn activation_argv(uid: u32, account: &UserAccount, activate_path: &s
     ]
 }
 
+/// The privileged command for one authenticated peer. Every
+/// requester-derived input comes from the peer's socket credentials: the
+/// account is looked up by the authenticated uid — the protocol has no field
+/// to override it — and that uid, name, and home populate the activation
+/// argv and environment.
+fn activation_argv_for_peer(peer: &PeerIdentity, activate_path: &str) -> Result<Vec<String>> {
+    let account = user_account(peer.euid)?;
+    Ok(activation_argv(peer.euid, &account, activate_path))
+}
+
 pub(crate) fn post_activation_maintenance(activate_path: &str) -> Vec<String> {
     let mut warnings = Vec::new();
     if let Err(error) = set_system_profile(activate_path) {
@@ -343,22 +358,6 @@ fn set_system_profile(activate_path: &str) -> Result<()> {
     Ok(())
 }
 
-/// Request-level cross-check, after the peer itself is already authorized:
-/// activation must be requested for the peer's own uid.
-fn authorize_request(peer: &PeerIdentity, request: &HelperRequest) -> Result<()> {
-    if let HelperRequest::ActivateStorePath { request } = request
-        && peer.euid != request.user_id
-    {
-        bail!(
-            "activation peer uid {} does not match requested uid {}",
-            peer.euid,
-            request.user_id
-        );
-    }
-
-    Ok(())
-}
-
 pub(crate) struct UserAccount {
     name: String,
     home: String,
@@ -388,16 +387,8 @@ pub(crate) fn user_account(_uid: u32) -> Result<UserAccount> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn request(path: &str) -> ActivateStorePathRequest {
-        ActivateStorePathRequest {
-            activate_path: path.to_string(),
-            user_name: "alice".to_string(),
-            user_id: 501,
-            home: "/Users/alice".to_string(),
-            nix_path: "/tmp/attacker-bin:/usr/bin".to_string(),
-        }
-    }
+    #[cfg(target_os = "macos")]
+    use crate::privileged_helper::protocol::HELPER_PROTOCOL_VERSION;
 
     fn account() -> UserAccount {
         UserAccount {
@@ -418,11 +409,10 @@ mod tests {
         assert_eq!(&argv[1..3], ["asuser", "501"]);
         assert_eq!(&argv[3..5], ["/usr/bin/env", "-i"]);
         assert!(argv.contains(&format!("PATH={ACTIVATION_PATH_ENV}")));
-        // Account values come from the peer lookup, not the request.
+        // Account values come from the peer lookup. The protocol no longer
+        // has fields for a client to claim these with.
         assert!(argv.contains(&"HOME=/Users/peer-alice".to_string()));
         assert!(argv.contains(&"USER=peer-alice".to_string()));
-        assert!(!argv.iter().any(|arg| arg.contains("/tmp/attacker-bin")));
-        assert!(!argv.iter().any(|arg| arg.contains("/Users/alice")));
         assert_eq!(
             argv.last().map(String::as_str),
             Some("/nix/store/abc123-darwin-system-25.05.20260629/activate")
@@ -451,10 +441,12 @@ mod tests {
         // A status request never inspects the peer; any real identity works.
         let (stream, _other_end) = UnixStream::pair().expect("socketpair");
         let peer = peer_auth::peer_identity(&stream).expect("peer identity");
-        let response = handle_request(&peer, HelperRequest::Status);
+        let response = handle_request(&peer, HelperOp::Status);
 
         assert!(response.ok);
         assert_eq!(response.code, 0);
+        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
+        assert!(!response.helper_build_version.is_empty());
     }
 
     #[test]
@@ -587,11 +579,82 @@ mod tests {
         assert!(canonical_activation_target("/nix/store/no-such-item-c1-test/activate").is_err());
     }
 
-    #[test]
-    fn read_request_parses_status_request() {
-        let request = read_request(&b"{\"op\":\"status\"}\n"[..]).expect("parse status");
+    fn framed(request: &HelperRequest) -> Vec<u8> {
+        let mut body = serde_json::to_vec(request).expect("serialize request");
+        body.push(b'\n');
+        body
+    }
 
-        assert_eq!(request, HelperRequest::Status);
+    #[cfg(target_os = "macos")]
+    fn authorized_response_to(body: &[u8]) -> HelperResponse {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let peer = peer_auth::peer_identity(&server).expect("peer identity");
+        (&client).write_all(body).expect("write request");
+
+        respond_authorized(&peer, &server).expect("responds")
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn authorized_current_version_request_crosses_the_gate_to_the_handler() {
+        let response = authorized_response_to(&framed(&HelperRequest::new(HelperOp::Status)));
+
+        assert!(response.ok);
+        assert_eq!(response.stdout, "nixmac helper ready");
+        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn version_rejection_becomes_a_versioned_protocol_error_without_a_handler() {
+        // Missing, lower, and higher versions, each on a body the version
+        // gate must stop. `ok: false` on the status shape proves the status
+        // handler never ran (it would answer ok "ready"); the skew
+        // classification on the others — whose operations are invalid or
+        // carry the v1 claimed fields — proves the gate rejected them before
+        // any operation shape was interpreted, let alone executed.
+        for body in [
+            // Missing: v1 status, no version field at all.
+            "{\"op\":\"status\"}\n".to_string(),
+            // Missing: v1 activation carrying the claimed identity/PATH fields.
+            r#"{"op":"activateStorePath","request":{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/tmp/attacker-bin"}}
+"#
+            .to_string(),
+            // Lower and higher versions on deliberately invalid operations.
+            "{\"protocolVersion\":1,\"op\":\"selfDestruct\"}\n".to_string(),
+            format!(
+                "{{\"protocolVersion\":{},\"op\":\"selfDestruct\"}}\n",
+                HELPER_PROTOCOL_VERSION + 1
+            ),
+        ] {
+            let response = authorized_response_to(body.as_bytes());
+
+            assert!(!response.ok);
+            assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
+            assert!(!response.helper_build_version.is_empty());
+            assert!(response.reports_protocol_skew());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn activation_argv_derives_from_the_authenticated_peer_account() {
+        // The peer identity of a socketpair end is this test process, so the
+        // argv must carry this process's uid and its user-database account —
+        // the lookup keys on the authenticated uid and nothing else.
+        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
+        let peer = peer_auth::peer_identity(&stream).expect("peer identity");
+        let me = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(peer.euid))
+            .expect("user lookup")
+            .expect("account exists");
+
+        let argv = activation_argv_for_peer(&peer, "/nix/store/abc-darwin-system/activate")
+            .expect("argv for peer");
+
+        assert_eq!(argv[1], "asuser");
+        assert_eq!(argv[2], peer.euid.to_string());
+        assert!(argv.contains(&format!("USER={}", me.name)));
+        assert!(argv.contains(&format!("HOME={}", me.dir.display())));
     }
 
     #[test]
@@ -623,13 +686,12 @@ mod tests {
             .expect("handler thread")
             .expect("stream handled");
 
-        let response: HelperResponse = serde_json::from_str(&reply).expect("response json");
+        // Authorization errors are versioned responses like every other:
+        // the strict client-side parse must accept the reply.
+        let response = HelperResponse::parse(&reply).expect("versioned response");
         assert!(!response.ok);
-        assert!(
-            response
-                .error
-                .expect("error message")
-                .contains(UNAUTHORIZED_CLIENT_ERROR)
-        );
+        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
+        assert!(!response.helper_build_version.is_empty());
+        assert!(response.reports_unauthorized_client());
     }
 }

--- a/apps/native/src-tauri/src/privileged_helper/protocol.rs
+++ b/apps/native/src-tauri/src/privileged_helper/protocol.rs
@@ -13,10 +13,26 @@ pub const HELPER_SOCKET_PATH: &str = "/var/run/nixmac/helper.sock";
 #[allow(dead_code)]
 pub const HELPER_SOCKET_DIR: &str = "/var/run/nixmac";
 /// Prefix of the daemon's response when the connecting peer fails
-/// authorization. The app matches on it to fall back to the interactive
-/// osascript path instead of surfacing a hard error (unsigned dev builds
-/// land here by design).
+/// authorization. The app matches on it — only through
+/// `HelperResponse::reports_unauthorized_client`, which requires it as a
+/// prefix — to fall back to the interactive osascript path instead of
+/// surfacing a hard error (unsigned dev builds land here by design).
 pub const UNAUTHORIZED_CLIENT_ERROR: &str = "unauthorized helper client";
+/// Wire marker for protocol-version skew: the prefix of `ProtocolSkew`'s
+/// display form, and therefore of the daemon's response `error` string when
+/// a request's version is missing or wrong. Classification cannot cross the
+/// JSON boundary, so a *daemon-reported* skew is detected from this marker —
+/// only through `HelperResponse::reports_protocol_skew`, which requires it
+/// as a prefix. For client-side failures use `is_protocol_skew`, never
+/// display text. Kept distinct from `UNAUTHORIZED_CLIENT_ERROR` so a
+/// version-skewed helper/app pairing is distinguishable from a rejected
+/// client.
+pub const UNSUPPORTED_PROTOCOL_ERROR: &str = "unsupported helper protocol version";
+/// Wire protocol the daemon and its clients speak. Version 2 dropped every
+/// claimed-identity field: the daemon derives the account from the socket
+/// peer's credentials, so there is nothing left for a client to assert about
+/// itself.
+pub const HELPER_PROTOCOL_VERSION: u32 = 2;
 const DEFAULT_SYNC_AGENT_INTERVAL_SECONDS: u32 = 900;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
@@ -28,7 +44,9 @@ pub struct HelperServiceStatus {
     pub authorized: bool,
     pub socket_available: bool,
     /// The daemon answered an authenticated status round-trip: the client
-    /// validated the daemon's signature and the daemon accepted this client.
+    /// validated the daemon's signature, the daemon accepted this client,
+    /// and both sides proved they speak the same protocol version. A
+    /// protocol-error response never sets this.
     pub responding: bool,
     pub detail: Option<String>,
 }
@@ -47,14 +65,15 @@ impl HelperServiceStatus {
     }
 }
 
+/// The activation target, and nothing else. Account name, uid, and home come
+/// from the socket peer's credentials, and the privileged `PATH` is fixed, so
+/// a client has nothing left to claim. Unknown fields are rejected rather
+/// than ignored: a v1 client's `userName`/`userId`/`home`/`nixPath` must fail
+/// loudly, never look like it was honored.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ActivateStorePathRequest {
     pub activate_path: String,
-    pub user_name: String,
-    pub user_id: u32,
-    pub home: String,
-    pub nix_path: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Type, PartialEq, Eq)]
@@ -67,16 +86,110 @@ pub struct SyncAgentLaunchConfig {
     pub start_interval_seconds: Option<u32>,
 }
 
+/// Everything a client puts on the socket. The version is outside the
+/// operation so it can be checked before the operation is acted on.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "op", rename_all = "camelCase")]
-pub enum HelperRequest {
-    Status,
-    ActivateStorePath { request: ActivateStorePathRequest },
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HelperRequest {
+    pub protocol_version: u32,
+    pub op: HelperOp,
 }
 
+impl HelperRequest {
+    pub fn new(op: HelperOp) -> Self {
+        Self {
+            protocol_version: HELPER_PROTOCOL_VERSION,
+            op,
+        }
+    }
+
+    /// Daemon-side gate: no operation is derived until the sender is known
+    /// to speak this daemon's protocol. The version is probed before the
+    /// strict parse so an alien shape is reported as version skew rather
+    /// than as whichever unfamiliar field serde trips over first.
+    pub fn parse(line: &str) -> Result<HelperOp> {
+        check_wire_version(line)?;
+        let request: Self = serde_json::from_str(line)?;
+        Ok(request.op)
+    }
+}
+
+/// Classified protocol-version skew. This is the error type behind every
+/// version-gate rejection, so consumers detect skew structurally with
+/// `is_protocol_skew` instead of parsing display text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProtocolSkew {
+    /// Version the other side sent; `None` when the shape carried no
+    /// version at all (the v1 wire).
+    pub peer_version: Option<u32>,
+}
+
+impl std::fmt::Display for ProtocolSkew {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.peer_version {
+            Some(version) => write!(
+                f,
+                "{UNSUPPORTED_PROTOCOL_ERROR} {version} (this build speaks {HELPER_PROTOCOL_VERSION})"
+            ),
+            None => write!(
+                f,
+                "{UNSUPPORTED_PROTOCOL_ERROR}: no protocolVersion field (this build speaks {HELPER_PROTOCOL_VERSION})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolSkew {}
+
+/// True when `error` is (or wraps) a version-gate `ProtocolSkew`. This is
+/// the client-side classification callers act on — the display text is not
+/// part of the contract.
+pub fn is_protocol_skew(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<ProtocolSkew>().is_some())
+}
+
+/// Reads only `protocolVersion` out of one wire line and requires it to be
+/// exactly this build's version. The probe deliberately ignores every other
+/// field: its job is to decide whether the rest of the shape may be
+/// interpreted at all, so it must parse shapes this build otherwise rejects
+/// (v1 carried no version field at all).
+fn check_wire_version(line: &str) -> Result<()> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct VersionProbe {
+        protocol_version: Option<u32>,
+    }
+
+    match serde_json::from_str::<VersionProbe>(line)?.protocol_version {
+        Some(HELPER_PROTOCOL_VERSION) => Ok(()),
+        peer_version => Err(ProtocolSkew { peer_version }.into()),
+    }
+}
+
+/// Externally tagged: serde honors `deny_unknown_fields` on a plain payload
+/// struct, but ignores it on the variants of an internally tagged enum, and
+/// rejecting unknown fields is the point of this shape.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub enum HelperOp {
+    Status,
+    ActivateStorePath(ActivateStorePathRequest),
+}
+
+/// Everything the daemon puts back on the socket. Every response — status,
+/// activation success or failure, and protocol errors alike — carries the
+/// version, because the constructors below stamp it and the daemon builds
+/// responses only through them. `helper_build_version` is diagnostic (for
+/// support and telemetry): release versions are not unique across rebuilds,
+/// so the update and trust decisions belong to the signature checks and the
+/// version gate, never to this string.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct HelperResponse {
+    pub protocol_version: u32,
+    pub helper_build_version: String,
     pub ok: bool,
     pub code: i32,
     pub stdout: String,
@@ -120,23 +233,62 @@ impl HelperResponse {
     }
 
     pub fn ok(stdout: impl Into<String>) -> Self {
+        Self::from_exit(true, 0, stdout.into())
+    }
+
+    pub fn error(code: i32, error: impl Into<String>) -> Self {
         Self {
-            ok: true,
-            code: 0,
-            stdout: stdout.into(),
+            error: Some(error.into()),
+            ..Self::from_exit(false, code, String::new())
+        }
+    }
+
+    /// Base constructor the other constructors delegate to; also used
+    /// directly for a finished activation command, where `ok` mirrors the
+    /// exit status. stderr stays empty in every case: the activation merges
+    /// its stderr into stdout (`2>&1`), and the other responses have none.
+    pub fn from_exit(ok: bool, code: i32, stdout: String) -> Self {
+        Self {
+            protocol_version: HELPER_PROTOCOL_VERSION,
+            helper_build_version: env!("NIXMAC_VERSION").to_string(),
+            ok,
+            code,
+            stdout,
             stderr: String::new(),
             error: None,
         }
     }
 
-    pub fn error(code: i32, error: impl Into<String>) -> Self {
-        Self {
-            ok: false,
-            code,
-            stdout: String::new(),
-            stderr: String::new(),
-            error: Some(error.into()),
-        }
+    /// Client-side gate, mirroring `HelperRequest::parse`: the version is
+    /// checked before `ok`, output, or error fields exist to be read, and a
+    /// missing or different version fails as a classified `ProtocolSkew`.
+    /// How to recover — reconciling the installed helper, or an interactive
+    /// fallback — is the caller's policy, not this layer's contract.
+    pub fn parse(line: &str) -> Result<Self> {
+        check_wire_version(line)?;
+        Ok(serde_json::from_str(line)?)
+    }
+
+    /// True when this daemon-reported response is the version gate's own
+    /// rejection. The marker is required as a prefix — the daemon puts the
+    /// classification first in `error` — so an unrelated failure that merely
+    /// mentions the marker text deeper in its message never classifies as
+    /// skew.
+    pub fn reports_protocol_skew(&self) -> bool {
+        self.reports_marker(UNSUPPORTED_PROTOCOL_ERROR)
+    }
+
+    /// True when this daemon-reported response is the daemon refusing the
+    /// connecting peer. Prefix-matched for the same reason as
+    /// `reports_protocol_skew`.
+    pub fn reports_unauthorized_client(&self) -> bool {
+        self.reports_marker(UNAUTHORIZED_CLIENT_ERROR)
+    }
+
+    fn reports_marker(&self, marker: &str) -> bool {
+        self.error
+            .as_deref()
+            .is_some_and(|error| error.starts_with(marker))
     }
 }
 
@@ -176,31 +328,26 @@ pub fn canonicalize_activate_path(path: impl AsRef<Path>) -> Result<PathBuf> {
     validate_canonical_activate_path(&canonical)
 }
 
-pub fn current_user_activation_request(activate_path: &Path) -> Result<ActivateStorePathRequest> {
+/// A ready-to-send activation envelope. Opaque on purpose: `activation_request`
+/// is the only constructor, so the client's activation entry point cannot be
+/// handed a status operation or a hand-assembled envelope with a different
+/// version or a non-canonicalized target.
+#[derive(Debug, Clone)]
+pub struct ActivationRequest(pub(crate) HelperRequest);
+
+/// Builds the versioned activation envelope for the current process.
+/// Resolving the path here is a convenience so an obviously wrong target
+/// fails before a round trip; the daemon canonicalizes and revalidates
+/// independently, and treats nothing in this request as trusted beyond the
+/// path it re-derives.
+pub fn activation_request(activate_path: &Path) -> Result<ActivationRequest> {
     let canonical = canonicalize_activate_path(activate_path)?;
-    let user_name = whoami::username().unwrap_or_else(|_| "root".to_string());
-    let user_id = current_user_id();
-    let home = std::env::var("HOME").unwrap_or_default();
-    let nix_path = crate::system::nix::get_nix_path();
 
-    Ok(ActivateStorePathRequest {
-        activate_path: canonical.to_string_lossy().into_owned(),
-        user_name,
-        user_id,
-        home,
-        nix_path,
-    })
-}
-
-#[cfg(unix)]
-fn current_user_id() -> u32 {
-    // SAFETY: `getuid` is thread-safe, has no preconditions, and cannot fail.
-    unsafe { libc::getuid() }
-}
-
-#[cfg(not(unix))]
-fn current_user_id() -> u32 {
-    0
+    Ok(ActivationRequest(HelperRequest::new(
+        HelperOp::ActivateStorePath(ActivateStorePathRequest {
+            activate_path: canonical.to_string_lossy().into_owned(),
+        }),
+    )))
 }
 
 #[allow(dead_code)]
@@ -354,21 +501,231 @@ mod tests {
     }
 
     #[test]
-    fn activation_request_json_ignores_removed_fields() {
-        // Wire compat with apps that still send canonicalLinkTarget or
-        // sshAuthSock: unknown fields are ignored on deserialization.
-        let json = r#"{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","sshAuthSock":"/tmp/ssh.sock","nixPath":"/bin","canonicalLinkTarget":"/Users/alice/.darwin"}"#;
-        let request: ActivateStorePathRequest = serde_json::from_str(json).expect("deserializes");
-        assert_eq!(request.user_id, 501);
+    fn request_round_trips_at_the_current_version() {
+        for op in [
+            HelperOp::Status,
+            HelperOp::ActivateStorePath(ActivateStorePathRequest {
+                activate_path: "/nix/store/abc-darwin-system/activate".to_string(),
+            }),
+        ] {
+            let wire = serde_json::to_string(&HelperRequest::new(op.clone())).expect("serializes");
+
+            assert!(wire.contains(&format!("\"protocolVersion\":{HELPER_PROTOCOL_VERSION}")));
+            assert_eq!(HelperRequest::parse(&wire).expect("parses"), op);
+        }
+    }
+
+    #[test]
+    fn request_rejects_other_protocol_versions_before_reading_the_shape() {
+        // The operation is deliberately invalid: getting the skew
+        // classification rather than an unknown-variant parse error proves
+        // the version gate wins before the rest of the shape is interpreted.
+        for version in [1, 3, 99] {
+            let json = format!("{{\"protocolVersion\":{version},\"op\":\"selfDestruct\"}}");
+            let error = HelperRequest::parse(&json).expect_err("version must be rejected");
+
+            assert!(is_protocol_skew(&error));
+            assert_eq!(
+                error.downcast_ref::<ProtocolSkew>(),
+                Some(&ProtocolSkew {
+                    peer_version: Some(version)
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn activation_request_rejects_claimed_identity_fields() {
+        // A v1 body at the current version: the claimed account values and
+        // requester PATH are a hard parse error now, so they can never look
+        // like they were honored.
+        let json = format!(
+            r#"{{"protocolVersion":{HELPER_PROTOCOL_VERSION},"op":{{"activateStorePath":{{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/tmp/attacker-bin"}}}}}}"#
+        );
+
+        assert!(HelperRequest::parse(&json).is_err());
+    }
+
+    #[test]
+    fn request_rejects_unknown_envelope_fields() {
+        let json = format!(
+            r#"{{"protocolVersion":{HELPER_PROTOCOL_VERSION},"op":"status","userId":501}}"#
+        );
+
+        assert!(HelperRequest::parse(&json).is_err());
+    }
+
+    #[test]
+    fn request_rejects_the_v1_wire_shape_as_protocol_skew() {
+        // v1 tagged the operation inline and carried no version at all. Both
+        // v1 shapes must be rejected, and classified as version skew rather
+        // than a shape error, before any operation is derived.
+        for v1 in [
+            r#"{"op":"status"}"#,
+            r#"{"op":"activateStorePath","request":{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/bin"}}"#,
+        ] {
+            let error = HelperRequest::parse(v1).expect_err("v1 shape must be rejected");
+
+            assert_eq!(
+                error.downcast_ref::<ProtocolSkew>(),
+                Some(&ProtocolSkew { peer_version: None })
+            );
+        }
+    }
+
+    /// The exact request parser the deployed v1 daemon uses, vendored as a
+    /// minimal fixture for the opposite temporal direction of the break.
+    #[derive(Deserialize)]
+    #[serde(tag = "op", rename_all = "camelCase")]
+    enum V1HelperRequest {
+        Status,
+        ActivateStorePath {
+            // Deserialized into but never read, like the payload fields.
+            #[allow(dead_code)]
+            request: V1ActivateStorePathRequest,
+        },
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    struct V1ActivateStorePathRequest {
+        activate_path: String,
+        user_name: String,
+        user_id: u32,
+        home: String,
+        nix_path: String,
+    }
+
+    #[test]
+    fn v1_daemon_parser_cannot_derive_an_activation_from_a_v2_request() {
+        // No-double-apply defense: if a still-resident v1 root daemon could
+        // parse a v2 activation request, it would execute the activation and
+        // answer with a versionless v1 response — which the v2 app rejects
+        // as skew, so any recovery it then attempts would re-run an
+        // already-finished activation. The v2 activation envelope must
+        // therefore be unparseable by the exact v1 request enum.
+        let activation = serde_json::to_string(&HelperRequest::new(HelperOp::ActivateStorePath(
+            ActivateStorePathRequest {
+                activate_path: "/nix/store/abc-darwin-system/activate".to_string(),
+            },
+        )))
+        .expect("serializes");
+
+        assert!(serde_json::from_str::<V1HelperRequest>(&activation).is_err());
+
+        // The v1 daemon does parse a v2 *status* request (its internally
+        // tagged enum ignores the unfamiliar protocolVersion field). That is
+        // the accepted read-only asymmetry — pinned here so an envelope
+        // change that alters it is revisited deliberately.
+        let status =
+            serde_json::to_string(&HelperRequest::new(HelperOp::Status)).expect("serializes");
+
+        assert!(matches!(
+            serde_json::from_str::<V1HelperRequest>(&status),
+            Ok(V1HelperRequest::Status)
+        ));
+    }
+
+    #[test]
+    fn every_response_shape_serializes_the_current_version() {
+        // Status, activation success, activation failure, and protocol-error
+        // responses: all carry the version and the diagnostic build version.
+        for response in [
+            HelperResponse::ok("nixmac helper ready"),
+            HelperResponse::from_exit(true, 0, "activated".to_string()),
+            HelperResponse::from_exit(false, 2, "activation exploded".to_string()),
+            HelperResponse::error(-1, format!("{UNSUPPORTED_PROTOCOL_ERROR} 1")),
+        ] {
+            assert!(!response.helper_build_version.is_empty());
+            let wire = serde_json::to_string(&response).expect("serializes");
+
+            assert!(wire.contains(&format!("\"protocolVersion\":{HELPER_PROTOCOL_VERSION}")));
+            assert!(wire.contains("\"helperBuildVersion\""));
+            assert_eq!(HelperResponse::parse(&wire).expect("parses"), response);
+        }
+    }
+
+    #[test]
+    fn response_parse_rejects_the_exact_v1_status_response() {
+        // What an installed v1 helper answers a status probe with. It must
+        // fail before ok/stdout/error are readable, classified as protocol
+        // skew for the caller's recovery policy to act on.
+        let v1 = r#"{"ok":true,"code":0,"stdout":"nixmac helper ready","stderr":"","error":null}"#;
+
+        let error = HelperResponse::parse(v1).expect_err("v1 response must be rejected");
+
+        assert!(is_protocol_skew(&error));
+        assert_eq!(
+            error.downcast_ref::<ProtocolSkew>(),
+            Some(&ProtocolSkew { peer_version: None })
+        );
+    }
+
+    #[test]
+    fn response_parse_rejects_other_protocol_versions_before_reading_the_shape() {
+        // The rest of the shape is deliberately invalid (missing required
+        // fields, an unknown one instead): getting the skew classification
+        // rather than a field-level parse error proves the version gate wins
+        // before any response field is interpreted.
+        for version in [1, 3, 99] {
+            let json = format!(r#"{{"protocolVersion":{version},"bogus":true}}"#);
+
+            let error = HelperResponse::parse(&json).expect_err("version must be rejected");
+
+            assert!(is_protocol_skew(&error));
+            assert_eq!(
+                error.downcast_ref::<ProtocolSkew>(),
+                Some(&ProtocolSkew {
+                    peer_version: Some(version)
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn daemon_markers_classify_only_as_prefixes() {
+        let skew = HelperResponse::error(
+            -1,
+            ProtocolSkew {
+                peer_version: Some(1),
+            }
+            .to_string(),
+        );
+        assert!(skew.reports_protocol_skew());
+        assert!(!skew.reports_unauthorized_client());
+
+        let refused =
+            HelperResponse::error(-1, format!("{UNAUTHORIZED_CLIENT_ERROR}: bad signature"));
+        assert!(refused.reports_unauthorized_client());
+        assert!(!refused.reports_protocol_skew());
+
+        // An unrelated failure that merely mentions a marker deeper in its
+        // message must not classify.
+        let unrelated = HelperResponse::error(
+            1,
+            format!(
+                "activation failed: log mentioned '{UNSUPPORTED_PROTOCOL_ERROR}' and '{UNAUTHORIZED_CLIENT_ERROR}'"
+            ),
+        );
+        assert!(!unrelated.reports_protocol_skew());
+        assert!(!unrelated.reports_unauthorized_client());
+        assert!(!HelperResponse::ok("nixmac helper ready").reports_protocol_skew());
+    }
+
+    #[test]
+    fn response_parse_rejects_unknown_fields() {
+        let wire = serde_json::to_string(&HelperResponse::ok("ready")).expect("serializes");
+        let with_extra = wire.replacen('{', r#"{"sshAuthSock":"/tmp/ssh.sock","#, 1);
+
+        assert!(HelperResponse::parse(&with_extra).is_err());
     }
 
     fn response(stdout: &str, stderr: &str, error: Option<&str>) -> HelperResponse {
         HelperResponse {
-            ok: false,
-            code: 1,
-            stdout: stdout.to_string(),
             stderr: stderr.to_string(),
             error: error.map(String::from),
+            ..HelperResponse::from_exit(false, 1, stdout.to_string())
         }
     }
 

--- a/apps/native/src-tauri/src/privileged_helper/service.rs
+++ b/apps/native/src-tauri/src/privileged_helper/service.rs
@@ -1,27 +1,37 @@
 use crate::privileged_helper::client;
-use crate::privileged_helper::protocol::HelperServiceStatus;
 #[cfg(target_os = "macos")]
 use crate::privileged_helper::protocol::{HELPER_LABEL, HELPER_PLIST_NAME};
+use crate::privileged_helper::protocol::{HelperResponse, HelperServiceStatus};
 use anyhow::Result;
 
 pub fn status() -> HelperServiceStatus {
     let mut status = platform_status();
     status.socket_available = client::socket_available();
     // SMAppService state and a socket path prove nothing about the daemon:
-    // only an authenticated round-trip (mutual code-signature validation)
-    // shows the connection actually works.
+    // only an authenticated round-trip (mutual code-signature validation at
+    // this build's protocol version) shows the connection actually works.
     if status.socket_available {
-        match client::status() {
-            Ok(response) if response.ok => status.responding = true,
-            Ok(response) => {
-                status.detail = Some(response.error.unwrap_or_else(|| {
-                    "helper answered the status probe with an error".to_string()
-                }));
-            }
-            Err(error) => status.detail = Some(format!("{error:#}")),
-        }
+        fold_status_probe(&mut status, client::status());
     }
     status
+}
+
+/// Folds one authenticated status round-trip into the service status. Only a
+/// same-version `ok` response marks the daemon responding: a version-skewed
+/// response fails `client::status` before its fields are readable and lands
+/// in the `Err` arm, and a daemon-reported protocol error arrives with
+/// `ok: false` — either way a protocol error can only ever reach `detail`.
+fn fold_status_probe(status: &mut HelperServiceStatus, probe: anyhow::Result<HelperResponse>) {
+    match probe {
+        Ok(response) if response.ok => status.responding = true,
+        Ok(response) => {
+            status.detail =
+                Some(response.error.unwrap_or_else(|| {
+                    "helper answered the status probe with an error".to_string()
+                }));
+        }
+        Err(error) => status.detail = Some(format!("{error:#}")),
+    }
 }
 
 pub fn register() -> Result<HelperServiceStatus> {
@@ -195,5 +205,84 @@ mod macos {
         let _ = std::process::Command::new("open")
             .arg("x-apple.systempreferences:com.apple.LoginItems-Settings.extension")
             .spawn();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privileged_helper::protocol::{HELPER_LABEL, UNSUPPORTED_PROTOCOL_ERROR};
+
+    fn probed_status() -> HelperServiceStatus {
+        HelperServiceStatus {
+            label: HELPER_LABEL.to_string(),
+            available: true,
+            registered: true,
+            authorized: true,
+            socket_available: true,
+            responding: false,
+            detail: None,
+        }
+    }
+
+    #[test]
+    fn same_version_ok_probe_sets_responding() {
+        let mut status = probed_status();
+
+        fold_status_probe(&mut status, Ok(HelperResponse::ok("nixmac helper ready")));
+
+        assert!(status.responding);
+        assert_eq!(status.detail, None);
+    }
+
+    #[test]
+    fn skew_rejected_probes_never_set_responding() {
+        // What reaches the fold when the daemon answered with the exact v1
+        // status response or a mismatched version: the client-side parse
+        // already classified it as skew, so the probe arrives as an error.
+        for wire in [
+            r#"{"ok":true,"code":0,"stdout":"nixmac helper ready","stderr":"","error":null}"#
+                .to_string(),
+            format!(
+                r#"{{"protocolVersion":{},"helperBuildVersion":"9.9.9","ok":true,"code":0,"stdout":"","stderr":"","error":null}}"#,
+                crate::privileged_helper::protocol::HELPER_PROTOCOL_VERSION + 1
+            ),
+        ] {
+            let mut status = probed_status();
+
+            fold_status_probe(&mut status, HelperResponse::parse(&wire));
+
+            assert!(!status.responding);
+            assert!(
+                status
+                    .detail
+                    .expect("skew detail")
+                    .contains(UNSUPPORTED_PROTOCOL_ERROR)
+            );
+        }
+    }
+
+    #[test]
+    fn parsed_protocol_error_response_never_sets_responding() {
+        // A same-version daemon reporting a protocol error (it rejected the
+        // request's version) parses fine — it must still never count as
+        // responding.
+        let mut status = probed_status();
+
+        fold_status_probe(
+            &mut status,
+            Ok(HelperResponse::error(
+                -1,
+                format!("{UNSUPPORTED_PROTOCOL_ERROR} 1 (this build speaks 2)"),
+            )),
+        );
+
+        assert!(!status.responding);
+        assert!(
+            status
+                .detail
+                .expect("protocol error detail")
+                .contains(UNSUPPORTED_PROTOCOL_ERROR)
+        );
     }
 }

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -831,8 +831,20 @@ fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult
     if !status.authorized || !status.socket_available {
         return None;
     }
+    // `responding` is the authenticated status round-trip `helper_service`
+    // already performed. Requiring it here is what keeps a version-skewed
+    // daemon from failing the apply: a daemon predating this app's protocol
+    // cannot answer the probe, so the osascript path takes over instead of
+    // the activation request coming back as an unparseable request.
+    if !status.responding {
+        info!(
+            "[darwin] privileged helper did not answer an authenticated status probe; falling back to osascript: {}",
+            status.detail.unwrap_or_default()
+        );
+        return None;
+    }
 
-    let request = match helper_protocol::current_user_activation_request(Path::new(activate_path)) {
+    let request = match helper_protocol::activation_request(Path::new(activate_path)) {
         Ok(request) => request,
         Err(error) => {
             return Some(Err(
@@ -841,17 +853,18 @@ fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult
         }
     };
 
-    match helper_client::activate_store_path(request) {
+    match helper_client::activate_store_path(&request) {
         Ok(response) => {
             // A live daemon that refuses this peer means the running build is
             // not signed as an approved client (unsigned dev build, or a
-            // helper/app version skew). The osascript prompt is the intended
-            // path there, not a hard failure.
+            // helper/app version skew). A daemon that does not speak this
+            // app's protocol version is the same situation with a different
+            // cause: an older helper still resident from a previous install.
+            // Falling back to the interactive prompt keeps the apply working
+            // in both cases until the installed helper is replaced by a
+            // current one.
             if !response.ok
-                && response
-                    .error
-                    .as_deref()
-                    .is_some_and(|error| error.contains(helper_protocol::UNAUTHORIZED_CLIENT_ERROR))
+                && (response.reports_protocol_skew() || response.reports_unauthorized_client())
             {
                 info!(
                     "[darwin] privileged helper rejected this client; falling back to osascript: {}",
@@ -878,6 +891,18 @@ fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult
             if error_text.contains(crate::privileged_helper::peer_auth::HELPER_VALIDATION_FAILED) {
                 warn!(
                     "[darwin] process at helper socket failed signature validation; falling back to osascript: {error:#}"
+                );
+                return None;
+            }
+            // The client rejects a response whose protocol version is
+            // missing or different before reading its fields, so version
+            // skew surfaces here as a classified error rather than a
+            // response. A skewed daemon cannot have run the activation — it
+            // could not have parsed the request — so falling back is safe
+            // until the installed helper is replaced by a current one.
+            if helper_protocol::is_protocol_skew(&error) {
+                info!(
+                    "[darwin] privileged helper speaks a different protocol version; falling back to osascript: {error:#}"
                 );
                 return None;
             }


### PR DESCRIPTION
## Summary

- new helper protocol: determining the identity from the socket, not from claimed values
- introduce helper protocol

internal code `C2`

## Test Plan

- [ ] Manual testing of a CI-build artifact

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
