### PR TITLE
ci: gate ready PRs on Linear issue references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,13 @@
 
 <!-- What does this PR do? Why? -->
 
+## Linear
+
+Related to ENG-___
+
+<!-- Prefer: Related to ENG-N (non-closing). Use Fixes ENG-N only if this PR fully completes the issue. -->
+<!-- Intentionally untracked? Add a visible body line: #no-linear: short reason -->
+
 ## Test Plan
 
 - [ ] No test plan needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,10 @@
 
 ## Linear
 
-Related to ENG-___
+Related to ENG-\_\_\_
 
 <!-- Prefer: Related to ENG-N (non-closing). Use Fixes ENG-N only if this PR fully completes the issue. -->
+
 <!-- Intentionally untracked? Add a visible body line: #no-linear: short reason -->
 
 ## Test Plan

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -2,7 +2,14 @@ name: Danger
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened, ready_for_review]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+      # Re-run when a ready PR converts back to draft so Linear fail → warn softens.
+      - converted_to_draft
 
 concurrency:
   group: danger-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/linear-pr-link.yml
+++ b/.github/workflows/linear-pr-link.yml
@@ -1,0 +1,46 @@
+name: Linear PR link
+
+# Lightweight required-ready gate: every non-draft PR must reference a Linear
+# issue (ENG-*/LAB-*) via title, branch, or magic-word body directive.
+# Policy lives in scripts/linear-pr-link/matcher.ts (shared with Danger).
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+  merge_group:
+
+concurrency:
+  group: linear-pr-link-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  linear-pr-link:
+    name: linear-pr-link
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Unit tests (matcher)
+        run: bun test scripts/linear-pr-link/matcher.test.ts
+
+      - name: Evaluate PR Linear link
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bun scripts/linear-pr-link/check.ts

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,9 +1,12 @@
 import { danger, fail, markdown, message, warn } from "danger";
 import { existsSync, readFileSync } from "node:fs";
+import { evaluateLinearLink } from "./scripts/linear-pr-link/matcher.ts";
 
 // Danger should point reviewers at useful context without becoming the most
 // brittle required check in the stack. Keep subjective process checks advisory
 // and reserve hard failures for changes that are objectively unsafe to merge.
+// Linear issue linkage is an objective traceability check — fail on ready PRs
+// (shared policy with the linear-pr-link workflow).
 
 // ---------------------------------------------------------------------------
 // PR snapshot
@@ -53,12 +56,6 @@ const matches = (predicate: (file: string) => boolean) => (files: readonly strin
 
 const codeBlock = (files: readonly string[]): string => files.map((f) => `- \`${f}\``).join("\n");
 
-// Linear issue ID — established convention is `ENG-<n>` (e.g. `ENG-502`, `ENG-277`),
-// referenced in PR titles, bodies, and branch names like `fkb/eng-494-...`. Match
-// any uppercase team prefix so the check survives a future team rename.
-const LINEAR_ISSUE_RE = /\b[A-Z]{2,}-\d+\b/;
-const NO_LINEAR_NEEDED_RE = /#no-linear\b/i;
-
 const TEST_PLAN_HEADING_RE = /(^|\n)#{2,3}\s*(test plan|testing instructions|how to test)\b/i;
 const NO_TEST_PLAN_NEEDED_RE = /^\s*-\s*\[[xX]\]\s*No test plan needed\b/im;
 const TEST_PLAN_PLACEHOLDER_RE = /^\s*-\s*\[[ xX]\]\s*No test plan needed\b.*$/gim;
@@ -97,6 +94,14 @@ const newRustModules = matches(isRustSource)(created);
 const newTsSourceFiles = matches(isTsSource)(created);
 const newTsTests = matches(isTsTest)(created);
 
+const linearLink = evaluateLinearLink({
+  title,
+  body,
+  branch: pr.head.ref ?? "",
+  authorLogin: pr.user?.login ?? "",
+  isDraft: pr.draft === true,
+});
+
 const flags = {
   isDraft: pr.draft === true,
   isWip: /\bWIP\b|^\s*\[wip\]/i.test(title),
@@ -104,11 +109,7 @@ const flags = {
   hasTestPlanSection: TEST_PLAN_HEADING_RE.test(body),
   hasTestPlan: substantiveTestPlan.length >= 10,
   noTestPlanNeeded: NO_TEST_PLAN_NEEDED_RE.test(testPlanSection),
-  hasLinearIssue:
-    LINEAR_ISSUE_RE.test(title) ||
-    LINEAR_ISSUE_RE.test(body) ||
-    LINEAR_ISSUE_RE.test(pr.head.ref ?? ""),
-  noLinearNeeded: NO_LINEAR_NEEDED_RE.test(body),
+  hasLinearIssue: linearLink.policySatisfied,
   hasNewUiComponents: newUiComponents.length > 0,
   hasNewStories: newStories.length > 0,
   hasNewRustModules: newRustModules.length > 0,
@@ -306,15 +307,26 @@ ${rows}
 // ---------------------------------------------------------------------------
 
 function checkLinearIssue(): void {
-  if (flags.isTrivial || flags.noLinearNeeded || flags.hasLinearIssue) {
+  if (linearLink.policySatisfied) {
+    if (linearLink.matchedIds.length > 0) {
+      message(`Linear link: ${linearLink.reason}`);
+    }
     return;
   }
 
-  warn(
-    "No Linear issue ID found in this PR's title, description, or branch name " +
-    "(expected something like `ENG-123`). Add one so this work is traceable in Linear, " +
-    "or add `#no-linear` to the PR description to acknowledge it's intentionally untracked.",
-  );
+  const help =
+    linearLink.reason +
+    " See `scripts/linear-pr-link/matcher.ts` for the full policy.";
+
+  // Drafts: advisory only (true GitHub draft — not WIP-in-title).
+  // Ready PRs: hard fail (objective traceability). The linear-pr-link workflow
+  // is the merge gate; Danger mirrors it for reviewer visibility.
+  if (flags.isDraft) {
+    warn(help);
+    return;
+  }
+
+  fail(help);
 }
 
 function checkTestPlan(): void {

--- a/scripts/linear-pr-link/check.ts
+++ b/scripts/linear-pr-link/check.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env bun
+/**
+ * CI entrypoint for the linear-pr-link required check.
+ *
+ * pull_request: evaluate title/body/branch/author/draft from the event.
+ * merge_group: re-check every PR associated with the head SHA via the API
+ *   (merge_group payloads do not include PR title/body). If no PRs are
+ *   associated, allow with a notice — PR-stage is the admission gate.
+ *
+ * Local dry-run:
+ *   PR_TITLE=... PR_BODY=... PR_BRANCH=... PR_AUTHOR=... PR_DRAFT=true \
+ *     bun scripts/linear-pr-link/check.ts
+ */
+
+import { readFileSync } from "node:fs";
+import { evaluateLinearLink, type LinearLinkInput } from "./matcher.ts";
+
+type GhPull = {
+  title?: string;
+  body?: string | null;
+  draft?: boolean;
+  user?: { login?: string } | null;
+  head?: { ref?: string } | null;
+  number?: number;
+  html_url?: string;
+};
+
+type EvalItem = { label: string; input: LinearLinkInput };
+
+async function main(): Promise<void> {
+  const resolved = await resolveInputs();
+  if (resolved.kind === "allow") {
+    console.log(resolved.message);
+    process.exit(0);
+  }
+
+  const inputs = resolved.items;
+  if (inputs.length === 0) {
+    console.error("linear-pr-link: no PR metadata to evaluate");
+    process.exit(1);
+  }
+
+  let failed = false;
+  for (const { label, input } of inputs) {
+    const result = evaluateLinearLink(input);
+    const tag = label ? `[${label}] ` : "";
+    if (result.ciAllowed) {
+      if (result.softDraft) {
+        console.log(`${tag}draft PR — advisory only: ${result.reason}`);
+      } else {
+        console.log(`${tag}ok: ${result.reason}`);
+      }
+      continue;
+    }
+    failed = true;
+    console.error(`${tag}FAIL: ${result.reason}`);
+  }
+
+  process.exit(failed ? 1 : 0);
+}
+
+type Resolved =
+  | { kind: "eval"; items: EvalItem[] }
+  | { kind: "allow"; message: string };
+
+async function resolveInputs(): Promise<Resolved> {
+  if (process.env.PR_TITLE !== undefined || process.env.PR_BRANCH !== undefined) {
+    return {
+      kind: "eval",
+      items: [
+        {
+          label: "env",
+          input: {
+            title: process.env.PR_TITLE ?? "",
+            body: process.env.PR_BODY ?? "",
+            branch: process.env.PR_BRANCH ?? "",
+            authorLogin: process.env.PR_AUTHOR ?? "",
+            isDraft: process.env.PR_DRAFT === "true",
+          },
+        },
+      ],
+    };
+  }
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    console.error("linear-pr-link: set GITHUB_EVENT_PATH or PR_* env vars");
+    process.exit(1);
+  }
+
+  const event = JSON.parse(readFileSync(eventPath, "utf8")) as Record<string, unknown>;
+  const eventName = process.env.GITHUB_EVENT_NAME ?? "";
+
+  if (eventName === "pull_request" || event.pull_request) {
+    const pr = (event.pull_request ?? {}) as GhPull;
+    return {
+      kind: "eval",
+      items: [
+        {
+          label: pr.number ? `PR #${pr.number}` : "pull_request",
+          input: {
+            title: pr.title ?? "",
+            body: pr.body ?? "",
+            branch: pr.head?.ref ?? "",
+            authorLogin: pr.user?.login ?? "",
+            isDraft: pr.draft === true,
+          },
+        },
+      ],
+    };
+  }
+
+  if (eventName === "merge_group" || event.merge_group) {
+    return resolveMergeGroup(event);
+  }
+
+  console.error(`linear-pr-link: unsupported event ${eventName || "(unknown)"}`);
+  process.exit(1);
+}
+
+async function resolveMergeGroup(event: Record<string, unknown>): Promise<Resolved> {
+  const mg = (event.merge_group ?? {}) as { head_sha?: string; head_ref?: string };
+  const headSha = mg.head_sha;
+  if (!headSha) {
+    console.error("linear-pr-link: merge_group missing head_sha");
+    process.exit(1);
+  }
+
+  const repo = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (!repo || !token) {
+    return {
+      kind: "allow",
+      message:
+        `linear-pr-link: merge_group without GITHUB_TOKEN — allowing ` +
+        `(PR-stage gate is authoritative; head ${headSha.slice(0, 7)})`,
+    };
+  }
+
+  const url = `https://api.github.com/repos/${repo}/commits/${headSha}/pulls`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "nixmac-linear-pr-link",
+    },
+  });
+
+  if (!res.ok) {
+    console.error(
+      `linear-pr-link: failed to list PRs for ${headSha}: ${res.status} ${await res.text()}`,
+    );
+    process.exit(1);
+  }
+
+  const pulls = (await res.json()) as GhPull[];
+  if (!Array.isArray(pulls) || pulls.length === 0) {
+    return {
+      kind: "allow",
+      message:
+        `linear-pr-link: no PRs associated with ${headSha.slice(0, 7)}; ` +
+        "allowing (PR-stage gate is authoritative for merge-queue admission)",
+    };
+  }
+
+  return {
+    kind: "eval",
+    items: pulls.map((pr) => ({
+      label: pr.number ? `PR #${pr.number}` : (pr.html_url ?? "pr"),
+      input: {
+        title: pr.title ?? "",
+        body: pr.body ?? "",
+        branch: pr.head?.ref ?? "",
+        authorLogin: pr.user?.login ?? "",
+        isDraft: pr.draft === true,
+      },
+    })),
+  };
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/linear-pr-link/matcher.test.ts
+++ b/scripts/linear-pr-link/matcher.test.ts
@@ -82,6 +82,14 @@ describe("evaluateLinearLink — success paths", () => {
     expect(r.matchedIds).toContain("ENG-1");
   });
 
+  test("body magic word and ID on separate lines does not link", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Related to\n\nENG-123\n",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
   test("body Fixed ENG-1", () => {
     const r = evaluateLinearLink({ ...base, body: "Fixed ENG-9" });
     expect(r.policySatisfied).toBe(true);

--- a/scripts/linear-pr-link/matcher.test.ts
+++ b/scripts/linear-pr-link/matcher.test.ts
@@ -49,6 +49,24 @@ describe("stripNonPolicyText", () => {
       "Document ",
     );
   });
+
+  test("removes indented Markdown code blocks", () => {
+    expect(stripNonPolicyText("Visible\n    Related to ENG-123\nDone")).toBe(
+      "Visible\n\nDone",
+    );
+    expect(stripNonPolicyText("Visible\n\tRelated to ENG-123\nDone")).toBe(
+      "Visible\n\nDone",
+    );
+  });
+
+  test("removes HTML code elements", () => {
+    expect(
+      stripNonPolicyText(
+        'Document <code class="example">Related to ENG-123</code> syntax',
+      ),
+    ).toBe("Document \n syntax");
+    expect(stripNonPolicyText("<pre>Related to ENG-123</pre>")).toBe("\n");
+  });
 });
 
 describe("parseExemption", () => {
@@ -255,6 +273,17 @@ describe("evaluateLinearLink — failure paths", () => {
       "```\nRelated to ENG-99",
       "<!-- Related to ENG-99",
       "`Related to ENG-99",
+    ]) {
+      expect(evaluateLinearLink({ ...base, body }).policySatisfied).toBe(false);
+    }
+  });
+
+  test("indented and HTML code cannot link", () => {
+    for (const body of [
+      "    Related to ENG-99",
+      "\tRelated to ENG-99",
+      "<code>Related to ENG-99</code>",
+      "<pre>Related to ENG-99</pre>",
     ]) {
       expect(evaluateLinearLink({ ...base, body }).policySatisfied).toBe(false);
     }

--- a/scripts/linear-pr-link/matcher.test.ts
+++ b/scripts/linear-pr-link/matcher.test.ts
@@ -21,7 +21,33 @@ describe("stripNonPolicyText", () => {
   });
 
   test("removes fenced code blocks", () => {
-    expect(stripNonPolicyText("a\n```\nRelated to ENG-1\n```\nb")).toBe("a\n\nb");
+    expect(stripNonPolicyText("a\n```\nRelated to ENG-1\n```\nb")).toBe(
+      "a\n\nb",
+    );
+  });
+
+  test("removes inline code spans", () => {
+    expect(stripNonPolicyText("Document `Related to ENG-123` syntax")).toBe(
+      "Document  syntax",
+    );
+  });
+
+  test("removes unterminated fenced code through end of body", () => {
+    expect(stripNonPolicyText("Visible\n```\nRelated to ENG-123")).toBe(
+      "Visible\n",
+    );
+  });
+
+  test("removes unterminated HTML comments through end of body", () => {
+    expect(stripNonPolicyText("Visible\n<!-- Related to ENG-123")).toBe(
+      "Visible\n",
+    );
+  });
+
+  test("removes unterminated inline code through end of body", () => {
+    expect(stripNonPolicyText("Document `Related to ENG-123")).toBe(
+      "Document ",
+    );
   });
 });
 
@@ -214,6 +240,24 @@ describe("evaluateLinearLink — failure paths", () => {
       body: "```\nRelated to ENG-99\n```\n",
     });
     expect(r.policySatisfied).toBe(false);
+  });
+
+  test("inline code cannot link", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Document `Related to ENG-99` syntax",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("unterminated hidden blocks cannot link", () => {
+    for (const body of [
+      "```\nRelated to ENG-99",
+      "<!-- Related to ENG-99",
+      "`Related to ENG-99",
+    ]) {
+      expect(evaluateLinearLink({ ...base, body }).policySatisfied).toBe(false);
+    }
   });
 
   test("#trivial is not an exemption", () => {

--- a/scripts/linear-pr-link/matcher.test.ts
+++ b/scripts/linear-pr-link/matcher.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "bun:test";
+import {
+  evaluateLinearLink,
+  parseExemption,
+  stripNonPolicyText,
+} from "./matcher.ts";
+
+const base = {
+  title: "",
+  body: "",
+  branch: "feature/something",
+  authorLogin: "farhankhalaf",
+  isDraft: false,
+};
+
+describe("stripNonPolicyText", () => {
+  test("removes HTML comments", () => {
+    expect(stripNonPolicyText("hello <!-- #no-linear: secret --> world")).toBe(
+      "hello  world",
+    );
+  });
+
+  test("removes fenced code blocks", () => {
+    expect(stripNonPolicyText("a\n```\nRelated to ENG-1\n```\nb")).toBe("a\n\nb");
+  });
+});
+
+describe("parseExemption", () => {
+  test("requires same-line reason", () => {
+    expect(parseExemption("#no-linear: chore only")).toBe("chore only");
+  });
+
+  test("rejects bare #no-linear", () => {
+    expect(parseExemption("#no-linear\nRelated stuff")).toBeNull();
+  });
+
+  test("rejects empty reason", () => {
+    expect(parseExemption("#no-linear:   ")).toBeNull();
+  });
+
+  test("rejects placeholder reason", () => {
+    expect(parseExemption("#no-linear: <reason>")).toBeNull();
+  });
+
+  test("does not match across lines via whitespace", () => {
+    expect(parseExemption("#no-linear:\nchore only")).toBeNull();
+  });
+});
+
+describe("evaluateLinearLink — success paths", () => {
+  test("title-only ENG-1", () => {
+    const r = evaluateLinearLink({ ...base, title: "feat: foo (ENG-1)" });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.ciAllowed).toBe(true);
+    expect(r.matchedIds).toContain("ENG-1");
+  });
+
+  test("branch eng-490 with separator", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      branch: "fkb/eng-494-guided-setup",
+    });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.matchedIds).toContain("ENG-494");
+  });
+
+  test("branch eng490 without separator", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      branch: "andrew/eng490-homebrew-onboarding",
+    });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.matchedIds).toContain("ENG-490");
+  });
+
+  test("body Related to ENG-1", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Summary\n\nRelated to ENG-1\n",
+    });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.matchedIds).toContain("ENG-1");
+  });
+
+  test("body Fixed ENG-1", () => {
+    const r = evaluateLinearLink({ ...base, body: "Fixed ENG-9" });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.matchedIds).toContain("ENG-9");
+  });
+
+  test("body Refs ENG-1", () => {
+    const r = evaluateLinearLink({ ...base, body: "Refs ENG-502" });
+    expect(r.policySatisfied).toBe(true);
+  });
+
+  test("body linear issue ENG-1", () => {
+    const r = evaluateLinearLink({ ...base, body: "linear issue ENG-12" });
+    expect(r.policySatisfied).toBe(true);
+  });
+
+  test("body magic word + linear.app URL", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Related to https://linear.app/darkmatter/issue/ENG-490/title",
+    });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.matchedIds).toContain("ENG-490");
+  });
+
+  test("LAB team allowed", () => {
+    const r = evaluateLinearLink({ ...base, title: "chore (LAB-10)" });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.matchedIds).toContain("LAB-10");
+  });
+
+  test("multiple IDs", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Related to ENG-1 and Fixes ENG-2",
+    });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.matchedIds).toEqual(expect.arrayContaining(["ENG-1", "ENG-2"]));
+  });
+
+  test("#no-linear: reason exempts", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "#no-linear: dependabot-adjacent tooling",
+    });
+    expect(r.policySatisfied).toBe(true);
+    expect(r.exemption).toContain("dependabot");
+  });
+
+  test("dependabot exempt", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      authorLogin: "dependabot[bot]",
+      title: "chore(deps): bump x",
+    });
+    expect(r.policySatisfied).toBe(true);
+  });
+
+  test("renovate exempt", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      authorLogin: "renovate[bot]",
+    });
+    expect(r.policySatisfied).toBe(true);
+  });
+});
+
+describe("evaluateLinearLink — failure paths", () => {
+  test("missing everything", () => {
+    const r = evaluateLinearLink({ ...base });
+    expect(r.policySatisfied).toBe(false);
+    expect(r.ciAllowed).toBe(false);
+    expect(r.softDraft).toBe(false);
+  });
+
+  test("bare body ENG-1 without magic word", () => {
+    const r = evaluateLinearLink({ ...base, body: "See ENG-1 for details" });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("FOO-1 not allowed team", () => {
+    const r = evaluateLinearLink({ ...base, title: "feat FOO-1" });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("vitest-3 branch is not a linear id", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      branch: "dependabot/npm_and_yarn/apps/native/vitest-3.2.6",
+      authorLogin: "someone",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("placeholder ENG-___ not an id", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Related to ENG-___",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("HTML comment cannot exempt", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Summary\n\n<!-- #no-linear: fake -->\n",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("HTML comment cannot link", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "Summary\n\n<!-- Related to ENG-99 -->\n",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("code fence cannot link", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      body: "```\nRelated to ENG-99\n```\n",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("#trivial is not an exemption", () => {
+    const r = evaluateLinearLink({ ...base, body: "#trivial\n" });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("bare #no-linear without reason fails", () => {
+    const r = evaluateLinearLink({ ...base, body: "#no-linear\n" });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("darkmatter[bot] not exempt", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      authorLogin: "darkmatter[bot]",
+      title: "feat: agent change",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+
+  test("skip ENG-1 suppresses title link", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      title: "feat (ENG-1)",
+      body: "skip ENG-1",
+    });
+    expect(r.policySatisfied).toBe(false);
+    expect(r.skippedIds).toContain("ENG-1");
+  });
+
+  test("ignore ENG-1 suppresses branch link", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      branch: "eng-1-fix",
+      body: "ignore ENG-1",
+    });
+    expect(r.policySatisfied).toBe(false);
+  });
+});
+
+describe("evaluateLinearLink — draft soft path", () => {
+  test("draft missing link: not policy-satisfied but ciAllowed", () => {
+    const r = evaluateLinearLink({ ...base, isDraft: true });
+    expect(r.policySatisfied).toBe(false);
+    expect(r.ciAllowed).toBe(true);
+    expect(r.softDraft).toBe(true);
+  });
+
+  test("non-draft WIP title missing link fails", () => {
+    const r = evaluateLinearLink({
+      ...base,
+      title: "WIP: experiment",
+      isDraft: false,
+    });
+    expect(r.policySatisfied).toBe(false);
+    expect(r.ciAllowed).toBe(false);
+  });
+});

--- a/scripts/linear-pr-link/matcher.ts
+++ b/scripts/linear-pr-link/matcher.ts
@@ -142,10 +142,16 @@ export function evaluateLinearLink(input: LinearLinkInput): LinearLinkResult {
     // fall through; still may have a real link
   }
 
-  const skippedIds = uniqueIds(findAll(UNLINK_RE, bodyVisible, normalizeUnlink));
-  const titleIds = uniqueIds(findAll(CANONICAL_ID_RE, title, normalizeCanonical));
+  const skippedIds = uniqueIds(
+    findAll(UNLINK_RE, bodyVisible, normalizeUnlink),
+  );
+  const titleIds = uniqueIds(
+    findAll(CANONICAL_ID_RE, title, normalizeCanonical),
+  );
   const branchIds = uniqueIds(findBranchIds(branch));
-  const bodyMagicIds = uniqueIds(findAll(MAGIC_LINK_RE, bodyVisible, normalizeMagic));
+  const bodyMagicIds = uniqueIds(
+    findAll(MAGIC_LINK_RE, bodyVisible, normalizeMagic),
+  );
 
   const linked = uniqueIds([...titleIds, ...branchIds, ...bodyMagicIds]).filter(
     (id) => !skippedIds.includes(id),
@@ -195,12 +201,39 @@ function failResult(
   };
 }
 
-/** Strip HTML comments and fenced code blocks so templates/snippets cannot satisfy the gate. */
+/** Strip hidden/code Markdown so templates and examples cannot satisfy the gate. */
 export function stripNonPolicyText(text: string): string {
-  return text
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/```[\s\S]*?```/g, "")
-    .replace(/~~~[\s\S]*?~~~/g, "");
+  const withoutBlocks = text
+    .replace(/<!--[\s\S]*?(?:-->|$)/g, "")
+    .replace(/```[\s\S]*?(?:```|$)/g, "")
+    .replace(/~~~[\s\S]*?(?:~~~|$)/g, "");
+  return stripInlineCodeSpans(withoutBlocks);
+}
+
+function stripInlineCodeSpans(text: string): string {
+  let visible = "";
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const opener = text.indexOf("`", cursor);
+    if (opener === -1) {
+      return visible + text.slice(cursor);
+    }
+    visible += text.slice(cursor, opener);
+
+    let delimiterEnd = opener;
+    while (text[delimiterEnd] === "`") {
+      delimiterEnd += 1;
+    }
+    const delimiter = text.slice(opener, delimiterEnd);
+    const closer = text.indexOf(delimiter, delimiterEnd);
+    if (closer === -1) {
+      return visible;
+    }
+    cursor = closer + delimiter.length;
+  }
+
+  return visible;
 }
 
 export function parseExemption(bodyVisible: string): string | null {

--- a/scripts/linear-pr-link/matcher.ts
+++ b/scripts/linear-pr-link/matcher.ts
@@ -67,14 +67,17 @@ const BRANCH_ID_RE = new RegExp(
 const MAGIC_WORD_ALT = MAGIC_WORDS.map(escapeRegExp).join("|");
 const UNLINK_WORD_ALT = UNLINK_WORDS.map(escapeRegExp).join("|");
 
-/** Magic word + canonical ID, or magic word + linear.app URL containing the ID. */
+/**
+ * Magic word + canonical ID, or magic word + linear.app URL containing the ID.
+ * Separator is horizontal whitespace only — IDs on a later line do not count.
+ */
 const MAGIC_LINK_RE = new RegExp(
-  `\\b(?:${MAGIC_WORD_ALT})\\s+(?:(?:${TEAM_ALT})-(\\d+)|https?://linear\\.app/[^\\s]*?/(?:issue|issues)/(?:${TEAM_ALT})-(\\d+)(?:\\b|/|\\?))`,
+  `\\b(?:${MAGIC_WORD_ALT})[ \\t]+(?:(?:${TEAM_ALT})-(\\d+)|https?://linear\\.app/[^\\s\\n]*?/(?:issue|issues)/(?:${TEAM_ALT})-(\\d+)(?:\\b|/|\\?))`,
   "gi",
 );
 
 const UNLINK_RE = new RegExp(
-  `\\b(?:${UNLINK_WORD_ALT})\\s+(?:${TEAM_ALT})-(\\d+)\\b`,
+  `\\b(?:${UNLINK_WORD_ALT})[ \\t]+(?:${TEAM_ALT})-(\\d+)\\b`,
   "gi",
 );
 

--- a/scripts/linear-pr-link/matcher.ts
+++ b/scripts/linear-pr-link/matcher.ts
@@ -1,0 +1,291 @@
+/**
+ * Shared Linear ↔ PR link policy for nixmac.
+ *
+ * Contract for agents / PR-create tools:
+ * - Pass a Linear issue id (ENG-N / LAB-N) or an explicit `#no-linear: <reason>`
+ * - Prefer body line: `Related to ENG-N` (non-closing) and title suffix `(ENG-N)`
+ *
+ * Used by Danger and the `linear-pr-link` GitHub Action.
+ */
+
+export const ALLOWED_TEAMS = ["ENG", "LAB"] as const;
+export type AllowedTeam = (typeof ALLOWED_TEAMS)[number];
+
+export const EXEMPT_BOT_LOGINS = new Set(["dependabot[bot]", "renovate[bot]"]);
+
+/** Linear magic words that attach a PR to an issue (closing + non-closing). */
+const MAGIC_WORDS = [
+  "close",
+  "closes",
+  "closed",
+  "closing",
+  "fix",
+  "fixes",
+  "fixed",
+  "fixing",
+  "resolve",
+  "resolves",
+  "resolved",
+  "resolving",
+  "complete",
+  "completes",
+  "completed",
+  "completing",
+  "implement",
+  "implements",
+  "implemented",
+  "implementing",
+  "ref",
+  "refs",
+  "references",
+  "part of",
+  "related to",
+  "relates to",
+  "contributes to",
+  "toward",
+  "towards",
+  "linear issue",
+] as const;
+
+/** Words that tell Linear *not* to link even if branch/title mention the ID. */
+const UNLINK_WORDS = ["skip", "ignore"] as const;
+
+const TEAM_ALT = ALLOWED_TEAMS.join("|");
+
+/** Canonical ID: ENG-123 / LAB-456 */
+const CANONICAL_ID_RE = new RegExp(`\\b(?:${TEAM_ALT})-(\\d+)\\b`, "gi");
+
+/**
+ * Branch forms used in the wild: eng-494, eng_494, eng490 (no separator).
+ * Captures team + number for normalization to TEAM-N.
+ */
+const BRANCH_ID_RE = new RegExp(
+  `(?:^|[^A-Za-z0-9])(?:${TEAM_ALT})[-_]?(\\d+)\\b`,
+  "gi",
+);
+
+const MAGIC_WORD_ALT = MAGIC_WORDS.map(escapeRegExp).join("|");
+const UNLINK_WORD_ALT = UNLINK_WORDS.map(escapeRegExp).join("|");
+
+/** Magic word + canonical ID, or magic word + linear.app URL containing the ID. */
+const MAGIC_LINK_RE = new RegExp(
+  `\\b(?:${MAGIC_WORD_ALT})\\s+(?:(?:${TEAM_ALT})-(\\d+)|https?://linear\\.app/[^\\s]*?/(?:issue|issues)/(?:${TEAM_ALT})-(\\d+)(?:\\b|/|\\?))`,
+  "gi",
+);
+
+const UNLINK_RE = new RegExp(
+  `\\b(?:${UNLINK_WORD_ALT})\\s+(?:${TEAM_ALT})-(\\d+)\\b`,
+  "gi",
+);
+
+/** Same-line exemption: `#no-linear: reason` — spaces/tabs only after colon (no newlines). */
+const EXEMPTION_LINE_RE = /^[^\S\n]*#no-linear:[ \t]*(\S[^\n]*)$/im;
+
+export type LinearLinkInput = {
+  title: string;
+  body: string;
+  branch: string;
+  authorLogin?: string;
+  isDraft?: boolean;
+};
+
+export type LinearLinkResult = {
+  /** Policy satisfied (linked, exempt bot, or reasoned exemption). */
+  policySatisfied: boolean;
+  /** CI / required-check may pass (policy satisfied OR draft soft path). */
+  ciAllowed: boolean;
+  /** Draft missing link — Danger should warn; Action succeeds. */
+  softDraft: boolean;
+  reason: string;
+  matchedIds: string[];
+  skippedIds: string[];
+  exemption: string | null;
+};
+
+export function evaluateLinearLink(input: LinearLinkInput): LinearLinkResult {
+  const title = input.title ?? "";
+  const branch = input.branch ?? "";
+  const authorLogin = input.authorLogin ?? "";
+  const isDraft = input.isDraft === true;
+  const bodyVisible = stripNonPolicyText(input.body ?? "");
+
+  if (EXEMPT_BOT_LOGINS.has(authorLogin)) {
+    return {
+      policySatisfied: true,
+      ciAllowed: true,
+      softDraft: false,
+      reason: `Exempt bot author \`${authorLogin}\``,
+      matchedIds: [],
+      skippedIds: [],
+      exemption: null,
+    };
+  }
+
+  const exemption = parseExemption(bodyVisible);
+  if (exemption) {
+    return {
+      policySatisfied: true,
+      ciAllowed: true,
+      softDraft: false,
+      reason: `Exempt via #no-linear: ${exemption}`,
+      matchedIds: [],
+      skippedIds: [],
+      exemption,
+    };
+  }
+
+  // Bare `#no-linear` without reason — not exempt
+  if (/#no-linear\b/i.test(bodyVisible) && !exemption) {
+    // fall through; still may have a real link
+  }
+
+  const skippedIds = uniqueIds(findAll(UNLINK_RE, bodyVisible, normalizeUnlink));
+  const titleIds = uniqueIds(findAll(CANONICAL_ID_RE, title, normalizeCanonical));
+  const branchIds = uniqueIds(findBranchIds(branch));
+  const bodyMagicIds = uniqueIds(findAll(MAGIC_LINK_RE, bodyVisible, normalizeMagic));
+
+  const linked = uniqueIds([...titleIds, ...branchIds, ...bodyMagicIds]).filter(
+    (id) => !skippedIds.includes(id),
+  );
+
+  if (linked.length > 0) {
+    return {
+      policySatisfied: true,
+      ciAllowed: true,
+      softDraft: false,
+      reason: `Linked via ${linked.join(", ")}`,
+      matchedIds: linked,
+      skippedIds,
+      exemption: null,
+    };
+  }
+
+  if (skippedIds.length > 0 && titleIds.length + branchIds.length > 0) {
+    // Explicit skip/ignore of the only IDs present
+    const msg =
+      `Linear link suppressed by skip/ignore for ${skippedIds.join(", ")}. ` +
+      `Add a different issue ref or \`#no-linear: <reason>\`.`;
+    return failResult(msg, [], skippedIds, isDraft);
+  }
+
+  const msg =
+    "No Linear issue reference found. Add `ENG-123` (or `LAB-123`) to the PR title or branch, " +
+    "or a magic-word line in the body such as `Related to ENG-123`, " +
+    "or `#no-linear: <reason>` if intentionally untracked.";
+  return failResult(msg, [], skippedIds, isDraft);
+}
+
+function failResult(
+  reason: string,
+  matchedIds: string[],
+  skippedIds: string[],
+  isDraft: boolean,
+): LinearLinkResult {
+  return {
+    policySatisfied: false,
+    ciAllowed: isDraft,
+    softDraft: isDraft,
+    reason,
+    matchedIds,
+    skippedIds,
+    exemption: null,
+  };
+}
+
+/** Strip HTML comments and fenced code blocks so templates/snippets cannot satisfy the gate. */
+export function stripNonPolicyText(text: string): string {
+  return text
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/~~~[\s\S]*?~~~/g, "");
+}
+
+export function parseExemption(bodyVisible: string): string | null {
+  const m = bodyVisible.match(EXEMPTION_LINE_RE);
+  if (!m) {
+    return null;
+  }
+  const reason = m[1]?.trim() ?? "";
+  // Reject pure placeholders
+  if (!reason || /^<?reason>?$/i.test(reason) || /^_+$/.test(reason)) {
+    return null;
+  }
+  return reason;
+}
+
+function findBranchIds(branch: string): string[] {
+  const out: string[] = [];
+  const re = new RegExp(BRANCH_ID_RE.source, "gi");
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(branch)) !== null) {
+    // m[0] includes possible leading separator; re-parse team from match
+    const chunk = m[0].replace(/^[^A-Za-z]+/, "");
+    const parts = chunk.match(new RegExp(`^(${TEAM_ALT})[-_]?(\\d+)$`, "i"));
+    if (parts) {
+      out.push(`${parts[1].toUpperCase()}-${parts[2]}`);
+    }
+  }
+  return out;
+}
+
+function findAll(
+  re: RegExp,
+  text: string,
+  normalize: (m: RegExpExecArray) => string | null,
+): string[] {
+  const out: string[] = [];
+  const flags = re.flags.includes("g") ? re.flags : `${re.flags}g`;
+  const local = new RegExp(re.source, flags);
+  let m: RegExpExecArray | null;
+  while ((m = local.exec(text)) !== null) {
+    const id = normalize(m);
+    if (id) {
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+function normalizeCanonical(m: RegExpExecArray): string | null {
+  const full = m[0];
+  const num = m[1];
+  const team = full.split("-")[0]?.toUpperCase();
+  if (!team || !num || !isAllowedTeam(team)) {
+    return null;
+  }
+  return `${team}-${num}`;
+}
+
+function normalizeMagic(m: RegExpExecArray): string | null {
+  const num = m[1] ?? m[2];
+  if (!num) {
+    return null;
+  }
+  // Recover team from full match
+  const teamMatch = m[0].match(new RegExp(`(?:${TEAM_ALT})-(\\d+)`, "i"));
+  if (!teamMatch) {
+    return null;
+  }
+  return `${teamMatch[0].split("-")[0].toUpperCase()}-${teamMatch[1]}`;
+}
+
+function normalizeUnlink(m: RegExpExecArray): string | null {
+  const num = m[1];
+  const teamMatch = m[0].match(new RegExp(`(?:${TEAM_ALT})-(\\d+)`, "i"));
+  if (!teamMatch || !num) {
+    return null;
+  }
+  return `${teamMatch[0].split("-")[0].toUpperCase()}-${num}`;
+}
+
+function isAllowedTeam(team: string): boolean {
+  return (ALLOWED_TEAMS as readonly string[]).includes(team.toUpperCase());
+}
+
+function uniqueIds(ids: string[]): string[] {
+  return [...new Set(ids)];
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/linear-pr-link/matcher.ts
+++ b/scripts/linear-pr-link/matcher.ts
@@ -205,8 +205,11 @@ function failResult(
 export function stripNonPolicyText(text: string): string {
   const withoutBlocks = text
     .replace(/<!--[\s\S]*?(?:-->|$)/g, "")
+    .replace(/<code\b[^>]*>[\s\S]*?(?:<\/code\s*>|$)/gi, "\n")
+    .replace(/<pre\b[^>]*>[\s\S]*?(?:<\/pre\s*>|$)/gi, "\n")
     .replace(/```[\s\S]*?(?:```|$)/g, "")
-    .replace(/~~~[\s\S]*?(?:~~~|$)/g, "");
+    .replace(/~~~[\s\S]*?(?:~~~|$)/g, "")
+    .replace(/^(?: {4,}| {0,3}\t).*$/gm, "");
   return stripInlineCodeSpans(withoutBlocks);
 }
 


### PR DESCRIPTION
## Summary

Implements the Linear ↔ PR link gate Cooper asked for:

- **Shared policy** in `scripts/linear-pr-link/matcher.ts` (title / branch / magic-word body; `ENG`+`LAB`; `#no-linear: reason`; dependabot/renovate exempt)
- **Lightweight Action** `linear-pr-link` (ubuntu, no ARC/Nix) on `pull_request` + `merge_group`
- **Danger** uses the same matcher: **fail** on ready PRs, **warn** on true drafts
- **PR template** defaults to `Related to ENG-___`

## Linear

#no-linear: process hygiene — org Linear↔PR gate from Cooper DM (no dedicated ENG ticket)

## Test Plan

- [x] `bun test scripts/linear-pr-link/matcher.test.ts` (35 cases)
- [x] CLI smoke: fail missing / pass title / draft soft / `#no-linear: reason`
- [ ] Confirm `linear-pr-link` check appears green on this PR
- [ ] After green: add `linear-pr-link` to ruleset 15037341 required checks (follow-up — not in this PR to avoid cold-flip)

## Docs

- [x] No docs update needed

## Follow-up (not in this PR)

1. Observe check context name on this PR
2. Snapshot ruleset → add required `linear-pr-link` → verify
3. Backfill other open ready PRs missing links
4. Wire agent PR-create paths to stamp `Related to ENG-N`