### PR TITLE
feat(helper)!: single-slot state machine and frozen control surface

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,6 +88,9 @@ jobs:
         run: cargo test --manifest-path src-tauri/Cargo.toml
         env:
           NIXMAC_ENV: production
+          # Packaged builds hard-fail without the packaged source revision
+          # (build.rs embeds it as the build identity).
+          NIXMAC_BUILD_ID: ${{ github.sha }}
   build:
     needs: rust-tests
     runs-on: [self-hosted, macOS]
@@ -170,6 +173,26 @@ jobs:
         run: cargo clippy --workspace --all-targets --features nixmac/codegen -- -D warnings
         env:
           NIXMAC_ENV: production
+          # Packaged builds hard-fail without the packaged source revision.
+          NIXMAC_BUILD_ID: ${{ github.sha }}
+
+      # Same test set as the Linux `rust-tests` job, run again here because a
+      # large share of this crate's behavioral coverage is
+      # `cfg(target_os = "macos")` and compiles away to nothing on Linux — the
+      # privileged helper's socket serving, peer authentication, and launchd
+      # paths among it. Without this step CI can be green while none of it has
+      # ever executed.
+      #
+      # Placed with clippy: after the toolchain and passkey patch are in place,
+      # before the sccache setup and the expensive release build, so a failure
+      # is fast and cheap. `NIXMAC_ENV`/`NIXMAC_BUILD_ID` match the clippy and
+      # build steps — build.rs reruns on those, so a different value here would
+      # force a rebuild of everything that follows.
+      - name: Rust unit tests (macOS)
+        run: cargo test -p nixmac
+        env:
+          NIXMAC_ENV: production
+          NIXMAC_BUILD_ID: ${{ github.sha }}
 
       # Decide what kind of build this is:
       #   - tag:     push of refs/tags/v* → ship that exact version on stable
@@ -252,6 +275,9 @@ jobs:
           # Pass DSNs and build metadata into the tauri action step so build.rs can read them
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           NIXMAC_ENV: production
+          # Build identity compiled into the GUI, helper, and sync agent; the
+          # sidecar build inherits it through the environment.
+          NIXMAC_BUILD_ID: ${{ github.sha }}
           NIXMAC_VERSION: ${{ steps.sync-version.outputs.build_version }}
           VITE_SERVER_URL: ${{ secrets.VITE_SERVER_URL }}
           SUBMITTED_FEEDBACK_DSN: ${{ secrets.SUBMITTED_FEEDBACK_DSN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,6 +3711,7 @@ dependencies = [
  "log",
  "nix",
  "objc",
+ "objc2-security",
  "once_cell",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -4064,6 +4065,16 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/apps/native/scripts/build-tauri-sidecars.mjs
+++ b/apps/native/scripts/build-tauri-sidecars.mjs
@@ -16,6 +16,9 @@ const tauriConf = JSON.parse(
   await readFile(path.join(root, "src-tauri", "tauri.conf.json"), "utf8"),
 );
 const minimumSystemVersion = tauriConf.bundle?.macOS?.minimumSystemVersion;
+// execa extends process.env by default, so NIXMAC_ENV and NIXMAC_BUILD_ID
+// reach build.rs unchanged: the helper and sync agent must compile in the same
+// build identity as the GUI built from this environment.
 const cargoEnv =
   process.platform === "darwin" && minimumSystemVersion
     ? { MACOSX_DEPLOYMENT_TARGET: minimumSystemVersion }

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -139,6 +139,22 @@ window-vibrancy = "0.6"
 core-foundation = "0.10"
 security-framework = "3"
 nix = { version = "0.31", features = ["socket", "user"] }
+# Named `errSecCS*` / `errSecCertificate*` / `CSSMERR_TP_*` status values,
+# generated from the Security.framework headers, for the privileged-helper peer
+# auth status table. A name that does not exist fails the build, where a
+# hand-transcribed number was silently wrong — and a wrong number there can
+# classify a peer nobody could judge as invalid, which authorizes removal.
+#
+# macOS-gated because it cannot build off Apple: 0.3.2 declares `mod generated`
+# with no cfg and an unconditional `#[link(name = "Security", kind =
+# "framework")]`, which rustc rejects with E0455 on other targets. The status
+# table it feeds is therefore macOS-only too, and so are that table's tests —
+# they run on the macOS runner, which executes `cargo test` alongside clippy.
+objc2-security = { version = "0.3.2", default-features = false, features = [
+  "CSCommon",
+  "SecBase",
+  "cssmerr",
+] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["user"] }

--- a/apps/native/src-tauri/build.rs
+++ b/apps/native/src-tauri/build.rs
@@ -3,6 +3,11 @@ mod env_keys {
     include!("src/env_keys.rs");
 }
 
+mod build_id {
+    #![allow(dead_code)]
+    include!("src/build_id.rs");
+}
+
 use std::path::Path;
 use std::process::Command;
 
@@ -88,6 +93,24 @@ fn embed_signing_team_id() {
     }
 }
 
+/// Embed the build identity (`NIXMAC_BUILD_ID`, supplied by CI from the
+/// packaged source revision) into every target of this crate — the GUI, the
+/// helper, and the sync agent. Packaged builds (`NIXMAC_ENV` = `production`)
+/// hard-fail on a missing or empty value; development builds fall back to a
+/// fixed literal. Git is deliberately never run here: the value must describe
+/// the packaged source, which only the build orchestrator knows.
+fn embed_build_id() {
+    println!("cargo:rerun-if-env-changed=NIXMAC_BUILD_ID");
+    println!("cargo:rerun-if-env-changed=NIXMAC_ENV");
+
+    let packaged = matches!(std::env::var("NIXMAC_ENV").as_deref(), Ok("production"));
+    let raw = std::env::var("NIXMAC_BUILD_ID").ok();
+    match build_id::resolve_build_id(raw.as_deref(), packaged) {
+        Ok(build_id) => println!("cargo:rustc-env=NIXMAC_BUILD_ID={build_id}"),
+        Err(error) => panic!("{error}"),
+    }
+}
+
 fn add_debug_swift_runtime_rpaths() {
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos")
         || std::env::var("PROFILE").as_deref() != Ok("debug")
@@ -127,6 +150,7 @@ fn add_debug_swift_runtime_rpaths() {
 fn main() {
     embed_build_profile();
     embed_signing_team_id();
+    embed_build_id();
     add_debug_swift_runtime_rpaths();
 
     // Set up passthrough for relevant environment variables.

--- a/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
+++ b/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
@@ -40,17 +40,79 @@ mod out_link {
     ));
 }
 
+use privileged_helper::client::{HelperClientError, HelperExchange};
+use privileged_helper::protocol::{ActivationResult, HelperReply};
+
+/// Every line this agent writes, stamped with the local time and sent to
+/// stderr, so a run's verdict sits next to the detail behind it — and next to
+/// the `nix build` output, which the child also writes to stderr — in the
+/// order it happened. The stamp is what tells one scheduled run from the next
+/// in a log that accumulates across runs.
+macro_rules! note {
+    ($($arg:tt)*) => {
+        eprintln!(
+            "[{}] nixmac-sync-agent: {}",
+            chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            format_args!($($arg)*)
+        )
+    };
+}
+
 fn main() {
     if let Err(error) = run_once() {
-        eprintln!("nixmac-sync-agent failed: {error:#}");
+        note!("run failed: {error:#}");
         std::process::exit(1);
+    }
+}
+
+/// What one `TryActivate` dispatch means for this run. The agent is an
+/// ordinary exact-build protocol client with no lifecycle role: a delivered
+/// result ends the run normally, and every obstacle defers activation to the
+/// next scheduled run — never a retry, never `Retire`, never the password
+/// path, and never a nonzero exit (the agent plist sets
+/// `KeepAlive.SuccessfulExit = false`, so a nonzero exit would trip the
+/// launchd restart loop instead of waiting for the next interval).
+enum DispatchOutcome {
+    /// Delivered success: activation set the durable system-profile GC
+    /// root, so the out-link can be cleaned up.
+    Activated(ActivationResult),
+    /// Delivered failure: reported, out-link kept (it GC-roots the built
+    /// closure for the next attempt), clean exit.
+    ActivationFailed(ActivationResult),
+    /// Any obstacle — `Busy`, `Retired`, a typed refusal, a helper that
+    /// fails authentication, an unreachable helper, an unparseable reply, a
+    /// lost connection: out-link kept, run reported as activation-deferred,
+    /// clean exit. The next scheduled run is a fresh request.
+    Deferred(String),
+}
+
+impl DispatchOutcome {
+    /// Whether this run may release the out-link. Only a delivered success
+    /// may: activation has set the durable system-profile GC root by then.
+    /// Every other outcome keeps it, because it GC-roots the built closure
+    /// for the next scheduled run's attempt.
+    fn releases_out_link(&self) -> bool {
+        matches!(self, DispatchOutcome::Activated(_))
+    }
+}
+
+fn classify_dispatch(outcome: Result<HelperExchange, HelperClientError>) -> DispatchOutcome {
+    match outcome {
+        Ok(exchange) => match exchange.reply {
+            HelperReply::ActivationResult(result) if result.ok => {
+                DispatchOutcome::Activated(result)
+            }
+            HelperReply::ActivationResult(result) => DispatchOutcome::ActivationFailed(result),
+            reply => DispatchOutcome::Deferred(reply.summary()),
+        },
+        Err(error) => DispatchOutcome::Deferred(error.to_string()),
     }
 }
 
 fn run_once() -> anyhow::Result<()> {
     let Some(config_dir) = non_empty_env("NIXMAC_SYNC_CONFIG_DIR") else {
-        verify_helper_ready();
-        println!("nixmac-sync-agent: no NIXMAC_SYNC_CONFIG_DIR configured; readiness probe only");
+        report_helper_socket();
+        note!("no NIXMAC_SYNC_CONFIG_DIR configured; nothing to do");
         return Ok(());
     };
     let host_attr = std::env::var("NIXMAC_SYNC_HOST_ATTR")
@@ -85,52 +147,60 @@ fn run_once() -> anyhow::Result<()> {
         // Build-only mode keeps nothing pinned: the goal is warming the store,
         // not rooting a closure that may never be activated.
         out_link::cleanup_out_link(&link);
-        println!("nixmac-sync-agent: build completed; unattended activation disabled");
+        note!("build completed; unattended activation disabled");
         return Ok(());
     }
 
     let activate_path = store_path.join("activate");
     let request = privileged_helper::protocol::activation_request(&activate_path)?;
-    let response = privileged_helper::client::activate_store_path(&request)?;
-    if !response.ok {
-        // Leave the out-link in place: it keeps the built closure GC-rooted
-        // for the next attempt, and that attempt's --out-link replaces it.
-        return Err(anyhow::anyhow!(
-            "activation failed ({}): {}",
-            response.code,
-            response.failure_detail()
-        ));
-    }
-    for warning in response.warnings() {
-        eprintln!("nixmac-sync-agent: {warning}");
+    let outcome = classify_dispatch(privileged_helper::client::activate_store_path(&request));
+
+    // One place decides the out-link's fate, so no reporting branch can
+    // release it by accident.
+    if outcome.releases_out_link() {
+        // Activation set the durable system-profile GC root, so the out-link
+        // is no longer needed. Also clear the `result` link older nixmac
+        // versions left in the config dir.
+        out_link::cleanup_out_link(&link);
+        out_link::remove_legacy_result_link(&config_dir);
     }
 
-    // Activation set the durable system-profile GC root, so the out-link is
-    // no longer needed. Also clear the `result` link older nixmac versions
-    // left in the config dir.
-    out_link::cleanup_out_link(&link);
-    out_link::remove_legacy_result_link(&config_dir);
-
-    println!("nixmac-sync-agent: build and activation completed");
+    match outcome {
+        DispatchOutcome::Activated(result) => {
+            for warning in result.warnings() {
+                note!("{warning}");
+            }
+            note!("build and activation completed");
+        }
+        DispatchOutcome::ActivationFailed(result) => {
+            note!(
+                "activation failed ({}): {}",
+                result.code,
+                result.failure_detail()
+            );
+            note!("build completed; activation failed");
+        }
+        DispatchOutcome::Deferred(reason) => {
+            note!("activation deferred until the next scheduled run: {reason}");
+            note!("build completed; activation deferred");
+        }
+    }
+    // Every dispatch outcome ends the run normally: the agent plist sets
+    // `KeepAlive.SuccessfulExit = false`, so a nonzero exit here would trip
+    // the launchd restart loop instead of waiting for the next interval.
     Ok(())
 }
 
-fn verify_helper_ready() {
-    match privileged_helper::client::status() {
-        Ok(response) if response.ok => {
-            println!("nixmac-sync-agent: helper ready");
-        }
-        Ok(response) => {
-            eprintln!(
-                "nixmac-sync-agent: helper unhealthy: {}",
-                response.failure_detail()
-            );
-            std::process::exit(2);
-        }
-        Err(error) => {
-            eprintln!("nixmac-sync-agent: helper unavailable: {error:#}");
-            std::process::exit(1);
-        }
+/// Diagnostic-only note for the mode with no sync config set. The agent may
+/// only send `TryActivate` — asking the helper what it is belongs to the GUI —
+/// so this reports the socket's presence and nothing more. It gates nothing,
+/// and it never fails the run: a nonzero exit here would trip the launchd
+/// restart loop.
+fn report_helper_socket() {
+    if privileged_helper::client::socket_available() {
+        note!("privileged helper socket present");
+    } else {
+        note!("privileged helper socket absent");
     }
 }
 
@@ -165,4 +235,106 @@ fn run_command_in_dir(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privileged_helper::protocol::{ActivationInfo, HelperStateName};
+
+    fn exchange(reply: HelperReply) -> Result<HelperExchange, HelperClientError> {
+        let (connection, _other_end) = std::os::unix::net::UnixStream::pair().expect("socketpair");
+        Ok(HelperExchange { reply, connection })
+    }
+
+    fn activation_info() -> ActivationInfo {
+        ActivationInfo {
+            request_id: "req-1".to_string(),
+            script_path: "/nix/store/abc-darwin-system/activate".to_string(),
+            client_kind: privileged_helper::peer_auth::ClientKind::Gui,
+        }
+    }
+
+    #[test]
+    fn delivered_success_is_the_only_outcome_that_releases_the_out_link() {
+        let outcome =
+            classify_dispatch(exchange(HelperReply::ActivationResult(ActivationResult {
+                ok: true,
+                code: 0,
+                stdout: "activated".to_string(),
+                error: None,
+            })));
+
+        assert!(matches!(outcome, DispatchOutcome::Activated(_)));
+        assert!(outcome.releases_out_link());
+    }
+
+    #[test]
+    fn delivered_failure_is_reported_with_the_out_link_kept() {
+        // A delivered failure ends the run normally — reported, out-link
+        // kept, no restart-loop exit (run_once returns Ok on this path).
+        let outcome =
+            classify_dispatch(exchange(HelperReply::ActivationResult(ActivationResult {
+                ok: false,
+                code: 2,
+                stdout: "activation exploded".to_string(),
+                error: None,
+            })));
+
+        assert!(matches!(outcome, DispatchOutcome::ActivationFailed(_)));
+        assert!(!outcome.releases_out_link());
+    }
+
+    #[test]
+    fn every_obstacle_defers_and_keeps_the_out_link() {
+        // Busy, Retired, each typed refusal, an unreachable helper, a failed
+        // helper authentication, a closed connection, an ambiguous I/O
+        // failure, and an unparseable reply: all defer to the next scheduled
+        // run. run_once returns Ok on the deferred path, so each of these is
+        // also a clean (zero) exit — never a launchd restart loop.
+        let obstacles: Vec<Result<HelperExchange, HelperClientError>> = vec![
+            exchange(HelperReply::Busy {
+                activation: activation_info(),
+            }),
+            exchange(HelperReply::Retired {
+                activation: Some(activation_info()),
+            }),
+            exchange(HelperReply::Retired { activation: None }),
+            exchange(HelperReply::BuildMismatch {
+                helper_build_id: "build-b".to_string(),
+            }),
+            exchange(HelperReply::CallerNotPermitted),
+            exchange(HelperReply::RequestNotUnderstood),
+            // A Status reply to TryActivate would be nonsense — still defer.
+            exchange(HelperReply::Status {
+                state: HelperStateName::Idle,
+                helper_build_id: "build-b".to_string(),
+                activation: None,
+            }),
+            Err(HelperClientError::Unreachable(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no socket",
+            ))),
+            Err(HelperClientError::AuthenticationFailed(anyhow::anyhow!(
+                "not the signed helper"
+            ))),
+            Err(HelperClientError::ClosedBeforeReply),
+            Err(HelperClientError::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "read timed out",
+            ))),
+            Err(HelperClientError::UnparseableReply(
+                "unknown reply tag".to_string(),
+            )),
+        ];
+
+        for obstacle in obstacles {
+            let outcome = classify_dispatch(obstacle);
+            assert!(
+                matches!(outcome, DispatchOutcome::Deferred(_)),
+                "expected a deferral"
+            );
+            assert!(!outcome.releases_out_link());
+        }
+    }
 }

--- a/apps/native/src-tauri/src/build_id.rs
+++ b/apps/native/src-tauri/src/build_id.rs
@@ -1,0 +1,85 @@
+// Build identity, shared between `build.rs` (which resolves the
+// `NIXMAC_BUILD_ID` build input and embeds the result) and the crate (whose
+// tests pin the resolution table).
+//
+// The value exists only to identify a build. The GUI, the helper, and the sync
+// agent of one build compile in the same string, and two builds match only
+// when the strings are byte-equal. Packaged builds normally supply a Git
+// commit, but nothing here — or on the wire — requires or validates Git
+// syntax.
+
+/// Literal used when a development build (`NIXMAC_ENV` unset or anything but
+/// `production`) supplies no build ID. Development rebuilds therefore share one
+/// identity; developers swap helpers with the explicit Disable/Grant workflow.
+pub const DEVELOPMENT_BUILD_ID: &str = "development";
+
+/// Resolves the `NIXMAC_BUILD_ID` build input.
+///
+/// A supplied identifier is taken byte-for-byte — no trimming, parsing, length
+/// rule, or character validation — because equality is the only operation
+/// performed on it anywhere. What is enforced is that no binary silently
+/// embeds an empty ID: packaged builds (`NIXMAC_ENV` = `production`, not the
+/// cargo profile, which is `release` even for local sidecar builds) fail when
+/// the value is missing or empty, and development builds fall back to the one
+/// fixed [`DEVELOPMENT_BUILD_ID`] literal.
+pub fn resolve_build_id(raw: Option<&str>, packaged: bool) -> Result<String, String> {
+    match raw.filter(|value| !value.is_empty()) {
+        Some(value) => Ok(value.to_string()),
+        None if packaged => Err(
+            "NIXMAC_BUILD_ID must be a non-empty value for packaged builds (NIXMAC_ENV=production); CI supplies it from the packaged source revision"
+                .to_string(),
+        ),
+        None => Ok(DEVELOPMENT_BUILD_ID.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_supplied_build_id_is_embedded_byte_for_byte() {
+        // The protocol only ever compares these strings for equality, so no
+        // shape is rejected: a Git commit, an abbreviation, uppercase, and a
+        // value that is not a commit at all are all embedded unchanged.
+        for supplied in [
+            "0123456789abcdef0123456789abcdef01234567",
+            "0123456",
+            "0123456789ABCDEF0123456789ABCDEF01234567",
+            "not-a-commit",
+            " padded ",
+            "release-2026.07.31+1",
+        ] {
+            for packaged in [true, false] {
+                assert_eq!(
+                    resolve_build_id(Some(supplied), packaged).unwrap(),
+                    supplied,
+                    "packaged: {packaged}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_packaged_build_fails_without_a_build_id() {
+        // Never silently embed an empty identity into a shipped binary.
+        assert!(resolve_build_id(None, true).is_err());
+        assert!(resolve_build_id(Some(""), true).is_err());
+    }
+
+    #[test]
+    fn a_development_build_falls_back_to_the_fixed_literal() {
+        assert_eq!(resolve_build_id(None, false).unwrap(), DEVELOPMENT_BUILD_ID);
+        assert_eq!(
+            resolve_build_id(Some(""), false).unwrap(),
+            DEVELOPMENT_BUILD_ID
+        );
+    }
+
+    #[test]
+    fn the_development_fallback_is_never_empty() {
+        // An empty build ID would compare unequal to every peer's, including
+        // another binary of the same build.
+        assert!(!DEVELOPMENT_BUILD_ID.is_empty());
+    }
+}

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -11,6 +11,10 @@
 // are declared by their parent `mod.rs` files so rust-analyzer resolves them via Cargo.
 mod ai;
 mod bootstrap;
+// Consumed by `build.rs` via include!; declared here so its resolution table
+// stays under `cargo test`.
+#[allow(dead_code)]
+mod build_id;
 mod cli;
 mod commands;
 mod db;

--- a/apps/native/src-tauri/src/privileged_helper/client.rs
+++ b/apps/native/src-tauri/src/privileged_helper/client.rs
@@ -1,8 +1,7 @@
 use crate::privileged_helper::peer_auth;
 use crate::privileged_helper::protocol::{
-    ActivationRequest, HELPER_SOCKET_PATH, HelperOp, HelperRequest, HelperResponse,
+    ActivationRequest, BUILD_ID, HELPER_SOCKET_PATH, HelperReply, HelperRequest,
 };
-use anyhow::{Context, Result, bail};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::time::Duration;
@@ -12,45 +11,256 @@ const ACTIVATION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 /// Status probes back the permissions UI; a wedged helper must not stall a
 /// permissions refresh, so they get a short leash instead of CLIENT_TIMEOUT.
 const STATUS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+/// `Retire` is answered promptly in every state, so its leash only needs to
+/// absorb scheduling latency, never activation time.
+#[allow(dead_code)]
+const RETIRE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Why one exchange with the helper produced no usable reply. Typed so every
+/// caller decides from structure, never from display text. The
+/// close-before-reply case is its own variant because it means something
+/// specific: the helper (or whatever holds the socket) declined this client
+/// before speaking — every caller treats it as "stop and re-observe". A
+/// close *after* a reply is not an error at all; it is observed by whoever
+/// holds [`HelperExchange::connection`] open.
+#[derive(Debug, thiserror::Error)]
+pub enum HelperClientError {
+    /// The connection could not be established at all.
+    #[error("failed to connect to {HELPER_SOCKET_PATH}: {0}")]
+    Unreachable(std::io::Error),
+    /// Whatever answers the socket failed the helper signature validation
+    /// (or was not root); no request bytes were sent to it.
+    #[error("helper peer failed authentication: {0:#}")]
+    AuthenticationFailed(anyhow::Error),
+    /// The peer closed the connection before any reply. A conforming helper
+    /// uses this for pre-authentication refusal or a connection dropped at
+    /// capacity, but after a `TryActivate` write the client cannot exclude a
+    /// helper crash after dispatch; callers must treat that outcome as
+    /// unknown rather than automatically compensating.
+    #[error("the helper closed the connection before replying")]
+    ClosedBeforeReply,
+    /// The reply did not arrive or could not be read (timeout included);
+    /// ambiguous — the request may or may not have been acted on.
+    #[error("helper connection failed mid-exchange: {0}")]
+    Io(std::io::Error),
+    /// A reply arrived but does not parse as any known reply shape. Treated
+    /// as a refusal everywhere: do not activate, do not mutate.
+    #[error("the helper sent a reply this build cannot parse: {0}")]
+    UnparseableReply(String),
+}
+
+/// One completed request/reply exchange. The connection is handed back open:
+/// the helper never closes an authenticated connection, so a later peer-side
+/// close on it always means the helper process ended — the liveness signal
+/// the replacement flow's unregister step is built on. Dropping it closes
+/// the connection, which is what every current caller wants.
+#[derive(Debug)]
+pub struct HelperExchange {
+    pub reply: HelperReply,
+    #[allow(dead_code)]
+    pub connection: UnixStream,
+}
 
 pub fn socket_available() -> bool {
     std::path::Path::new(HELPER_SOCKET_PATH).exists()
 }
 
-fn request_with_timeout(request: &HelperRequest, timeout: Duration) -> Result<HelperResponse> {
-    let mut stream = UnixStream::connect(HELPER_SOCKET_PATH)
-        .with_context(|| format!("failed to connect to {HELPER_SOCKET_PATH}"))?;
-    stream.set_read_timeout(Some(timeout))?;
-    stream.set_write_timeout(Some(CLIENT_TIMEOUT))?;
+fn exchange(
+    request: &HelperRequest,
+    read_timeout: Duration,
+) -> Result<HelperExchange, HelperClientError> {
+    let stream = UnixStream::connect(HELPER_SOCKET_PATH).map_err(HelperClientError::Unreachable)?;
+    stream
+        .set_read_timeout(Some(read_timeout))
+        .map_err(HelperClientError::Io)?;
+    stream
+        .set_write_timeout(Some(CLIENT_TIMEOUT))
+        .map_err(HelperClientError::Io)?;
 
     // Reciprocal check: whatever answers on the socket must be the signed
     // root helper before this process sends it anything.
-    peer_auth::validate_helper_peer(&stream)?;
+    peer_auth::validate_helper_peer(&stream).map_err(HelperClientError::AuthenticationFailed)?;
 
-    let body = serde_json::to_vec(request)?;
-    stream.write_all(&body)?;
-    stream.write_all(b"\n")?;
-    stream.flush()?;
+    exchange_on(stream, request)
+}
 
-    let mut line = String::new();
-    BufReader::new(stream).read_line(&mut line)?;
-    if line.trim().is_empty() {
-        bail!("helper returned an empty response");
+/// The post-authentication half of one exchange: send exactly one request,
+/// read exactly one reply, hand the still-open connection back.
+fn exchange_on(
+    stream: UnixStream,
+    request: &HelperRequest,
+) -> Result<HelperExchange, HelperClientError> {
+    let mut line = request.encode();
+    line.push('\n');
+    // A write failure on a freshly closed connection is the helper declining
+    // this client before any bytes — the same signal as an empty read.
+    (&stream)
+        .write_all(line.as_bytes())
+        .and_then(|()| (&stream).flush())
+        .map_err(|error| match error.kind() {
+            std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset => {
+                HelperClientError::ClosedBeforeReply
+            }
+            _ => HelperClientError::Io(error),
+        })?;
+
+    let mut reply_line = String::new();
+    let bytes_read =
+        BufReader::new(&stream)
+            .read_line(&mut reply_line)
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::ConnectionReset => HelperClientError::ClosedBeforeReply,
+                _ => HelperClientError::Io(error),
+            })?;
+    // Nothing at all came back: the peer closed before replying. Every caller
+    // treats this as stop-and-re-observe — it is the same signal a helper at
+    // its connection cap sends, deliberately indistinguishable from an
+    // authentication refusal.
+    if bytes_read == 0 {
+        return Err(HelperClientError::ClosedBeforeReply);
     }
 
-    // The response's protocol version is checked before any of its fields
-    // are used; a missing or different version fails as a classified
-    // protocol skew for callers to act on.
-    HelperResponse::parse(&line)
+    let reply = HelperReply::parse(&reply_line)
+        .map_err(|error| HelperClientError::UnparseableReply(format!("{error:#}")))?;
+    Ok(HelperExchange {
+        reply,
+        connection: stream,
+    })
 }
 
-pub fn status() -> Result<HelperResponse> {
-    request_with_timeout(&HelperRequest::new(HelperOp::Status), STATUS_PROBE_TIMEOUT)
+/// Sends `Status`. GUI-only by protocol policy: the sync agent has no
+/// lifecycle role and the helper refuses every request from it but
+/// `TryActivate`.
+pub fn status() -> Result<HelperExchange, HelperClientError> {
+    exchange(&HelperRequest::Status, STATUS_PROBE_TIMEOUT)
 }
 
-/// Sends an activation envelope. `ActivationRequest` is only constructible
-/// through `protocol::activation_request`, so this entry point cannot be
-/// handed a status operation or a hand-assembled version.
-pub fn activate_store_path(request: &ActivationRequest) -> Result<HelperResponse> {
-    request_with_timeout(&request.0, ACTIVATION_TIMEOUT)
+/// Sends `Retire`. GUI-only by protocol policy, like [`status`]. Dead code
+/// until the GUI's helper-replacement reconciliation is wired up in a later
+/// change; it lives here now because this file owns the wire vocabulary.
+#[allow(dead_code)]
+pub fn retire() -> Result<HelperExchange, HelperClientError> {
+    exchange(&HelperRequest::Retire, RETIRE_TIMEOUT)
+}
+
+/// Dispatches `TryActivate`, stamped with this build's ID — the helper admits
+/// it only if that ID is exactly its own. `ActivationRequest` is only
+/// constructible through `protocol::activation_request`, so this entry point
+/// cannot be handed a hand-assembled body with a non-canonicalized target. The
+/// reply arrives on the same connection when the activation completes.
+pub fn activate_store_path(
+    request: &ActivationRequest,
+) -> Result<HelperExchange, HelperClientError> {
+    exchange(
+        &HelperRequest::TryActivate {
+            build_id: BUILD_ID.to_string(),
+            body: request.0.clone(),
+        },
+        ACTIVATION_TIMEOUT,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privileged_helper::protocol::HelperStateName;
+    use std::io::Read;
+
+    /// Runs `exchange_on` against a socketpair whose far end is driven by
+    /// `respond`, which receives the request line the client wrote.
+    fn exchange_against(
+        respond: impl FnOnce(String, UnixStream) + Send + 'static,
+    ) -> Result<HelperExchange, HelperClientError> {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let far_end = std::thread::spawn(move || {
+            let mut request = String::new();
+            {
+                let mut reader = BufReader::new(server.try_clone().expect("clone"));
+                reader.read_line(&mut request).expect("read request");
+            }
+            respond(request, server);
+        });
+        let result = exchange_on(client, &HelperRequest::Status);
+        far_end.join().expect("far end");
+        result
+    }
+
+    #[test]
+    fn a_reply_leaves_the_connection_open_for_the_caller_to_hold() {
+        // The connection comes back open: a later peer-side close on it is
+        // the liveness signal, so the exchange must not consume it.
+        // The far end is handed back through this channel so it stays alive
+        // past the assertions — otherwise the close under test would be the
+        // test harness's own.
+        let (far_end_keepalive, held) = std::sync::mpsc::channel();
+        let exchange = exchange_against(move |request, mut server| {
+            // `Status` is kind-only: it carries no build ID, because it is the
+            // request that has to work against a helper of any build.
+            assert_eq!(request, "{\"kind\":\"status\"}\n");
+            let reply = HelperReply::Status {
+                state: HelperStateName::Idle,
+                helper_build_id: BUILD_ID.to_string(),
+                activation: None,
+            };
+            server
+                .write_all(format!("{}\n", reply.encode()).as_bytes())
+                .expect("write reply");
+            far_end_keepalive.send(server).expect("hand back far end");
+        })
+        .expect("exchange succeeds");
+        let still_open = held.recv().expect("far end handed back");
+
+        assert!(matches!(exchange.reply, HelperReply::Status { .. }));
+        // Silence, not EOF: a zero-length read would mean the far end went
+        // away, which is precisely what the caller watches for later.
+        exchange
+            .connection
+            .set_read_timeout(Some(std::time::Duration::from_millis(100)))
+            .expect("set timeout");
+        let mut probe = [0u8; 1];
+        match (&exchange.connection).read(&mut probe) {
+            Ok(0) => panic!("the exchange consumed the connection"),
+            Ok(_) => panic!("unexpected bytes after the one reply"),
+            Err(error) => assert!(matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            )),
+        }
+
+        // Once the far end really goes away, the same read reports EOF —
+        // the liveness signal itself.
+        drop(still_open);
+        assert_eq!((&exchange.connection).read(&mut probe).expect("read"), 0);
+    }
+
+    #[test]
+    fn a_close_before_any_reply_is_its_own_typed_outcome() {
+        // Stop-and-re-observe: an authentication refusal and a helper at its
+        // connection cap are deliberately indistinguishable here, and neither
+        // is an ambiguous I/O failure.
+        let error = exchange_against(|_request, server| drop(server))
+            .expect_err("a close before any reply must not succeed");
+
+        assert!(matches!(error, HelperClientError::ClosedBeforeReply));
+    }
+
+    #[test]
+    fn a_reply_this_build_cannot_parse_is_a_typed_refusal_equivalent() {
+        // What a helper from a build predating these reply shapes answers
+        // with. It must never be mistaken for a state or a result.
+        for wire in [
+            r#"{"ok":true,"code":0,"stdout":"nixmac helper ready","error":null}"#,
+            r#"{"reply":"somethingNew"}"#,
+            "not json",
+        ] {
+            let error = exchange_against(move |_request, mut server| {
+                server
+                    .write_all(format!("{wire}\n").as_bytes())
+                    .expect("write reply");
+            })
+            .expect_err("an unparseable reply must not succeed");
+
+            assert!(matches!(error, HelperClientError::UnparseableReply(_)));
+        }
+    }
 }

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -1,7 +1,7 @@
-use crate::privileged_helper::peer_auth::{self, PeerIdentity};
+use crate::privileged_helper::peer_auth::{self, ClientKind, ClientValidation, PeerIdentity};
 use crate::privileged_helper::protocol::{
-    ActivateStorePathRequest, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HELPER_WARNING_PREFIX,
-    HelperOp, HelperRequest, HelperResponse, UNAUTHORIZED_CLIENT_ERROR,
+    ActivationInfo, ActivationResult, BUILD_ID, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH,
+    HELPER_WARNING_PREFIX, HelperReply, HelperRequest, HelperStateName, TryActivateBody,
     validate_canonical_activate_path,
 };
 use anyhow::{Context, Result, anyhow, bail};
@@ -11,9 +11,18 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
 
 /// Post-auth cap on the request line; real requests are well under 4 KiB.
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
+
+/// Hard cap on concurrently served connections. At capacity, the (cap+1)th
+/// connection is accepted and closed before authentication and before any
+/// protocol bytes — deliberately indistinguishable from the unauthenticated
+/// close, which every client already treats as "stop and re-observe". No
+/// frozen "at capacity" reply shape exists or may be added.
+pub(crate) const MAX_CONCURRENT_CONNECTIONS: usize = 4;
 
 /// Fixed PATH for the privileged activation: root-owned system and Nix
 /// profile directories only. The protocol has no field for a requester to
@@ -32,6 +41,412 @@ const STICKY_BIT: u32 = 0o1000;
 /// Sudoers rule older helpers created (and could leave behind on forced
 /// termination). No longer written; removed on startup if present.
 const LEGACY_SUDOERS_PATH: &str = "/etc/sudoers.d/nixmac-activate-helper";
+
+// ---------------------------------------------------------------------------
+// The single-slot state machine — the helper's one stateful center.
+// ---------------------------------------------------------------------------
+
+/// The four states, one per `HelperStateName`. Process-lifetime only — nothing
+/// here is persisted, so a relaunched helper starts `Idle`.
+#[derive(Debug, Clone)]
+enum SlotState {
+    Idle,
+    Activating(ActivationInfo),
+    /// X is still running and retirement is latched: this helper will never
+    /// start another activation.
+    Retiring(ActivationInfo),
+    /// No activation is running and this helper will never start another.
+    Retired,
+}
+
+impl SlotState {
+    fn name(&self) -> HelperStateName {
+        match self {
+            SlotState::Idle => HelperStateName::Idle,
+            SlotState::Activating(_) => HelperStateName::Activating,
+            SlotState::Retiring(_) => HelperStateName::Retiring,
+            SlotState::Retired => HelperStateName::Retired,
+        }
+    }
+
+    fn activation(&self) -> Option<ActivationInfo> {
+        match self {
+            SlotState::Activating(activation) | SlotState::Retiring(activation) => {
+                Some(activation.clone())
+            }
+            SlotState::Idle | SlotState::Retired => None,
+        }
+    }
+}
+
+/// The single slot: one activation at a time, and the only state this process
+/// keeps.
+///
+/// A private mutex guards the state, and each operation below is one bounded
+/// in-memory transition. The guard and the state itself never escape, and the
+/// lock is never held across activation, authentication, protocol encoding,
+/// socket I/O, reply writing, or any other external work — so `Status` and
+/// `Retire` stay prompt in every state, including while an activation runs.
+///
+/// There is deliberately no queue: a request that cannot be served now is
+/// refused with a typed reply, never parked.
+pub(crate) struct ActivationSlot {
+    state: Mutex<SlotState>,
+}
+
+impl ActivationSlot {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(SlotState::Idle),
+        }
+    }
+
+    /// Every mutation below is a whole-value assignment, so recovery from a
+    /// poisoned mutex still observes one of the four states.
+    fn lock(&self) -> std::sync::MutexGuard<'_, SlotState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// An owned view: the state's name and X, if one is running.
+    fn snapshot(&self) -> (HelperStateName, Option<ActivationInfo>) {
+        let state = self.lock();
+        (state.name(), state.activation())
+    }
+
+    fn status_reply(&self, helper_build_id: &str) -> HelperReply {
+        let (state, activation) = self.snapshot();
+        HelperReply::Status {
+            state,
+            helper_build_id: helper_build_id.to_string(),
+            activation,
+        }
+    }
+
+    /// The `Retire` transition. It takes effect before the reply that reports
+    /// it: a `Retired` reply is built only after the state is already
+    /// `Retired`, so no concurrent request can be admitted after it. During an
+    /// activation, retirement latches and the reply is `Busy(X)`.
+    fn retire(&self) -> HelperReply {
+        let mut state = self.lock();
+        match &*state {
+            SlotState::Idle => {
+                *state = SlotState::Retired;
+                HelperReply::Retired { activation: None }
+            }
+            SlotState::Activating(activation) => {
+                let activation = activation.clone();
+                *state = SlotState::Retiring(activation.clone());
+                HelperReply::Busy { activation }
+            }
+            // Already latched: X is still running, so still not safe to
+            // unregister.
+            SlotState::Retiring(activation) => HelperReply::Busy {
+                activation: activation.clone(),
+            },
+            SlotState::Retired => HelperReply::Retired { activation: None },
+        }
+    }
+
+    /// `TryActivate` admission: `Ok` carries the permit proving the state is
+    /// already `Activating(X)`; `Err` is the immediate state-derived refusal.
+    /// The decision and the transition are one atomic step serialized across
+    /// all connections. X's client kind is stamped from the helper's own
+    /// validation of the submitting client, never from the request body.
+    fn admit<'slot>(
+        &'slot self,
+        body: &TryActivateBody,
+        client_kind: ClientKind,
+    ) -> std::result::Result<ActivationPermit<'slot>, HelperReply> {
+        let mut state = self.lock();
+        match &*state {
+            SlotState::Idle => {
+                *state = SlotState::Activating(ActivationInfo {
+                    request_id: body.request_id.clone(),
+                    script_path: body.script_path.clone(),
+                    client_kind,
+                });
+                // The permit outlives this call; the lock does not.
+                drop(state);
+                Ok(ActivationPermit { slot: self })
+            }
+            SlotState::Activating(activation) => Err(HelperReply::Busy {
+                activation: activation.clone(),
+            }),
+            // The deliberate latched-state asymmetry: a retiring helper tells
+            // `TryActivate` it is (about to be) retired — permanent for this
+            // process — carrying X while it finishes.
+            SlotState::Retiring(activation) => Err(HelperReply::Retired {
+                activation: Some(activation.clone()),
+            }),
+            SlotState::Retired => Err(HelperReply::Retired { activation: None }),
+        }
+    }
+
+    /// Leaves `Activating`/`Retiring` when the admitted activation ends. Only
+    /// [`ActivationPermit`]'s drop calls this.
+    fn finish_activation(&self) {
+        let mut state = self.lock();
+        match &*state {
+            SlotState::Activating(_) => *state = SlotState::Idle,
+            // A latched retirement wins over the activation ending, unwinding
+            // included: the helper must not come back activatable after a
+            // `Retire` it already acknowledged.
+            SlotState::Retiring(_) => *state = SlotState::Retired,
+            SlotState::Idle | SlotState::Retired => {}
+        }
+    }
+}
+
+/// Proof that this request owns the single activation slot. It is constructed
+/// only by successful admission and guarantees the finish transition on every
+/// exit path, including unwind.
+struct ActivationPermit<'slot> {
+    slot: &'slot ActivationSlot,
+}
+
+impl ActivationPermit<'_> {
+    /// Consumes the permit — which destroys it, performing the transition —
+    /// and only then builds the reply reporting the activation's end. The
+    /// explicit `drop` is load-bearing: left implicit, `self` would fall out
+    /// of scope *after* the tail expression built the reply.
+    ///
+    /// Two separate things keep the contract's transition-before-the-reply,
+    /// and neither is the type system: this is the only place the helper
+    /// constructs an `ActivationResult` reply (`HelperReply` is an ordinary
+    /// public enum — keeping it the only place is a review rule), and the
+    /// permit is scoped to `serve_connection`'s activation arm, so its
+    /// destructor runs before any byte of the reply is written whatever that
+    /// arm does.
+    fn into_result_reply(self, result: ActivationResult) -> HelperReply {
+        drop(self);
+        HelperReply::ActivationResult(result)
+    }
+}
+
+impl Drop for ActivationPermit<'_> {
+    fn drop(&mut self) {
+        self.slot.finish_activation();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request handling.
+// ---------------------------------------------------------------------------
+
+enum RequestAction<'slot> {
+    /// Reply immediately; any state transition it reports already happened.
+    Reply(HelperReply),
+    /// Admitted: the slot is `Activating(X)`; the caller runs the
+    /// activation, lets the slot transition out of `Activating`, and only
+    /// then sends the result reply.
+    RunActivation {
+        body: TryActivateBody,
+        permit: ActivationPermit<'slot>,
+    },
+}
+
+/// Which requests each authenticated caller may make. The GUI owns the
+/// helper's lifecycle; the sync agent has none — it may only ask for an
+/// activation, and gets the frozen `CallerNotPermitted` refusal for anything
+/// else.
+fn caller_may_send(client_kind: ClientKind, request: &HelperRequest) -> bool {
+    match client_kind {
+        ClientKind::Gui => true,
+        ClientKind::SyncAgent => matches!(request, HelperRequest::TryActivate { .. }),
+    }
+}
+
+/// Decides one authenticated request, in this order: the request either parses
+/// completely or is not understood → the caller may or may not send it → a
+/// `TryActivate` build ID either equals this helper's or is a build mismatch →
+/// state-based reply. `Status` and `Retire` carry no build ID and are answered
+/// in every state.
+fn decide_request<'slot>(
+    slot: &'slot ActivationSlot,
+    client_kind: ClientKind,
+    helper_build_id: &str,
+    line: &str,
+) -> RequestAction<'slot> {
+    let Some(request) = HelperRequest::parse(line) else {
+        return RequestAction::Reply(HelperReply::RequestNotUnderstood);
+    };
+    if !caller_may_send(client_kind, &request) {
+        return RequestAction::Reply(HelperReply::CallerNotPermitted);
+    }
+    match request {
+        HelperRequest::Status => RequestAction::Reply(slot.status_reply(helper_build_id)),
+        HelperRequest::Retire => RequestAction::Reply(slot.retire()),
+        HelperRequest::TryActivate { build_id, body } => {
+            if build_id != helper_build_id {
+                return RequestAction::Reply(HelperReply::BuildMismatch {
+                    helper_build_id: helper_build_id.to_string(),
+                });
+            }
+            match slot.admit(&body, client_kind) {
+                Ok(permit) => RequestAction::RunActivation { body, permit },
+                Err(refusal) => RequestAction::Reply(refusal),
+            }
+        }
+    }
+}
+
+/// An authenticated connection's client: kernel-derived identity plus the
+/// pinned requirement that matched.
+pub(crate) struct AuthedClient {
+    pub(crate) identity: PeerIdentity,
+    pub(crate) kind: ClientKind,
+}
+
+type Authenticator = dyn Fn(&UnixStream) -> Option<AuthedClient> + Send + Sync;
+type ActivationRunner = dyn Fn(&AuthedClient, &TryActivateBody) -> ActivationResult + Send + Sync;
+
+/// Everything one daemon instance serves connections with. The slot is the
+/// only state; the closures are injection seams so the connection semantics
+/// are testable without a signed peer or a real activation.
+pub(crate) struct ServeConfig {
+    pub(crate) slot: ActivationSlot,
+    pub(crate) helper_build_id: String,
+    pub(crate) authenticate: Box<Authenticator>,
+    pub(crate) run_activation: Box<ActivationRunner>,
+}
+
+/// Serves one connection: authenticate (an unauthenticated peer receives no
+/// protocol bytes — dropping the stream closes it), read exactly one
+/// request, reply, then leave the connection open and ignore further bytes
+/// until the peer closes it. The helper never closes an authenticated
+/// connection.
+fn serve_connection(mut stream: UnixStream, config: &ServeConfig) -> Result<()> {
+    let Some(client) = (config.authenticate)(&stream) else {
+        return Ok(());
+    };
+
+    let frame = read_request_line(stream.try_clone()?)?;
+    let action = match frame {
+        RequestFrame::PeerClosed => {
+            // The peer closed without sending a request; nothing to answer.
+            return Ok(());
+        }
+        RequestFrame::Complete(line) => match std::str::from_utf8(&line) {
+            Ok(line) => decide_request(&config.slot, client.kind, &config.helper_build_id, line),
+            // Invalid UTF-8 is an unreadable request, not a connection error.
+            // The authenticated peer receives the frozen refusal and the helper
+            // then follows the normal keep-open/ignore path below.
+            Err(_) => RequestAction::Reply(HelperReply::RequestNotUnderstood),
+        },
+        // A missing terminator or a line beyond the existing cap is an
+        // unreadable request. Never dispatch from a valid-looking prefix.
+        RequestFrame::Malformed => RequestAction::Reply(HelperReply::RequestNotUnderstood),
+    };
+    let reply = match action {
+        RequestAction::Reply(reply) => reply,
+        RequestAction::RunActivation { body, permit } => {
+            let result = (config.run_activation)(&client, &body);
+            permit.into_result_reply(result)
+        }
+    };
+    stream.write_all(reply.encode().as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+
+    ignore_further_bytes(stream);
+    Ok(())
+}
+
+enum RequestFrame {
+    PeerClosed,
+    Complete(Vec<u8>),
+    Malformed,
+}
+
+/// Reads one newline-terminated request as raw bytes. UTF-8 decoding belongs
+/// to request classification, and a missing terminator or a line beyond the
+/// existing cap is malformed rather than an admissible JSON prefix.
+fn read_request_line(stream: impl Read) -> std::io::Result<RequestFrame> {
+    let mut line = Vec::new();
+    BufReader::new(stream)
+        .take(MAX_REQUEST_BYTES + 1)
+        .read_until(b'\n', &mut line)?;
+    if line.is_empty() {
+        Ok(RequestFrame::PeerClosed)
+    } else if line.len() as u64 <= MAX_REQUEST_BYTES && line.last() == Some(&b'\n') {
+        Ok(RequestFrame::Complete(line))
+    } else {
+        Ok(RequestFrame::Malformed)
+    }
+}
+
+/// Post-reply: the connection stays open (the peer may hold it as a liveness
+/// signal) and every further byte is discarded until the peer closes. Only a
+/// peer-side close ends this loop — a signal-interrupted read must not, or
+/// the helper would close an authenticated connection and forge the very
+/// signal a client reads as "the helper process ended".
+fn ignore_further_bytes(mut stream: UnixStream) {
+    let mut sink = [0u8; 1024];
+    loop {
+        match stream.read(&mut sink) {
+            Ok(0) => return,
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => return,
+        }
+    }
+}
+
+/// Holds one of the bounded connection slots and releases it on drop —
+/// including while unwinding. A slot leaked by a panicking connection thread
+/// would never come back for the rest of the process lifetime, and four of
+/// them would wedge the helper into refusing every connection.
+struct ConnectionSlot(Arc<AtomicUsize>);
+
+impl ConnectionSlot {
+    /// Takes a slot, or `None` at capacity.
+    fn acquire(active: &Arc<AtomicUsize>) -> Option<Self> {
+        active
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                (count < MAX_CONCURRENT_CONNECTIONS).then_some(count + 1)
+            })
+            .ok()
+            .map(|_| Self(Arc::clone(active)))
+    }
+}
+
+impl Drop for ConnectionSlot {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// Accept loop with bounded concurrent connection handling.
+pub(crate) fn serve(listener: UnixListener, config: Arc<ServeConfig>) -> Result<()> {
+    let active = Arc::new(AtomicUsize::new(0));
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let Some(slot) = ConnectionSlot::acquire(&active) else {
+                    // At capacity: accepted and closed before authentication
+                    // and before any protocol bytes.
+                    drop(stream);
+                    continue;
+                };
+                let config = Arc::clone(&config);
+                let spawned = std::thread::Builder::new().spawn(move || {
+                    // Dropped when this thread ends by any route, panic
+                    // included, so the slot always returns.
+                    let _slot = slot;
+                    if let Err(error) = serve_connection(stream, &config) {
+                        eprintln!("nixmac-helper: request failed: {error:#}");
+                    }
+                });
+                if spawned.is_err() {
+                    eprintln!("nixmac-helper: failed to spawn connection thread");
+                }
+            }
+            Err(error) => eprintln!("nixmac-helper: connection failed: {error}"),
+        }
+    }
+
+    Ok(())
+}
 
 pub fn run_daemon() -> Result<()> {
     if let Err(error) = fs::remove_file(LEGACY_SUDOERS_PATH)
@@ -52,18 +467,17 @@ pub fn run_daemon() -> Result<()> {
     let listener = UnixListener::bind(socket_path)?;
     harden_socket_permissions(socket_path)?;
 
-    for stream in listener.incoming() {
-        match stream {
-            Ok(stream) => {
-                if let Err(error) = handle_stream(stream) {
-                    eprintln!("nixmac-helper: request failed: {error:#}");
-                }
-            }
-            Err(error) => eprintln!("nixmac-helper: connection failed: {error}"),
-        }
-    }
-
-    Ok(())
+    serve(
+        listener,
+        Arc::new(ServeConfig {
+            slot: ActivationSlot::new(),
+            helper_build_id: BUILD_ID.to_string(),
+            authenticate: Box::new(authenticate_peer),
+            run_activation: Box::new(|client, body| {
+                run_activation_for_client(&client.identity, body)
+            }),
+        }),
+    )
 }
 
 fn harden_socket_permissions(socket_path: &Path) -> Result<()> {
@@ -86,40 +500,47 @@ fn admin_group_id() -> Option<u32> {
         .map(|group| group.gid.as_raw())
 }
 
-fn handle_stream(mut stream: UnixStream) -> Result<()> {
-    // The peer is authorized from its socket credentials before the request
-    // body is touched: an unauthorized peer must never reach the reader or
-    // the JSON parser.
-    let response = match authorize_peer(&stream) {
-        Ok(peer) => respond_authorized(&peer, &stream)?,
-        Err(error) => HelperResponse::error(-1, format!("{UNAUTHORIZED_CLIENT_ERROR}: {error:#}")),
+/// Pre-authentication admission: the socket-credential policy first, then
+/// per-binary signature classification. A peer failing either is closed
+/// before any protocol bytes — never a typed refusal.
+fn authenticate_peer(stream: &UnixStream) -> Option<AuthedClient> {
+    let identity = match peer_auth::peer_identity(stream) {
+        Ok(identity) => identity,
+        Err(error) => {
+            eprintln!("nixmac-helper: failed to read peer identity: {error:#}");
+            return None;
+        }
     };
-    serde_json::to_writer(&mut stream, &response)?;
-    stream.write_all(b"\n")?;
-    stream.flush()?;
-    Ok(())
-}
-
-/// Post-authorization request handling: only a request that clears the
-/// version gate reaches an operation handler; anything else — version skew,
-/// a v1 shape, unknown fields, framing violations — becomes a versioned
-/// protocol-error response without an operation being derived.
-fn respond_authorized(peer: &PeerIdentity, stream: &UnixStream) -> Result<HelperResponse> {
-    Ok(match read_request(stream.try_clone()?) {
-        Ok(op) => handle_request(peer, op),
-        Err(error) => HelperResponse::error(-1, error.to_string()),
-    })
-}
-
-fn authorize_peer(stream: &UnixStream) -> Result<PeerIdentity> {
-    let peer = peer_auth::peer_identity(stream)?;
-    check_peer_policy(peer.euid, peer_auth::console_user_uid())?;
-    peer_auth::validate_client_code(&peer)?;
-    Ok(peer)
+    if let Err(error) = check_peer_policy(identity.euid, peer_auth::console_user_uid()) {
+        eprintln!("nixmac-helper: rejected peer: {error:#}");
+        return None;
+    }
+    match peer_auth::classify_client(&identity) {
+        ClientValidation::Valid(kind) => Some(AuthedClient { identity, kind }),
+        ClientValidation::Invalid(detail) | ClientValidation::Error(detail) => {
+            eprintln!("nixmac-helper: rejected peer: {detail}");
+            None
+        }
+    }
 }
 
 /// The peer must be the active console user; root is rejected outright (the
 /// GUI and sync agent always run in the user session).
+///
+/// Note the breadth deliberately: this gate covers `Status` and `Retire` too,
+/// not just activation, and it runs *before* signature validation — a peer
+/// failing it is closed without protocol bytes rather than answered with a
+/// typed refusal. That is narrower than the published helper contract, which
+/// scopes user-level policy to activation alone and would have a
+/// signature-valid non-console peer authenticated and answered. Narrower is
+/// the conservative direction, and it is what the socket's own permissions
+/// already imply (the socket is mode 0600 owned by the console user, so a
+/// second login session cannot reach it at all). Consequences worth knowing
+/// before widening or narrowing this: a second-session GUI reports and defers
+/// instead of converging, and the contract's residual risk about `Retire`
+/// being accepted from any local signature-valid copy is correspondingly
+/// smaller. Changing the socket's ownership or mode is a separate piece of
+/// work; do not scope this gate down without it.
 fn check_peer_policy(peer_euid: u32, console_uid: Option<u32>) -> Result<()> {
     if peer_euid == 0 {
         bail!("root peers may not drive activation");
@@ -133,36 +554,28 @@ fn check_peer_policy(peer_euid: u32, console_uid: Option<u32>) -> Result<()> {
     Ok(())
 }
 
-/// Reads one framed request and returns the operation only if the sender
-/// speaks this daemon's protocol version. A version mismatch and an
-/// unrecognized field are both hard errors here, so no operation is derived
-/// from a request the daemon does not fully understand.
-fn read_request(stream: impl Read) -> Result<HelperOp> {
-    let mut line = String::new();
-    BufReader::new(stream)
-        .take(MAX_REQUEST_BYTES)
-        .read_line(&mut line)?;
-    if !line.ends_with('\n') && line.len() as u64 >= MAX_REQUEST_BYTES {
-        bail!("request exceeds {MAX_REQUEST_BYTES} bytes");
-    }
-    HelperRequest::parse(&line)
-}
+// ---------------------------------------------------------------------------
+// Activation execution (unchanged hardening rules).
+// ---------------------------------------------------------------------------
 
-fn handle_request(peer: &PeerIdentity, op: HelperOp) -> HelperResponse {
-    match op {
-        HelperOp::Status => HelperResponse::ok("nixmac helper ready"),
-        HelperOp::ActivateStorePath(request) => match activate_store_path(peer, &request) {
-            Ok(response) => response,
-            Err(error) => HelperResponse::error(-1, error.to_string()),
+/// Runs one admitted activation to completion and folds every failure into
+/// the result reply, so an activation that could not run still reports an
+/// outcome rather than unwinding. (Leaving the `Activating` state does not
+/// depend on that: `ActivationPermit` covers the unwinding path too.)
+fn run_activation_for_client(peer: &PeerIdentity, body: &TryActivateBody) -> ActivationResult {
+    match activate_script_path(peer, &body.script_path) {
+        Ok(result) => result,
+        Err(error) => ActivationResult {
+            ok: false,
+            code: -1,
+            stdout: String::new(),
+            error: Some(format!("{error:#}")),
         },
     }
 }
 
-fn activate_store_path(
-    peer: &PeerIdentity,
-    request: &ActivateStorePathRequest,
-) -> Result<HelperResponse> {
-    let activate_path = canonical_activation_target(&request.activate_path)?;
+fn activate_script_path(peer: &PeerIdentity, script_path: &str) -> Result<ActivationResult> {
+    let activate_path = canonical_activation_target(script_path)?;
     let argv = activation_argv_for_peer(peer, &activate_path)?;
     let (status, mut stdout) = run_activation_command(&argv)?;
 
@@ -175,11 +588,12 @@ fn activate_store_path(
         }
     }
 
-    Ok(HelperResponse::from_exit(
-        status.success(),
-        status.code().unwrap_or(-1),
+    Ok(ActivationResult {
+        ok: status.success(),
+        code: status.code().unwrap_or(-1),
         stdout,
-    ))
+        error: None,
+    })
 }
 
 /// Resolves and authorizes the activation target at the privileged boundary,
@@ -387,8 +801,998 @@ pub(crate) fn user_account(_uid: u32) -> Result<UserAccount> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Barrier;
+
+    // Build IDs identify a build and are only ever compared, so the tests use
+    // values that are deliberately not commit-shaped.
+    const HELPER_BUILD: &str = "build-a";
+    const OTHER_BUILD: &str = "build-b";
+    const SCRIPT: &str = "/nix/store/abc-darwin-system/activate";
+
+    fn body(request_id: &str) -> TryActivateBody {
+        TryActivateBody {
+            request_id: request_id.to_string(),
+            script_path: SCRIPT.to_string(),
+        }
+    }
+
+    fn status_line() -> String {
+        HelperRequest::Status.encode()
+    }
+
+    fn retire_line() -> String {
+        HelperRequest::Retire.encode()
+    }
+
+    fn try_activate_line(build_id: &str, request_id: &str) -> String {
+        HelperRequest::TryActivate {
+            build_id: build_id.to_string(),
+            body: body(request_id),
+        }
+        .encode()
+    }
+
+    fn decide<'slot>(
+        slot: &'slot ActivationSlot,
+        kind: ClientKind,
+        line: &str,
+    ) -> RequestAction<'slot> {
+        decide_request(slot, kind, HELPER_BUILD, line)
+    }
+
+    fn state_of(slot: &ActivationSlot) -> HelperStateName {
+        slot.snapshot().0
+    }
+
+    fn reply_of(action: RequestAction<'_>) -> HelperReply {
+        match action {
+            RequestAction::Reply(reply) => reply,
+            RequestAction::RunActivation { .. } => panic!("expected a reply, got an admission"),
+        }
+    }
+
+    fn activation_info() -> ActivationInfo {
+        ActivationInfo {
+            request_id: "req-1".to_string(),
+            script_path: SCRIPT.to_string(),
+            client_kind: ClientKind::Gui,
+        }
+    }
+
+    /// Builds the state needed to test occupied-slot replies without creating
+    /// a permit whose borrow would prevent returning the slot.
+    fn activating_slot() -> ActivationSlot {
+        ActivationSlot {
+            state: Mutex::new(SlotState::Activating(activation_info())),
+        }
+    }
+
+    /// Puts a slot into `Retiring(X)`.
+    fn retiring_slot() -> ActivationSlot {
+        let slot = activating_slot();
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &retire_line())),
+            HelperReply::Busy { .. }
+        ));
+        slot
+    }
+
+    /// Puts a slot into `Retired`.
+    fn retired_slot() -> ActivationSlot {
+        let slot = ActivationSlot::new();
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &retire_line())),
+            HelperReply::Retired { activation: None }
+        ));
+        slot
+    }
+
+    // ------------------------------------------------------------------
+    // The full request × state table.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn table_idle() {
+        let slot = ActivationSlot::new();
+        match reply_of(decide(&slot, ClientKind::Gui, &status_line())) {
+            HelperReply::Status {
+                state: HelperStateName::Idle,
+                helper_build_id,
+                activation: None,
+            } => assert_eq!(helper_build_id, HELPER_BUILD),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // TryActivate from Idle: admitted, state becomes Activating(X).
+        let slot = ActivationSlot::new();
+        let admission = decide(
+            &slot,
+            ClientKind::Gui,
+            &try_activate_line(HELPER_BUILD, "req-1"),
+        );
+        assert!(matches!(&admission, RequestAction::RunActivation { .. }));
+        assert_eq!(state_of(&slot), HelperStateName::Activating);
+        drop(admission);
+
+        // Retire from Idle: state becomes Retired, then the reply reports it.
+        let slot = ActivationSlot::new();
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &retire_line())),
+            HelperReply::Retired { activation: None }
+        ));
+        assert_eq!(state_of(&slot), HelperStateName::Retired);
+    }
+
+    #[test]
+    fn table_activating() {
+        // Status names the state and carries X.
+        let slot = activating_slot();
+        match reply_of(decide(&slot, ClientKind::Gui, &status_line())) {
+            HelperReply::Status {
+                state: HelperStateName::Activating,
+                activation: Some(activation),
+                ..
+            } => {
+                assert_eq!(activation.request_id, "req-1");
+                assert_eq!(activation.script_path, SCRIPT);
+                assert_eq!(activation.client_kind, ClientKind::Gui);
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // TryActivate: Busy(X).
+        match reply_of(decide(
+            &slot,
+            ClientKind::SyncAgent,
+            &try_activate_line(HELPER_BUILD, "req-2"),
+        )) {
+            HelperReply::Busy { activation } => assert_eq!(activation.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // Retire: retirement latches, reply Busy(X).
+        match reply_of(decide(&slot, ClientKind::Gui, &retire_line())) {
+            HelperReply::Busy { activation } => assert_eq!(activation.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+        assert_eq!(state_of(&slot), HelperStateName::Retiring);
+    }
+
+    #[test]
+    fn table_retiring_asymmetries() {
+        // The two deliberate asymmetries while retirement is latched:
+        // TryActivate gets Retired (carrying X while it finishes), Retire gets
+        // Busy(X).
+        let slot = retiring_slot();
+
+        match reply_of(decide(
+            &slot,
+            ClientKind::Gui,
+            &try_activate_line(HELPER_BUILD, "req-2"),
+        )) {
+            HelperReply::Retired {
+                activation: Some(activation),
+            } => assert_eq!(activation.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        match reply_of(decide(&slot, ClientKind::Gui, &retire_line())) {
+            HelperReply::Busy { activation } => assert_eq!(activation.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // Status names the state verbatim and still carries X.
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &status_line())),
+            HelperReply::Status {
+                state: HelperStateName::Retiring,
+                activation: Some(_),
+                ..
+            }
+        ));
+        assert_eq!(state_of(&slot), HelperStateName::Retiring);
+    }
+
+    #[test]
+    fn table_retired() {
+        let slot = retired_slot();
+
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &status_line())),
+            HelperReply::Status {
+                state: HelperStateName::Retired,
+                activation: None,
+                ..
+            }
+        ));
+        assert!(matches!(
+            reply_of(decide(
+                &slot,
+                ClientKind::Gui,
+                &try_activate_line(HELPER_BUILD, "req-2")
+            )),
+            HelperReply::Retired { activation: None }
+        ));
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &retire_line())),
+            HelperReply::Retired { activation: None }
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // Refusal order, caller policy, and cross-build tolerance.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn a_request_that_does_not_parse_gets_request_not_understood() {
+        let slot = ActivationSlot::new();
+        for line in [
+            "",
+            "garbage",
+            // A shape a previous release put on this socket.
+            r#"{"op":"status"}"#,
+            // A kind outside the closed set.
+            r#"{"kind":"selfDestruct"}"#,
+            // A TryActivate whose body this build does not honor: the request
+            // is parsed as a whole, so a malformed body is a malformed
+            // request. There is deliberately no promise that a build mismatch
+            // is noticed first.
+            r#"{"kind":"tryActivate","buildId":"build-a"}"#,
+            r#"{"kind":"tryActivate","buildId":"build-a","body":{"somethingElse":1}}"#,
+            r#"{"kind":"tryActivate","buildId":"build-b","body":{"futureField":true}}"#,
+        ] {
+            assert!(
+                matches!(
+                    reply_of(decide(&slot, ClientKind::Gui, line)),
+                    HelperReply::RequestNotUnderstood
+                ),
+                "line: {line:?}"
+            );
+        }
+        assert_eq!(state_of(&slot), HelperStateName::Idle);
+    }
+
+    #[test]
+    fn the_sync_agent_may_only_ask_for_an_activation() {
+        // The agent has no lifecycle role: Status and Retire from it are
+        // refused with the frozen typed refusal, and Retire in particular
+        // must not take effect.
+        let slot = ActivationSlot::new();
+        for line in [status_line(), retire_line()] {
+            assert!(matches!(
+                reply_of(decide(&slot, ClientKind::SyncAgent, &line)),
+                HelperReply::CallerNotPermitted
+            ));
+        }
+        assert_eq!(state_of(&slot), HelperStateName::Idle);
+
+        // Its own request is served like the GUI's.
+        let admission = decide(
+            &slot,
+            ClientKind::SyncAgent,
+            &try_activate_line(HELPER_BUILD, "req-1"),
+        );
+        assert!(matches!(&admission, RequestAction::RunActivation { .. }));
+        drop(admission);
+    }
+
+    #[test]
+    fn an_unpermitted_caller_and_another_build_get_their_own_refusals() {
+        // The two checks cannot collide, so their order is unobservable and
+        // deliberately untested: `Status`/`Retire` carry no build ID, and
+        // `TryActivate` is permitted for both client kinds. What is pinned is
+        // that each condition produces its own typed refusal.
+        let slot = ActivationSlot::new();
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::SyncAgent, &retire_line())),
+            HelperReply::CallerNotPermitted
+        ));
+
+        for kind in [ClientKind::Gui, ClientKind::SyncAgent] {
+            match reply_of(decide(
+                &slot,
+                kind,
+                &try_activate_line(OTHER_BUILD, "req-1"),
+            )) {
+                HelperReply::BuildMismatch { helper_build_id } => {
+                    assert_eq!(helper_build_id, HELPER_BUILD);
+                }
+                other => panic!("unexpected reply: {other:?}"),
+            }
+        }
+        assert_eq!(state_of(&slot), HelperStateName::Idle);
+    }
+
+    #[test]
+    fn an_empty_peer_build_id_is_a_build_mismatch_not_a_parse_failure() {
+        // An empty ID is readable and simply unequal to this helper's, so the
+        // caller learns it must upgrade rather than that it was not understood.
+        let slot = ActivationSlot::new();
+        assert!(matches!(
+            reply_of(decide(
+                &slot,
+                ClientKind::Gui,
+                &try_activate_line("", "req-1")
+            )),
+            HelperReply::BuildMismatch { .. }
+        ));
+        assert_eq!(state_of(&slot), HelperStateName::Idle);
+    }
+
+    #[test]
+    fn control_requests_are_answered_whatever_the_peers_build() {
+        // Status and Retire carry no build ID at all, and unknown fields on
+        // them are ignored: a GUI of any build discovers and retires this
+        // helper. Their replies parse normally in the client.
+        let slot = ActivationSlot::new();
+        let reply = reply_of(decide(
+            &slot,
+            ClientKind::Gui,
+            r#"{"kind":"status","fieldFromAnotherBuild":1}"#,
+        ));
+        assert!(matches!(reply, HelperReply::Status { .. }));
+        assert_eq!(
+            HelperReply::parse(&reply.encode()).expect("reply parses"),
+            reply
+        );
+
+        let reply = reply_of(decide(
+            &slot,
+            ClientKind::Gui,
+            r#"{"kind":"retire","fieldFromAnotherBuild":1}"#,
+        ));
+        assert!(matches!(reply, HelperReply::Retired { activation: None }));
+        assert_eq!(
+            HelperReply::parse(&reply.encode()).expect("reply parses"),
+            reply
+        );
+        assert_eq!(state_of(&slot), HelperStateName::Retired);
+    }
+
+    // ------------------------------------------------------------------
+    // Slot concurrency and transition ordering.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn exactly_one_activation_admitted_under_concurrent_try_activate() {
+        // Admission and the transition into Activating are one atomic step,
+        // serialized across all connections: with the slot never finishing,
+        // exactly one of the concurrent requests — from either client kind —
+        // may be admitted; every other gets Busy(X).
+        let slot = Arc::new(ActivationSlot::new());
+        let decisions_made = Arc::new(Barrier::new(9));
+        let observations_done = Arc::new(Barrier::new(9));
+        let mut handles = Vec::new();
+        for index in 0..8 {
+            let slot = Arc::clone(&slot);
+            let decisions_made = Arc::clone(&decisions_made);
+            let observations_done = Arc::clone(&observations_done);
+            let kind = if index % 2 == 0 {
+                ClientKind::Gui
+            } else {
+                ClientKind::SyncAgent
+            };
+            handles.push(std::thread::spawn(move || {
+                let action = decide_request(
+                    &slot,
+                    kind,
+                    HELPER_BUILD,
+                    &try_activate_line(HELPER_BUILD, &format!("req-{index}")),
+                );
+                let admitted = match &action {
+                    RequestAction::RunActivation { .. } => true,
+                    RequestAction::Reply(HelperReply::Busy { .. }) => false,
+                    RequestAction::Reply(other) => panic!("unexpected reply: {other:?}"),
+                };
+                // Keep the admitted permit alive until every thread has made
+                // its decision and the main thread has observed the slot.
+                decisions_made.wait();
+                observations_done.wait();
+                admitted
+            }));
+        }
+        decisions_made.wait();
+        assert_eq!(state_of(&slot), HelperStateName::Activating);
+        observations_done.wait();
+        let admitted = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("thread"))
+            .filter(|admitted| *admitted)
+            .count();
+
+        assert_eq!(admitted, 1);
+        assert_eq!(state_of(&slot), HelperStateName::Idle);
+    }
+
+    #[test]
+    fn status_and_retire_are_not_blocked_by_the_activation() {
+        // The slot is Activating (the admitted activation has not finished):
+        // Status and Retire decisions remain prompt because the transition
+        // mutex is never held across an activation.
+        let slot = activating_slot();
+
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &status_line())),
+            HelperReply::Status { .. }
+        ));
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &retire_line())),
+            HelperReply::Busy { .. }
+        ));
+    }
+
+    #[test]
+    fn activation_end_transition_precedes_the_result_reply() {
+        // Single-threaded, so the ordering is observed rather than raced for:
+        // producing the result reply consumes the permit, and by the time that
+        // reply value exists the slot is already free for the next request.
+        let slot = ActivationSlot::new();
+        let permit = slot
+            .admit(&body("req-1"), ClientKind::Gui)
+            .expect("first activation admitted");
+        assert_eq!(state_of(&slot), HelperStateName::Activating);
+
+        let reply = permit.into_result_reply(ActivationResult {
+            ok: true,
+            code: 0,
+            stdout: "activated".to_string(),
+            error: None,
+        });
+
+        assert!(matches!(reply, HelperReply::ActivationResult(_)));
+        assert_eq!(state_of(&slot), HelperStateName::Idle);
+        let second = slot
+            .admit(&body("req-2"), ClientKind::Gui)
+            .expect("second activation admitted");
+        drop(second);
+    }
+
+    #[test]
+    fn latched_activation_end_retires() {
+        let slot = ActivationSlot::new();
+        let permit = slot
+            .admit(&body("req-1"), ClientKind::Gui)
+            .expect("activation admitted");
+        assert!(matches!(slot.retire(), HelperReply::Busy { .. }));
+        drop(permit);
+        assert_eq!(state_of(&slot), HelperStateName::Retired);
+    }
+
+    #[test]
+    fn retired_reply_to_retire_is_sent_only_from_the_retired_state() {
+        // The transition takes effect before the reply: whenever Retire is
+        // answered Retired, the slot is already Retired, so no concurrent
+        // request can be admitted after it.
+        let slot = ActivationSlot::new();
+        let reply = reply_of(decide(&slot, ClientKind::Gui, &retire_line()));
+        assert!(matches!(reply, HelperReply::Retired { .. }));
+        assert_eq!(state_of(&slot), HelperStateName::Retired);
+        assert!(matches!(
+            reply_of(decide(
+                &slot,
+                ClientKind::Gui,
+                &try_activate_line(HELPER_BUILD, "req-9")
+            )),
+            HelperReply::Retired { activation: None }
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // Connection semantics.
+    // ------------------------------------------------------------------
+
     #[cfg(target_os = "macos")]
-    use crate::privileged_helper::protocol::HELPER_PROTOCOL_VERSION;
+    fn test_config(kind: ClientKind) -> Arc<ServeConfig> {
+        Arc::new(ServeConfig {
+            slot: ActivationSlot::new(),
+            helper_build_id: HELPER_BUILD.to_string(),
+            authenticate: Box::new(move |stream| {
+                let identity = peer_auth::peer_identity(stream).ok()?;
+                Some(AuthedClient { identity, kind })
+            }),
+            run_activation: Box::new(|_, _| ActivationResult {
+                ok: true,
+                code: 0,
+                stdout: "activated".to_string(),
+                error: None,
+            }),
+        })
+    }
+
+    #[cfg(target_os = "macos")]
+    fn refusing_config() -> Arc<ServeConfig> {
+        Arc::new(ServeConfig {
+            slot: ActivationSlot::new(),
+            helper_build_id: HELPER_BUILD.to_string(),
+            authenticate: Box::new(|_| None),
+            run_activation: Box::new(|_, _| unreachable!("no activation from a refused peer")),
+        })
+    }
+
+    /// A daemon over a real listener whose activation blocks until the
+    /// returned gate is released — the fake long activation the concurrency
+    /// obligations are stated against.
+    #[cfg(target_os = "macos")]
+    #[allow(clippy::type_complexity)]
+    fn blocking_activation_daemon() -> (
+        std::path::PathBuf,
+        Arc<ServeConfig>,
+        Arc<(Mutex<bool>, std::sync::Condvar)>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("helper-test.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+        let gate = Arc::new((Mutex::new(false), std::sync::Condvar::new()));
+        let runner_gate = Arc::clone(&gate);
+        let config = Arc::new(ServeConfig {
+            slot: ActivationSlot::new(),
+            helper_build_id: HELPER_BUILD.to_string(),
+            authenticate: Box::new(|stream| {
+                let identity = peer_auth::peer_identity(stream).ok()?;
+                Some(AuthedClient {
+                    identity,
+                    kind: ClientKind::Gui,
+                })
+            }),
+            run_activation: Box::new(move |_, _| {
+                let (released, signal) = &*runner_gate;
+                let mut released = released.lock().expect("gate");
+                while !*released {
+                    released = signal.wait(released).expect("gate wait");
+                }
+                ActivationResult {
+                    ok: true,
+                    code: 0,
+                    stdout: "activated".to_string(),
+                    error: None,
+                }
+            }),
+        });
+        let serving = Arc::clone(&config);
+        std::thread::spawn(move || serve(listener, serving));
+        (socket_path, config, gate, dir)
+    }
+
+    /// Sends one request line on a fresh connection and returns the reply
+    /// plus the still-open connection.
+    #[cfg(target_os = "macos")]
+    fn request_on_new_connection(socket_path: &Path, line: &str) -> (HelperReply, UnixStream) {
+        let client = UnixStream::connect(socket_path).expect("connect");
+        client
+            .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+            .expect("set timeout");
+        (&client)
+            .write_all(format!("{line}\n").as_bytes())
+            .expect("write request");
+        let mut reply = String::new();
+        {
+            let mut reader = BufReader::new(client.try_clone().expect("clone"));
+            reader.read_line(&mut reply).expect("read reply");
+        }
+        (HelperReply::parse(&reply).expect("reply parses"), client)
+    }
+
+    /// Sends a raw request through the authenticated connection handler, then
+    /// parses the newline-framed bytes exactly as a client does. Unlike the
+    /// decision-table tests, this covers framing, request reading, the helper's
+    /// socket write, and reply parsing together.
+    #[cfg(target_os = "macos")]
+    fn raw_request_through_wire(line: &str) -> HelperReply {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let config = test_config(ClientKind::Gui);
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        (&client)
+            .write_all(format!("{line}\n").as_bytes())
+            .expect("write request");
+        let mut reply = String::new();
+        {
+            let mut reader = BufReader::new(client.try_clone().expect("clone"));
+            reader.read_line(&mut reply).expect("read reply");
+        }
+        let reply = HelperReply::parse(&reply).expect("client parses reply");
+
+        // The authenticated handler deliberately stays open after its reply;
+        // close the peer so the test can join it.
+        drop(client);
+        handler.join().expect("handler").expect("serves");
+        reply
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn cross_build_control_requests_are_answered_through_the_real_wire_path() {
+        // A GUI from another build asks with fields this build never heard of;
+        // the answers must still come back on the wire.
+        assert!(matches!(
+            raw_request_through_wire(r#"{"kind":"status","fieldFromAnotherBuild":9999}"#),
+            HelperReply::Status {
+                state: HelperStateName::Idle,
+                ..
+            }
+        ));
+        assert!(matches!(
+            raw_request_through_wire(r#"{"kind":"retire","fieldFromAnotherBuild":9999}"#),
+            HelperReply::Retired { activation: None }
+        ));
+        assert!(matches!(
+            raw_request_through_wire(r#"{"kind":"selfDestruct"}"#),
+            HelperReply::RequestNotUnderstood
+        ));
+
+        // A TryActivate body from another build: syntactically valid JSON that
+        // exceeds serde_json's materialization depth. It is a request this
+        // build cannot parse, so it is not understood — the build ID it
+        // carries is never reached, and nothing dispatches from the readable
+        // prefix.
+        let nested = format!("{}null{}", "[".repeat(150), "]".repeat(150));
+        let future_body = format!(
+            r#"{{"kind":"tryActivate","buildId":"{OTHER_BUILD}","body":{{"requestId":"req-future","scriptPath":"{SCRIPT}","future":{nested}}}}}"#
+        );
+        assert!(matches!(
+            raw_request_through_wire(&future_body),
+            HelperReply::RequestNotUnderstood
+        ));
+
+        // A well-formed request from another build does reach the comparison.
+        assert!(matches!(
+            raw_request_through_wire(&try_activate_line(OTHER_BUILD, "req-future")),
+            HelperReply::BuildMismatch { .. }
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn status_and_retire_are_answered_while_an_activation_actually_runs() {
+        let (socket_path, config, gate, _dir) = blocking_activation_daemon();
+
+        // Dispatch an activation that will not finish until released, on its
+        // own connection, and wait until the slot really is occupied.
+        let activation = std::thread::spawn({
+            let socket_path = socket_path.clone();
+            move || {
+                request_on_new_connection(&socket_path, &try_activate_line(HELPER_BUILD, "req-1"))
+            }
+        });
+        while state_of(&config.slot) != HelperStateName::Activating {
+            std::thread::yield_now();
+        }
+
+        // Status is answered promptly and carries X.
+        let (status, _status_connection) = request_on_new_connection(&socket_path, &status_line());
+        match status {
+            HelperReply::Status {
+                state: HelperStateName::Activating,
+                activation: Some(info),
+                ..
+            } => assert_eq!(info.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // Retire is answered promptly too: Busy(X), retirement latched.
+        let (retire, _retire_connection) = request_on_new_connection(&socket_path, &retire_line());
+        match retire {
+            HelperReply::Busy { activation } => assert_eq!(activation.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+        assert_eq!(state_of(&config.slot), HelperStateName::Retiring);
+
+        // Releasing the activation delivers its result, and the latched
+        // retirement takes effect before that result reply is sent.
+        {
+            let (released, signal) = &*gate;
+            *released.lock().expect("gate") = true;
+            signal.notify_all();
+        }
+        let (result, _activation_connection) = activation.join().expect("activation");
+        assert!(matches!(
+            result,
+            HelperReply::ActivationResult(ActivationResult { ok: true, .. })
+        ));
+        assert_eq!(state_of(&config.slot), HelperStateName::Retired);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn reply_leaves_the_connection_open_and_ignores_further_bytes() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let config = test_config(ClientKind::Gui);
+        let handler = {
+            let config = Arc::clone(&config);
+            std::thread::spawn(move || serve_connection(server, &config))
+        };
+
+        (&client)
+            .write_all(format!("{}\n", status_line()).as_bytes())
+            .expect("write request");
+        let mut reply = String::new();
+        {
+            // Scoped so this duplicate descriptor is closed before the drop
+            // below: it is what actually has to close for the handler to see
+            // the peer go away.
+            let mut reader = BufReader::new(client.try_clone().expect("clone"));
+            reader.read_line(&mut reply).expect("read reply");
+        }
+        assert!(matches!(
+            HelperReply::parse(&reply).expect("reply parses"),
+            HelperReply::Status { .. }
+        ));
+
+        // Further bytes are ignored and the helper does not close: a timed
+        // read observes silence (WouldBlock), never EOF.
+        (&client)
+            .write_all(b"garbage after reply\n")
+            .expect("write");
+        client
+            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .expect("set timeout");
+        let mut probe = [0u8; 8];
+        match (&client).read(&mut probe) {
+            Ok(0) => panic!("helper closed an authenticated connection"),
+            Ok(_) => panic!("helper wrote bytes after its one reply"),
+            Err(error) => assert!(matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            )),
+        }
+
+        // The peer closing its end releases the handler.
+        drop(client);
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn invalid_utf8_gets_request_not_understood_and_the_connection_stays_open() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let config = test_config(ClientKind::Gui);
+        let handler = {
+            let config = Arc::clone(&config);
+            std::thread::spawn(move || serve_connection(server, &config))
+        };
+
+        (&client).write_all(b"\xff\n").expect("write invalid UTF-8");
+        let mut reply = String::new();
+        {
+            let mut reader = BufReader::new(client.try_clone().expect("clone"));
+            reader.read_line(&mut reply).expect("read refusal");
+        }
+        assert_eq!(
+            reply,
+            format!("{}\n", HelperReply::RequestNotUnderstood.encode())
+        );
+
+        client
+            .set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .expect("set timeout");
+        let mut probe = [0u8; 1];
+        match (&client).read(&mut probe) {
+            Ok(0) => panic!("helper closed an authenticated connection"),
+            Ok(_) => panic!("helper wrote bytes after its one refusal"),
+            Err(error) => assert!(matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            )),
+        }
+
+        drop(client);
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[test]
+    fn a_connection_slot_is_released_even_when_its_thread_unwinds() {
+        // A leaked slot never comes back for the process lifetime, and four
+        // leaks would wedge the helper into refusing every connection — so
+        // the slot must survive a panicking connection thread.
+        let active = Arc::new(AtomicUsize::new(0));
+        for _ in 0..MAX_CONCURRENT_CONNECTIONS * 3 {
+            let slot = ConnectionSlot::acquire(&active).expect("a slot is free");
+            let panicked = std::thread::spawn(move || {
+                let _slot = slot;
+                panic!("connection handling exploded");
+            })
+            .join();
+
+            assert!(panicked.is_err(), "the thread was supposed to panic");
+            assert_eq!(active.load(Ordering::Acquire), 0, "slot was not released");
+        }
+    }
+
+    #[test]
+    fn the_activation_slot_is_released_even_when_the_activation_unwinds() {
+        // A slot stranded in Activating would make the helper report an
+        // activation that is not running and refuse every later TryActivate
+        // with Busy(X) for the rest of its process lifetime — and a GUI's
+        // retire loop waits on Busy(X) unbounded by design, so nothing
+        // recovers.
+        let slot = ActivationSlot::new();
+        let permit = slot
+            .admit(&body("req-1"), ClientKind::Gui)
+            .expect("activation admitted");
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _permit = permit;
+            panic!("activation exploded");
+        }));
+
+        assert!(unwound.is_err(), "the activation was supposed to panic");
+        assert_eq!(state_of(&slot), HelperStateName::Idle);
+
+        // Latched retirement still wins over the unwind: the helper must not
+        // come back activatable after a Retire it already acknowledged.
+        let latched = ActivationSlot::new();
+        let permit = latched
+            .admit(&body("req-2"), ClientKind::Gui)
+            .expect("activation admitted");
+        assert!(matches!(latched.retire(), HelperReply::Busy { .. }));
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _permit = permit;
+            panic!("activation exploded");
+        }));
+
+        assert!(unwound.is_err(), "the activation was supposed to panic");
+        assert_eq!(state_of(&latched), HelperStateName::Retired);
+    }
+
+    #[test]
+    fn slots_are_handed_out_up_to_the_cap_and_no_further() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let held: Vec<ConnectionSlot> = (0..MAX_CONCURRENT_CONNECTIONS)
+            .map(|_| ConnectionSlot::acquire(&active).expect("a slot is free"))
+            .collect();
+
+        assert!(ConnectionSlot::acquire(&active).is_none());
+
+        drop(held);
+        assert!(ConnectionSlot::acquire(&active).is_some());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn unauthenticated_peer_is_closed_before_any_protocol_bytes() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let config = refusing_config();
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        // The peer never even sends a request; the close must come first.
+        let mut probe = [0u8; 8];
+        assert_eq!((&client).read(&mut probe).expect("read"), 0);
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn oversized_valid_prefix_is_refused_as_request_not_understood() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let config = test_config(ClientKind::Gui);
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        // The first MAX_REQUEST_BYTES bytes are a valid Status envelope plus
+        // JSON whitespace. Accepting that prefix before reading the suffix
+        // would dispatch an oversized, incomplete frame.
+        let mut oversized = status_line().into_bytes();
+        oversized.resize(MAX_REQUEST_BYTES as usize, b' ');
+        oversized.extend_from_slice(b"x\n");
+        (&client).write_all(&oversized).expect("write");
+
+        let mut reply = String::new();
+        BufReader::new(client.try_clone().expect("clone"))
+            .read_line(&mut reply)
+            .expect("read reply");
+        assert!(matches!(
+            HelperReply::parse(&reply).expect("reply parses"),
+            HelperReply::RequestNotUnderstood
+        ));
+        drop(client);
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn connections_past_the_cap_are_closed_without_protocol_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("helper-test.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+        let config = test_config(ClientKind::Gui);
+        std::thread::spawn(move || serve(listener, config));
+
+        // Fill every slot: each connection completes a request/reply and is
+        // then deliberately held open (the helper never closes it, so the
+        // slot stays occupied until this test drops the client end).
+        let mut held = Vec::new();
+        for _ in 0..MAX_CONCURRENT_CONNECTIONS {
+            let client = UnixStream::connect(&socket_path).expect("connect");
+            (&client)
+                .write_all(format!("{}\n", status_line()).as_bytes())
+                .expect("write request");
+            let mut reply = String::new();
+            BufReader::new(client.try_clone().expect("clone"))
+                .read_line(&mut reply)
+                .expect("read reply");
+            assert!(HelperReply::parse(&reply).is_ok());
+            held.push(client);
+        }
+
+        // The (cap+1)th connection is accepted and closed before any bytes.
+        let extra = UnixStream::connect(&socket_path).expect("connect");
+        extra
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .expect("set timeout");
+        let mut probe = [0u8; 8];
+        assert_eq!((&extra).read(&mut probe).expect("read"), 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn activation_result_reply_arrives_after_the_slot_transition() {
+        // End-to-end over a socketpair: the admitted activation completes,
+        // and by the time its result reply is readable, a second TryActivate
+        // is admissible (transition-before-reply).
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let config = test_config(ClientKind::Gui);
+        let handler = {
+            let config = Arc::clone(&config);
+            std::thread::spawn(move || serve_connection(server, &config))
+        };
+
+        (&client)
+            .write_all(format!("{}\n", try_activate_line(HELPER_BUILD, "req-1")).as_bytes())
+            .expect("write request");
+        let mut reply = String::new();
+        BufReader::new(client.try_clone().expect("clone"))
+            .read_line(&mut reply)
+            .expect("read reply");
+        match HelperReply::parse(&reply).expect("reply parses") {
+            HelperReply::ActivationResult(result) => assert!(result.ok),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // A smoke check that the whole path holds together, not the proof of
+        // the ordering: this thread reaches its assertion after a wake-up and
+        // three serde round-trips, so a handler that transitioned late would
+        // still normally get there first. The ordering itself rests on
+        // `into_result_reply` being the helper's only construction site for
+        // this reply — pinned single-threaded by
+        // `activation_end_transition_precedes_the_result_reply` — and on the
+        // permit being scoped to `serve_connection`'s activation arm.
+        let admission = decide(
+            &config.slot,
+            ClientKind::Gui,
+            &try_activate_line(HELPER_BUILD, "req-2"),
+        );
+        assert!(
+            matches!(&admission, RequestAction::RunActivation { .. }),
+            "the slot was still occupied when its result reply arrived"
+        );
+        drop(admission);
+
+        drop(client);
+        handler.join().expect("handler").expect("serves");
+    }
+
+    // ------------------------------------------------------------------
+    // Peer policy (unchanged) and activation hardening (unchanged).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn peer_policy_rejects_root_peer() {
+        assert!(check_peer_policy(0, Some(501)).is_err());
+    }
+
+    #[test]
+    fn peer_policy_rejects_uid_not_matching_console_user() {
+        assert!(check_peer_policy(502, Some(501)).is_err());
+    }
+
+    #[test]
+    fn peer_policy_rejects_when_no_console_user() {
+        assert!(check_peer_policy(501, None).is_err());
+    }
+
+    #[test]
+    fn peer_policy_accepts_console_user_peer() {
+        assert!(check_peer_policy(501, Some(501)).is_ok());
+    }
 
     fn account() -> UserAccount {
         UserAccount {
@@ -409,8 +1813,8 @@ mod tests {
         assert_eq!(&argv[1..3], ["asuser", "501"]);
         assert_eq!(&argv[3..5], ["/usr/bin/env", "-i"]);
         assert!(argv.contains(&format!("PATH={ACTIVATION_PATH_ENV}")));
-        // Account values come from the peer lookup. The protocol no longer
-        // has fields for a client to claim these with.
+        // Account values come from the peer lookup. The protocol has no
+        // fields for a client to claim these with.
         assert!(argv.contains(&"HOME=/Users/peer-alice".to_string()));
         assert!(argv.contains(&"USER=peer-alice".to_string()));
         assert_eq!(
@@ -437,36 +1841,23 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn helper_status_request_returns_ready_response() {
-        // A status request never inspects the peer; any real identity works.
+    fn activation_argv_derives_from_the_authenticated_peer_account() {
+        // The peer identity of a socketpair end is this test process, so the
+        // argv must carry this process's uid and its user-database account —
+        // the lookup keys on the authenticated uid and nothing else.
         let (stream, _other_end) = UnixStream::pair().expect("socketpair");
         let peer = peer_auth::peer_identity(&stream).expect("peer identity");
-        let response = handle_request(&peer, HelperOp::Status);
+        let me = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(peer.euid))
+            .expect("user lookup")
+            .expect("account exists");
 
-        assert!(response.ok);
-        assert_eq!(response.code, 0);
-        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-        assert!(!response.helper_build_version.is_empty());
-    }
+        let argv = activation_argv_for_peer(&peer, "/nix/store/abc-darwin-system/activate")
+            .expect("argv for peer");
 
-    #[test]
-    fn peer_policy_rejects_root_peer() {
-        assert!(check_peer_policy(0, Some(501)).is_err());
-    }
-
-    #[test]
-    fn peer_policy_rejects_uid_not_matching_console_user() {
-        assert!(check_peer_policy(502, Some(501)).is_err());
-    }
-
-    #[test]
-    fn peer_policy_rejects_when_no_console_user() {
-        assert!(check_peer_policy(501, None).is_err());
-    }
-
-    #[test]
-    fn peer_policy_accepts_console_user_peer() {
-        assert!(check_peer_policy(501, Some(501)).is_ok());
+        assert_eq!(argv[1], "asuser");
+        assert_eq!(argv[2], peer.euid.to_string());
+        assert!(argv.contains(&format!("USER={}", me.name)));
+        assert!(argv.contains(&format!("HOME={}", me.dir.display())));
     }
 
     #[test]
@@ -577,121 +1968,5 @@ mod tests {
     fn canonical_target_rejects_non_store_and_missing_paths() {
         assert!(canonical_activation_target("/tmp/activate").is_err());
         assert!(canonical_activation_target("/nix/store/no-such-item-c1-test/activate").is_err());
-    }
-
-    fn framed(request: &HelperRequest) -> Vec<u8> {
-        let mut body = serde_json::to_vec(request).expect("serialize request");
-        body.push(b'\n');
-        body
-    }
-
-    #[cfg(target_os = "macos")]
-    fn authorized_response_to(body: &[u8]) -> HelperResponse {
-        let (client, server) = UnixStream::pair().expect("socketpair");
-        let peer = peer_auth::peer_identity(&server).expect("peer identity");
-        (&client).write_all(body).expect("write request");
-
-        respond_authorized(&peer, &server).expect("responds")
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn authorized_current_version_request_crosses_the_gate_to_the_handler() {
-        let response = authorized_response_to(&framed(&HelperRequest::new(HelperOp::Status)));
-
-        assert!(response.ok);
-        assert_eq!(response.stdout, "nixmac helper ready");
-        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn version_rejection_becomes_a_versioned_protocol_error_without_a_handler() {
-        // Missing, lower, and higher versions, each on a body the version
-        // gate must stop. `ok: false` on the status shape proves the status
-        // handler never ran (it would answer ok "ready"); the skew
-        // classification on the others — whose operations are invalid or
-        // carry the v1 claimed fields — proves the gate rejected them before
-        // any operation shape was interpreted, let alone executed.
-        for body in [
-            // Missing: v1 status, no version field at all.
-            "{\"op\":\"status\"}\n".to_string(),
-            // Missing: v1 activation carrying the claimed identity/PATH fields.
-            r#"{"op":"activateStorePath","request":{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/tmp/attacker-bin"}}
-"#
-            .to_string(),
-            // Lower and higher versions on deliberately invalid operations.
-            "{\"protocolVersion\":1,\"op\":\"selfDestruct\"}\n".to_string(),
-            format!(
-                "{{\"protocolVersion\":{},\"op\":\"selfDestruct\"}}\n",
-                HELPER_PROTOCOL_VERSION + 1
-            ),
-        ] {
-            let response = authorized_response_to(body.as_bytes());
-
-            assert!(!response.ok);
-            assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-            assert!(!response.helper_build_version.is_empty());
-            assert!(response.reports_protocol_skew());
-        }
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn activation_argv_derives_from_the_authenticated_peer_account() {
-        // The peer identity of a socketpair end is this test process, so the
-        // argv must carry this process's uid and its user-database account —
-        // the lookup keys on the authenticated uid and nothing else.
-        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
-        let peer = peer_auth::peer_identity(&stream).expect("peer identity");
-        let me = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(peer.euid))
-            .expect("user lookup")
-            .expect("account exists");
-
-        let argv = activation_argv_for_peer(&peer, "/nix/store/abc-darwin-system/activate")
-            .expect("argv for peer");
-
-        assert_eq!(argv[1], "asuser");
-        assert_eq!(argv[2], peer.euid.to_string());
-        assert!(argv.contains(&format!("USER={}", me.name)));
-        assert!(argv.contains(&format!("HOME={}", me.dir.display())));
-    }
-
-    #[test]
-    fn read_request_rejects_oversized_line() {
-        let mut body = vec![b' '; MAX_REQUEST_BYTES as usize + 1];
-        body.push(b'\n');
-
-        let error = read_request(&body[..]).expect_err("oversized request must fail");
-
-        assert!(error.to_string().contains("exceeds"));
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn unauthorized_peer_gets_error_response_without_its_body_being_read() {
-        // The unsigned test binary can never pass code validation, so
-        // handle_stream must answer with an authorization error even though
-        // this end never sends a request line — proof the body is not read
-        // (or parsed) before authorization.
-        let (client, server) = UnixStream::pair().expect("socketpair");
-        let handler = std::thread::spawn(move || handle_stream(server));
-
-        let mut reply = String::new();
-        BufReader::new(client)
-            .read_line(&mut reply)
-            .expect("read response");
-        handler
-            .join()
-            .expect("handler thread")
-            .expect("stream handled");
-
-        // Authorization errors are versioned responses like every other:
-        // the strict client-side parse must accept the reply.
-        let response = HelperResponse::parse(&reply).expect("versioned response");
-        assert!(!response.ok);
-        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-        assert!(!response.helper_build_version.is_empty());
-        assert!(response.reports_unauthorized_client());
     }
 }

--- a/apps/native/src-tauri/src/privileged_helper/peer_auth.rs
+++ b/apps/native/src-tauri/src/privileged_helper/peer_auth.rs
@@ -7,17 +7,26 @@
 // live process → `SecCodeCheckValidity` against a pinned signing requirement.
 // Path strings never participate in the decision.
 //
+// Validation has exactly three results, as distinct types: valid (the pinned
+// requirement is satisfied), invalid (the code demonstrably does not satisfy
+// it — a completed judgment, even where the platform expresses it as an
+// error code), and error (no judgment could be reached). An error is never
+// treated as invalid: removal decisions elsewhere hang on that distinction.
+//
 // Compiled into the app, the sync agent, and the helper binaries via
 // `include!` (like `protocol.rs`), so no inner doc comments here.
 
 #[cfg(target_os = "macos")]
 use anyhow::Context;
 use anyhow::{Result, bail};
+// SDK-generated Security.framework status constants; see
+// `INVALID_SIGNATURE_STATUSES`. Aliased because the generated names keep their
+// C spelling. macOS-only: the crate links Security.framework unconditionally
+// and cannot build off Apple.
+#[cfg(target_os = "macos")]
+use objc2_security as sec;
+use serde::{Deserialize, Serialize};
 use std::os::unix::net::UnixStream;
-
-// Marker embedded in client-side daemon-validation failures so callers can
-// distinguish "impostor/stale helper at the socket" from "helper not running".
-pub const HELPER_VALIDATION_FAILED: &str = "helper at socket failed signature validation";
 
 // Everything below up to `AuditToken` builds macOS signing requirements; on
 // other targets only the `bail!` stubs are reachable, so mute dead-code there
@@ -29,6 +38,63 @@ pub const APP_CODE_IDENTIFIER: &str = "com.darkmatter.nixmac";
 pub const SYNC_AGENT_CODE_IDENTIFIER: &str = "com.darkmatter.nixmac.sync-agent";
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub const HELPER_CODE_IDENTIFIER: &str = "com.darkmatter.nixmac.helper";
+
+// Which pinned per-binary requirement a validated client satisfied. Derived
+// from the validated code object only — nothing a peer sends can influence
+// it. Serialized inside the protocol's activation info (X), hence the wire
+// names.
+//
+// These values ride inside X, which is part of the frozen `Status` and
+// `Busy(X)` replies, so the wire name of an existing kind may NEVER change or
+// be removed: the load-bearing upgrade direction is a new GUI reading the
+// installed old helper's replies, and a renamed value breaks exactly that.
+//
+// Adding a kind is weaker but not free. It only affects the reverse direction
+// — an older client reading a newer helper — where every reader is a
+// non-actor: an old client's `TryActivate` is refused as a build mismatch
+// before any `Busy(X)` could be sent, the sync agent may send nothing else at
+// all, and an old GUI is displaced and forbidden from mutating anyway. Each
+// would report an unparseable reply and defer. So a third kind degrades old
+// observers rather than deadlocking an upgrade; add one only as a deliberate
+// decision, knowing no test will fail when you do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ClientKind {
+    Gui,
+    SyncAgent,
+}
+
+impl std::fmt::Display for ClientKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ClientKind::Gui => "app",
+            ClientKind::SyncAgent => "sync agent",
+        })
+    }
+}
+
+// One signature validation's outcome. `Invalid` is a completed judgment
+// (unsigned, ad-hoc, wrong team or identifier — the answer is no); `Error`
+// means no judgment could be reached (dead peer, resource exhaustion,
+// evaluation failure) and is never treated as invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub enum SignatureValidation {
+    Valid,
+    Invalid(String),
+    Error(String),
+}
+
+// The helper's classification of a connecting client against the per-binary
+// pinned requirements, evaluated separately; the requirement that matched is
+// the client's kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub enum ClientValidation {
+    Valid(ClientKind),
+    Invalid(String),
+    Error(String),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
@@ -50,17 +116,21 @@ pub fn requirement_mode() -> RequirementMode {
     }
 }
 
-// The signing team is injected at build time; without it every peer fails
-// validation (fail closed) and unsigned dev builds fall through to the
+// The signing team is injected at build time; without it no judgment can be
+// reached (an error, fail closed) and unsigned dev builds fall through to the
 // interactive osascript path.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn configured_team_id() -> Option<&'static str> {
     option_env!("NIXMAC_TEAM_ID").filter(|team_id| !team_id.trim().is_empty())
 }
 
-// Requirement the daemon checks against a connecting client (app or sync
-// agent). Pure so requirement construction is unit-testable without Security
-// framework calls.
+// Per-binary pinned requirements. Each pins IDENTITY only — anchor, signing
+// team, and that binary's designated identifier — never a hash, version, or
+// anything release-specific: every requirement must be satisfied by every
+// past and future release of its binary, because cross-release validation is
+// what every upgrade depends on. The GUI and sync-agent requirements are
+// mutually exclusive by construction (each pins its own identifier), so the
+// one that matches is the client's kind.
 //
 // Deliberately no `entitlement[…] exists` clause: a custom entitlement is a
 // restricted entitlement, and AMFI refuses to spawn a binary carrying one
@@ -68,26 +138,29 @@ pub fn configured_team_id() -> Option<&'static str> {
 // Developer ID included, and Developer ID distribution cannot obtain such a
 // profile. Adding one here would require shipping an app that cannot launch,
 // and it would prove nothing extra: the anchor, team OU, and identifier pins
-// below already mean only our own signed app or sync agent can match.
+// below already mean only our own signed binaries can match.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-pub fn client_requirement_string(mode: RequirementMode, team_id: &str) -> String {
-    format!(
-        "{anchor} and certificate leaf[subject.OU] = \"{team_id}\" \
-         and (identifier \"{app}\" or identifier \"{agent}\")",
-        anchor = anchor_clause(mode),
-        app = APP_CODE_IDENTIFIER,
-        agent = SYNC_AGENT_CODE_IDENTIFIER,
-    )
+pub fn gui_client_requirement_string(mode: RequirementMode, team_id: &str) -> String {
+    identity_requirement(mode, team_id, APP_CODE_IDENTIFIER)
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn sync_agent_client_requirement_string(mode: RequirementMode, team_id: &str) -> String {
+    identity_requirement(mode, team_id, SYNC_AGENT_CODE_IDENTIFIER)
 }
 
 // Requirement the client checks against the daemon before sending a request.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn helper_requirement_string(mode: RequirementMode, team_id: &str) -> String {
+    identity_requirement(mode, team_id, HELPER_CODE_IDENTIFIER)
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn identity_requirement(mode: RequirementMode, team_id: &str, identifier: &str) -> String {
     format!(
         "{anchor} and certificate leaf[subject.OU] = \"{team_id}\" \
-         and identifier \"{helper}\"",
+         and identifier \"{identifier}\"",
         anchor = anchor_clause(mode),
-        helper = HELPER_CODE_IDENTIFIER,
     )
 }
 
@@ -102,6 +175,89 @@ fn anchor_clause(mode: RequirementMode) -> &'static str {
         }
         RequirementMode::Development => "anchor apple generic",
     }
+}
+
+// Security-framework validation statuses that are completed negative
+// judgments rather than failures to reach a judgment. Every value is the
+// `objc2-security` constant generated from the SDK's Security.framework
+// headers (`CSCommon.h`, `SecBase.h`, `cssmerr.h`), so a name that does not
+// exist is a build failure rather than a silently mis-transcribed number.
+//
+// Membership is still ours to maintain, and stays explicit: treating a new or
+// ambiguous status as invalid could authorize removal of a helper whose
+// identity was never actually judged.
+//
+// macOS-only, following the SDK crate that supplies the constants. Nothing off
+// Apple can produce these statuses — only `validate_signature`'s macOS arm
+// consults the table — so the tests over it are macOS-only too and run on the
+// macOS CI runner.
+#[cfg(target_os = "macos")]
+const INVALID_SIGNATURE_STATUSES: &[i32] = &[
+    // The code has no acceptable signature or does not satisfy the pinned
+    // requirement (unsigned, ad-hoc, wrong team, or wrong identifier).
+    sec::errSecCSGuestInvalid,
+    sec::errSecCSUnsigned,
+    sec::errSecCSSignatureFailed,
+    sec::errSecCSBadDictionaryFormat,
+    sec::errSecCSReqInvalid,
+    sec::errSecCSReqFailed,
+    sec::errSecCSBadObjectFormat,
+    sec::errSecCSHostReject,
+    sec::errSecCSSignatureInvalid,
+    sec::errSecCSStaticCodeChanged,
+    sec::errSecCSInfoPlistFailed,
+    sec::errSecCSNoMainExecutable,
+    sec::errSecCSBadBundleFormat,
+    sec::errSecCSBadMainExecutable,
+    sec::errSecCSInvalidPlatform,
+    sec::errSecCSInvalidTeamIdentifier,
+    sec::errSecCSBadTeamIdentifier,
+    sec::errSecCSSignatureUntrusted,
+    sec::errSecMultipleExecSegments,
+    sec::errSecCSInvalidEntitlements,
+    sec::errSecCSInvalidRuntimeVersion,
+    sec::errSecCSRevokedNotarization,
+    // A seal or nested component was checked and demonstrably failed. Dynamic
+    // validation currently checks only identity-bearing sealed components,
+    // but these remain negative judgments if Security returns them.
+    sec::errSecCSResourcesNotSealed,
+    sec::errSecCSResourcesNotFound,
+    sec::errSecCSResourcesInvalid,
+    sec::errSecCSBadResource,
+    sec::errSecCSResourceRulesInvalid,
+    sec::errSecCSResourceDirectoryFailed,
+    sec::errSecCSUnsignedNestedCode,
+    sec::errSecCSBadNestedCode,
+    sec::errSecCSResourceNotSupported,
+    sec::errSecCSRegularFile,
+    sec::errSecCSUnsealedAppRoot,
+    sec::errSecCSWeakResourceRules,
+    sec::errSecCSDSStoreSymlink,
+    sec::errSecCSAmbiguousBundleFormat,
+    sec::errSecCSBadFrameworkVersion,
+    sec::errSecCSUnsealedFrameworkRoot,
+    sec::errSecCSWeakResourceEnvelope,
+    sec::errSecCSInvalidSymlink,
+    sec::errSecCSInvalidAssociatedFileData,
+    // Certificate trust reached a negative conclusion. These may surface as
+    // either legacy CSSM or modern Security.framework statuses.
+    sec::CSSMERR_TP_CERT_EXPIRED,
+    sec::CSSMERR_TP_CERT_REVOKED,
+    sec::CSSMERR_TP_NOT_TRUSTED,
+    sec::errSecCertificateExpired,
+    sec::errSecCertificateRevoked,
+    sec::errSecNotTrusted,
+];
+
+// The explicit platform mapping behind the valid/invalid/error trichotomy.
+// A status in the table means validation completed and the peer did not
+// satisfy the pinned identity requirement. Everything else remains an error:
+// the peer may have died, resources may be exhausted, the verifier may be
+// unable to read the code, or the platform may have produced a status whose
+// semantics this build does not know well enough to authorize removal.
+#[cfg(target_os = "macos")]
+pub fn signature_judgment_completed(status: i32) -> bool {
+    INVALID_SIGNATURE_STATUSES.contains(&status)
 }
 
 // Raw kernel audit token (opaque; only Security framework and libbsm may
@@ -137,72 +293,150 @@ pub fn peer_identity(_stream: &UnixStream) -> Result<PeerIdentity> {
     bail!("peer credential validation is only implemented on macOS")
 }
 
-// Daemon-side check: the live peer code object must satisfy the client
-// requirement for this build's mode and configured team.
+// Daemon-side classification: the live peer code object is evaluated against
+// each per-binary pinned client requirement separately; the one that matches
+// is the client's kind. Invalid only when every evaluation completed its
+// judgment; any judgment-preventing failure makes the whole classification
+// an error.
 #[cfg(target_os = "macos")]
-pub fn validate_client_code(peer: &PeerIdentity) -> Result<()> {
-    let team_id = configured_team_id()
-        .ok_or_else(|| anyhow::anyhow!("no signing team configured (NIXMAC_TEAM_ID)"))?;
-    check_code_validity(
-        &peer.audit_token,
-        &client_requirement_string(requirement_mode(), team_id),
-    )
+pub fn classify_client(peer: &PeerIdentity) -> ClientValidation {
+    let Some(team_id) = configured_team_id() else {
+        return ClientValidation::Error("no signing team configured (NIXMAC_TEAM_ID)".to_string());
+    };
+    let mode = requirement_mode();
+    let mut failures = Vec::new();
+    for (kind, requirement) in [
+        (
+            ClientKind::Gui,
+            gui_client_requirement_string(mode, team_id),
+        ),
+        (
+            ClientKind::SyncAgent,
+            sync_agent_client_requirement_string(mode, team_id),
+        ),
+    ] {
+        match validate_signature(&peer.audit_token, &requirement) {
+            SignatureValidation::Valid => return ClientValidation::Valid(kind),
+            SignatureValidation::Invalid(detail) => failures.push((kind, detail, true)),
+            SignatureValidation::Error(detail) => failures.push((kind, detail, false)),
+        }
+    }
+    let judgment_completed = failures.iter().all(|(_, _, completed)| *completed);
+    let detail = failures
+        .iter()
+        .map(|(kind, detail, _)| format!("{kind}: {detail}"))
+        .collect::<Vec<_>>()
+        .join("; ");
+    if judgment_completed {
+        ClientValidation::Invalid(detail)
+    } else {
+        ClientValidation::Error(detail)
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn validate_client_code(_peer: &PeerIdentity) -> Result<()> {
+pub fn classify_client(_peer: &PeerIdentity) -> ClientValidation {
+    ClientValidation::Error("peer code validation is only implemented on macOS".to_string())
+}
+
+// Client-side assessment of whatever answers on the helper socket: the
+// peer's euid plus the trichotomous validation against the pinned helper
+// requirement. `Err` means the peer's identity could not even be read — a
+// judgment-preventing failure, so callers treat it as the error class.
+#[cfg(target_os = "macos")]
+pub fn assess_helper_peer(stream: &UnixStream) -> Result<(u32, SignatureValidation)> {
+    let peer = peer_identity(stream)?;
+    let Some(team_id) = configured_team_id() else {
+        return Ok((
+            peer.euid,
+            SignatureValidation::Error("no signing team configured (NIXMAC_TEAM_ID)".to_string()),
+        ));
+    };
+    let requirement = helper_requirement_string(requirement_mode(), team_id);
+    Ok((
+        peer.euid,
+        validate_signature(&peer.audit_token, &requirement),
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn assess_helper_peer(_stream: &UnixStream) -> Result<(u32, SignatureValidation)> {
     bail!("peer code validation is only implemented on macOS")
 }
 
-// Client-side reciprocal check, run after connect and before writing the
-// request: the process on the other end must be root and must be the signed
-// helper — not an impostor squatting on the socket path.
-#[cfg(target_os = "macos")]
+// Client-side authenticated gate, run after connect and before writing any
+// request: the process on the other end must be root and must validate as
+// the signed helper — not an impostor squatting on the socket path.
 pub fn validate_helper_peer(stream: &UnixStream) -> Result<()> {
-    validate_helper_peer_inner(stream).context(HELPER_VALIDATION_FAILED)
-}
-
-#[cfg(target_os = "macos")]
-fn validate_helper_peer_inner(stream: &UnixStream) -> Result<()> {
-    let peer = peer_identity(stream)?;
-    if peer.euid != 0 {
-        bail!("helper peer euid {} is not root", peer.euid);
+    let (euid, validation) = assess_helper_peer(stream)?;
+    if euid != 0 {
+        bail!("helper peer euid {euid} is not root");
     }
-    let team_id = configured_team_id()
-        .ok_or_else(|| anyhow::anyhow!("no signing team configured (NIXMAC_TEAM_ID)"))?;
-    check_code_validity(
-        &peer.audit_token,
-        &helper_requirement_string(requirement_mode(), team_id),
-    )
+    match validation {
+        SignatureValidation::Valid => Ok(()),
+        SignatureValidation::Invalid(detail) => {
+            bail!("helper at socket failed signature validation: {detail}")
+        }
+        SignatureValidation::Error(detail) => {
+            bail!("helper signature validation could not complete: {detail}")
+        }
+    }
 }
 
-#[cfg(not(target_os = "macos"))]
-pub fn validate_helper_peer(_stream: &UnixStream) -> Result<()> {
-    bail!("{HELPER_VALIDATION_FAILED}: only implemented on macOS")
-}
-
+// One signature validation with the explicit trichotomy mapping applied.
 #[cfg(target_os = "macos")]
-fn check_code_validity(token: &AuditToken, requirement_text: &str) -> Result<()> {
+pub fn validate_signature(token: &AuditToken, requirement_text: &str) -> SignatureValidation {
     use core_foundation::base::TCFType;
     use core_foundation::data::CFData;
     use security_framework::os::macos::code_signing::{
         Flags, GuestAttributes, SecCode, SecRequirement,
     };
 
-    let requirement: SecRequirement = requirement_text
-        .parse()
-        .with_context(|| format!("invalid signing requirement: {requirement_text}"))?;
+    let requirement: SecRequirement = match requirement_text.parse() {
+        Ok(requirement) => requirement,
+        Err(error) => {
+            return SignatureValidation::Error(format!(
+                "invalid signing requirement {requirement_text}: {error}"
+            ));
+        }
+    };
 
     let token_bytes: Vec<u8> = token.val.iter().flat_map(|v| v.to_ne_bytes()).collect();
     let token_data = CFData::from_buffer(&token_bytes);
     let mut attributes = GuestAttributes::new();
     attributes.set_audit_token(token_data.as_concrete_TypeRef());
 
-    let code = SecCode::copy_guest_with_attribues(None, &attributes, Flags::NONE)
-        .context("failed to resolve peer code object from audit token")?;
-    code.check_validity(Flags::NONE, &requirement)
-        .context("peer code failed signing-requirement validation")?;
-    Ok(())
+    // A peer whose code object cannot be resolved (it died, or the system is
+    // out of resources) prevented the judgment — an error, never invalid.
+    let code = match SecCode::copy_guest_with_attribues(None, &attributes, Flags::NONE) {
+        Ok(code) => code,
+        Err(error) => {
+            return SignatureValidation::Error(format!(
+                "failed to resolve peer code object from audit token: {error}"
+            ));
+        }
+    };
+    match code.check_validity(Flags::NONE, &requirement) {
+        Ok(()) => SignatureValidation::Valid,
+        Err(error) => {
+            let status = error.code();
+            if signature_judgment_completed(status) {
+                SignatureValidation::Invalid(format!(
+                    "peer code failed signing-requirement validation ({status})"
+                ))
+            } else {
+                SignatureValidation::Error(format!(
+                    "signing-requirement evaluation failed ({status}): {error}"
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
+pub fn validate_signature(_token: &AuditToken, _requirement_text: &str) -> SignatureValidation {
+    SignatureValidation::Error("peer code validation is only implemented on macOS".to_string())
 }
 
 // Uid of the active console user via SCDynamicStoreCopyConsoleUser.
@@ -259,34 +493,218 @@ mod tests {
     const TEAM: &str = "TESTTEAMID";
 
     #[test]
-    fn production_client_requirement_pins_developer_id_chain() {
-        let requirement = client_requirement_string(RequirementMode::Production, TEAM);
+    fn production_requirements_pin_developer_id_chain() {
+        // Pinned by equality, not by fragments: this is the other half of
+        // `requirements_pin_identity_only_never_a_hash_or_version`, which
+        // builds its expected string from this same clause and so cannot
+        // catch anything added inside it.
+        assert_eq!(
+            anchor_clause(RequirementMode::Production),
+            "anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13]"
+        );
 
-        assert!(requirement.starts_with("anchor apple generic"));
-        assert!(requirement.contains("certificate 1[field.1.2.840.113635.100.6.2.6]"));
-        assert!(requirement.contains("certificate leaf[field.1.2.840.113635.100.6.1.13]"));
-        assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac.sync-agent\""));
+        for requirement in [
+            gui_client_requirement_string(RequirementMode::Production, TEAM),
+            sync_agent_client_requirement_string(RequirementMode::Production, TEAM),
+            helper_requirement_string(RequirementMode::Production, TEAM),
+        ] {
+            assert!(requirement.starts_with("anchor apple generic"));
+            assert!(requirement.contains("certificate 1[field.1.2.840.113635.100.6.2.6]"));
+            assert!(requirement.contains("certificate leaf[field.1.2.840.113635.100.6.1.13]"));
+            assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
+        }
     }
 
     #[test]
-    fn development_client_requirement_pins_team_without_developer_id_markers() {
-        let requirement = client_requirement_string(RequirementMode::Development, TEAM);
+    fn development_requirements_pin_team_without_developer_id_markers() {
+        assert_eq!(
+            anchor_clause(RequirementMode::Development),
+            "anchor apple generic"
+        );
+
+        let requirement = gui_client_requirement_string(RequirementMode::Development, TEAM);
 
         assert!(requirement.starts_with("anchor apple generic"));
         assert!(!requirement.contains("field.1.2.840.113635.100.6.2.6"));
         assert!(!requirement.contains("field.1.2.840.113635.100.6.1.13"));
         assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac.sync-agent\""));
     }
 
     #[test]
-    fn helper_requirement_pins_helper_identifier() {
-        let requirement = helper_requirement_string(RequirementMode::Production, TEAM);
+    fn each_client_requirement_pins_exactly_its_own_identifier() {
+        // Mutually exclusive by construction: the requirement that matches
+        // IS the client's kind, so neither may accept the other binary.
+        let gui = gui_client_requirement_string(RequirementMode::Production, TEAM);
+        assert!(gui.contains("identifier \"com.darkmatter.nixmac\""));
+        assert!(!gui.contains(SYNC_AGENT_CODE_IDENTIFIER));
 
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac.helper\""));
-        assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
+        let agent = sync_agent_client_requirement_string(RequirementMode::Production, TEAM);
+        assert!(agent.contains("identifier \"com.darkmatter.nixmac.sync-agent\""));
+
+        let helper = helper_requirement_string(RequirementMode::Production, TEAM);
+        assert!(helper.contains("identifier \"com.darkmatter.nixmac.helper\""));
+        assert!(!helper.contains(SYNC_AGENT_CODE_IDENTIFIER));
+    }
+
+    // macOS-only for its second half, which reads the SDK status constants.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_nixmac_binary_of_the_wrong_kind_is_invalid_not_an_error() {
+        // The two halves that compose this judgment, stated together because
+        // the conclusion is what the legacy classification depends on:
+        //
+        // 1. Each requirement pins only its own binary's identifier, so a
+        //    genuine nixmac binary evaluated against another kind's
+        //    requirement does not satisfy it...
+        let gui = gui_client_requirement_string(RequirementMode::Production, TEAM);
+        let agent = sync_agent_client_requirement_string(RequirementMode::Production, TEAM);
+        let helper = helper_requirement_string(RequirementMode::Production, TEAM);
+        assert!(!gui.contains(SYNC_AGENT_CODE_IDENTIFIER));
+        assert!(!gui.contains(HELPER_CODE_IDENTIFIER));
+        assert!(!agent.contains(&format!("identifier \"{APP_CODE_IDENTIFIER}\"")));
+        assert!(!agent.contains(HELPER_CODE_IDENTIFIER));
+        assert!(!helper.contains(SYNC_AGENT_CODE_IDENTIFIER));
+
+        // 2. ...and the platform reports that non-satisfaction as
+        //    errSecCSReqFailed, which is a completed judgment. So the answer
+        //    is "no", never "could not tell" — an error would wrongly select
+        //    nothing where invalid selects the legacy removal path.
+        assert!(signature_judgment_completed(sec::errSecCSReqFailed));
+    }
+
+    #[test]
+    fn requirements_pin_identity_only_never_a_hash_or_version() {
+        // A hash/version/release/build-ID constraint would make a genuine
+        // older or newer nixmac binary fail validation — new GUIs would
+        // classify old helpers as legacy and direct-kill them. Identity only,
+        // forever.
+        //
+        // Asserted as exact equality rather than a forbidden-substring list:
+        // any clause added here fails, including one nobody thought to name.
+        // The expected string reuses `anchor_clause`, so this test says only
+        // that nothing but anchor, team, and identifier is present — the two
+        // tests above pin the anchor's own content by equality, which is what
+        // closes the gap.
+        for mode in [RequirementMode::Production, RequirementMode::Development] {
+            let anchor = anchor_clause(mode);
+            for (requirement, identifier) in [
+                (
+                    gui_client_requirement_string(mode, TEAM),
+                    APP_CODE_IDENTIFIER,
+                ),
+                (
+                    sync_agent_client_requirement_string(mode, TEAM),
+                    SYNC_AGENT_CODE_IDENTIFIER,
+                ),
+                (
+                    helper_requirement_string(mode, TEAM),
+                    HELPER_CODE_IDENTIFIER,
+                ),
+            ] {
+                assert_eq!(
+                    requirement,
+                    format!(
+                        "{anchor} and certificate leaf[subject.OU] = \"{TEAM}\" and identifier \"{identifier}\""
+                    )
+                );
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn invalid_classified_platform_codes_are_completed_judgments() {
+        // The explicit mapping covers the contract's named identity failures
+        // and each broader completed-negative category Security can report.
+        // Named via `stringify!` so a failure reports which status, without
+        // restating the name as a string literal beside the constant.
+        macro_rules! assert_completed_judgment {
+            ($($status:path),+ $(,)?) => {
+                $(assert!(
+                    signature_judgment_completed($status),
+                    concat!(stringify!($status), " must be invalid"),
+                );)+
+            };
+        }
+        assert_completed_judgment!(
+            sec::errSecCSUnsigned,
+            sec::errSecCSSignatureFailed,
+            sec::errSecCSReqFailed,
+            sec::errSecCSGuestInvalid,
+            sec::errSecCSResourcesInvalid,
+            sec::errSecCSInfoPlistFailed,
+            sec::errSecCSBadNestedCode,
+            sec::errSecCSSignatureUntrusted,
+            sec::errSecCSRevokedNotarization,
+            sec::CSSMERR_TP_CERT_REVOKED,
+            sec::errSecCertificateRevoked,
+        );
+
+        // Every entry in the maintained table is intentionally classified as
+        // a completed judgment. This catches a future predicate rewrite that
+        // accidentally drops one of the SDK-backed cases.
+        for status in INVALID_SIGNATURE_STATUSES {
+            assert!(signature_judgment_completed(*status), "status {status}");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn other_statuses_are_judgment_preventing_errors() {
+        // Anything not in the explicit invalid set prevented the judgment:
+        // an error, never invalid (an error must never select removal).
+        for status in [
+            0,
+            -1,
+            // memFullErr (resource exhaustion) lives in MacTypes.h, outside the
+            // Security headers, so it has no generated constant.
+            -108,
+            sec::errSecCSNoSuchCode,             // the peer is gone
+            sec::errSecCSSignatureNotVerifiable, // verifier could not read code
+            sec::errSecCSInternalError,
+            sec::errSecCSDBAccess,
+            sec::errSecCSCancelled,
+            i32::MIN,
+        ] {
+            assert!(!signature_judgment_completed(status), "status {status}");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn this_test_binary_classifies_as_invalid_not_error() {
+        // The test binary is unsigned (or ad-hoc signed on Apple silicon):
+        // either way the judgment completes with "no". Landing in Error here
+        // would break the trichotomy — a merely-unsigned peer must be a
+        // completed judgment.
+        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
+        let peer = peer_identity(&stream).expect("peer identity");
+
+        match classify_client(&peer) {
+            ClientValidation::Invalid(_) => {}
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn assess_helper_peer_reports_euid_and_a_completed_judgment() {
+        // A socketpair peer is this (non-root, unsigned/ad-hoc) process: the
+        // assessment must carry the real euid and an Invalid judgment — the
+        // shape the legacy-vs-error distinction is built from.
+        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
+
+        let (euid, validation) = assess_helper_peer(&stream).expect("assessment");
+
+        assert_eq!(euid, nix::unistd::geteuid().as_raw());
+        assert!(matches!(validation, SignatureValidation::Invalid(_)));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn validate_helper_peer_rejects_this_non_root_test_process() {
+        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
+
+        assert!(validate_helper_peer(&stream).is_err());
     }
 }

--- a/apps/native/src-tauri/src/privileged_helper/protocol.rs
+++ b/apps/native/src-tauri/src/privileged_helper/protocol.rs
@@ -1,3 +1,4 @@
+use crate::privileged_helper::peer_auth::ClientKind;
 use anyhow::{Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -12,27 +13,11 @@ pub const SYNC_AGENT_PLIST_NAME: &str = "com.darkmatter.nixmac.sync-agent.plist"
 pub const HELPER_SOCKET_PATH: &str = "/var/run/nixmac/helper.sock";
 #[allow(dead_code)]
 pub const HELPER_SOCKET_DIR: &str = "/var/run/nixmac";
-/// Prefix of the daemon's response when the connecting peer fails
-/// authorization. The app matches on it — only through
-/// `HelperResponse::reports_unauthorized_client`, which requires it as a
-/// prefix — to fall back to the interactive osascript path instead of
-/// surfacing a hard error (unsigned dev builds land here by design).
-pub const UNAUTHORIZED_CLIENT_ERROR: &str = "unauthorized helper client";
-/// Wire marker for protocol-version skew: the prefix of `ProtocolSkew`'s
-/// display form, and therefore of the daemon's response `error` string when
-/// a request's version is missing or wrong. Classification cannot cross the
-/// JSON boundary, so a *daemon-reported* skew is detected from this marker —
-/// only through `HelperResponse::reports_protocol_skew`, which requires it
-/// as a prefix. For client-side failures use `is_protocol_skew`, never
-/// display text. Kept distinct from `UNAUTHORIZED_CLIENT_ERROR` so a
-/// version-skewed helper/app pairing is distinguishable from a rejected
-/// client.
-pub const UNSUPPORTED_PROTOCOL_ERROR: &str = "unsupported helper protocol version";
-/// Wire protocol the daemon and its clients speak. Version 2 dropped every
-/// claimed-identity field: the daemon derives the account from the socket
-/// peer's credentials, so there is nothing left for a client to assert about
-/// itself.
-pub const HELPER_PROTOCOL_VERSION: u32 = 2;
+/// Build identity compiled into this binary (`build.rs` embeds it for the GUI,
+/// helper, and sync-agent targets alike). It identifies a build and nothing
+/// else: the only operation performed on it is exact string equality, so no
+/// syntax is required or checked — not here, and not on any peer's value.
+pub const BUILD_ID: &str = env!("NIXMAC_BUILD_ID");
 const DEFAULT_SYNC_AGENT_INTERVAL_SECONDS: u32 = 900;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
@@ -43,10 +28,10 @@ pub struct HelperServiceStatus {
     pub registered: bool,
     pub authorized: bool,
     pub socket_available: bool,
-    /// The daemon answered an authenticated status round-trip: the client
-    /// validated the daemon's signature, the daemon accepted this client,
-    /// and both sides proved they speak the same protocol version. A
-    /// protocol-error response never sets this.
+    /// The daemon answered an authenticated `Status` round-trip naming a
+    /// state: the client validated the daemon's signature and the daemon
+    /// accepted this client. A typed refusal or an unparseable reply never
+    /// sets this.
     pub responding: bool,
     pub detail: Option<String>,
 }
@@ -65,136 +50,122 @@ impl HelperServiceStatus {
     }
 }
 
-/// The activation target, and nothing else. Account name, uid, and home come
-/// from the socket peer's credentials, and the privileged `PATH` is fixed, so
-/// a client has nothing left to claim. Unknown fields are rejected rather
-/// than ignored: a v1 client's `userName`/`userId`/`home`/`nixPath` must fail
-/// loudly, never look like it was honored.
-#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct ActivateStorePathRequest {
-    pub activate_path: String,
-}
+// ---------------------------------------------------------------------------
+// Requests.
+//
+// Three request shapes, tagged by `kind`, and the set is closed forever. A
+// request either parses completely or is not understood: there is no envelope
+// to read separately from a body, and no version field — a receiver that
+// cannot parse a request cannot serve it either way.
+//
+// `Status` and `Retire` are the cross-build control language and are frozen
+// forever: a new GUI must be able to ask an older installed helper what it is
+// and to retire it. `TryActivate` only ever succeeds between binaries of the
+// same build (it carries a build ID that must equal the helper's), so its
+// shape may evolve freely.
+// ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Type, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct SyncAgentLaunchConfig {
-    pub config_dir: Option<String>,
-    pub host_attr: Option<String>,
-    pub sync_pull: bool,
-    pub unattended_apply: bool,
-    pub start_interval_seconds: Option<u32>,
-}
-
-/// Everything a client puts on the socket. The version is outside the
-/// operation so it can be checked before the operation is acted on.
+/// The `TryActivate` activation body: the client-generated request ID and the
+/// activation script path. NOT frozen. Unknown fields are rejected so a field
+/// this build does not honor can never look like it was.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct HelperRequest {
-    pub protocol_version: u32,
-    pub op: HelperOp,
+pub struct TryActivateBody {
+    pub request_id: String,
+    pub script_path: String,
+}
+
+/// Everything a client may put on the socket. `Status` and `Retire` are
+/// kind-only: they carry no build ID because they are exactly the requests
+/// that must work across builds. FROZEN — the `kind` tags and the two
+/// kind-only shapes may never change, and no kind may ever be added.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum HelperRequest {
+    Status,
+    Retire,
+    /// The sender's build ID plus its activation body. The helper compares the
+    /// ID after parsing the whole request, as a race guard on an exchange that
+    /// is only ever same-build.
+    #[serde(rename_all = "camelCase")]
+    TryActivate {
+        build_id: String,
+        body: TryActivateBody,
+    },
 }
 
 impl HelperRequest {
-    pub fn new(op: HelperOp) -> Self {
-        Self {
-            protocol_version: HELPER_PROTOCOL_VERSION,
-            op,
-        }
+    /// Serializes one request line, without the trailing newline the caller
+    /// appends.
+    pub fn encode(&self) -> String {
+        serde_json::to_string(self).expect("helper request serializes")
     }
 
-    /// Daemon-side gate: no operation is derived until the sender is known
-    /// to speak this daemon's protocol. The version is probed before the
-    /// strict parse so an alien shape is reported as version skew rather
-    /// than as whichever unfamiliar field serde trips over first.
-    pub fn parse(line: &str) -> Result<HelperOp> {
-        check_wire_version(line)?;
-        let request: Self = serde_json::from_str(line)?;
-        Ok(request.op)
+    /// Reads one wire line. `None` means the request is not understood — not
+    /// JSON, an unknown kind, or a malformed activation body — which the
+    /// helper answers with the frozen request-not-understood refusal. Unknown
+    /// fields on a known kind are ignored, so a future build's `Status` still
+    /// reads as `Status`.
+    pub fn parse(line: &str) -> Option<Self> {
+        serde_json::from_str(line).ok()
     }
 }
 
-/// Classified protocol-version skew. This is the error type behind every
-/// version-gate rejection, so consumers detect skew structurally with
-/// `is_protocol_skew` instead of parsing display text.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ProtocolSkew {
-    /// Version the other side sent; `None` when the shape carried no
-    /// version at all (the v1 wire).
-    pub peer_version: Option<u32>,
+// ---------------------------------------------------------------------------
+// Replies.
+// ---------------------------------------------------------------------------
+
+/// The four helper states, named verbatim in `Status` replies so every
+/// caller can distinguish them. Part of the frozen surface.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum HelperStateName {
+    Idle,
+    Activating,
+    /// An activation is still running and retirement is latched: this helper
+    /// will never start another one.
+    Retiring,
+    Retired,
 }
 
-impl std::fmt::Display for ProtocolSkew {
+impl std::fmt::Display for HelperStateName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.peer_version {
-            Some(version) => write!(
-                f,
-                "{UNSUPPORTED_PROTOCOL_ERROR} {version} (this build speaks {HELPER_PROTOCOL_VERSION})"
-            ),
-            None => write!(
-                f,
-                "{UNSUPPORTED_PROTOCOL_ERROR}: no protocolVersion field (this build speaks {HELPER_PROTOCOL_VERSION})"
-            ),
-        }
+        f.write_str(match self {
+            HelperStateName::Idle => "idle",
+            HelperStateName::Activating => "activating",
+            HelperStateName::Retiring => "retiring",
+            HelperStateName::Retired => "retired",
+        })
     }
 }
 
-impl std::error::Error for ProtocolSkew {}
-
-/// True when `error` is (or wraps) a version-gate `ProtocolSkew`. This is
-/// the client-side classification callers act on — the display text is not
-/// part of the contract.
-pub fn is_protocol_skew(error: &anyhow::Error) -> bool {
-    error
-        .chain()
-        .any(|cause| cause.downcast_ref::<ProtocolSkew>().is_some())
-}
-
-/// Reads only `protocolVersion` out of one wire line and requires it to be
-/// exactly this build's version. The probe deliberately ignores every other
-/// field: its job is to decide whether the rest of the shape may be
-/// interpreted at all, so it must parse shapes this build otherwise rejects
-/// (v1 carried no version field at all).
-fn check_wire_version(line: &str) -> Result<()> {
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct VersionProbe {
-        protocol_version: Option<u32>,
-    }
-
-    match serde_json::from_str::<VersionProbe>(line)?.protocol_version {
-        Some(HELPER_PROTOCOL_VERSION) => Ok(()),
-        peer_version => Err(ProtocolSkew { peer_version }.into()),
-    }
-}
-
-/// Externally tagged: serde honors `deny_unknown_fields` on a plain payload
-/// struct, but ignores it on the variants of an internally tagged enum, and
-/// rejecting unknown fields is the point of this shape.
+/// X: the in-flight activation's identity — the client-generated request ID
+/// and script path from the `TryActivate` body, plus the submitting client's
+/// kind, which the helper stamps from its own validation of that client,
+/// never from the body. Informational only; no decision branches on these
+/// fields. Its representation inside `Status` and `Busy(X)` replies is part
+/// of the frozen surface.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub enum HelperOp {
-    Status,
-    ActivateStorePath(ActivateStorePathRequest),
+pub struct ActivationInfo {
+    pub request_id: String,
+    pub script_path: String,
+    pub client_kind: ClientKind,
 }
 
-/// Everything the daemon puts back on the socket. Every response — status,
-/// activation success or failure, and protocol errors alike — carries the
-/// version, because the constructors below stamp it and the daemon builds
-/// responses only through them. `helper_build_version` is diagnostic (for
-/// support and telemetry): release versions are not unique across rebuilds,
-/// so the update and trust decisions belong to the signature checks and the
-/// version gate, never to this string. There is no stderr field: the
-/// activation runs with stderr merged into stdout (`2>&1`), so `stdout` is
-/// the whole interleaved log, and helper-level failures use `error`.
+/// A finished activation's result, sent on the same connection when the
+/// activation completes; within this protocol it is the only way to learn an
+/// activation's outcome. NOT frozen — it never crosses builds. There is no
+/// stderr field: the activation runs with stderr merged into stdout, so
+/// `stdout` is the whole interleaved log and helper-level failures use
+/// `error`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct HelperResponse {
-    pub protocol_version: u32,
-    pub helper_build_version: String,
+#[serde(rename_all = "camelCase")]
+pub struct ActivationResult {
     pub ok: bool,
     pub code: i32,
     pub stdout: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
@@ -202,12 +173,12 @@ pub struct HelperResponse {
 /// the (merged) stdout, so consumers can surface them.
 pub const HELPER_WARNING_PREFIX: &str = "nixmac-helper: warning:";
 
-impl HelperResponse {
+impl ActivationResult {
     /// Human-readable failure detail: the explicit error when present, else
     /// the tail of stdout — the helper merges the activation's stderr into
-    /// stdout (`2>&1`), so on a plain nonzero exit the detail lives there.
-    /// Used by the sync-agent binary (this file is `include!`d there), hence
-    /// dead code in targets that report through other paths.
+    /// stdout, so on a plain nonzero exit the detail lives there. Used by the
+    /// sync-agent binary (this file is `include!`d there), hence dead code in
+    /// targets that report through other paths.
     #[allow(dead_code)]
     pub fn failure_detail(&self) -> String {
         if let Some(error) = self.error.as_deref().filter(|error| !error.is_empty()) {
@@ -229,62 +200,127 @@ impl HelperResponse {
             .filter(|line| line.starts_with(HELPER_WARNING_PREFIX))
             .collect()
     }
+}
 
-    pub fn ok(stdout: impl Into<String>) -> Self {
-        Self::from_exit(true, 0, stdout.into())
+/// Everything the helper puts back on the socket, tagged by `reply`.
+///
+/// Frozen forever: the `Status` reply (including X's representation), the
+/// `Retired` and `Busy(X)` replies, and the three typed refusals
+/// (`BuildMismatch`, `CallerNotPermitted`, `RequestNotUnderstood`). The
+/// `ActivationResult` reply is NOT frozen — it never crosses builds.
+///
+/// Refusals are typed wire shapes; nothing classifies a reply from display
+/// strings.
+///
+/// The `reply` tag of every frozen variant below may NEVER be renamed or
+/// removed: a new GUI must be able to parse the replies of the older installed
+/// helper it is replacing, and that is the direction every upgrade depends on.
+///
+/// Adding a variant is a separate question, and the reply table answers it:
+/// each request already has a fixed set of permitted replies, so a new variant
+/// may not be sent in answer to `Status` or `Retire` regardless of whether
+/// older clients could parse it. A genuinely new reply belongs on an unfrozen
+/// exchange (today, only `TryActivate`'s result).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "reply", rename_all = "camelCase")]
+pub enum HelperReply {
+    /// State named verbatim, the helper's build ID, and X while an activation
+    /// runs. This is the cross-build discovery exchange: the build ID is read
+    /// whatever it contains, empty included — an empty ID is simply unequal to
+    /// this build's, never a reason to reject the reply.
+    #[serde(rename_all = "camelCase")]
+    Status {
+        state: HelperStateName,
+        helper_build_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        activation: Option<ActivationInfo>,
+    },
+    /// To `Retire`: the helper is in the `Retired` state NOW — the
+    /// safe-to-unregister signal for a running helper. To `TryActivate`: this
+    /// helper will never start the caller's activation (permanent for this
+    /// process); `activation` carries X while a retirement-latched activation
+    /// is still finishing.
+    Retired {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        activation: Option<ActivationInfo>,
+    },
+    /// To `TryActivate`: an activation is running; transient. To `Retire`:
+    /// retirement is latched, X still running — not safe to unregister yet.
+    Busy { activation: ActivationInfo },
+    /// The completion-time result of an admitted `TryActivate`.
+    ActivationResult(ActivationResult),
+    /// Typed refusal: the `TryActivate` sender's build ID is not exactly the
+    /// helper's. The helper must be upgraded or disabled — this is a refusal,
+    /// never permission to activate some other way.
+    #[serde(rename_all = "camelCase")]
+    BuildMismatch { helper_build_id: String },
+    /// Typed refusal: the authenticated caller may not make this request (the
+    /// sync agent may only send `TryActivate`).
+    CallerNotPermitted,
+    /// Typed refusal: the request did not parse — not JSON, an unknown kind,
+    /// or a malformed activation body.
+    RequestNotUnderstood,
+}
+
+impl HelperReply {
+    pub fn encode(&self) -> String {
+        serde_json::to_string(self).expect("helper reply serializes")
     }
 
-    pub fn error(code: i32, error: impl Into<String>) -> Self {
-        Self {
-            error: Some(error.into()),
-            ..Self::from_exit(false, code, String::new())
-        }
-    }
-
-    /// Base constructor the other constructors delegate to; also used
-    /// directly for a finished activation command, where `ok` mirrors the
-    /// exit status and `stdout` is the merged activation log.
-    pub fn from_exit(ok: bool, code: i32, stdout: String) -> Self {
-        Self {
-            protocol_version: HELPER_PROTOCOL_VERSION,
-            helper_build_version: env!("NIXMAC_VERSION").to_string(),
-            ok,
-            code,
-            stdout,
-            error: None,
-        }
-    }
-
-    /// Client-side gate, mirroring `HelperRequest::parse`: the version is
-    /// checked before `ok`, output, or error fields exist to be read, and a
-    /// missing or different version fails as a classified `ProtocolSkew`.
-    /// How to recover — reconciling the installed helper, or an interactive
-    /// fallback — is the caller's policy, not this layer's contract.
+    /// Client-side parse. A reply that does not parse is treated as a
+    /// refusal by every caller: do not activate, do not mutate, report and
+    /// defer.
     pub fn parse(line: &str) -> Result<Self> {
-        check_wire_version(line)?;
-        Ok(serde_json::from_str(line)?)
+        let reply: Self = serde_json::from_str(line)?;
+        if let HelperReply::Status {
+            state, activation, ..
+        } = &reply
+        {
+            let activation_required = matches!(
+                state,
+                HelperStateName::Activating | HelperStateName::Retiring
+            );
+            if activation_required != activation.is_some() {
+                bail!("Status state {state} carries an invalid activation payload");
+            }
+        }
+        Ok(reply)
     }
 
-    /// True when this daemon-reported response is the version gate's own
-    /// rejection. The marker is required as a prefix — the daemon puts the
-    /// classification first in `error` — so an unrelated failure that merely
-    /// mentions the marker text deeper in its message never classifies as
-    /// skew.
-    pub fn reports_protocol_skew(&self) -> bool {
-        self.reports_marker(UNSUPPORTED_PROTOCOL_ERROR)
-    }
-
-    /// True when this daemon-reported response is the daemon refusing the
-    /// connecting peer. Prefix-matched for the same reason as
-    /// `reports_protocol_skew`.
-    pub fn reports_unauthorized_client(&self) -> bool {
-        self.reports_marker(UNAUTHORIZED_CLIENT_ERROR)
-    }
-
-    fn reports_marker(&self, marker: &str) -> bool {
-        self.error
-            .as_deref()
-            .is_some_and(|error| error.starts_with(marker))
+    /// One-line human description for reports and logs. Display only —
+    /// classification always goes through the typed variants, never through
+    /// this text.
+    #[allow(dead_code)]
+    pub fn summary(&self) -> String {
+        match self {
+            HelperReply::Status {
+                state,
+                helper_build_id,
+                ..
+            } => format!("helper is {state} at build {helper_build_id}"),
+            HelperReply::Retired { .. } => {
+                "the helper is retired and will never start another activation".to_string()
+            }
+            HelperReply::Busy { activation } => format!(
+                "the helper is running an activation ({} submitted by the {})",
+                activation.script_path, activation.client_kind
+            ),
+            HelperReply::ActivationResult(result) if result.ok => {
+                "activation completed".to_string()
+            }
+            HelperReply::ActivationResult(result) => {
+                format!("activation failed (exit code {})", result.code)
+            }
+            HelperReply::BuildMismatch { helper_build_id } => format!(
+                "the installed helper is from a different nixmac build (build {helper_build_id})"
+            ),
+            HelperReply::CallerNotPermitted => {
+                "the helper does not permit this caller to make that request".to_string()
+            }
+            HelperReply::RequestNotUnderstood => {
+                "the helper did not understand the request".to_string()
+            }
+        }
     }
 }
 
@@ -324,26 +360,24 @@ pub fn canonicalize_activate_path(path: impl AsRef<Path>) -> Result<PathBuf> {
     validate_canonical_activate_path(&canonical)
 }
 
-/// A ready-to-send activation envelope. Opaque on purpose: `activation_request`
+/// A ready-to-send activation body. Opaque on purpose: `activation_request`
 /// is the only constructor, so the client's activation entry point cannot be
-/// handed a status operation or a hand-assembled envelope with a different
-/// version or a non-canonicalized target.
+/// handed a hand-assembled body with a non-canonicalized target.
 #[derive(Debug, Clone)]
-pub struct ActivationRequest(pub(crate) HelperRequest);
+pub struct ActivationRequest(pub(crate) TryActivateBody);
 
-/// Builds the versioned activation envelope for the current process.
-/// Resolving the path here is a convenience so an obviously wrong target
-/// fails before a round trip; the daemon canonicalizes and revalidates
-/// independently, and treats nothing in this request as trusted beyond the
-/// path it re-derives.
+/// Builds the `TryActivate` body for the current process, with a fresh
+/// client-generated request ID. Resolving the path here is a convenience so
+/// an obviously wrong target fails before a round trip; the helper
+/// canonicalizes and revalidates independently, and treats nothing in this
+/// request as trusted beyond the path it re-derives.
 pub fn activation_request(activate_path: &Path) -> Result<ActivationRequest> {
     let canonical = canonicalize_activate_path(activate_path)?;
 
-    Ok(ActivationRequest(HelperRequest::new(
-        HelperOp::ActivateStorePath(ActivateStorePathRequest {
-            activate_path: canonical.to_string_lossy().into_owned(),
-        }),
-    )))
+    Ok(ActivationRequest(TryActivateBody {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        script_path: canonical.to_string_lossy().into_owned(),
+    }))
 }
 
 #[allow(dead_code)]
@@ -374,6 +408,16 @@ pub fn helper_launch_daemon_plist() -> String {
 </plist>
 "#
     )
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncAgentLaunchConfig {
+    pub config_dir: Option<String>,
+    pub host_attr: Option<String>,
+    pub sync_pull: bool,
+    pub unattended_apply: bool,
+    pub start_interval_seconds: Option<u32>,
 }
 
 pub fn sync_agent_plist(program_path: &str, config: Option<&SyncAgentLaunchConfig>) -> String {
@@ -458,6 +502,346 @@ fn escape_xml(value: &str) -> String {
 mod tests {
     use super::*;
 
+    const BUILD_A: &str = "build-a";
+    const BUILD_B: &str = "build-b";
+    const SCRIPT: &str = "/nix/store/abc-darwin-system/activate";
+
+    fn activation_info(kind: ClientKind) -> ActivationInfo {
+        ActivationInfo {
+            request_id: "req-1".to_string(),
+            script_path: SCRIPT.to_string(),
+            client_kind: kind,
+        }
+    }
+
+    fn try_activate(build_id: &str) -> HelperRequest {
+        HelperRequest::TryActivate {
+            build_id: build_id.to_string(),
+            body: TryActivateBody {
+                request_id: "req-1".to_string(),
+                script_path: SCRIPT.to_string(),
+            },
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Frozen-surface golden fixtures.
+    //
+    // The frozen surface is the cross-build control language and nothing
+    // else: `Status`, `Retire`, their replies, and the typed refusals. Each
+    // fixture below says exactly which bytes may never change. `TryActivate`
+    // and its result are explicitly unfrozen and covered by ordinary
+    // round-trip tests further down.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn frozen_control_requests() {
+        // FROZEN SURFACE — these two fixtures may never change. They carry no
+        // build ID and no version: they are exactly the requests that must
+        // work when the peer is from another build.
+        for (request, fixture) in [
+            (HelperRequest::Status, r#"{"kind":"status"}"#),
+            (HelperRequest::Retire, r#"{"kind":"retire"}"#),
+        ] {
+            assert_eq!(request.encode(), fixture);
+            assert_eq!(HelperRequest::parse(fixture).expect("parses"), request);
+        }
+    }
+
+    #[test]
+    fn frozen_framing_is_one_newline_terminated_json_line() {
+        // FROZEN SURFACE — the framing may never change. Every exchange on
+        // this socket is one newline-terminated JSON line in each direction,
+        // and both sides read exactly one newline-delimited frame. Switching
+        // to length-prefixed or multi-line framing would break every
+        // cross-build exchange while leaving the shape fixtures above
+        // passing, so it is pinned here rather than only in the behavioral
+        // socket tests.
+        let request = HelperRequest::Status.encode();
+        let reply = HelperReply::Retired { activation: None }.encode();
+
+        // Encoders emit exactly one line and never the terminator itself —
+        // the caller appends it, so a terminator here would frame two lines.
+        for encoded in [&request, &reply] {
+            assert!(!encoded.contains('\n'), "encoded {encoded:?} spans lines");
+        }
+
+        // What actually goes on the wire, byte for byte.
+        assert_eq!(format!("{request}\n"), "{\"kind\":\"status\"}\n");
+        assert_eq!(format!("{reply}\n"), "{\"reply\":\"retired\"}\n");
+    }
+
+    #[test]
+    fn frozen_status_reply_per_state() {
+        // FROZEN SURFACE — one fixture per state; none may ever change.
+        let cases = [
+            (
+                HelperReply::Status {
+                    state: HelperStateName::Idle,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: None,
+                },
+                format!(r#"{{"reply":"status","state":"idle","helperBuildId":"{BUILD_A}"}}"#),
+            ),
+            (
+                HelperReply::Status {
+                    state: HelperStateName::Activating,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: Some(activation_info(ClientKind::Gui)),
+                },
+                format!(
+                    r#"{{"reply":"status","state":"activating","helperBuildId":"{BUILD_A}","activation":{{"requestId":"req-1","scriptPath":"{SCRIPT}","clientKind":"gui"}}}}"#
+                ),
+            ),
+            (
+                HelperReply::Status {
+                    state: HelperStateName::Retiring,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: Some(activation_info(ClientKind::SyncAgent)),
+                },
+                format!(
+                    r#"{{"reply":"status","state":"retiring","helperBuildId":"{BUILD_A}","activation":{{"requestId":"req-1","scriptPath":"{SCRIPT}","clientKind":"syncAgent"}}}}"#
+                ),
+            ),
+            (
+                HelperReply::Status {
+                    state: HelperStateName::Retired,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: None,
+                },
+                format!(r#"{{"reply":"status","state":"retired","helperBuildId":"{BUILD_A}"}}"#),
+            ),
+        ];
+
+        for (reply, fixture) in cases {
+            assert_eq!(reply.encode(), fixture);
+            assert_eq!(HelperReply::parse(&fixture).expect("parses"), reply);
+        }
+    }
+
+    #[test]
+    fn frozen_retire_replies_including_busy_with_activation_info() {
+        // FROZEN SURFACE — the complete Retire replies; may never change.
+        let retired = HelperReply::Retired { activation: None };
+        assert_eq!(retired.encode(), r#"{"reply":"retired"}"#);
+        assert_eq!(
+            HelperReply::parse(r#"{"reply":"retired"}"#).expect("parses"),
+            retired
+        );
+
+        let busy = HelperReply::Busy {
+            activation: activation_info(ClientKind::Gui),
+        };
+        let busy_fixture = r#"{"reply":"busy","activation":{"requestId":"req-1","scriptPath":"/nix/store/abc-darwin-system/activate","clientKind":"gui"}}"#;
+        assert_eq!(busy.encode(), busy_fixture);
+        assert_eq!(HelperReply::parse(busy_fixture).expect("parses"), busy);
+    }
+
+    #[test]
+    fn frozen_typed_refusals() {
+        // FROZEN SURFACE — the three typed refusals; may never change.
+        let build_mismatch = HelperReply::BuildMismatch {
+            helper_build_id: BUILD_B.to_string(),
+        };
+        let build_mismatch_fixture =
+            format!(r#"{{"reply":"buildMismatch","helperBuildId":"{BUILD_B}"}}"#);
+        assert_eq!(build_mismatch.encode(), build_mismatch_fixture);
+        assert_eq!(
+            HelperReply::parse(&build_mismatch_fixture).expect("parses"),
+            build_mismatch
+        );
+
+        assert_eq!(
+            HelperReply::CallerNotPermitted.encode(),
+            r#"{"reply":"callerNotPermitted"}"#
+        );
+        assert_eq!(
+            HelperReply::parse(r#"{"reply":"callerNotPermitted"}"#).expect("parses"),
+            HelperReply::CallerNotPermitted
+        );
+
+        assert_eq!(
+            HelperReply::RequestNotUnderstood.encode(),
+            r#"{"reply":"requestNotUnderstood"}"#
+        );
+        assert_eq!(
+            HelperReply::parse(r#"{"reply":"requestNotUnderstood"}"#).expect("parses"),
+            HelperReply::RequestNotUnderstood
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Request and reply semantics beyond the golden bytes.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn try_activate_round_trips_with_its_build_id_and_body() {
+        // Unfrozen: an ordinary round trip, not a byte fixture.
+        let request = try_activate(BUILD_A);
+        let encoded = request.encode();
+
+        assert_eq!(HelperRequest::parse(&encoded).expect("parses"), request);
+        match HelperRequest::parse(&encoded).expect("parses") {
+            HelperRequest::TryActivate { build_id, body } => {
+                assert_eq!(build_id, BUILD_A);
+                assert_eq!(body.script_path, SCRIPT);
+            }
+            other => panic!("unexpected request: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unknown_kind_is_not_understood() {
+        // The kind set is closed forever; anything else is a request no
+        // receiver may serve.
+        assert!(HelperRequest::parse(r#"{"kind":"selfDestruct"}"#).is_none());
+    }
+
+    #[test]
+    fn a_control_request_from_another_build_still_reads_as_itself() {
+        // Cross-build tolerance in the direction that matters: an older or
+        // newer build's Status/Retire — including fields this build knows
+        // nothing about — must still be recognized, because these are the
+        // requests that discover and retire a helper that is not this build.
+        assert_eq!(
+            HelperRequest::parse(r#"{"kind":"status","somethingNew":true}"#).expect("parses"),
+            HelperRequest::Status
+        );
+        assert_eq!(
+            HelperRequest::parse(r#"{"kind":"retire","somethingNew":{"nested":1}}"#)
+                .expect("parses"),
+            HelperRequest::Retire
+        );
+    }
+
+    #[test]
+    fn shipped_pre_build_id_wire_shapes_are_not_understood() {
+        // The shapes previous releases put on this socket carry no kind
+        // field; they must never be misread as a request.
+        for line in [
+            r#"{"op":"status"}"#,
+            r#"{"protocolVersion":2,"op":"status"}"#,
+            r#"{"protocolVersion":2,"op":{"activateStorePath":{"activatePath":"/nix/store/abc-darwin-system/activate"}}}"#,
+            "not json at all",
+            "",
+        ] {
+            assert!(HelperRequest::parse(line).is_none(), "line: {line:?}");
+        }
+    }
+
+    #[test]
+    fn a_malformed_try_activate_is_not_understood() {
+        // A missing body, a body field this build does not honor, and a
+        // missing build ID all fail the one parse — there is no partially
+        // readable request to act on.
+        for line in [
+            r#"{"kind":"tryActivate","buildId":"build-a"}"#,
+            r#"{"kind":"tryActivate","body":{"requestId":"req-1","scriptPath":"/nix/store/abc-darwin-system/activate"}}"#,
+            r#"{"kind":"tryActivate","buildId":"build-a","body":{"requestId":"req-1","scriptPath":"/nix/store/abc-darwin-system/activate","nixPath":"/tmp/attacker-bin"}}"#,
+            r#"{"kind":"tryActivate","buildId":"build-a","body":{"somethingElse":1}}"#,
+        ] {
+            assert!(HelperRequest::parse(line).is_none(), "line: {line:?}");
+        }
+    }
+
+    #[test]
+    fn a_peer_build_id_is_read_whatever_it_contains() {
+        // Build IDs are compared, never validated: every string is a readable
+        // ID, the empty string included. An empty peer ID is simply unequal to
+        // this build's non-empty one — rejecting the request or reply that
+        // carries it would instead make the mismatch unreportable.
+        for build_id in ["", " ", "0123456", "not-a-commit", "\u{1f600}"] {
+            let request = try_activate(build_id);
+            assert_eq!(
+                HelperRequest::parse(&request.encode()).expect("parses"),
+                request
+            );
+
+            let status = HelperReply::Status {
+                state: HelperStateName::Idle,
+                helper_build_id: build_id.to_string(),
+                activation: None,
+            };
+            assert_eq!(
+                HelperReply::parse(&status.encode()).expect("parses"),
+                status
+            );
+
+            let mismatch = HelperReply::BuildMismatch {
+                helper_build_id: build_id.to_string(),
+            };
+            assert_eq!(
+                HelperReply::parse(&mismatch.encode()).expect("parses"),
+                mismatch
+            );
+        }
+    }
+
+    #[test]
+    fn reply_parse_tolerates_unknown_fields_and_rejects_unknown_tags() {
+        // Frozen replies from other builds must keep parsing even if a
+        // diagnostic field is ever (wrongly) added; an unknown reply tag is
+        // an unparseable reply, which every client treats as a refusal.
+        let with_extra = format!(
+            r#"{{"reply":"status","state":"idle","helperBuildId":"{BUILD_A}","note":"diagnostic"}}"#
+        );
+        assert!(matches!(
+            HelperReply::parse(&with_extra).expect("parses"),
+            HelperReply::Status {
+                state: HelperStateName::Idle,
+                ..
+            }
+        ));
+
+        assert!(HelperReply::parse(r#"{"reply":"shutdown"}"#).is_err());
+        assert!(HelperReply::parse(r#"{"ok":true,"code":0,"stdout":"ready"}"#).is_err());
+        assert!(HelperReply::parse("").is_err());
+    }
+
+    #[test]
+    fn status_reply_rejects_state_activation_mismatches() {
+        let impossible = [
+            HelperReply::Status {
+                state: HelperStateName::Idle,
+                helper_build_id: BUILD_A.to_string(),
+                activation: Some(activation_info(ClientKind::Gui)),
+            },
+            HelperReply::Status {
+                state: HelperStateName::Activating,
+                helper_build_id: BUILD_A.to_string(),
+                activation: None,
+            },
+            HelperReply::Status {
+                state: HelperStateName::Retiring,
+                helper_build_id: BUILD_A.to_string(),
+                activation: None,
+            },
+            HelperReply::Status {
+                state: HelperStateName::Retired,
+                helper_build_id: BUILD_A.to_string(),
+                activation: Some(activation_info(ClientKind::SyncAgent)),
+            },
+        ];
+
+        for reply in impossible {
+            let wire = reply.encode();
+            assert!(
+                HelperReply::parse(&wire).is_err(),
+                "impossible Status parsed: {wire}"
+            );
+        }
+    }
+
+    #[test]
+    fn activation_request_canonicalizes_and_generates_request_ids() {
+        // Non-store paths fail before any round trip.
+        assert!(activation_request(Path::new("/tmp/result/activate")).is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // Path validation (unchanged behavior).
+    // ------------------------------------------------------------------
+
     #[test]
     fn validate_accepts_direct_nix_store_activate_path() {
         let path = validate_canonical_activate_path(
@@ -497,249 +881,24 @@ mod tests {
     }
 
     #[test]
-    fn request_round_trips_at_the_current_version() {
-        for op in [
-            HelperOp::Status,
-            HelperOp::ActivateStorePath(ActivateStorePathRequest {
-                activate_path: "/nix/store/abc-darwin-system/activate".to_string(),
-            }),
-        ] {
-            let wire = serde_json::to_string(&HelperRequest::new(op.clone())).expect("serializes");
-
-            assert!(wire.contains(&format!("\"protocolVersion\":{HELPER_PROTOCOL_VERSION}")));
-            assert_eq!(HelperRequest::parse(&wire).expect("parses"), op);
-        }
-    }
-
-    #[test]
-    fn request_rejects_other_protocol_versions_before_reading_the_shape() {
-        // The operation is deliberately invalid: getting the skew
-        // classification rather than an unknown-variant parse error proves
-        // the version gate wins before the rest of the shape is interpreted.
-        for version in [1, 3, 99] {
-            let json = format!("{{\"protocolVersion\":{version},\"op\":\"selfDestruct\"}}");
-            let error = HelperRequest::parse(&json).expect_err("version must be rejected");
-
-            assert!(is_protocol_skew(&error));
-            assert_eq!(
-                error.downcast_ref::<ProtocolSkew>(),
-                Some(&ProtocolSkew {
-                    peer_version: Some(version)
-                })
-            );
-        }
-    }
-
-    #[test]
-    fn activation_request_rejects_claimed_identity_fields() {
-        // A v1 body at the current version: the claimed account values and
-        // requester PATH are a hard parse error now, so they can never look
-        // like they were honored.
-        let json = format!(
-            r#"{{"protocolVersion":{HELPER_PROTOCOL_VERSION},"op":{{"activateStorePath":{{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/tmp/attacker-bin"}}}}}}"#
-        );
-
-        assert!(HelperRequest::parse(&json).is_err());
-    }
-
-    #[test]
-    fn request_rejects_unknown_envelope_fields() {
-        let json = format!(
-            r#"{{"protocolVersion":{HELPER_PROTOCOL_VERSION},"op":"status","userId":501}}"#
-        );
-
-        assert!(HelperRequest::parse(&json).is_err());
-    }
-
-    #[test]
-    fn request_rejects_the_v1_wire_shape_as_protocol_skew() {
-        // v1 tagged the operation inline and carried no version at all. Both
-        // v1 shapes must be rejected, and classified as version skew rather
-        // than a shape error, before any operation is derived.
-        for v1 in [
-            r#"{"op":"status"}"#,
-            r#"{"op":"activateStorePath","request":{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/bin"}}"#,
-        ] {
-            let error = HelperRequest::parse(v1).expect_err("v1 shape must be rejected");
-
-            assert_eq!(
-                error.downcast_ref::<ProtocolSkew>(),
-                Some(&ProtocolSkew { peer_version: None })
-            );
-        }
-    }
-
-    /// The exact request parser the deployed v1 daemon uses, vendored as a
-    /// minimal fixture for the opposite temporal direction of the break.
-    #[derive(Deserialize)]
-    #[serde(tag = "op", rename_all = "camelCase")]
-    enum V1HelperRequest {
-        Status,
-        ActivateStorePath {
-            // Deserialized into but never read, like the payload fields.
-            #[allow(dead_code)]
-            request: V1ActivateStorePathRequest,
-        },
-    }
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    #[allow(dead_code)]
-    struct V1ActivateStorePathRequest {
-        activate_path: String,
-        user_name: String,
-        user_id: u32,
-        home: String,
-        nix_path: String,
-    }
-
-    #[test]
-    fn v1_daemon_parser_cannot_derive_an_activation_from_a_v2_request() {
-        // No-double-apply defense: if a still-resident v1 root daemon could
-        // parse a v2 activation request, it would execute the activation and
-        // answer with a versionless v1 response — which the v2 app rejects
-        // as skew, so any recovery it then attempts would re-run an
-        // already-finished activation. The v2 activation envelope must
-        // therefore be unparseable by the exact v1 request enum.
-        let activation = serde_json::to_string(&HelperRequest::new(HelperOp::ActivateStorePath(
-            ActivateStorePathRequest {
-                activate_path: "/nix/store/abc-darwin-system/activate".to_string(),
-            },
-        )))
-        .expect("serializes");
-
-        assert!(serde_json::from_str::<V1HelperRequest>(&activation).is_err());
-
-        // The v1 daemon does parse a v2 *status* request (its internally
-        // tagged enum ignores the unfamiliar protocolVersion field). That is
-        // the accepted read-only asymmetry — pinned here so an envelope
-        // change that alters it is revisited deliberately.
-        let status =
-            serde_json::to_string(&HelperRequest::new(HelperOp::Status)).expect("serializes");
-
-        assert!(matches!(
-            serde_json::from_str::<V1HelperRequest>(&status),
-            Ok(V1HelperRequest::Status)
-        ));
-    }
-
-    #[test]
-    fn every_response_shape_serializes_the_current_version() {
-        // Status, activation success, activation failure, and protocol-error
-        // responses: all carry the version and the diagnostic build version.
-        for response in [
-            HelperResponse::ok("nixmac helper ready"),
-            HelperResponse::from_exit(true, 0, "activated".to_string()),
-            HelperResponse::from_exit(false, 2, "activation exploded".to_string()),
-            HelperResponse::error(-1, format!("{UNSUPPORTED_PROTOCOL_ERROR} 1")),
-        ] {
-            assert!(!response.helper_build_version.is_empty());
-            let wire = serde_json::to_string(&response).expect("serializes");
-
-            assert!(wire.contains(&format!("\"protocolVersion\":{HELPER_PROTOCOL_VERSION}")));
-            assert!(wire.contains("\"helperBuildVersion\""));
-            assert_eq!(HelperResponse::parse(&wire).expect("parses"), response);
-        }
-    }
-
-    #[test]
-    fn response_parse_rejects_the_exact_v1_status_response() {
-        // What an installed v1 helper answers a status probe with. It must
-        // fail before ok/stdout/error are readable, classified as protocol
-        // skew for the caller's recovery policy to act on.
-        let v1 = r#"{"ok":true,"code":0,"stdout":"nixmac helper ready","stderr":"","error":null}"#;
-
-        let error = HelperResponse::parse(v1).expect_err("v1 response must be rejected");
-
-        assert!(is_protocol_skew(&error));
-        assert_eq!(
-            error.downcast_ref::<ProtocolSkew>(),
-            Some(&ProtocolSkew { peer_version: None })
-        );
-    }
-
-    #[test]
-    fn response_parse_rejects_other_protocol_versions_before_reading_the_shape() {
-        // The rest of the shape is deliberately invalid (missing required
-        // fields, an unknown one instead): getting the skew classification
-        // rather than a field-level parse error proves the version gate wins
-        // before any response field is interpreted.
-        for version in [1, 3, 99] {
-            let json = format!(r#"{{"protocolVersion":{version},"bogus":true}}"#);
-
-            let error = HelperResponse::parse(&json).expect_err("version must be rejected");
-
-            assert!(is_protocol_skew(&error));
-            assert_eq!(
-                error.downcast_ref::<ProtocolSkew>(),
-                Some(&ProtocolSkew {
-                    peer_version: Some(version)
-                })
-            );
-        }
-    }
-
-    #[test]
-    fn daemon_markers_classify_only_as_prefixes() {
-        let skew = HelperResponse::error(
-            -1,
-            ProtocolSkew {
-                peer_version: Some(1),
-            }
-            .to_string(),
-        );
-        assert!(skew.reports_protocol_skew());
-        assert!(!skew.reports_unauthorized_client());
-
-        let refused =
-            HelperResponse::error(-1, format!("{UNAUTHORIZED_CLIENT_ERROR}: bad signature"));
-        assert!(refused.reports_unauthorized_client());
-        assert!(!refused.reports_protocol_skew());
-
-        // An unrelated failure that merely mentions a marker deeper in its
-        // message must not classify.
-        let unrelated = HelperResponse::error(
-            1,
-            format!(
-                "activation failed: log mentioned '{UNSUPPORTED_PROTOCOL_ERROR}' and '{UNAUTHORIZED_CLIENT_ERROR}'"
-            ),
-        );
-        assert!(!unrelated.reports_protocol_skew());
-        assert!(!unrelated.reports_unauthorized_client());
-        assert!(!HelperResponse::ok("nixmac helper ready").reports_protocol_skew());
-    }
-
-    #[test]
-    fn response_parse_rejects_unknown_fields() {
-        let wire = serde_json::to_string(&HelperResponse::ok("ready")).expect("serializes");
-        let with_extra = wire.replacen('{', r#"{"sshAuthSock":"/tmp/ssh.sock","#, 1);
-
-        assert!(HelperResponse::parse(&with_extra).is_err());
-    }
-
-    fn response(stdout: &str, error: Option<&str>) -> HelperResponse {
-        HelperResponse {
-            error: error.map(String::from),
-            ..HelperResponse::from_exit(false, 1, stdout.to_string())
-        }
-    }
-
-    #[test]
     fn failure_detail_prefers_error_then_stdout_tail() {
-        assert_eq!(response("out", Some("boom")).failure_detail(), "boom");
+        let failed = |stdout: &str, error: Option<&str>| ActivationResult {
+            ok: false,
+            code: 1,
+            stdout: stdout.to_string(),
+            error: error.map(String::from),
+        };
+
+        assert_eq!(failed("out", Some("boom")).failure_detail(), "boom");
         // The helper merges activation stderr into stdout, so a plain nonzero
         // exit must still produce a detail.
         assert_eq!(
-            response("activation exploded\n", None).failure_detail(),
+            failed("activation exploded\n", None).failure_detail(),
             "activation exploded"
         );
-    }
 
-    #[test]
-    fn failure_detail_returns_stdout_tail_only() {
         let lines: Vec<String> = (1..=30).map(|n| format!("line {n}")).collect();
-        let detail = response(&lines.join("\n"), None).failure_detail();
-
+        let detail = failed(&lines.join("\n"), None).failure_detail();
         assert!(detail.starts_with("line 11"));
         assert!(detail.ends_with("line 30"));
     }
@@ -749,7 +908,12 @@ mod tests {
         let stdout = format!(
             "activated\n{HELPER_WARNING_PREFIX} failed to update system profile\nplain line"
         );
-        let with_warning = response(&stdout, None);
+        let with_warning = ActivationResult {
+            ok: true,
+            code: 0,
+            stdout,
+            error: None,
+        };
 
         assert_eq!(
             with_warning.warnings(),
@@ -757,7 +921,6 @@ mod tests {
                 "{HELPER_WARNING_PREFIX} failed to update system profile"
             )]
         );
-        assert!(response("no warnings here\n", None).warnings().is_empty());
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/service.rs
+++ b/apps/native/src-tauri/src/privileged_helper/service.rs
@@ -1,36 +1,33 @@
-use crate::privileged_helper::client;
+use crate::privileged_helper::client::{self, HelperClientError};
 #[cfg(target_os = "macos")]
 use crate::privileged_helper::protocol::{HELPER_LABEL, HELPER_PLIST_NAME};
-use crate::privileged_helper::protocol::{HelperResponse, HelperServiceStatus};
+use crate::privileged_helper::protocol::{HelperReply, HelperServiceStatus};
 use anyhow::Result;
 
 pub fn status() -> HelperServiceStatus {
     let mut status = platform_status();
     status.socket_available = client::socket_available();
     // SMAppService state and a socket path prove nothing about the daemon:
-    // only an authenticated round-trip (mutual code-signature validation at
-    // this build's protocol version) shows the connection actually works.
+    // only an authenticated round-trip (mutual code-signature validation)
+    // shows the connection actually works.
     if status.socket_available {
-        fold_status_probe(&mut status, client::status());
+        fold_status_probe(&mut status, client::status().map(|exchange| exchange.reply));
     }
     status
 }
 
-/// Folds one authenticated status round-trip into the service status. Only a
-/// same-version `ok` response marks the daemon responding: a version-skewed
-/// response fails `client::status` before its fields are readable and lands
-/// in the `Err` arm, and a daemon-reported protocol error arrives with
-/// `ok: false` — either way a protocol error can only ever reach `detail`.
-fn fold_status_probe(status: &mut HelperServiceStatus, probe: anyhow::Result<HelperResponse>) {
+/// Folds one status round-trip into the service status. Only an
+/// authenticated `Status` reply naming a state marks the daemon responding;
+/// a typed refusal, an unparseable reply, or any exchange failure can only
+/// ever reach `detail`.
+fn fold_status_probe(
+    status: &mut HelperServiceStatus,
+    probe: Result<HelperReply, HelperClientError>,
+) {
     match probe {
-        Ok(response) if response.ok => status.responding = true,
-        Ok(response) => {
-            status.detail =
-                Some(response.error.unwrap_or_else(|| {
-                    "helper answered the status probe with an error".to_string()
-                }));
-        }
-        Err(error) => status.detail = Some(format!("{error:#}")),
+        Ok(HelperReply::Status { .. }) => status.responding = true,
+        Ok(reply) => status.detail = Some(reply.summary()),
+        Err(error) => status.detail = Some(error.to_string()),
     }
 }
 
@@ -211,7 +208,8 @@ mod macos {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::privileged_helper::protocol::{HELPER_LABEL, UNSUPPORTED_PROTOCOL_ERROR};
+    use crate::privileged_helper::peer_auth::ClientKind;
+    use crate::privileged_helper::protocol::{ActivationInfo, HELPER_LABEL, HelperStateName};
 
     fn probed_status() -> HelperServiceStatus {
         HelperServiceStatus {
@@ -225,64 +223,80 @@ mod tests {
         }
     }
 
-    #[test]
-    fn same_version_ok_probe_sets_responding() {
-        let mut status = probed_status();
-
-        fold_status_probe(&mut status, Ok(HelperResponse::ok("nixmac helper ready")));
-
-        assert!(status.responding);
-        assert_eq!(status.detail, None);
-    }
-
-    #[test]
-    fn skew_rejected_probes_never_set_responding() {
-        // What reaches the fold when the daemon answered with the exact v1
-        // status response or a mismatched version: the client-side parse
-        // already classified it as skew, so the probe arrives as an error.
-        for wire in [
-            r#"{"ok":true,"code":0,"stdout":"nixmac helper ready","stderr":"","error":null}"#
-                .to_string(),
-            format!(
-                r#"{{"protocolVersion":{},"helperBuildVersion":"9.9.9","ok":true,"code":0,"stdout":"","stderr":"","error":null}}"#,
-                crate::privileged_helper::protocol::HELPER_PROTOCOL_VERSION + 1
-            ),
-        ] {
-            let mut status = probed_status();
-
-            fold_status_probe(&mut status, HelperResponse::parse(&wire));
-
-            assert!(!status.responding);
-            assert!(
-                status
-                    .detail
-                    .expect("skew detail")
-                    .contains(UNSUPPORTED_PROTOCOL_ERROR)
-            );
+    fn status_reply(state: HelperStateName) -> HelperReply {
+        let activation = matches!(
+            state,
+            HelperStateName::Activating | HelperStateName::Retiring
+        )
+        .then(|| ActivationInfo {
+            request_id: "req-1".to_string(),
+            script_path: "/nix/store/abc-darwin-system/activate".to_string(),
+            client_kind: ClientKind::Gui,
+        });
+        HelperReply::Status {
+            state,
+            helper_build_id: "build-a".to_string(),
+            activation,
         }
     }
 
     #[test]
-    fn parsed_protocol_error_response_never_sets_responding() {
-        // A same-version daemon reporting a protocol error (it rejected the
-        // request's version) parses fine — it must still never count as
-        // responding.
-        let mut status = probed_status();
+    fn authenticated_status_reply_sets_responding_whatever_the_state() {
+        // `responding` means the daemon answered an authenticated Status
+        // round-trip naming a state — any of the four.
+        for state in [
+            HelperStateName::Idle,
+            HelperStateName::Activating,
+            HelperStateName::Retiring,
+            HelperStateName::Retired,
+        ] {
+            let mut status = probed_status();
 
-        fold_status_probe(
-            &mut status,
-            Ok(HelperResponse::error(
-                -1,
-                format!("{UNSUPPORTED_PROTOCOL_ERROR} 1 (this build speaks 2)"),
+            fold_status_probe(&mut status, Ok(status_reply(state)));
+
+            assert!(status.responding);
+            assert_eq!(status.detail, None);
+        }
+    }
+
+    #[test]
+    fn typed_refusals_never_set_responding() {
+        for reply in [
+            HelperReply::BuildMismatch {
+                helper_build_id: "build-b".to_string(),
+            },
+            HelperReply::CallerNotPermitted,
+            HelperReply::RequestNotUnderstood,
+        ] {
+            let mut status = probed_status();
+
+            fold_status_probe(&mut status, Ok(reply));
+
+            assert!(!status.responding);
+            assert!(status.detail.is_some());
+        }
+    }
+
+    #[test]
+    fn exchange_failures_never_set_responding() {
+        // What reaches the fold when an installed daemon from a previous
+        // release answers with a reply this build cannot parse, or the
+        // exchange fails outright.
+        for error in [
+            HelperClientError::UnparseableReply("unknown reply shape".to_string()),
+            HelperClientError::ClosedBeforeReply,
+            HelperClientError::AuthenticationFailed(anyhow::anyhow!("not the signed helper")),
+            HelperClientError::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "read timed out",
             )),
-        );
+        ] {
+            let mut status = probed_status();
 
-        assert!(!status.responding);
-        assert!(
-            status
-                .detail
-                .expect("protocol error detail")
-                .contains(UNSUPPORTED_PROTOCOL_ERROR)
-        );
+            fold_status_probe(&mut status, Err(error));
+
+            assert!(!status.responding);
+            assert!(status.detail.is_some());
+        }
     }
 }

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -831,11 +831,14 @@ fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult
     if !status.authorized || !status.socket_available {
         return None;
     }
-    // `responding` is the authenticated status round-trip `helper_service`
-    // already performed. Requiring it here is what keeps a version-skewed
-    // daemon from failing the apply: a daemon predating this app's protocol
-    // cannot answer the probe, so the osascript path takes over instead of
-    // the activation request coming back as an unparseable request.
+    // `responding` is the authenticated `Status` round-trip
+    // `helper_service::status` already performed. Requiring it here is what
+    // keeps a helper from a previous release from failing the apply: it cannot
+    // answer this build's probe with a reply this build parses, so the
+    // osascript path takes over instead of the activation request coming back
+    // refused. This is transitional: the contract forbids a `Status` preflight
+    // from gating activation dispatch, and the wiring change that replaces this
+    // whole function with the Apply decision tables removes it.
     if !status.responding {
         info!(
             "[darwin] privileged helper did not answer an authenticated status probe; falling back to osascript: {}",
@@ -854,72 +857,80 @@ fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult
     };
 
     match helper_client::activate_store_path(&request) {
-        Ok(response) => {
-            // A live daemon that refuses this peer means the running build is
-            // not signed as an approved client (unsigned dev build, or a
-            // helper/app version skew). A daemon that does not speak this
-            // app's protocol version is the same situation with a different
-            // cause: an older helper still resident from a previous install.
-            // Falling back to the interactive prompt keeps the apply working
-            // in both cases until the installed helper is replaced by a
-            // current one.
-            if !response.ok
-                && (response.reports_protocol_skew() || response.reports_unauthorized_client())
-            {
-                info!(
-                    "[darwin] privileged helper rejected this client; falling back to osascript: {}",
-                    response.error.unwrap_or_default()
-                );
-                return None;
-            }
-
-            Some(Ok(ActivateResult {
-                success: response.ok,
-                code: response.code,
-                stdout: response.stdout,
-                // The response has no stderr: the activation log arrives
+        Ok(exchange) => match exchange.reply {
+            helper_protocol::HelperReply::ActivationResult(result) => Some(Ok(ActivateResult {
+                success: result.ok,
+                code: result.code,
+                stdout: result.stdout,
+                // The result has no stderr: the activation log arrives
                 // merged into stdout, so only a helper-level error belongs
                 // in the stderr slot consumers show for failures.
-                stderr: response.error.unwrap_or_default(),
-            }))
-        }
-        Err(error) => {
-            let error_text = format!("{error:#}");
-            if error_text.contains("failed to connect to /var/run/nixmac/helper.sock") {
-                info!(
-                    "[darwin] privileged helper socket was stale; falling back to osascript: {error:#}"
-                );
-                return None;
-            }
-            if error_text.contains(crate::privileged_helper::peer_auth::HELPER_VALIDATION_FAILED) {
-                warn!(
-                    "[darwin] process at helper socket failed signature validation; falling back to osascript: {error:#}"
-                );
-                return None;
-            }
-            // The client rejects a response whose protocol version is
-            // missing or different before reading its fields, so version
-            // skew surfaces here as a classified error rather than a
-            // response. A skewed daemon cannot have run the activation — it
-            // could not have parsed the request — so falling back is safe
-            // until the installed helper is replaced by a current one.
-            if helper_protocol::is_protocol_skew(&error) {
-                info!(
-                    "[darwin] privileged helper speaks a different protocol version; falling back to osascript: {error:#}"
-                );
-                return None;
-            }
-
-            Some(Ok(ActivateResult {
+                stderr: result.error.unwrap_or_default(),
+            })),
+            // Every other reply means the helper did not start this
+            // activation: report rather than silently substituting the
+            // password path. No typed refusal is permission to activate some
+            // other way — a build mismatch says the installed helper must be
+            // upgraded or disabled, and a request-not-understood (which an
+            // alien peer could answer with) says even less. Do not "fix" any
+            // of these into a password-path fallback.
+            reply => Some(Ok(ActivateResult {
                 success: false,
                 code: -1,
                 stdout: String::new(),
                 stderr: format!(
-                    "Privileged helper activation did not return a response: {error:#}. Activation may still be running; nixmac did not fall back to the password prompt."
+                    "Privileged helper did not start the activation: {}. nixmac did not fall back to the password prompt.",
+                    reply.summary()
                 ),
-            }))
+            })),
+        },
+        Err(error) if helper_error_allows_password_fallback(&error) => {
+            // These failures happen before the client writes any request
+            // bytes, so this flow knows it did not dispatch an activation.
+            match &error {
+                helper_client::HelperClientError::Unreachable(_) => info!(
+                    "[darwin] privileged helper socket was stale; falling back to osascript: {error}"
+                ),
+                helper_client::HelperClientError::AuthenticationFailed(_) => warn!(
+                    "[darwin] process at helper socket failed signature validation; falling back to osascript: {error}"
+                ),
+                // Whatever the gate admits is by definition pre-dispatch; log
+                // it rather than panicking inside a privileged apply if that
+                // list ever grows.
+                _ => info!("[darwin] falling back to osascript: {error}"),
+            }
+            None
         }
+        // Once the activation exchange starts writing, a close, malformed
+        // reply, or other I/O failure cannot prove that the helper did not
+        // run the request. The outcome is unknown; this flow stops without
+        // compensating through the administrator-password path.
+        Err(error) => Some(Ok(ActivateResult {
+            success: false,
+            code: -1,
+            stdout: String::new(),
+            stderr: format!(
+                "Privileged helper activation did not return a trustworthy result: {error}. Activation may have completed or may still be running; nixmac did not fall back to the password prompt."
+            ),
+        })),
     }
+}
+
+/// Only failures proven to precede all request bytes may select the
+/// administrator-password fallback. Every other exchange error follows the
+/// contract's unknown-outcome rule.
+///
+/// Transitional, like the status-probe gate above: the contract decides
+/// password eligibility before dispatch from reconciled service state and lets
+/// no helper-exchange error select it — including this authentication failure,
+/// which is where unsigned development builds land today. The wiring change
+/// that brings in the Apply decision tables removes this function.
+fn helper_error_allows_password_fallback(error: &helper_client::HelperClientError) -> bool {
+    matches!(
+        error,
+        helper_client::HelperClientError::Unreachable(_)
+            | helper_client::HelperClientError::AuthenticationFailed(_)
+    )
 }
 
 /// Handle activation failures and determine the appropriate error response.
@@ -1362,6 +1373,7 @@ fn run_darwin_rebuild(
 mod activation_safety_tests {
     use super::{
         ActivateResult, activation_failure_left_system_untouched, classify_activate_error,
+        helper_error_allows_password_fallback,
     };
 
     fn failed_activation(stdout: &str, stderr: &str) -> ActivateResult {
@@ -1405,5 +1417,29 @@ mod activation_safety_tests {
             "authorization_denied"
         ));
         assert!(!activation_failure_left_system_untouched("generic_error"));
+    }
+
+    #[test]
+    fn only_proven_pre_dispatch_helper_errors_allow_password_fallback() {
+        use crate::privileged_helper::client::HelperClientError;
+
+        let unreachable = HelperClientError::Unreachable(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no listener",
+        ));
+        let authentication = HelperClientError::AuthenticationFailed(anyhow::anyhow!("wrong peer"));
+        assert!(helper_error_allows_password_fallback(&unreachable));
+        assert!(helper_error_allows_password_fallback(&authentication));
+
+        let mid_exchange = HelperClientError::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "result lost",
+        ));
+        let malformed = HelperClientError::UnparseableReply("future shape".to_string());
+        assert!(!helper_error_allows_password_fallback(
+            &HelperClientError::ClosedBeforeReply
+        ));
+        assert!(!helper_error_allows_password_fallback(&mid_exchange));
+        assert!(!helper_error_allows_password_fallback(&malformed));
     }
 }

--- a/apps/native/src-tauri/src/system/permissions.rs
+++ b/apps/native/src-tauri/src/system/permissions.rs
@@ -639,8 +639,8 @@ pub fn request_permission(permission_id: &str) -> Result<Permission> {
 }
 
 /// Wait for a freshly registered helper daemon to come up and answer a
-/// status round-trip. launchd starts it asynchronously after approval, so the
-/// socket appears a moment after `register()` returns.
+/// `Status` round-trip. launchd starts it asynchronously after approval, so
+/// the socket appears a moment after `register()` returns.
 fn await_helper_ready() -> Result<()> {
     const ATTEMPTS: u32 = 10;
     const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
@@ -653,19 +653,25 @@ fn await_helper_ready() -> Result<()> {
         if !crate::privileged_helper::client::socket_available() {
             continue;
         }
-        match crate::privileged_helper::client::status() {
-            Ok(response) if response.ok => return Ok(()),
-            Ok(response) => {
-                last_error = anyhow::anyhow!(
-                    response
-                        .error
-                        .unwrap_or_else(|| "helper returned an error".to_string())
-                );
-            }
+        match probe_helper_status() {
+            Ok(()) => return Ok(()),
             Err(error) => last_error = error,
         }
     }
     Err(last_error)
+}
+
+/// One authenticated `Status` round-trip, reduced to ok-or-why-not. A reply
+/// naming a state is the helper working; a typed refusal, an unparseable
+/// reply, and every exchange failure are reported as-is.
+fn probe_helper_status() -> Result<()> {
+    match crate::privileged_helper::client::status() {
+        Ok(exchange) => match exchange.reply {
+            crate::privileged_helper::protocol::HelperReply::Status { .. } => Ok(()),
+            reply => Err(anyhow::anyhow!("{}", reply.summary())),
+        },
+        Err(error) => Err(anyhow::anyhow!("{error}")),
+    }
 }
 
 /// One authenticated status round-trip to an already-installed helper
@@ -684,20 +690,32 @@ fn probe_installed_helper() -> (PermissionStatus, Option<String>) {
         );
     }
     match crate::privileged_helper::client::status() {
-        Ok(response) if response.ok => (PermissionStatus::Granted, None),
-        Ok(response) => (
+        Ok(exchange) => match exchange.reply {
+            crate::privileged_helper::protocol::HelperReply::Status { .. } => {
+                (PermissionStatus::Granted, None)
+            }
+            reply => (
+                PermissionStatus::Pending,
+                Some(format!(
+                    "The helper is running but did not answer a status probe: {}. {INSTALL_FROM_APPLICATIONS}",
+                    reply.summary()
+                )),
+            ),
+        },
+        // A close before any reply is deliberately ambiguous: the helper sends
+        // it both for a client it will not serve and for a connection dropped
+        // at its concurrency cap, and a helper that died mid-exchange looks
+        // the same. Report all of that, not just the refusal.
+        Err(crate::privileged_helper::client::HelperClientError::ClosedBeforeReply) => (
             PermissionStatus::Pending,
             Some(format!(
-                "The helper is running but refused this app: {}. {INSTALL_FROM_APPLICATIONS}",
-                response
-                    .error
-                    .unwrap_or_else(|| "unknown error".to_string())
+                "The helper closed the connection without answering: it declined this app, is busy with other connections, or stopped. {INSTALL_FROM_APPLICATIONS}"
             )),
         ),
         Err(error) => (
             PermissionStatus::Pending,
             Some(format!(
-                "The helper did not answer a status probe: {error:#}. {INSTALL_FROM_APPLICATIONS}"
+                "The helper did not answer a status probe: {error}. {INSTALL_FROM_APPLICATIONS}"
             )),
         ),
     }
@@ -742,20 +760,31 @@ fn check_privileged_helper() -> (PermissionStatus, Option<String>) {
         );
     }
     match crate::privileged_helper::client::status() {
-        Ok(response) if response.ok => (PermissionStatus::Granted, None),
-        Ok(response) => (
+        Ok(exchange) => match exchange.reply {
+            crate::privileged_helper::protocol::HelperReply::Status { .. } => {
+                (PermissionStatus::Granted, None)
+            }
+            reply => (
+                PermissionStatus::Pending,
+                Some(format!(
+                    "The helper is registered but did not answer a status probe: {}. Unattended sync will fall back to password prompts until a matching signed build talks to it.",
+                    reply.summary()
+                )),
+            ),
+        },
+        // Ambiguous by design, as above: declined client, connection cap, or a
+        // helper that stopped all close the same way.
+        Err(crate::privileged_helper::client::HelperClientError::ClosedBeforeReply) => (
             PermissionStatus::Pending,
-            Some(format!(
-                "The helper is running but refused this app: {}. Unattended sync will fall back to password prompts until a matching signed build talks to it.",
-                response
-                    .error
-                    .unwrap_or_else(|| "unknown error".to_string())
-            )),
+            Some(
+                "The helper closed the connection without answering: it declined this app, is busy with other connections, or stopped. Unattended sync will fall back to password prompts until a matching signed build talks to it."
+                    .to_string(),
+            ),
         ),
         Err(error) => (
             PermissionStatus::Pending,
             Some(format!(
-                "The helper is registered but did not answer a status probe: {error:#}."
+                "The helper is registered but did not answer a status probe: {error}."
             )),
         ),
     }

--- a/docs/privileged-helper-upgrade-contract.md
+++ b/docs/privileged-helper-upgrade-contract.md
@@ -1,0 +1,721 @@
+# Privileged helper upgrade contract
+
+Status: normative. This document defines how nixmac's privileged helper is
+installed, replaced, retired, and removed, and the guarantees every
+participant may rely on. It applies to the `SMAppService` helper on macOS 13
+and later; earlier macOS versions use the administrator-password path and
+none of this contract.
+
+The GUI's internal reconciliation *procedure* is deliberately not part of
+this document — it may change between releases, and is described in
+nixmac's internal engineering documentation. The guarantees that
+procedure must keep are part of this document, in §8. Everything in this
+document — those guarantees included — may not change.
+
+Read §1–§2 for the design. §3–§10 are the rules, in the order an implementor
+needs them; everything there is binding.
+
+______________________________________________________________________
+
+## 1. The problem
+
+nixmac uses a privileged helper so an approved installation can activate an
+already-built system generation without an administrator password on every
+apply. The GUI, the helper, and the background sync agent are separate
+processes compiled from the same build.
+
+Replacing `nixmac.app` on disk changes their files, but already-running
+processes continue executing the previous build until they exit. So after an
+update a new GUI routinely finds an *older* helper still running as root,
+and must be able to inspect it, stop it from taking new work, and replace
+it — without an administrator password, without interrupting an activation,
+and without ever having seen that older build's code.
+
+## 2. The approach
+
+Seven ideas carry the whole design.
+
+1. **Same build activates; any build negotiates.** `TryActivate` requires
+   the client's build ID to equal the helper's byte for byte, so an
+   activation only ever runs between binaries that shipped together.
+   `Status` and `Retire` carry no build ID and work between any two builds,
+   forever. That split is the entire cross-version story — there is no
+   version negotiation anywhere. (§4, §5)
+1. **Fixed rendezvous points.** The launchd label, the socket path, and the
+   helper plist filename are identical in every build, permanently. That is
+   how a new GUI finds a helper from an arbitrarily old build, skipped
+   releases included. (§4)
+1. **A frozen control language.** `Status`, `Retire`, and three typed
+   refusals never change shape in any future build: a GUI must be able to
+   parse what an unknown-vintage helper says, and the reverse. Everything
+   outside that frozen set may change freely, because `TryActivate` only ever
+   *succeeds* between binaries of the same build. (§4)
+1. **One slot, never a queue.** The helper runs at most one activation and
+   holds no work. Admission and the state transition are a single atomic
+   step; anything it cannot serve right now is refused immediately with a
+   typed reply. (§5, §6)
+1. **The helper owns retirement.** A new GUI cannot safely kill an old
+   helper, so it asks. `Retire` latches "never start another activation";
+   the helper answers `Retired` only once nothing is running, and that
+   reply — on a connection still open — is the only safe-to-unregister
+   signal a live helper can give (§7 rule 1; rules 2 and 3 cover a helper
+   that is absent or unverifiable). (§5, §7)
+1. **Never interrupt, never guess.** A running activation is root mutation
+   in flight; no nixmac code deliberately interrupts it, the two accepted
+   windows (§10.1, §10.2) excepted. If a result is lost, the outcome is
+   unknown and stays unknown: no automatic retry and no password fallback in
+   the flow that lost it. Every trust and termination decision comes from a
+   live observation, never from stored state. (§6)
+1. **Reconciliation converges; it does not resume.** The GUI has no upgrade
+   state machine and remembers no progress between attempts. Each run
+   observes the world and drives toward the stored goal; an interrupted run
+   is simply re-run. (§8)
+
+### What an upgrade looks like
+
+Illustrative only — the binding rules are §7 and §8. The new GUI is the sole
+actor; the old GUI prepares nothing and hands off nothing.
+
+1. The new GUI starts and reads the stored preference — install, keep, or
+   remove. That is the *goal*, never a safety input.
+1. It observes `SMAppService`. If a helper is listening, it authenticates
+   the peer and asks `Status`, learning that helper's build ID and state.
+1. Build ID already equal to its own, from `Idle` or plain `Activating`:
+   done, nothing to do.
+1. Otherwise it sends `Retire` and waits through `Busy(X)` for as long as
+   the running activation takes.
+1. On `Retired` it confirms, immediately beforehand, that the peer has not
+   closed that still-held connection, calls `unregister`, and then registers
+   the bundled helper.
+1. It verifies the result with an authenticated `Status` reporting its own
+   build ID from `Idle` or plain `Activating` (or accepts `requiresApproval`
+   as the normal pending state).
+
+Four branches leave that line (§7, §8.6, §8.9). A registration that is
+`enabled` with positively no listener is unregistered directly, with no
+protocol exchange (§7 rule 2). A registration at `requiresApproval` is left
+pending and mutated in no way (§8.6) — §7 rule 2 also permits unregistering
+that one, but only when the goal is removal. A **root** helper whose
+signature validates as **invalid** cannot be asked anything, so it is removed
+rather than drained (§7 rule 3, §9) — whereas a validation *error*, or a
+non-root peer, authorizes nothing. And anything else — any other refusal, a
+close, an ambiguous failure — ends the attempt with a report; the next
+reconciliation starts over from fresh observation.
+
+______________________________________________________________________
+
+## 3. Definitions
+
+**Build ID** — the opaque string identifying the build a binary came from,
+compiled into the GUI, helper, and sync agent of one build. It exists only
+to identify a build: the protocol neither requires nor validates any
+particular syntax, and two build IDs match only when the strings are
+byte-equal. Production builds normally use a Git commit, but nothing in the
+protocol depends on that. Every genuine binary carries a non-empty build ID,
+enforced when it is built; the wire nevertheless accepts whatever string a
+peer sends, including the empty string, which simply cannot equal a non-empty
+local ID. No participant may reject an otherwise valid reply merely because
+the build ID it reports is empty.
+
+**Signature validation** — evaluating a socket peer's code signature,
+identified by its kernel audit token, against nixmac's pinned **per-binary**
+code-signing requirements. A client validating the helper evaluates the
+helper's requirement; the helper validating a client evaluates the GUI and
+sync-agent requirements (mutually exclusive by construction — each pins its
+own binary's designated identifier), and the one that matches is the
+client's **kind**; nothing the peer sends can influence it. Every
+requirement pins **identity** — signing team and designated identifier —
+never a build ID, version, release, or executable hash: it must be satisfied
+by every past and future build of its binary, because cross-build validation
+is what every upgrade depends on. Validation has exactly three results:
+
+- **valid** — the appropriate requirement is satisfied;
+- **invalid** — the code demonstrably does not satisfy it, including
+  unsigned, ad-hoc-signed, or wrong-identity code and a nixmac binary of the
+  wrong kind, even where a platform API expresses that judgment as an error
+  code;
+- **error** — no judgment could be reached (peer died, resources exhausted,
+  evaluation failed). An error is never treated as invalid.
+
+**Authenticated** — the peer's signature validation returned valid, before
+any protocol bytes were read from or written to that connection. A client
+validating the helper additionally requires the peer to be root. An
+unauthenticated peer receives no protocol bytes; the connection is closed.
+**Root** always means effective uid 0, everywhere in this document.
+
+**Apply** — the GUI's user-initiated activation flow. The sync agent's
+scheduled runs are not Apply. (The helper derives the requesting user's
+identity from the kernel, never from request content; which users may
+request activation is the application protocol's policy, outside this
+document.)
+
+**Activation** — the helper runs the activation script of a built system
+generation as root. Activation is ordered root mutation, not a transaction:
+interrupting it can leave the system partially mutated.
+
+**Canonical install** — the app is a `.app` bundle whose real,
+symlink-resolved path is directly under `/Applications`, not
+runtime-translocated.
+
+## 4. What never changes
+
+### Identifiers
+
+The launchd service label, the helper socket path, and the helper plist
+filename inside the bundle are identical in every build, permanently — this
+is what lets a new GUI find, inspect, and replace a helper from any older
+build, including skipped releases. The socket lives in a root-owned
+directory; the helper creates the directory and binds the socket at startup,
+which requires root.
+
+### The frozen surface
+
+The frozen surface is the cross-build control language: everything a GUI
+needs in order to talk to a helper built from any other build. These wire
+shapes never change in any future build.
+
+- **How a request states its kind, and how a reply states its kind.** The
+  request-kind set (`Status`, `TryActivate`, `Retire`) is closed forever;
+  anything else is a request-not-understood refusal.
+- **The complete `Status` request and reply**, including X's representation
+  (§5). Two more sets close with it: the state set (`Idle`, `Activating`,
+  `Retiring`, `Retired`) and the client-kind set (GUI, sync agent). A helper
+  of any build reports only those, so a GUI of any build can always parse
+  what it finds — a fifth state or a third client kind would leave older
+  GUIs unable to read a `Status` they must act on.
+- **The complete `Retire` request and its replies** — `Retired` and
+  `Busy(X)`, including X's representation.
+- **The typed refusal replies**, a closed set of three: build mismatch —
+  which reports the helper's own build ID, so a client of any build can say
+  what it found — caller not permitted, and request not understood.
+
+Everything else — in particular the `TryActivate` body and its result — may
+change between builds, because `TryActivate` only ever succeeds between
+binaries of the same build. A helper that receives a newer `TryActivate`
+body it cannot understand answers with the frozen request-not-understood
+refusal.
+
+There is **no protocol version field**. Each request is one self-describing
+tagged shape: `Status` and `Retire` carry nothing but their kind,
+`TryActivate` carries the sender's build ID and its activation body.
+Cross-build compatibility comes from the frozen surface plus the exact
+build-ID check on `TryActivate`, not from version negotiation.
+
+## 5. The helper
+
+### States
+
+The helper is a single-slot state machine, always in exactly one of four
+states:
+
+| State | Meaning |
+|---|---|
+| `Idle` | No activation is running. |
+| `Activating(X)` | Activation X is running. When X finishes, the helper returns to `Idle`. |
+| `Retiring(X)` | X is running and retirement is latched; the helper enters `Retired` the moment X finishes. |
+| `Retired` | No activation is running and the helper will never start another. Permanent for the rest of the process lifetime. |
+
+X identifies the in-flight activation: the client-generated request ID and
+activation script path — carried in the `TryActivate` body, which every
+future body must include — plus the submitting client's kind, which the
+helper takes from its own validation of that client, never from the body.
+These fields are informational; no rule in this document branches on them.
+
+X's representation inside `Status` replies and `Retire`'s `Busy(X)` reply is
+part of the frozen surface. `TryActivate`'s **state-derived** replies —
+`Busy(X)`, `Retired`, and its activation result — are **not** frozen: a
+`TryActivate` from a different build never reaches state admission, so those
+replies never cross builds. Its typed refusals are frozen like every other
+refusal, because those are exactly the ones that do cross builds.
+
+Three structural facts about the slot:
+
+- On any connection the helper accepts, it answers `Status` and `Retire`
+  promptly at all times, including while an activation is running.
+- At most one activation exists at any instant, regardless of how many
+  connections are open: the admission decision and the transition into
+  `Activating` are one atomic step, serialized across all connections.
+- Every state transition takes effect **before** the reply that reports it
+  is sent — including the end of an activation: when X finishes, the
+  transition to `Idle` (or `Retired`, if latched) takes effect before X's
+  result reply is sent, so a client holding a result may immediately
+  re-dispatch. In particular, a `Retired` reply **to a `Retire` request** is
+  sent only from the `Retired` state, so no concurrent request can be
+  admitted after it.
+
+### Requests
+
+The protocol has exactly three requests:
+
+| Request | Permitted caller | Build ID | Stability |
+|---|---|---|---|
+| `Status` | authenticated GUI only | not carried; answered whatever the caller's build | frozen forever |
+| `TryActivate(X)` | authenticated GUI, authenticated sync agent | carried; must equal the helper's exactly | body and result may change between builds |
+| `Retire` | authenticated GUI only | not carried; answered whatever the caller's build | frozen forever |
+
+The sync agent is an activation client and nothing else: it sends only
+`TryActivate`, and a `Status` or `Retire` from it is refused as
+caller-not-permitted.
+
+### Connections
+
+One request per connection: a client opens a connection, sends exactly one
+request, and reads exactly one reply; concurrent requests use separate
+connections. The helper serves a small fixed number of connections
+concurrently (four); a connection beyond that cap is closed before
+authentication and before any protocol bytes — there is no wire shape for
+it, and a client sees only a closed connection. Requests are size-bounded
+(64 KiB); an oversized request is rejected outright and never parsed as a
+valid truncated prefix.
+
+After replying, the helper leaves the connection open and ignores further
+bytes on it; the helper never closes an authenticated connection while it is
+alive (unauthenticated and over-cap connections are the exceptions — closed
+before any bytes). Ordinary clients close their own end once they have the
+reply.
+
+A peer-side close on a connection the helper has already answered therefore
+always means the helper process ended — unregister rule 1 (§7) uses exactly
+this as its liveness signal, which is why a replacement holds its answered
+`Retire` connection open until the moment it unregisters. A close *before*
+any reply is weaker: it may instead be the helper declining a client it
+could not validate, or the connection cap; either way the client stops and
+re-observes.
+
+### Refusal order
+
+A request may be refusable for several reasons at once; the reply is decided
+in this fixed order:
+
+1. a request that cannot be parsed in full — unknown kind, malformed shape,
+   malformed activation body, or oversized — is refused as
+   request-not-understood;
+1. then caller not permitted;
+1. then, for `TryActivate`, build mismatch;
+1. finally the state-based reply from the table below.
+
+Because the body is parsed before the build ID is compared, a `TryActivate`
+from a different build may be refused either as a build mismatch or — if
+that helper cannot parse the newer body — as request-not-understood. There
+is no promise about which. Both are refusals, neither starts an activation,
+and a client treats them the same way: the helper has to be replaced or
+disabled, and no activation happened.
+
+### Reply table
+
+| State | `Status` | `TryActivate(Y)` | `Retire` |
+|---|---|---|---|
+| `Idle` | state, helper build ID | starts Y; state becomes `Activating(Y)`; the reply is sent when Y completes and carries Y's result | state becomes `Retired`, then reply `Retired` |
+| `Activating(X)` | state, helper build ID, X | `Busy(X)` | state becomes `Retiring(X)`, then reply `Busy(X)` |
+| `Retiring(X)` | state, helper build ID, X | `Retired` (carrying X's info while it finishes) | `Busy(X)` |
+| `Retired` | state, helper build ID | `Retired` | `Retired` |
+
+The `Status` reply names the state verbatim — all four states are
+distinguishable by any caller. Cross-cutting rows applying in every state: a
+`TryActivate` that parses but whose client build ID is not exactly the
+helper's gets the typed build-mismatch refusal before any privileged work
+(one that does not parse gets request-not-understood instead — see the
+refusal order above); `Status` or `Retire` from a sync agent gets
+caller-not-permitted; a request that cannot be parsed gets
+request-not-understood.
+
+### Reply meanings — read carefully
+
+- **`Status`** is the cross-build discovery exchange: it is how a GUI of any
+  build learns what helper is installed — its build ID and its state.
+  Together with `Retire`, it is what reconciliation uses against a helper of
+  any other build. It is never an admission input for an activation.
+- **`Busy(X)` to `TryActivate`**: an activation is running. Transient; a
+  later request may succeed.
+- **`Retired` to `TryActivate`**: this helper will never start the caller's
+  activation. Permanent for this helper process. It does **not** mean the
+  helper is in the `Retired` state — activation X may still be finishing.
+- **`Busy(X)` to `Retire`**: retirement is latched, X still running. Not
+  safe to unregister yet.
+- **`Retired` to `Retire`**: the helper is in the `Retired` state **now**.
+  This reply — and only this reply — is the safe-to-unregister signal for a
+  **running** helper (§7 rule 1). Rules 2 and 3 cover registrations with no
+  live authenticated helper and need no reply.
+- **Build mismatch** means this helper must be upgraded or disabled before it
+  can activate anything for this caller. It is a refusal, never a licence to
+  activate some other way.
+- **The `TryActivate` result reply** arrives on the same connection when the
+  activation completes and carries its success or failure. A client waits for
+  it under **one generous bound and nothing shorter** — an activation
+  legitimately runs for many minutes, so the bound is set far outside the range
+  of any real one. What is binding is that shape — one bound, generous, far out;
+  the value itself is a build's own choice and no part of this contract, and it
+  is 30 minutes today. Within that range only a peer close or an
+  unparseable reply ends the wait. The short read deadlines belong on
+  connecting, on `Status`, and on `Retire`, and none of them may be reused
+  here: a leash at their scale manufactures unknown outcomes out of ordinary
+  long applies, while expiry of a bound this far out is evidence of a wedged
+  helper rather than of a slow apply. **Within this protocol, the result reply
+  is the only way to learn an activation's
+  outcome.** `Status` reports that an activation is running, never whether a
+  finished one succeeded. (Inspecting the resulting system state is outside
+  the protocol — see §6, unknown outcomes.)
+
+A client that receives a reply it cannot parse treats it as a refusal: do
+not activate, do not mutate anything, report and defer.
+
+## 6. Invariants
+
+1. **A running activation is never deliberately interrupted** — not by the
+   helper, the GUI, a timeout, or an update. The only exceptions are the
+   explicitly accepted residual windows (§10.1's legacy/unverifiable removal
+   and §10.2's crash-relaunch windows); nothing may be added to them. If an
+   activation truly hangs forever, the recovery boundary is a reboot.
+1. **No nixmac code terminates the helper except `SMAppService`
+   unregister.** The helper never exits on its own, and its launchd
+   configuration keeps it alive rather than expiring it. Crashes remain
+   possible — launchd relaunches a crashed helper — which is exactly what
+   §7 rule 1's liveness check exists for.
+1. **The helper never queues work.** One activation slot; every request that
+   cannot be served now is refused immediately with a typed reply.
+1. **Synchronization is bounded and never spans external work.** The
+   helper's activation slot may wait only to enter a bounded, in-memory
+   state-transition critical section. No lock is held across activation,
+   authentication, protocol encoding, socket I/O, reply writing, or any
+   other external or blocking work. Admission and the transition into
+   `Activating` remain one atomic step; an occupied activation state produces
+   its immediate state-derived reply and never queues the request.
+1. **Helper state is process-lifetime only.** Neither retirement nor the
+   activation slot nor any in-flight request is ever persisted. A relaunched
+   helper starts `Idle`.
+1. **Stored state is never a safety input.** The stored helper preference
+   selects the goal — install, keep, or remove — but every trust or
+   termination decision comes from live observation: an authenticated peer's
+   reply, or the OS-backed observations of unregister rules 2 and 3.
+1. **A lost activation result is never compensated automatically** — no
+   automatic re-dispatch, no administrator-password fallback within the flow
+   that lost it.
+
+### Unknown outcomes
+
+If a client dispatched `TryActivate` and stopped waiting before the result
+arrived — the connection was lost, or its one generous bound expired (§5) — the
+outcome is unknown: succeeded, failed, or still running.
+The flow that lost it stops there (invariant 7). The protocol state remains
+observable — `Status` shows whether that activation still runs. A **new**
+activation requires fresh intent (the user applying again; the agent's next
+scheduled run) and goes through normal admission; nothing about a lost
+result blocks a fresh request, and the single slot makes doubling
+impossible. Whether the lost activation succeeded is a question about the
+resulting system state, answered outside this protocol.
+
+## 7. When unregister is allowed
+
+`unregister` terminates the running helper (Apple-documented). It may be
+invoked in exactly three situations and no others.
+
+1. **Retired helper.** The running helper answered `Retired` to `Retire` on a
+   connection the caller still holds open, and immediately before invoking
+   unregister the caller confirms the peer has not closed it. A peer-side
+   close — on that connection or any other the replacement is using — means
+   the helper may have died and been relaunched `Idle`: the attempt is
+   abandoned and reported, every lock or slot it held is released, and a
+   later reconciliation converges from freshly observed state.
+1. **No running process.** `SMAppService` reports `requiresApproval` (an
+   approval-pending service has no process), or `enabled` with **positively
+   no listener** — defined here, once, for the whole document: connection
+   attempts fail because the socket is missing or refuses connections,
+   repeatedly over a bounded window; a timeout, slow reply, or any ambiguous
+   failure never counts as absence. The final absence check is made
+   immediately before invoking unregister; the interval between them is a
+   residual window of the same kind as rule 1's.
+1. **Legacy or unverifiable helper.** The registration under nixmac's
+   service label is `enabled` and the socket peer is a root process whose
+   validation returned **invalid**. An **error** never selects this rule. The
+   classification is re-evaluated from live observation on every run — never
+   implement a has-migrated latch (stored state deciding safety, and it would
+   make a tampered helper unremovable). It fires once for an intact
+   installation, and again only in the tampered case under residual risks.
+
+If the socket peer is not root, no rule applies: report an error and mutate
+nothing. A non-root peer can only mean broken permissions or an impostor, and
+removal decisions are never made from untrusted observations.
+
+## 8. What reconciliation must guarantee
+
+The GUI reconciles the installed helper with its own build using an internal
+procedure that is not part of this contract and may change between releases.
+Whatever its shape, it must keep these promises.
+
+**Who may mutate**
+
+- **8.1 Observation-derived, always.** Every step follows from what is observable
+  at that moment — `SMAppService` state, authenticated replies, the stored
+  preference. No progress is remembered between attempts, and there is no
+  recovery mode distinct from the normal one: an interrupted attempt is simply
+  re-run, and converges.
+- **8.2 Registration requires user opt-in.** Only from a canonical install, and
+  only on the explicit Grant action or by adopting a pre-existing registration
+  (the pre-contract legacy one included) as the user's earlier opt-in. Never
+  otherwise.
+- **8.3 Disable sticks.** The explicit Disable action removes the helper — retire
+  first if it is running, then unregister — and no automatic path may override
+  it, the legacy migration included.
+- **8.4 A displaced GUI mutates nothing.** Running from a non-canonical location,
+  or with a compiled build ID differing from the on-disk bundle's (the bundle
+  was replaced under it): no helper mutation, no stored writes. It only
+  reports what the user should do — move the app, restart the app.
+- **8.5 The new GUI is the only actor in an upgrade.** Finder replacement (quit,
+  replace bundle, relaunch) and the built-in updater (install, relaunch) both
+  converge on its ordinary startup reconciliation; the old GUI never prepares,
+  drains, or unregisters anything. An activation running across the switch
+  finishes under the old helper, and its result goes to a connection that no
+  longer exists — an unknown outcome. When a helper connection closes
+  mid-activation, the GUI reports that the activation may have been
+  interrupted and the system may be partially mutated.
+
+**Approval and verification**
+
+- **8.6 Approval is a state, not an error.** `requiresApproval` means macOS
+  registered the helper but the user has not enabled it in System Settings —
+  never approved, or later revoked — and it is reported as a persistent
+  pending state. Startup and refresh never open System Settings, never
+  re-register a registration that is pending approval, never loop; only the
+  explicit Grant action may open Login Items, repeatedly if clicked again. No registration churn either way.
+  Re-running reconciliation on a cadence is not the loop this rule forbids. A
+  run that mutates nothing may be repeated for as long as the state persists —
+  an approval may be days away, and re-observing costs nothing. (§8.9's
+  indefinite wait is inside a single attempt; this is about repeating whole
+  attempts.) Repetition that *mutates* must be bounded: after a
+  bounded number of consecutive runs that unregister or register, the GUI
+  reports and leaves repair to the next launch or user action. The ban is on
+  registration churn and on opening System Settings, not on re-observation.
+  While pending, Apply uses the administrator-password path and the sync agent
+  defers activation. Approval may arrive weeks later: the next reconciliation
+  (startup or any status refresh) observes `enabled` and proceeds normally,
+  and a build ID that no longer matches the GUI (approval predating an app
+  update) is the ordinary different-build case — retired and replaced.
+  This contract does not assume approval survives a bundle replacement; every
+  post-approval observation converges through the same reconciliation.
+- **8.7 Every registration is verified.** A replacement is complete only when an
+  authenticated `Status` reply reports the exact GUI build ID from `Idle` or
+  plain `Activating`; `Retired` or `Retiring` is a failure, and
+  `requiresApproval` is the normal pending state, not a failure. Anything else
+  is reported as a failure and repaired by a later reconciliation, never by an
+  unguarded retry loop.
+
+**Admission and waiting**
+
+- **8.8 `TryActivate` is the sole admission check.** No probe result — `Status` or
+  otherwise — may gate the dispatch of an activation; the helper decides
+  admission atomically (§5). `Status` is reconciliation's discovery exchange,
+  and `TryActivate`'s own build-ID check is the race guard that makes a stale
+  discovery harmless. Establishing "positively no listener" by its defined
+  repeated connection attempts is observation, not a gating probe, and is
+  permitted.
+- **8.9 Only `Busy(X)` is waited on indefinitely.** During a replacement, an
+  authenticated `Busy(X)` is the single outcome reconciliation retries without
+  limit: fresh `Retire` requests at bounded intervals, unbounded in total,
+  until `Retired`. Every other refusal or communication failure ends the
+  attempt with a report, to be repaired by a later reconciliation.
+- **8.10 Waiting on the OS is bounded.** That previous rule is about retrying a
+  refused or failed exchange; waiting on the OS is different, and
+  reconciliation may do it through bounded, explicitly-defined windows that
+  cannot mutate anything on their own:
+  establishing "positively no listener" by repeated connection attempts,
+  letting a freshly registered helper start listening before verification
+  judges it missing, and awaiting the unregister completion callback. Each has
+  a defined bound, and exceeding it ends the attempt with a report like any
+  other failure. A genuinely hung activation stays a reboot boundary and is
+  never force-killed.
+
+**The other two activation paths**
+
+- **8.11 The password path needs proven quiet.** The administrator-password path
+  itself requires no canonical install, but it is selected only when nixmac
+  knows no helper activation is running or was dispatched: no registration
+  exists, its service definition is broken (`notFound`), it is pending
+  approval, or its socket is positively not listening. That eligibility is
+  decided **before** any helper exchange, from reconciled service state.
+  nixmac never *selects* the password path while an `enabled` registration
+  could still admit sync-agent work — even one the user never granted or has
+  since disabled; such a registration is first adopted or removed. The
+  guarantee is evaluated when the path is selected; §10.4 records the windows in
+  which the world changes after that — one of them lasting as long as the
+  activation — overlap included. Once a helper exchange has been attempted,
+  nothing it produces can select the password
+  path: a build mismatch or any other typed refusal, an unparseable reply, an
+  authentication failure, a close, a timeout, an ambiguous connection failure,
+  an unknown `TryActivate` outcome, or anything unidentifiable answering the
+  helper's socket all stop the flow and report. The path is refused — never
+  silently substituted — in every one of those cases, and while an activation
+  is running or the helper is being replaced.
+- **8.12 The sync agent has no lifecycle role.** It is an ordinary exact-build-ID
+  protocol client: it sends only `TryActivate` and never consults the stored
+  helper preference. On any obstacle — `Busy`, `Retired`, any typed refusal, a
+  helper that fails authentication, an unreachable helper, an unparseable
+  reply — it keeps its built result and defers activation to its next
+  scheduled run. It never calls `Retire` or `Status` (both refused as
+  caller-not-permitted) and never uses the password path. Upgrades never stop,
+  kill, or hand off a running agent: killing one is harmless because agents
+  perform no root mutation, and an activation already dispatched completes in
+  the helper regardless.
+
+## 9. One-time legacy migration
+
+The previously shipped helper is unsigned and predates this contract; it
+cannot `Retire`. On the first launch of this release over such an
+installation, reconciliation classifies the socket peer — root, validation
+**invalid** — as the legacy helper and writes zero protocol bytes to it. An
+existing registration counts as the user's earlier opt-in, so migration is
+automatic: unregister directly (§7 rule 3), register the bundled helper under
+the same verification as any other registration, and proceed through the
+normal approval flow if macOS asks again. A user who had explicitly disabled
+the helper instead gets removal without replacement.
+
+Only a completed **invalid** judgment authorizes this path. Inability to
+reach a judgment authorizes nothing.
+
+Migration is not guaranteed to be one run. A pre-contract GUI still running
+in another login session obeys none of this contract and can re-register the
+old helper underneath a migration in progress. That is why the classification
+is re-derived from live observation every time and never latched: the next
+reconciliation simply sees the legacy helper again and migrates again, until
+no pre-contract GUI is left running.
+
+Accepted residual risk: this unregister terminates the helper even if it is
+mid-activation, and an old client's activation may race the unregister. For an
+intact installation it happens exactly once — every contract-era helper
+validates as valid and takes the `Retire` path, whatever its build ID, and a
+validation error selects nothing. The same removal is deliberately reachable
+for a contract-era helper whose signature stops validating (tampered or
+corrupted bundle, revoked identity): an invalid root peer cannot prove a
+drain — no reply from it can be trusted — so removal is the only sound
+direction. Such a helper is treated exactly as legacy, interruption risk
+included.
+
+## 10. Residual risks and accepted limits
+
+- **10.1 Legacy migration race** (§9): once for an intact installation, and again
+  only if a contract-era helper's signature stops validating — an
+  unverifiable root peer is removed, never drained.
+- **10.2 Crash-relaunch windows**: between the `Retired` reply and unregister (§7
+  rule 1), or between the final absence check and unregister (rule 2), the
+  helper could crash or be relaunched `Idle` by launchd's `KeepAlive` and in
+  principle admit a fresh activation before unregister lands. The
+  immediately-before checks shrink both windows to the interval between check
+  and call. Accepted.
+- **10.3 Concurrent login sessions converge, not coordinate**: a second user's GUI
+  (fast user switching) can interleave reconciliation with the first's.
+  Same-build GUIs interleave at worst into a failed register or a failed
+  verification, reported and repaired by the next attempt — which may be an
+  automatic one on each session's own cadence, bounded per session by the rule
+  in §8.6; a different-build
+  **contract-era** GUI is displaced (§8) and cannot mutate at all. A
+  pre-contract GUI has no such gate and can undo a migration step from a
+  second session; convergence there comes from re-classifying live on every
+  run, not from displacement. No cross-session lock. Accepted.
+- **10.4 The password path is a point-in-time decision**: it is selected from the
+  state observed at that moment. nixmac does not register a helper while a
+  password activation it started is running — but it only knows one is running
+  once that activation has been recorded, and the record is taken after the
+  observation that selected the path — so nixmac's own reconciliation can
+  complete a replacement in between and leave an eligible helper behind.
+  Independent actors need no such window and are not bounded by it: a user
+  approving the helper in Login Items, or a `KeepAlive` relaunch after a
+  positive-absence observation, can make one eligible at any moment while the
+  password activation runs. Either way a scheduled sync-agent run could then
+  activate alongside it. Accepted, and closing the record gap would remove only
+  the first of the two.
+- **10.5 Retirement as denial of convenience**: `Retire` is accepted from any
+  authenticated GUI, any build, any location — that breadth is what makes
+  cross-build upgrades work. A signature-valid nixmac copy run by any local
+  user can therefore retire the helper. Bounded: no privilege gained, no
+  activation interrupted, automatic recovery at the next reconciliation.
+  Accepted.
+- **10.6 Disable completes at the next GUI run**: if the GUI crashes between
+  recording the disable and finishing the removal, the still-enabled helper
+  keeps serving scheduled sync-agent activations until the next GUI run
+  resumes the removal (Apply refuses meanwhile). Bounded by that next run;
+  Disable is a preference, not a security boundary. Accepted.
+- **10.7 Same-build-ID development rebuilds are invisible** to build-ID-based
+  identity. Developers use the explicit Disable/Grant workflow. No
+  byte-level code identity is added to compensate.
+- **10.8 Connection slots are finite**: the helper accepts four connections at a
+  time, and a long activation plus a replacement's held-open `Retire`
+  connection already occupy two. Beyond the cap a client sees only a closed
+  connection and re-observes later, so a local actor holding slots open can
+  stall reconciliation and Apply. Bounded: no privilege gained, no activation
+  interrupted, and it clears as soon as those clients close or the machine
+  reboots. Accepted.
+- **10.9 A wedged helper** — unresponsive, or `Busy(X)` forever because an
+  activation truly hangs — is never force-killed. Apply blocks until §5's bound
+  expires, then reports an unknown outcome; a later apply is refused `Busy(X)`
+  for as long as the activation hangs. The documented recovery is a reboot,
+  after which reconciliation converges from observed state.
+- **10.10 A result can outlive its reader**: quitting or relaunching the GUI while
+  an apply runs loses that activation's result (unknown outcome). The
+  activation itself always completes under invariant 1.
+- **10.11 Unregister can race a result reply**: X's transition to `Retired` becomes
+  observable to a concurrent `Retire` before X's result bytes are written, so
+  in principle a `Retire`/unregister pair could terminate the helper between
+  the two and leave the apply client reporting an unknown outcome for an
+  activation that actually finished. The window is the width of one reply
+  write against a full unregister round trip. Nothing is mutated twice and
+  invariant 1 is untouched — only the reporting is lost. Accepted, in
+  preference to delaying the transition, which is what lets a client holding a
+  result re-dispatch immediately.
+
+______________________________________________________________________
+
+## Appendix: design evidence (non-normative)
+
+Added 2026-08-04, after this design was adversarially challenged with
+simpler alternatives. This appendix binds nothing; it records what the
+rules above rest on, so the next simplification attempt starts from the
+evidence instead of rediscovering it.
+
+The load-bearing platform facts, and what each one forces:
+
+- **A replaced daemon executable requires re-registration or the service
+  may not launch.** Apple's normative `SMAppService` class documentation
+  states that updating a bundled LaunchDaemon executable or property list
+  requires re-registration, and recommends unregistering first when the
+  executable changed. This forces an upgrade to be unregister → register
+  with the GUI as the sole actor — §2.5's shape and §8.5 are consequences
+  of the platform, not conventions. It rules out every design in which
+  launchd itself starts the new build: on-demand socket activation, and a
+  helper that exits upon observing its bundle replaced so that
+  `KeepAlive` relaunches the new binary, both depend on launchd
+  relaunching a replaced executable without re-registration — the exact
+  case Apple documents as unsupported, and one that strands the
+  installation with no helper and no actor left to repair it.
+- **Unregister terminates the process; its completion callback signals
+  process termination.** (Apple's `unregister` documentation.) That
+  documentation promises nothing about application-level work — the
+  callback is not a transaction barrier for an activation in flight.
+  This is the drain protocol's entire justification: a running
+  activation must be proven finished
+  before unregister, and for a live, verifiable helper only the helper
+  itself can prove that — §2.5, §5's `Retire`, §7 rule 1. Rules 2 and 3
+  unregister without that proof precisely where no live verifiable
+  helper exists to give it, under §10.1's and §10.2's accepted risks.
+- **Apple declines to guarantee that unregister/re-register never
+  requires renewed user approval.** (Apple DTS, explicitly declining to
+  prove that negative.) §8.6's treatment of post-replacement
+  `requiresApproval` as a normal pending state rests on this, and any
+  redesign would keep it.
+
+What this means for future challenges: the drain protocol is the direct
+consequence of the first two facts plus exactly one architectural
+choice — the helper is also the process that executes the activation.
+Only that choice is revisable: an executor detached from the helper
+process, surviving unregister, would make helper replacement harmless by
+construction. Revising it is only worthwhile **before** the first
+release of this contract — once one build carrying the frozen surface
+(§4) ships, that surface is a permanent commitment whatever replaces the
+rest.
+
+The challenge also surfaced one sub-window worth naming: the helper
+performs post-activation maintenance (updating the system profile to
+point at the activated generation) after a successful activation, and
+§9's rule-3 unregister can land between the two — the activation
+succeeded, but the system profile still names the previous generation.
+This is a narrower sub-window of §10.1's accepted interruption risk with
+a distinct consequence, noted here so §10.1's acceptance is read as
+including it knowingly.


### PR DESCRIPTION
## Summary

A helper installed by one build must be replaceable by the next, and a new
GUI can only speak what the installed helper already understands. The
requests that cross builds — `Status`, `Retire`, their replies, and the
typed refusals — are therefore frozen here, before any release depends on
them.

- `Status` and `Retire` are kind-only and answered in every state, so a
  peer of any build can discover and retire this helper. `TryActivate`
  carries a build ID and is admitted only on exact equality.
- Build identity is an opaque string compared for equality, never parsed.
  Packaged builds fail without one; development builds share a literal.
- One activation at a time in a four-state in-memory slot. A request that
  cannot be served now is refused with a typed reply, never queued.
- Signature validation keeps the valid/invalid/error split: only a
  completed negative judgment authorizes the legacy removal path, and the
  status table is built from SDK constants, so a wrong name fails the
  build rather than misclassifying a peer.
- The sync agent may only ask for an activation; every obstacle defers to
  its next scheduled run with the out-link kept.

Upgrade behavior is not reachable yet: nothing calls `Retire`, and Apply
keeps its transitional probe-and-fallback shape.

BREAKING CHANGE: the build input is NIXMAC_BUILD_ID, so a build
environment that sets the old name gets the development fallback or fails.
An already-installed helper from an earlier build cannot serve this one;
replace it through Disable then Grant.


internal code `E1a`

## Test Plan

- [ ] Manual testing of a CI-build artifact

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
