### PR TITLE
feat(use-apply): pre-generate commit msg before activation

### DIFF
--- a/apps/native/src/components/widget/layout/merge-section.test.tsx
+++ b/apps/native/src/components/widget/layout/merge-section.test.tsx
@@ -1,0 +1,121 @@
+import { initialUiState, uiActions, viewModelActions } from "@nixmac/state";
+import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSummary } from "@/hooks/use-summary";
+import { MergeSection } from "./merge-section";
+
+const mocks = vi.hoisted(() => ({
+  generateCommitMessage: vi.fn<() => Promise<string>>(),
+  handleCommit: vi.fn<() => Promise<void>>(),
+}));
+
+// The orpc client is the boundary under test: use-summary's real
+// interaction with them is exercised for real.
+vi.mock("@/lib/orpc", () => ({
+  client: {
+    summarizedChanges: {
+      generateCommitMessage: mocks.generateCommitMessage,
+    },
+  },
+}));
+
+vi.mock("@/hooks/use-git-operations", () => ({
+  useGitOperations: () => ({
+    handleCommit: mocks.handleCommit,
+  }),
+}));
+
+function resetStores() {
+  uiActions.setState({ ...initialUiState });
+  viewModelActions.setState({
+    evolveEvents: [],
+    changeMap: null,
+    git: null,
+    evolve: null,
+    build: {
+      externalBuildDetected: false,
+      upstreamUpdateAvailable: false,
+      rebuildNeeded: false,
+    },
+  });
+}
+
+describe("MergeSection commit-message generation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handleCommit.mockResolvedValue(undefined);
+    resetStores();
+  });
+
+  it("does not regenerate on mount when the apply-time prefetch already produced a suggestion", () => {
+    uiActions.setCommitMessageSuggestion("feat: prefetched\n\nbody");
+    mocks.generateCommitMessage.mockResolvedValue("feat: should not run");
+
+    render(<MergeSection />);
+
+    expect(mocks.generateCommitMessage).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText("Commit message…")).toHaveValue("feat: prefetched");
+  });
+
+  it("generates once on mount when no suggestion exists", async () => {
+    mocks.generateCommitMessage.mockResolvedValue("feat: generated\n\nbody");
+
+    render(<MergeSection />);
+
+    expect(mocks.generateCommitMessage).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Commit message…")).toHaveValue("feat: generated");
+    });
+  });
+
+  it("joins the in-flight prefetch instead of issuing a second IPC call (fast build)", async () => {
+    let resolve: (message: string) => void = () => {};
+    mocks.generateCommitMessage.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    // The apply-time prefetch is still in flight when the save panel mounts.
+    const { result: summary } = renderHook(() => useSummary());
+    let prefetch: Promise<void> = Promise.resolve();
+    act(() => {
+      prefetch = summary.current.generateCommitMessage({ force: true });
+    });
+
+    render(<MergeSection />);
+
+    expect(mocks.generateCommitMessage).toHaveBeenCalledTimes(1);
+    // The field is disabled while the joined generation is pending — text
+    // typed into it would be remounted away when the resolve re-seeds.
+    // Committing mid-generation would submit an empty subject (disabled
+    // inputs are omitted from FormData), so the button stays gated too.
+    expect(screen.getByRole("button", { name: "Commit" })).toBeDisabled();
+    await act(async () => {
+      resolve("feat: prefetched late");
+      await prefetch;
+    });
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Commit message…")).toHaveValue("feat: prefetched late");
+    });
+    expect(screen.getByPlaceholderText("Commit message…")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Commit" })).toBeEnabled();
+  });
+
+  it("regenerates on demand from the Regenerate button", async () => {
+    mocks.generateCommitMessage.mockResolvedValue("feat: first");
+    render(<MergeSection />);
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Commit message…")).toHaveValue("feat: first");
+    });
+
+    mocks.generateCommitMessage.mockResolvedValue("feat: second");
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Regenerate commit message"));
+    });
+
+    expect(mocks.generateCommitMessage).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Commit message…")).toHaveValue("feat: second");
+    });
+  });
+});

--- a/apps/native/src/components/widget/layout/merge-section.tsx
+++ b/apps/native/src/components/widget/layout/merge-section.tsx
@@ -22,6 +22,10 @@ export function MergeSection() {
   const [isGenerating, setIsGenerating] = useState(false);
 
   useEffect(() => {
+    // Apply starts this work while activation is in progress. Keep that result
+    // instead of clearing it and issuing the same request after Save opens.
+    if (commitMessageSuggestion) return;
+
     let cancelled = false;
     setIsGenerating(true);
     generateCommitMessage().finally(() => {
@@ -30,7 +34,7 @@ export function MergeSection() {
     return () => {
       cancelled = true;
     };
-  }, [generateCommitMessage, changeMap]);
+  }, [commitMessageSuggestion, generateCommitMessage, changeMap]);
 
   async function handleRegenerate() {
     setIsGenerating(true);

--- a/apps/native/src/components/widget/layout/merge-section.tsx
+++ b/apps/native/src/components/widget/layout/merge-section.tsx
@@ -22,8 +22,17 @@ export function MergeSection() {
   const [isGenerating, setIsGenerating] = useState(false);
 
   useEffect(() => {
+    // Short-circuit when a suggestion is already set: the apply-time
+    // prefetch has covered this diff, and regenerating here would clear
+    // and clobber it. Read via getState for the latest value without
+    // re-running this effect on every suggestion change.
+    if (useUiState.getState().commitMessageSuggestion) {
+      return;
+    }
     let cancelled = false;
     setIsGenerating(true);
+    // Single-flight: when the prefetch is still in flight (fast build),
+    // this joins it instead of issuing a second IPC call.
     generateCommitMessage().finally(() => {
       if (!cancelled) setIsGenerating(false);
     });
@@ -74,7 +83,7 @@ export function MergeSection() {
               key={commitMessageSuggestion}
               className="border-border bg-background mb-2 flex-1"
               defaultValue={commitSubject || commitMessageSuggestion || ""}
-              disabled={isProcessing}
+              disabled={isProcessing || isGenerating}
               name="commitMsg"
               placeholder="Commit message…"
             />
@@ -95,7 +104,7 @@ export function MergeSection() {
 
         <Button
           className="bg-slate-200 hover:bg-slate-300 text-slate-800"
-          disabled={isProcessing}
+          disabled={isProcessing || isGenerating}
           type="submit"
         >
           {processingAction === "merge" ? (

--- a/apps/native/src/components/widget/layout/merge-section.tsx
+++ b/apps/native/src/components/widget/layout/merge-section.tsx
@@ -22,10 +22,6 @@ export function MergeSection() {
   const [isGenerating, setIsGenerating] = useState(false);
 
   useEffect(() => {
-    // Apply starts this work while activation is in progress. Keep that result
-    // instead of clearing it and issuing the same request after Save opens.
-    if (commitMessageSuggestion) return;
-
     let cancelled = false;
     setIsGenerating(true);
     generateCommitMessage().finally(() => {
@@ -34,7 +30,7 @@ export function MergeSection() {
     return () => {
       cancelled = true;
     };
-  }, [commitMessageSuggestion, generateCommitMessage, changeMap]);
+  }, [generateCommitMessage, changeMap]);
 
   async function handleRegenerate() {
     setIsGenerating(true);

--- a/apps/native/src/hooks/use-apply.test.ts
+++ b/apps/native/src/hooks/use-apply.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   checkAppManagement: vi.fn(),
   checkEtcClobber: vi.fn(),
   finalizeApply: vi.fn(),
-  generateCommitMessage: vi.fn<(options?: { clear?: boolean }) => Promise<void>>(),
+  generateCommitMessage: vi.fn<(options?: { clear?: boolean; force?: boolean }) => Promise<void>>(),
   triggerRebuild: vi.fn(),
 }));
 

--- a/apps/native/src/hooks/use-apply.test.ts
+++ b/apps/native/src/hooks/use-apply.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   checkAppManagement: vi.fn(),
   checkEtcClobber: vi.fn(),
   finalizeApply: vi.fn(),
+  generateCommitMessage: vi.fn<(options?: { clear?: boolean }) => Promise<void>>(),
   triggerRebuild: vi.fn(),
 }));
 
@@ -24,6 +25,12 @@ vi.mock("@/lib/orpc", () => ({
 vi.mock("@/hooks/use-rebuild-stream", () => ({
   useRebuildStream: () => ({
     triggerRebuild: mocks.triggerRebuild,
+  }),
+}));
+
+vi.mock("@/hooks/use-summary", () => ({
+  useSummary: () => ({
+    generateCommitMessage: mocks.generateCommitMessage,
   }),
 }));
 
@@ -65,6 +72,7 @@ describe("useApply", () => {
     mocks.checkEtcClobber.mockResolvedValue(makeEtcClobberResult({ ok: true, conflicts: [] }));
     mocks.checkAppManagement.mockResolvedValue(makeAppManagementResult());
     mocks.finalizeApply.mockResolvedValue(undefined);
+    mocks.generateCommitMessage.mockResolvedValue(undefined);
     mocks.triggerRebuild.mockResolvedValue(undefined);
   });
 
@@ -153,5 +161,26 @@ describe("useApply", () => {
 
     expect(mocks.triggerRebuild).toHaveBeenCalledTimes(1);
     expect(mocks.triggerRebuild).toHaveBeenCalledWith(expect.objectContaining({ context: "apply" }));
+  });
+
+  it("prefetches the commit message without delaying activation", async () => {
+    let resolveCommitMessage: (() => void) | undefined;
+    mocks.generateCommitMessage.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        resolveCommitMessage = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useApply());
+
+    await act(async () => {
+      await result.current.handleApply();
+    });
+
+    expect(mocks.generateCommitMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.triggerRebuild).toHaveBeenCalledTimes(1);
+    expect(mocks.generateCommitMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.triggerRebuild.mock.invocationCallOrder[0],
+    );
+    resolveCommitMessage?.();
   });
 });

--- a/apps/native/src/hooks/use-apply.ts
+++ b/apps/native/src/hooks/use-apply.ts
@@ -85,7 +85,8 @@ export function useApply() {
     // now so it is available as soon as the successful build reaches Save.
     // This is intentionally not awaited: an inference failure must not delay
     // or prevent activation, and the save panel still supports regeneration.
-    void generateCommitMessage();
+    // `force`: a previous run's in-flight generation may carry an older diff.
+    void generateCommitMessage({ force: true });
 
     await triggerRebuild({
       context: "apply",

--- a/apps/native/src/hooks/use-apply.ts
+++ b/apps/native/src/hooks/use-apply.ts
@@ -1,4 +1,5 @@
 import { useRebuildStream } from "@/hooks/use-rebuild-stream";
+import { useSummary } from "@/hooks/use-summary";
 import type { AppManagementCheckResult } from "@/ipc/types";
 import { client } from "@/lib/orpc";
 import { uiActions } from "@nixmac/state";
@@ -63,6 +64,7 @@ async function hasAppManagementBlockers(): Promise<boolean> {
  */
 export function useApply() {
   const { triggerRebuild } = useRebuildStream();
+  const { generateCommitMessage } = useSummary();
 
   const handleApply = async () => {
     uiActions.setProcessing(true, "apply");
@@ -78,6 +80,12 @@ export function useApply() {
       uiActions.setProcessing(false);
       return;
     }
+
+    // The diff is final before activation starts. Generate its commit message
+    // now so it is available as soon as the successful build reaches Save.
+    // This is intentionally not awaited: an inference failure must not delay
+    // or prevent activation, and the save panel still supports regeneration.
+    void generateCommitMessage();
 
     await triggerRebuild({
       context: "apply",

--- a/apps/native/src/hooks/use-evolve.test.ts
+++ b/apps/native/src/hooks/use-evolve.test.ts
@@ -73,6 +73,16 @@ describe("useEvolve", () => {
     expect(useUiState.getState().evolvePrompt).toBe("");
   });
 
+  it("clears the previous commit-message suggestion when a new evolution starts", async () => {
+    mocks.evolve.mockResolvedValue(undefined);
+    uiActions.setEvolvePrompt("install vim");
+    uiActions.setCommitMessageSuggestion("feat: stale suggestion");
+
+    await useEvolve().handleEvolve();
+
+    expect(useUiState.getState().commitMessageSuggestion).toBeNull();
+  });
+
   it("surfaces failures without clearing the prompt", async () => {
     mocks.evolve.mockRejectedValue(new Error("AI evolution failed: boom"));
 

--- a/apps/native/src/hooks/use-evolve.ts
+++ b/apps/native/src/hooks/use-evolve.ts
@@ -16,6 +16,7 @@ import { modelForProvider } from "@/lib/providers/ai-models";
  * `darwin:evolve:event` payload, handled by `viewmodel/evolution.ts`.
  */
 const evolveFromManual = async () => {
+  uiActions.setCommitMessageSuggestion(null);
   await client.darwin.evolveFromManual();
 };
 
@@ -45,6 +46,7 @@ const handleEvolve = async () => {
   uiActions.clearLogs();
   uiActions.setConversationalResponse(null);
   uiActions.setEvolutionTelemetry(null);
+  uiActions.setCommitMessageSuggestion(null);
   // A new evolution means "follow the live backend step" — drop any manual
   // step-override (e.g. the user clicked Back to refine) so the result lands
   // on the live Review step instead of staying behind on Describe.

--- a/apps/native/src/hooks/use-evolve.ts
+++ b/apps/native/src/hooks/use-evolve.ts
@@ -1,3 +1,5 @@
+import { clearCommitMessageSuggestion } from "@/hooks/use-summary";
+
 import { EVOLUTION_CANCELLED_MSG } from "@/lib/constants";
 import { uiActions, useUiState, viewModelActions } from "@nixmac/state";
 import { tauriAPI } from "@/ipc/api";
@@ -16,7 +18,9 @@ import { modelForProvider } from "@/lib/providers/ai-models";
  * `darwin:evolve:event` payload, handled by `viewmodel/evolution.ts`.
  */
 const evolveFromManual = async () => {
-  uiActions.setCommitMessageSuggestion(null);
+  // Route through use-summary so an in-flight generation for the old diff
+  // cannot resolve and repopulate the suggestion after the clear.
+  clearCommitMessageSuggestion();
   await client.darwin.evolveFromManual();
 };
 
@@ -46,7 +50,7 @@ const handleEvolve = async () => {
   uiActions.clearLogs();
   uiActions.setConversationalResponse(null);
   uiActions.setEvolutionTelemetry(null);
-  uiActions.setCommitMessageSuggestion(null);
+  clearCommitMessageSuggestion();
   // A new evolution means "follow the live backend step" — drop any manual
   // step-override (e.g. the user clicked Back to refine) so the result lands
   // on the live Review step instead of staying behind on Describe.

--- a/apps/native/src/hooks/use-git-operations.ts
+++ b/apps/native/src/hooks/use-git-operations.ts
@@ -1,3 +1,5 @@
+import { clearCommitMessageSuggestion } from "@/hooks/use-summary";
+
 import { uiActions } from "@nixmac/state";
 import type { FileDiffContents } from "@/ipc/types";
 import { client } from "@/lib/orpc";
@@ -63,7 +65,7 @@ const handleCommit = async ({ message }: { message: string }) => {
     // The backend clears the evolve state, refreshes the git-state cell, and
     // resets the change-map cell; the `*_changed` events mirror everything.
     await client.git.commit({ message });
-    uiActions.setCommitMessageSuggestion(null);
+    clearCommitMessageSuggestion();
     uiActions.appendLog("✓ Committed successfully\n");
     uiActions.setError(null);
     toast.success("Committed successfully");

--- a/apps/native/src/hooks/use-git-operations.ts
+++ b/apps/native/src/hooks/use-git-operations.ts
@@ -34,7 +34,9 @@ function compactFileDiffContents(
   contents: Partial<Record<string, FileDiffContents>>,
 ): Record<string, FileDiffContents> {
   return Object.fromEntries(
-    Object.entries(contents).filter((entry): entry is [string, FileDiffContents] => entry[1] != null),
+    Object.entries(contents).filter(
+      (entry): entry is [string, FileDiffContents] => entry[1] != null,
+    ),
   );
 }
 
@@ -61,6 +63,7 @@ const handleCommit = async ({ message }: { message: string }) => {
     // The backend clears the evolve state, refreshes the git-state cell, and
     // resets the change-map cell; the `*_changed` events mirror everything.
     await client.git.commit({ message });
+    uiActions.setCommitMessageSuggestion(null);
     uiActions.appendLog("✓ Committed successfully\n");
     uiActions.setError(null);
     toast.success("Committed successfully");

--- a/apps/native/src/hooks/use-summary.test.ts
+++ b/apps/native/src/hooks/use-summary.test.ts
@@ -1,0 +1,151 @@
+import { initialUiState, uiActions, useUiState } from "@nixmac/state";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSummary } from "./use-summary";
+
+const mocks = vi.hoisted(() => ({
+  generateCommitMessage: vi.fn<() => Promise<string>>(),
+}));
+
+vi.mock("@/lib/orpc", () => ({
+  client: {
+    summarizedChanges: {
+      generateCommitMessage: mocks.generateCommitMessage,
+    },
+  },
+}));
+
+describe("useSummary generateCommitMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uiActions.setState({ ...initialUiState });
+  });
+
+  it("clears the suggestion synchronously and stores the resolved message", async () => {
+    uiActions.setCommitMessageSuggestion("stale suggestion");
+    let resolve: (message: string) => void = () => {};
+    mocks.generateCommitMessage.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const { result } = renderHook(() => useSummary());
+
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.generateCommitMessage();
+    });
+    // Default clear runs before the IPC resolves.
+    expect(useUiState.getState().commitMessageSuggestion).toBeNull();
+
+    await act(async () => {
+      resolve("feat: fresh\n\nbody");
+      await pending;
+    });
+    expect(useUiState.getState().commitMessageSuggestion).toBe("feat: fresh\n\nbody");
+  });
+
+  it("joins concurrent callers onto a single in-flight IPC call", async () => {
+    let resolve: (message: string) => void = () => {};
+    mocks.generateCommitMessage.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const { result } = renderHook(() => useSummary());
+
+    let first: Promise<void> = Promise.resolve();
+    let second: Promise<void> = Promise.resolve();
+    act(() => {
+      first = result.current.generateCommitMessage();
+    });
+    act(() => {
+      second = result.current.generateCommitMessage();
+    });
+    expect(mocks.generateCommitMessage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolve("feat: joined");
+      await first;
+      await second;
+    });
+    expect(useUiState.getState().commitMessageSuggestion).toBe("feat: joined");
+  });
+
+  it("a clear during flight prevents the resolve from resurrecting the suggestion", async () => {
+    let resolve: (message: string) => void = () => {};
+    mocks.generateCommitMessage.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const { result } = renderHook(() => useSummary());
+
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.generateCommitMessage();
+    });
+    act(() => {
+      result.current.clearCommitMessageSuggestion();
+    });
+    expect(useUiState.getState().commitMessageSuggestion).toBeNull();
+
+    await act(async () => {
+      resolve("feat: stale diff");
+      await pending;
+    });
+    // The generation started before the clear; its late resolve must not
+    // repopulate the field for a diff the user has moved past.
+    expect(useUiState.getState().commitMessageSuggestion).toBeNull();
+  });
+
+  it("force supersedes an in-flight generation and drops its stale resolve", async () => {
+    let resolveFirst: (message: string) => void = () => {};
+    let resolveSecond: (message: string) => void = () => {};
+    mocks.generateCommitMessage
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveSecond = r;
+        }),
+      );
+    const { result } = renderHook(() => useSummary());
+
+    let first: Promise<void> = Promise.resolve();
+    let second: Promise<void> = Promise.resolve();
+    act(() => {
+      first = result.current.generateCommitMessage();
+    });
+    act(() => {
+      second = result.current.generateCommitMessage({ force: true });
+    });
+    expect(mocks.generateCommitMessage).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveSecond("feat: new diff");
+      await second;
+    });
+    expect(useUiState.getState().commitMessageSuggestion).toBe("feat: new diff");
+
+    await act(async () => {
+      resolveFirst("feat: old diff");
+      await first;
+    });
+    expect(useUiState.getState().commitMessageSuggestion).toBe("feat: new diff");
+  });
+
+  it("keeps the existing suggestion when inference fails", async () => {
+    mocks.generateCommitMessage.mockRejectedValue(new Error("inference failed"));
+    uiActions.setCommitMessageSuggestion("manual draft");
+    const { result } = renderHook(() => useSummary());
+
+    await act(async () => {
+      await result.current.generateCommitMessage({ clear: false });
+    });
+    expect(useUiState.getState().commitMessageSuggestion).toBe("manual draft");
+  });
+});

--- a/apps/native/src/hooks/use-summary.ts
+++ b/apps/native/src/hooks/use-summary.ts
@@ -14,17 +14,62 @@ const findChangeMap = async (): Promise<void> => {
   }
 };
 
-const generateCommitMessage = async (options?: { clear?: boolean }) => {
+let commitMessageGeneration: Promise<void> | null = null;
+let commitMessageEpoch = 0;
+
+/**
+ * Generate (or join) the commit-message inference for the current diff.
+ *
+ * Single-flight: concurrent callers — the apply-time prefetch, the save
+ * panel's mount effect, the Regenerate button — join one in-flight IPC
+ * call instead of racing duplicate inference over the same diff. Only a
+ * `force` start (the diff is final at Apply) detaches and supersedes.
+ */
+const generateCommitMessage = async (options?: {
+  clear?: boolean;
+  force?: boolean;
+}) => {
   const clear = options?.clear ?? true;
+  const force = options?.force ?? false;
+  if (!force && commitMessageGeneration) {
+    return commitMessageGeneration;
+  }
+  // Invalidate any in-flight generation: its resolve must not resurrect a
+  // suggestion for a diff the user has already moved past.
+  const epoch = ++commitMessageEpoch;
   if (clear) {
     uiActions.setCommitMessageSuggestion(null);
   }
-  try {
-    const message = await client.summarizedChanges.generateCommitMessage();
-    uiActions.setCommitMessageSuggestion(message);
-  } catch {
-    // Keep existing on error — user can type manually
-  }
+  const run = (async () => {
+    try {
+      const message = await client.summarizedChanges.generateCommitMessage();
+      if (epoch === commitMessageEpoch) {
+        uiActions.setCommitMessageSuggestion(message);
+      }
+    } catch {
+      // Keep existing on error — user can type manually
+    } finally {
+      // A superseded flight (force restart, clear) must not detach the
+      // current handle — only the flight that still owns the epoch may.
+      if (epoch === commitMessageEpoch) {
+        commitMessageGeneration = null;
+      }
+    }
+  })();
+  commitMessageGeneration = run;
+  return run;
+};
+
+/**
+ * Clear the suggestion and invalidate any in-flight generation, so a stale
+ * resolve cannot repopulate the field for a diff that no longer exists.
+ * Callers that reset UI state between diffs (evolve, commit) must use this
+ * instead of `uiActions.setCommitMessageSuggestion(null)`.
+ */
+export const clearCommitMessageSuggestion = () => {
+  commitMessageEpoch += 1;
+  commitMessageGeneration = null;
+  uiActions.setCommitMessageSuggestion(null);
 };
 
 const generateCurrentSummary = async () => {
@@ -43,5 +88,11 @@ const summarizeOnFocus = () => {
 };
 
 export function useSummary() {
-  return { findChangeMap, generateCommitMessage, generateCurrentSummary, summarizeOnFocus };
+  return {
+    clearCommitMessageSuggestion,
+    findChangeMap,
+    generateCommitMessage,
+    generateCurrentSummary,
+    summarizeOnFocus,
+  };
 }


### PR DESCRIPTION
Fire generateCommitMessage() as an unawaited side effect at the start of
handleApply — the diff is final before activation starts, and the save
panel can regenerate on failure. An inference failure must not block or
delay activation.

Merge-section's existing effect must not clobber the in-flight
suggestion: short-circuit when commitMessageSuggestion is already set.

## How the clobber and races are closed

- `use-summary.generateCommitMessage` is now single-flight: concurrent callers (apply-time prefetch, save-panel mount effect, Regenerate) join one in-flight IPC call instead of racing duplicate inference over the same diff. `force: true` (used by the Apply prefetch, where the diff is final) supersedes any older flight.
- The save-panel mount effect short-circuits when a suggestion is already set — the prefetched message is used as-is, never cleared and regenerated.
- `clearCommitMessageSuggestion()` replaces raw `setCommitMessageSuggestion(null)` at the evolve/commit reset points; it bumps an epoch so a stale in-flight resolve cannot resurrect a suggestion for a diff the user has moved past.
- The commit-message input and Commit button are disabled while a generation is pending: text typed into a field whose content is about to be replaced would be remounted away, and a disabled input is omitted from FormData, so committing mid-generation would submit an empty subject.

## Test Plan

- `bun run test:unit` — 373 tests, including:
  - `use-summary.test.ts` (new): synchronous clear, single-flight join, clear-during-flight invalidation, force supersede with stale-resolve drop, failure keeps the draft.
  - `merge-section.test.tsx` (new): no regeneration on mount when prefetched; exactly one IPC when the panel mounts mid-flight (fast build); field + Commit button disabled until the joined resolve lands and re-enabled after; Regenerate issues a second call.
  - existing `use-apply` / `use-evolve` suites unchanged and green.
- `bun run build` (tsc + vite) and `bun run check` clean.

#no-linear
