### PR TITLE
chore: remove `--workspace` extra arg from VSCode rust-analyzer settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
   "rust-analyzer.check.command": "clippy",
-  "rust-analyzer.check.allTargets": true,
-  "rust-analyzer.check.extraArgs": ["--workspace"]
+  "rust-analyzer.check.allTargets": true
 }


### PR DESCRIPTION
## Summary

This arg got picked up somewhere in the environment (where, I'm not 100% sure what changed) and duplicated which broke clippy in vscode.

<!-- What does this PR do? Why? -->

## Test Plan

Starting from `devenv shell`, vscode rust-analyzer works.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed