### PR TITLE
feat(helper)!: wire reconciliation into startup and apply

### DIFF
--- a/apps/native/src-tauri/src/commands/permissions.rs
+++ b/apps/native/src-tauri/src/commands/permissions.rs
@@ -26,8 +26,9 @@ pub async fn refresh_permissions(app: AppHandle) -> Result<(), String> {
 /// For manual permissions (full-disk), this opens System Settings.
 #[tauri::command]
 pub async fn permissions_request(
+    app: AppHandle,
     permission_id: String,
 ) -> Result<shared_types::Permission, String> {
-    permissions::request_permission(&permission_id)
+    permissions::request_permission(&app, &permission_id)
         .map_err(|e| capture_err("permissions_request", e))
 }

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -722,6 +722,18 @@ fn run_gui_mode(
                 }
             });
 
+            // Reconcile the installed privileged helper with this build. This is
+            // the only actor in an upgrade: a Finder replacement and the
+            // updater's relaunch both converge here, on the new GUI's ordinary
+            // startup, and the old one prepares nothing.
+            //
+            // Off the main thread, and off the startup path: the run makes
+            // ServiceManagement calls *on* the main queue and awaits them, and it
+            // waits — legitimately, for as long as it takes — on an activation a
+            // previous build's helper is still running. It reports through the
+            // permission row; nothing here waits for it.
+            system::helper_permission::start_converging(handle);
+
             // Background initialize the nix-darwin docs index once at startup for fast option-shape lookup.
             let docs_handle = handle.clone();
             tauri::async_runtime::spawn_blocking(move || {

--- a/apps/native/src-tauri/src/orpc/darwin.rs
+++ b/apps/native/src-tauri/src/orpc/darwin.rs
@@ -3,14 +3,14 @@
 use super::{OrpcCtx, helpers::internal_err};
 use crate::commands::{apply, evolve, rollback};
 use crate::privileged_helper::{
-    protocol::{HelperServiceStatus, SyncAgentLaunchConfig},
-    service,
+    protocol::SyncAgentLaunchConfig,
     sync_agent::{self, SyncAgentStatus},
 };
 use crate::shared_types::{
     AppManagementCheckResult, BuildCheckResult, EtcClobberCheckResult, EvolveCancelResult,
     OkResult, RebuildStatus, RollbackResult,
 };
+use crate::system::helper_permission;
 use orpc::*;
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -66,6 +66,28 @@ struct RestoreTargetInput {
 #[serde(rename_all = "camelCase")]
 struct InstallSyncAgentInput {
     config: Option<SyncAgentLaunchConfig>,
+}
+
+/// What one reconciliation run found, for a client that only has to display it:
+/// whether the helper is installed and answering at this build, and the sentence
+/// that says what else is true.
+#[derive(Debug, Deserialize, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+struct HelperReport {
+    at_this_build: bool,
+    detail: String,
+}
+
+impl HelperReport {
+    fn of(report: &crate::privileged_helper::reconcile::Reconciled) -> Self {
+        Self {
+            at_this_build: matches!(
+                report,
+                crate::privileged_helper::reconcile::Reconciled::AtThisBuild
+            ),
+            detail: helper_permission::describe(report),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Type)]
@@ -193,16 +215,28 @@ async fn rebuild_status(ctx: OrpcCtx, _input: ()) -> Result<RebuildStatus, ORPCE
         .map_err(|error| internal_err("darwin.rebuildStatus", error))
 }
 
-async fn helper_status(_ctx: OrpcCtx, _input: ()) -> Result<HelperServiceStatus, ORPCError> {
-    Ok(service::status())
+/// One run of the reconciliation function, reported. It takes no decision of its
+/// own and opens nothing — only [`helper_grant`] opens Login Items. The one thing
+/// it may store is the adoption: a registration that already exists is recorded as
+/// the user's earlier opt-in before anything is mutated under it.
+///
+/// The same single run a status refresh makes, and no more than that: a refresh
+/// also starts the convergence loop, and this does not.
+async fn helper_status(ctx: OrpcCtx, _input: ()) -> Result<HelperReport, ORPCError> {
+    Ok(HelperReport::of(&helper_permission::observe(&ctx.app)))
 }
 
-async fn helper_register(_ctx: OrpcCtx, _input: ()) -> Result<HelperServiceStatus, ORPCError> {
-    service::register().map_err(|error| internal_err("darwin.helperRegister", error))
+/// The explicit Grant action. Grant is the only action that may open Login
+/// Items; `permissions.request("privileged-helper")` is the same action reached
+/// from the permission row.
+async fn helper_grant(ctx: OrpcCtx, _input: ()) -> Result<HelperReport, ORPCError> {
+    Ok(HelperReport::of(&helper_permission::grant(&ctx.app)))
 }
 
-async fn helper_unregister(_ctx: OrpcCtx, _input: ()) -> Result<HelperServiceStatus, ORPCError> {
-    service::unregister().map_err(|error| internal_err("darwin.helperUnregister", error))
+/// The explicit Disable action: retire a running helper, unregister it, and
+/// register nothing. No later automatic run overrides it.
+async fn helper_disable(ctx: OrpcCtx, _input: ()) -> Result<HelperReport, ORPCError> {
+    Ok(HelperReport::of(&helper_permission::disable(&ctx.app)))
 }
 
 async fn sync_agent_status(_ctx: OrpcCtx, _input: ()) -> Result<SyncAgentStatus, ORPCError> {
@@ -278,14 +312,14 @@ pub fn routes() -> Router<OrpcCtx> {
             .output(orpc_specta::specta::<RebuildStatus>())
             .handler(rebuild_status),
         "helperStatus" => os::<OrpcCtx>()
-            .output(orpc_specta::specta::<HelperServiceStatus>())
+            .output(orpc_specta::specta::<HelperReport>())
             .handler(helper_status),
-        "helperRegister" => os::<OrpcCtx>()
-            .output(orpc_specta::specta::<HelperServiceStatus>())
-            .handler(helper_register),
-        "helperUnregister" => os::<OrpcCtx>()
-            .output(orpc_specta::specta::<HelperServiceStatus>())
-            .handler(helper_unregister),
+        "helperGrant" => os::<OrpcCtx>()
+            .output(orpc_specta::specta::<HelperReport>())
+            .handler(helper_grant),
+        "helperDisable" => os::<OrpcCtx>()
+            .output(orpc_specta::specta::<HelperReport>())
+            .handler(helper_disable),
         "syncAgentStatus" => os::<OrpcCtx>()
             .output(orpc_specta::specta::<SyncAgentStatus>())
             .handler(sync_agent_status),

--- a/apps/native/src-tauri/src/orpc/permissions.rs
+++ b/apps/native/src-tauri/src/orpc/permissions.rs
@@ -25,8 +25,8 @@ async fn refresh(ctx: OrpcCtx, _input: ()) -> Result<(), ORPCError> {
         .map_err(|e| internal_err("permissions.refresh", e))
 }
 
-async fn request(_ctx: OrpcCtx, input: RequestInput) -> Result<Permission, ORPCError> {
-    cmd::permissions_request(input.permission_id)
+async fn request(ctx: OrpcCtx, input: RequestInput) -> Result<Permission, ORPCError> {
+    cmd::permissions_request(ctx.app, input.permission_id)
         .await
         .map_err(|e| internal_err("permissions.request", e))
 }

--- a/apps/native/src-tauri/src/privileged_helper/client.rs
+++ b/apps/native/src-tauri/src/privileged_helper/client.rs
@@ -7,7 +7,15 @@ use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
-const ACTIVATION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+/// The one generous bound in this client, and deliberately not one of the short
+/// leashes above: an activation legitimately runs for many minutes, so nothing
+/// shorter can be put here without turning ordinary long applies into lost
+/// results. Half an hour is the accepted ceiling. An activation still running
+/// when it expires is reported as an unknown outcome by an apply and as a
+/// deferral by the sync agent — neither compensates for it, and the activation
+/// itself keeps running. Do not reuse this on `Status` or `Retire`, and do not
+/// shorten it to match them.
+const ACTIVATION_TIMEOUT: Duration = Duration::from_mins(30);
 /// Status probes back the permissions UI; a wedged helper must not stall a
 /// permissions refresh, so they get a short leash instead of CLIENT_TIMEOUT.
 const STATUS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -82,6 +90,11 @@ pub enum AssessedExchange {
     Unidentified(String),
 }
 
+/// Whether the socket path exists. Diagnostic only — it proves nothing about a
+/// helper, which is why nothing in the app reads it: the sync agent's no-config
+/// mode prints it, and every decision comes from an authenticated exchange or
+/// from the absence window in `socket_probe`.
+#[allow(dead_code)] // Used by the sync agent binary this module is shared into.
 pub fn socket_available() -> bool {
     std::path::Path::new(HELPER_SOCKET_PATH).exists()
 }
@@ -203,13 +216,6 @@ fn exchange_on(
         reply,
         connection: stream,
     })
-}
-
-/// Sends `Status`. GUI-only by protocol policy: the sync agent has no
-/// lifecycle role and the helper refuses every request from it but
-/// `TryActivate`.
-pub fn status() -> Result<HelperExchange, HelperClientError> {
-    exchange(&HelperRequest::Status, STATUS_PROBE_TIMEOUT)
 }
 
 /// Sends `Status`, keeping the peer assessment. Reconciliation's discovery

--- a/apps/native/src-tauri/src/privileged_helper/mod.rs
+++ b/apps/native/src-tauri/src/privileged_helper/mod.rs
@@ -9,10 +9,6 @@ pub mod client;
 pub mod helper_runtime;
 pub mod peer_auth;
 pub mod protocol;
-// Complete and unreachable from production: nothing calls the reconciliation
-// function yet. The change that wires it into startup, the grant and disable
-// actions, apply, and the updater removes this.
-#[allow(dead_code)]
 pub mod reconcile;
 pub mod root_activation;
 pub mod service;

--- a/apps/native/src-tauri/src/privileged_helper/protocol.rs
+++ b/apps/native/src-tauri/src/privileged_helper/protocol.rs
@@ -20,36 +20,6 @@ pub const HELPER_SOCKET_DIR: &str = "/var/run/nixmac";
 pub const BUILD_ID: &str = env!("NIXMAC_BUILD_ID");
 const DEFAULT_SYNC_AGENT_INTERVAL_SECONDS: u32 = 900;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct HelperServiceStatus {
-    pub label: String,
-    pub available: bool,
-    pub registered: bool,
-    pub authorized: bool,
-    pub socket_available: bool,
-    /// The daemon answered an authenticated `Status` round-trip naming a
-    /// state: the client validated the daemon's signature and the daemon
-    /// accepted this client. A typed refusal or an unparseable reply never
-    /// sets this.
-    pub responding: bool,
-    pub detail: Option<String>,
-}
-
-impl HelperServiceStatus {
-    pub fn unavailable(detail: impl Into<String>) -> Self {
-        Self {
-            label: HELPER_LABEL.to_string(),
-            available: false,
-            registered: false,
-            authorized: false,
-            socket_available: false,
-            responding: false,
-            detail: Some(detail.into()),
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Requests.
 //

--- a/apps/native/src-tauri/src/privileged_helper/reconcile.rs
+++ b/apps/native/src-tauri/src/privileged_helper/reconcile.rs
@@ -197,7 +197,8 @@ pub enum Stopped {
 // The sentences the permissions UI shows. Written here, next to the variants
 // they explain, because that is where this app already puts helper detail text
 // (`system::permissions` composes the same kind of string and the panel renders
-// it verbatim). No caller until the change that wires the report into the UI.
+// it verbatim). `system::helper_permission` is what turns one of these into the
+// row's detail.
 
 impl std::fmt::Display for Displacement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -542,7 +543,11 @@ mod evidence {
     }
 }
 
-use evidence::{Committed, RetiredHelper};
+// `Committed` is nameable outside this module because the environment methods
+// that demand one are; minting one is not — `Committed::checked` stays visible
+// only in here, so the register step remains the only place one comes from.
+pub use evidence::Committed;
+use evidence::RetiredHelper;
 
 /// Which of the three rules authorizes one unregister.
 ///
@@ -589,8 +594,12 @@ pub enum PeerReply<C> {
 /// Everything a run observes or does, injected so the decisions above can be
 /// driven through every case without a helper, a bundle, or a settings store.
 ///
-/// Only observations and effects live here. No method decides anything, and
-/// none of them can open System Settings.
+/// Only observations and effects live here, and no method decides anything about
+/// the goal or the helper. Nothing this function does asks for System Settings
+/// either: the capability is absent from this trait, so a run cannot open a pane
+/// whatever it observes. The GUI's Grant action opens Login Items around its own
+/// call to this function — never from inside one — which is what keeps startup
+/// and status refreshes from opening anything.
 pub trait Environment {
     /// An answered connection, held open. Opaque: the only thing done with one
     /// is asking whether its peer is still there.
@@ -725,9 +734,7 @@ impl<R: Runtime> Environment for LiveEnvironment<'_, R> {
     }
 
     fn unregister(&self) -> Result<(), String> {
-        service::unregister()
-            .map(|_status| ())
-            .map_err(|error| format!("{error:#}"))
+        service::unregister().map_err(|error| format!("{error:#}"))
     }
 
     fn replace_helper(
@@ -1319,7 +1326,11 @@ impl<E: Environment> Run<'_, E> {
 /// Re-evaluated before each one rather than once per pass: both facts can
 /// change while a pass runs — an app can be moved, and a bundle can be
 /// replaced by an update — and what they guard is destructive.
-fn gates<E: Environment>(env: &E) -> Result<(), Reconciled> {
+///
+/// Public for one reason: Apply asks the same question before deciding whether
+/// it may touch a helper, and a second implementation of it could disagree with
+/// this one.
+pub fn gates<E: Environment>(env: &E) -> Result<(), Reconciled> {
     // Canonical install. A copy running from anywhere else observes and
     // reports only: it may not even ask a helper to retire.
     if let InstallLocation::Elsewhere(observed) = env.install_location() {

--- a/apps/native/src-tauri/src/privileged_helper/service.rs
+++ b/apps/native/src-tauri/src/privileged_helper/service.rs
@@ -1,7 +1,5 @@
-use crate::privileged_helper::client::{self, HelperClientError};
 #[cfg(target_os = "macos")]
-use crate::privileged_helper::protocol::{HELPER_LABEL, HELPER_PLIST_NAME};
-use crate::privileged_helper::protocol::{HelperReply, HelperServiceStatus};
+use crate::privileged_helper::protocol::HELPER_PLIST_NAME;
 use anyhow::Result;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::{Duration, Instant};
@@ -150,49 +148,22 @@ impl std::fmt::Display for RegisterFailure {
 /// run the work somewhere other than a main queue it has no run loop to drain.
 type LaterMainQueueTurn<'a> = &'a dyn Fn(Box<dyn FnOnce() + Send + 'static>);
 
-pub fn status() -> HelperServiceStatus {
-    let mut status = platform_status();
-    status.socket_available = client::socket_available();
-    // SMAppService state and a socket path prove nothing about the daemon:
-    // only an authenticated round-trip (mutual code-signature validation)
-    // shows the connection actually works.
-    if status.socket_available {
-        fold_status_probe(&mut status, client::status().map(|exchange| exchange.reply));
-    }
-    status
-}
-
-/// Folds one status round-trip into the service status. Only an
-/// authenticated `Status` reply naming a state marks the daemon responding;
-/// a typed refusal, an unparseable reply, or any exchange failure can only
-/// ever reach `detail`.
-fn fold_status_probe(
-    status: &mut HelperServiceStatus,
-    probe: Result<HelperReply, HelperClientError>,
-) {
-    match probe {
-        Ok(HelperReply::Status { .. }) => status.responding = true,
-        Ok(reply) => status.detail = Some(reply.summary()),
-        Err(error) => status.detail = Some(error.to_string()),
-    }
-}
-
-/// The typed registration status of nixmac's helper service.
+/// The typed registration status of nixmac's helper service — the only thing
+/// this module reports about it.
 ///
-/// What the GUI's helper reconciliation decides from; the permissions UI reads
-/// the folded [`status`] instead.
+/// There is deliberately no folded "is the helper working" readout here: what a
+/// helper is and whether it may be used are the reconciliation function's to
+/// decide, from an authenticated `Status` reply, and a status flag summarising a
+/// socket round-trip is exactly what an activation must never be admitted on.
 pub fn registration_status() -> Result<RegistrationStatus> {
     platform_registration_status()
 }
 
-pub fn register() -> Result<HelperServiceStatus> {
-    platform_register()?;
-    Ok(status())
-}
-
-pub fn unregister() -> Result<HelperServiceStatus> {
-    platform_unregister()?;
-    Ok(status())
+/// Removes the registration, synchronously. The running helper is killed, and
+/// this call does not wait for that: only [`replace_helper`] does, because only
+/// a replacement needs to know the old process is gone.
+pub fn unregister() -> Result<()> {
+    platform_unregister()
 }
 
 /// Replaces the registered helper: unregisters, waits for the running process
@@ -381,43 +352,12 @@ fn on_later_main_queue_turn(work: Box<dyn FnOnce() + Send + 'static>) {
 }
 
 #[cfg(target_os = "macos")]
-fn platform_status() -> HelperServiceStatus {
-    match macos::registration_status() {
-        Ok(status) => HelperServiceStatus {
-            label: HELPER_LABEL.to_string(),
-            available: true,
-            registered: status != RegistrationStatus::NotRegistered,
-            authorized: status == RegistrationStatus::Enabled,
-            socket_available: false,
-            responding: false,
-            detail: Some(status.to_string()),
-        },
-        Err(error) => HelperServiceStatus::unavailable(error.to_string()),
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn platform_status() -> HelperServiceStatus {
-    HelperServiceStatus::unavailable("SMAppService is only available on macOS")
-}
-
-#[cfg(target_os = "macos")]
 fn platform_registration_status() -> Result<RegistrationStatus> {
     macos::registration_status()
 }
 
 #[cfg(not(target_os = "macos"))]
 fn platform_registration_status() -> Result<RegistrationStatus> {
-    anyhow::bail!("SMAppService is only available on macOS")
-}
-
-#[cfg(target_os = "macos")]
-fn platform_register() -> Result<()> {
-    macos::register_service()
-}
-
-#[cfg(not(target_os = "macos"))]
-fn platform_register() -> Result<()> {
     anyhow::bail!("SMAppService is only available on macOS")
 }
 
@@ -495,18 +435,10 @@ mod macos {
         })
     }
 
-    pub fn register_service() -> Result<()> {
-        autoreleasepool(|_| {
-            let service = daemon_service()?;
-            unsafe { service.registerAndReturnError() }
-                .map_err(|error| anyhow!(describe(&error, "SMAppService register failed")))
-        })
-    }
-
-    /// [`register_service`] reporting the platform failure structurally. Runs
-    /// wherever it is dispatched — the caller guarantees a later main-queue turn
-    /// — and builds its own service from the compiled plist name, so no retained
-    /// object is ever moved between threads.
+    /// Registers, reporting the platform failure structurally. Runs wherever it
+    /// is dispatched — the caller guarantees a later main-queue turn — and builds
+    /// its own service from the compiled plist name, so no retained object is
+    /// ever moved between threads.
     pub fn register_service_reporting_error() -> ServiceCallOutcome {
         autoreleasepool(|_| {
             let service = daemon_service().map_err(|error| adapter_error(error.to_string()))?;
@@ -632,98 +564,7 @@ mod macos {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::privileged_helper::peer_auth::ClientKind;
-    use crate::privileged_helper::protocol::{ActivationInfo, HELPER_LABEL, HelperStateName};
     use std::cell::Cell;
-
-    fn probed_status() -> HelperServiceStatus {
-        HelperServiceStatus {
-            label: HELPER_LABEL.to_string(),
-            available: true,
-            registered: true,
-            authorized: true,
-            socket_available: true,
-            responding: false,
-            detail: None,
-        }
-    }
-
-    fn status_reply(state: HelperStateName) -> HelperReply {
-        let activation = matches!(
-            state,
-            HelperStateName::Activating | HelperStateName::Retiring
-        )
-        .then(|| ActivationInfo {
-            request_id: "req-1".to_string(),
-            script_path: "/nix/store/abc-darwin-system/activate".to_string(),
-            client_kind: ClientKind::Gui,
-        });
-        HelperReply::Status {
-            state,
-            helper_build_id: "build-a".to_string(),
-            activation,
-        }
-    }
-
-    #[test]
-    fn authenticated_status_reply_sets_responding_whatever_the_state() {
-        // `responding` means the daemon answered an authenticated Status
-        // round-trip naming a state — any of the four.
-        for state in [
-            HelperStateName::Idle,
-            HelperStateName::Activating,
-            HelperStateName::Retiring,
-            HelperStateName::Retired,
-        ] {
-            let mut status = probed_status();
-
-            fold_status_probe(&mut status, Ok(status_reply(state)));
-
-            assert!(status.responding);
-            assert_eq!(status.detail, None);
-        }
-    }
-
-    #[test]
-    fn typed_refusals_never_set_responding() {
-        for reply in [
-            HelperReply::BuildMismatch {
-                helper_build_id: "build-b".to_string(),
-            },
-            HelperReply::CallerNotPermitted,
-            HelperReply::RequestNotUnderstood,
-        ] {
-            let mut status = probed_status();
-
-            fold_status_probe(&mut status, Ok(reply));
-
-            assert!(!status.responding);
-            assert!(status.detail.is_some());
-        }
-    }
-
-    #[test]
-    fn exchange_failures_never_set_responding() {
-        // What reaches the fold when an installed daemon from a previous
-        // release answers with a reply this build cannot parse, or the
-        // exchange fails outright.
-        for error in [
-            HelperClientError::UnparseableReply("unknown reply shape".to_string()),
-            HelperClientError::ClosedBeforeReply,
-            HelperClientError::AuthenticationFailed(anyhow::anyhow!("not the signed helper")),
-            HelperClientError::Io(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "read timed out",
-            )),
-        ] {
-            let mut status = probed_status();
-
-            fold_status_probe(&mut status, Err(error));
-
-            assert!(!status.responding);
-            assert!(status.detail.is_some());
-        }
-    }
 
     #[test]
     fn the_four_smappservice_statuses_map_by_raw_value() {

--- a/apps/native/src-tauri/src/rebuild/activation_path.rs
+++ b/apps/native/src-tauri/src/rebuild/activation_path.rs
@@ -1,0 +1,958 @@
+// Which of the two activation paths one apply may use.
+//
+// There are exactly two ways nixmac activates a built generation: it asks the
+// privileged helper, or it prompts for an administrator password. This module
+// decides which, and its whole purpose is that the decision is made *before*
+// any bytes reach the helper, from reconciled service state — and that nothing
+// a helper exchange returns afterwards can select the password path. A refusal
+// is reported; it is never quietly substituted with a password prompt.
+//
+// Two things carry that, and they are types rather than discipline:
+//
+//   * [`Route`] comes from `route`, a total match over the stored decision and
+//     all four registration statuses. A status the platform can report has
+//     nowhere to hide, and only one pairing dispatches.
+//   * The password path exists only as [`ApplyEnvironment::password_activate`],
+//     which records that a password activation is running for as long as it
+//     runs. No seam prompts without recording, so a helper cannot be registered
+//     underneath a prompt this process started.
+
+use crate::privileged_helper::client::HelperClientError;
+use crate::privileged_helper::protocol::{ActivationInfo, HelperReply};
+use crate::privileged_helper::service::RegistrationStatus;
+use crate::privileged_helper::socket_probe::ListenerObservation;
+use crate::rebuild::darwin::ActivateResult;
+use crate::shared_types::HelperPreference;
+
+/// Everything one apply observes or does about the two paths, injected so every
+/// row below can be driven without a helper, a bundle, or a settings store.
+///
+/// Observations and effects only — no method here decides which path an apply
+/// takes. The one method that answers anything is `password_activate`, which
+/// refuses while a replacement holds the slot, and that is not a choice between
+/// paths: it is the record and the prompt being inseparable (see above).
+pub trait ApplyEnvironment {
+    /// The stored decision about the helper, read as-is: only the replacement
+    /// function ever resolves "undecided".
+    fn preference(&self) -> Result<HelperPreference, String>;
+
+    /// The sentence to carry when this copy of nixmac may not touch a helper at
+    /// all — it runs from outside `/Applications`, or its bundle was replaced
+    /// underneath it. `None` when it may.
+    fn displacement(&self) -> Option<String>;
+
+    /// What `SMAppService` reports about nixmac's helper registration.
+    fn registration_status(&self) -> Result<RegistrationStatus, String>;
+
+    /// Sends `TryActivate` and waits for its result. An activation legitimately
+    /// runs for many minutes, so an implementation must not leash this wait to
+    /// the short deadlines the other exchanges use; the live one bounds it only
+    /// at `client::ACTIVATION_TIMEOUT`, past which the outcome is unknown.
+    fn dispatch_activation(&self, activate_path: &str) -> Result<HelperReply, DispatchFailure>;
+
+    /// Whether anything is listening on the helper socket, over the full
+    /// absence window. Pure observation, and the only thing that can establish
+    /// that an `enabled` registration has no process behind it.
+    fn observe_listener(&self) -> ListenerObservation;
+
+    /// Runs the administrator-password activation, recording for as long as it
+    /// runs that one is running.
+    ///
+    /// Bundled deliberately: a caller cannot prompt without the record, so the
+    /// replacement function's register step can never land underneath a
+    /// password activation this process started.
+    fn password_activate(&self, activate_path: &str) -> PasswordActivation;
+}
+
+/// Why a dispatch produced no reply.
+pub enum DispatchFailure {
+    /// The exchange with the helper.
+    Exchange(HelperClientError),
+    /// The request could not even be assembled, because the activation path is
+    /// not one the helper accepts. Nothing was dispatched, and no other path is
+    /// tried: that is an error about this apply, not about the helper.
+    Unusable(anyhow::Error),
+}
+
+/// What the password path did, or why it did not run.
+pub enum PasswordActivation {
+    /// The prompt ran; this is its outcome.
+    Ran(Result<ActivateResult, anyhow::Error>),
+    /// A helper replacement holds the reconciliation slot, so nothing was
+    /// started. Between an unregister and the register that follows it,
+    /// `SMAppService` transiently reports `notRegistered` — which the table
+    /// below would otherwise read as "no helper, the password path is safe".
+    HelperBeingReplaced,
+}
+
+/// Activates `activate_path` by whichever path is allowed, or reports that
+/// neither is.
+///
+/// A refusal comes back as a failed [`ActivateResult`] carrying the report — the
+/// same shape a failed activation has, which every consumer already renders.
+pub fn activate<E: ApplyEnvironment>(
+    env: &E,
+    activate_path: &str,
+) -> Result<ActivateResult, anyhow::Error> {
+    let helper = helper_use(env.preference(), env.displacement());
+    match route(&helper, env.registration_status()) {
+        Route::Dispatch => dispatch(env, activate_path, &helper),
+        Route::Password => password(env, activate_path, &helper),
+        Route::Refuse(reason) => Ok(refused(reason, &helper)),
+    }
+}
+
+/// Whether this apply may use a helper at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HelperUse {
+    /// The stored decision is `granted`, and this copy may touch a helper.
+    Permitted,
+    /// It may not. `note` is the extra sentence its refusals carry: move the
+    /// app, restart the app, or why the stored decision could not be read.
+    Withheld { note: Option<String> },
+}
+
+/// Folds the stored decision and the two displacement gates into the one
+/// question the table asks.
+///
+/// Every failure lands on `Withheld`, and `Withheld` is not the password path:
+/// it still refuses while a registration is enabled. So neither an unreadable
+/// decision nor a displaced copy can talk nixmac into password-activating
+/// underneath a helper.
+fn helper_use(
+    preference: Result<HelperPreference, String>,
+    displacement: Option<String>,
+) -> HelperUse {
+    // A copy running from outside `/Applications`, or one whose bundle was
+    // replaced while it ran, touches no helper whatever the decision says.
+    if let Some(note) = displacement {
+        return HelperUse::Withheld { note: Some(note) };
+    }
+    match preference {
+        Ok(HelperPreference::Granted) => HelperUse::Permitted,
+        // Undecided or disabled: an existing registration is the replacement
+        // function's to adopt or remove, not this apply's to use.
+        Ok(HelperPreference::Unset | HelperPreference::Disabled) => {
+            HelperUse::Withheld { note: None }
+        }
+        Err(detail) => HelperUse::Withheld {
+            note: Some(format!(
+                "The stored helper decision could not be read: {detail}."
+            )),
+        },
+    }
+}
+
+/// Which path this apply takes, decided before any helper exchange.
+#[derive(Debug, PartialEq, Eq)]
+enum Route {
+    /// Send `TryActivate`. The helper decides admission atomically, and no
+    /// probe result gates this dispatch.
+    Dispatch,
+    /// The administrator-password path: nixmac knows no helper activation is
+    /// running or was dispatched.
+    Password,
+    /// Neither path. Reported, never silently substituted.
+    Refuse(Reason),
+}
+
+/// Why an apply refuses — one variant per case the contract names, so a missing
+/// row would be a missing variant rather than a silent password prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Reason {
+    /// A registration is enabled that this apply may not use. It could still
+    /// admit a scheduled sync-agent activation, so nixmac does not
+    /// password-activate underneath it; the replacement function adopts or
+    /// removes it first.
+    HelperStillInstalled,
+    /// `SMAppService` could not be read, so nothing proves the helper quiet.
+    RegistrationUnreadable(String),
+    /// The helper is being replaced right now.
+    HelperBeingReplaced,
+    /// Something holds the helper socket that could not be identified: a
+    /// validation that reached no judgment, or a peer that is not root.
+    PeerUnidentified(String),
+    /// The socket could not be used and its absence could not be proven either.
+    SocketUnusable(String),
+    /// The installed helper cannot run this build's activation — a build
+    /// mismatch, or a helper too old to parse this build's request body. Both
+    /// mean the same thing: it must be replaced or disabled first.
+    HelperUpdateRequired(String),
+    /// An activation is already running, and the `ActivationInfo` says whose.
+    ActivationRunning(ActivationInfo),
+    /// An authenticated helper answered something that is not an activation
+    /// result.
+    HelperRefused(String),
+    /// The request was dispatched and the outcome is not known.
+    UnknownOutcome(String),
+}
+
+impl std::fmt::Display for Reason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HelperStillInstalled => f.write_str(
+                "The unattended sync helper is still installed but is not enabled for this app, so nixmac did not activate and did not fall back to the administrator-password prompt. Enable or disable the helper, then apply again.",
+            ),
+            Self::RegistrationUnreadable(detail) => write!(
+                f,
+                "The unattended sync helper's registration could not be read ({detail}), so nixmac did not activate."
+            ),
+            Self::HelperBeingReplaced => f.write_str(
+                "The unattended sync helper is being replaced, so nixmac did not activate. Apply again once that has finished.",
+            ),
+            Self::PeerUnidentified(detail) => write!(
+                f,
+                "The process answering the helper socket could not be identified ({detail}), so nixmac did not activate and did not fall back to the administrator-password prompt."
+            ),
+            Self::SocketUnusable(detail) => write!(
+                f,
+                "The helper socket could not be used and its absence could not be established either ({detail}), so nixmac did not activate."
+            ),
+            Self::HelperUpdateRequired(detail) => write!(
+                f,
+                "The installed unattended sync helper cannot run this build's activation: {detail}. nixmac replaces it the next time it reads the helper — opening Settings → Permissions does that now, and so does relaunching nixmac; apply again after that."
+            ),
+            Self::ActivationRunning(activation) => write!(
+                f,
+                "An activation is already running ({} submitted by the {}), so nixmac did not start another.",
+                activation.script_path, activation.client_kind
+            ),
+            Self::HelperRefused(detail) => write!(
+                f,
+                "The unattended sync helper did not start the activation: {detail}. nixmac did not fall back to the administrator-password prompt."
+            ),
+            Self::UnknownOutcome(detail) => write!(
+                f,
+                "The unattended sync helper did not return a trustworthy result: {detail}. The activation may have completed or may still be running; nixmac did not fall back to the administrator-password prompt."
+            ),
+        }
+    }
+}
+
+/// The table. Total over the stored decision and all four statuses.
+fn route(helper: &HelperUse, status: Result<RegistrationStatus, String>) -> Route {
+    let status = match status {
+        Ok(status) => status,
+        Err(detail) => return Route::Refuse(Reason::RegistrationUnreadable(detail)),
+    };
+    match (helper, status) {
+        // Granted, and a registration is enabled: dispatch and let the helper
+        // decide admission.
+        (HelperUse::Permitted, RegistrationStatus::Enabled) => Route::Dispatch,
+        // Enabled, but not this apply's to use. Refusing is what keeps nixmac
+        // from password-activating while that registration could still admit a
+        // scheduled sync-agent activation.
+        (HelperUse::Withheld { .. }, RegistrationStatus::Enabled) => {
+            Route::Refuse(Reason::HelperStillInstalled)
+        }
+        // Proven quiet: nothing registered, a registration pending approval
+        // (which has no process), or a service definition that is not there.
+        (
+            _,
+            RegistrationStatus::NotRegistered
+            | RegistrationStatus::RequiresApproval
+            | RegistrationStatus::NotFound,
+        ) => Route::Password,
+    }
+}
+
+/// Dispatches the activation and reads what came back.
+///
+/// Only an activation result is an activation. Every other reply and every
+/// failure is a refusal — with one exception that is not one: a connection that
+/// was never established wrote no request bytes, so nothing was dispatched, and
+/// the absence it may prove is still a pre-dispatch observation.
+fn dispatch<E: ApplyEnvironment>(
+    env: &E,
+    activate_path: &str,
+    helper: &HelperUse,
+) -> Result<ActivateResult, anyhow::Error> {
+    match env.dispatch_activation(activate_path) {
+        // The activation ran in the helper. Its own success or failure is the
+        // apply's, and this is the only way to learn it.
+        Ok(HelperReply::ActivationResult(result)) => Ok(ActivateResult {
+            success: result.ok,
+            code: result.code,
+            stdout: result.stdout,
+            // The result has no stderr: the activation log arrives merged into
+            // stdout, so only a helper-level error belongs in the stderr slot
+            // consumers show for failures.
+            stderr: result.error.unwrap_or_default(),
+        }),
+        Ok(reply) => Ok(refused(reply_refusal(reply), helper)),
+        // Not a refusal and not an outcome: the apply itself cannot be
+        // expressed, so it fails rather than looking for another path.
+        Err(DispatchFailure::Unusable(error)) => Err(error),
+        Err(DispatchFailure::Exchange(error)) => match exchange_failure(error) {
+            ExchangeFailure::Refused(reason) => Ok(refused(reason, helper)),
+            // Nothing was dispatched. Whether the socket has no process at all —
+            // the one remaining observation that proves quiet — takes the full
+            // absence window to establish.
+            ExchangeFailure::NeverConnected(connect_error) => match env.observe_listener() {
+                ListenerObservation::PositivelyAbsent => password(env, activate_path, helper),
+                ListenerObservation::Listening => Ok(refused(
+                    Reason::SocketUnusable(format!(
+                        "{connect_error}; something is listening on it but did not answer"
+                    )),
+                    helper,
+                )),
+                ListenerObservation::Ambiguous(detail) => Ok(refused(
+                    Reason::SocketUnusable(format!("{connect_error}; {detail}")),
+                    helper,
+                )),
+            },
+        },
+    }
+}
+
+/// What one failed exchange means for this apply.
+#[derive(Debug, PartialEq, Eq)]
+enum ExchangeFailure {
+    /// No connection was established, so no request bytes were written and
+    /// nothing was dispatched.
+    NeverConnected(String),
+    /// Everything else. Report it — an exchange that was attempted can never
+    /// select the password path, whether or not it proved anything.
+    Refused(Reason),
+}
+
+/// Reads one exchange failure. Total over the client's error set.
+fn exchange_failure(error: HelperClientError) -> ExchangeFailure {
+    match error {
+        HelperClientError::Unreachable(ref connect_error) => {
+            ExchangeFailure::NeverConnected(connect_error.to_string())
+        }
+        // Nothing was written to this peer either, but an unidentified process
+        // holding the helper socket is exactly what makes "no activation is
+        // running" impossible to establish.
+        HelperClientError::AuthenticationFailed(ref failure) => {
+            ExchangeFailure::Refused(Reason::PeerUnidentified(format!("{failure:#}")))
+        }
+        // Past the request write, nothing can prove the helper did not run it —
+        // a close, an I/O failure mid-exchange, and a reply this build cannot
+        // read are all unknown outcomes.
+        HelperClientError::ClosedBeforeReply
+        | HelperClientError::Io(_)
+        | HelperClientError::UnparseableReply(_) => {
+            ExchangeFailure::Refused(Reason::UnknownOutcome(error.to_string()))
+        }
+    }
+}
+
+/// Reads one reply that is not an activation result.
+fn reply_refusal(reply: HelperReply) -> Reason {
+    match reply {
+        HelperReply::Busy { activation } => Reason::ActivationRunning(activation),
+        // This helper will never start this activation: it is retiring or
+        // already retired, so it is on its way out.
+        HelperReply::Retired { .. } => Reason::HelperBeingReplaced,
+        // One thing to a client: the installed helper cannot run this build's
+        // activation. There is deliberately no promise about which of the two an
+        // older helper answers with.
+        HelperReply::BuildMismatch { .. } | HelperReply::RequestNotUnderstood => {
+            Reason::HelperUpdateRequired(reply.summary())
+        }
+        other => Reason::HelperRefused(other.summary()),
+    }
+}
+
+fn password<E: ApplyEnvironment>(
+    env: &E,
+    activate_path: &str,
+    helper: &HelperUse,
+) -> Result<ActivateResult, anyhow::Error> {
+    match env.password_activate(activate_path) {
+        PasswordActivation::Ran(outcome) => outcome,
+        PasswordActivation::HelperBeingReplaced => Ok(refused(Reason::HelperBeingReplaced, helper)),
+    }
+}
+
+/// One refusal, as the failed result every consumer already renders.
+fn refused(reason: Reason, helper: &HelperUse) -> ActivateResult {
+    let mut report = reason.to_string();
+    // A displaced copy's refusals carry what the user should do about it.
+    if let HelperUse::Withheld { note: Some(note) } = helper {
+        report.push(' ');
+        report.push_str(note);
+    }
+    ActivateResult {
+        success: false,
+        code: -1,
+        stdout: String::new(),
+        stderr: report,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privileged_helper::peer_auth::ClientKind;
+    use crate::privileged_helper::protocol::ActivationResult;
+    use std::cell::RefCell;
+
+    const ACTIVATE_PATH: &str = "/nix/store/abc-darwin-system/activate";
+
+    /// What one apply is allowed to do, and what it did.
+    struct World {
+        preference: Result<HelperPreference, String>,
+        displacement: Option<String>,
+        status: Result<RegistrationStatus, String>,
+        /// What `TryActivate` comes back with, when it is sent at all.
+        dispatch: RefCell<Option<Result<HelperReply, HelperClientError>>>,
+        /// The activation body cannot be assembled from the path at all.
+        unusable: bool,
+        listener: ListenerObservation,
+        /// Whether a replacement holds the slot when the prompt is reached.
+        replacement_in_flight: bool,
+        acts: RefCell<Vec<Act>>,
+    }
+
+    /// The three things that can actually happen, in order. Every "never the
+    /// password path" assertion is about this sequence.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Act {
+        Dispatched,
+        Probed,
+        Prompted,
+    }
+
+    impl Default for World {
+        fn default() -> Self {
+            Self {
+                preference: Ok(HelperPreference::Granted),
+                displacement: None,
+                status: Ok(RegistrationStatus::Enabled),
+                dispatch: RefCell::new(None),
+                unusable: false,
+                listener: ListenerObservation::PositivelyAbsent,
+                replacement_in_flight: false,
+                acts: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl World {
+        /// Granted, enabled, and the helper answers `reply`.
+        fn answering(reply: HelperReply) -> Self {
+            Self {
+                dispatch: RefCell::new(Some(Ok(reply))),
+                ..Self::default()
+            }
+        }
+
+        /// Granted, enabled, and the exchange fails.
+        fn failing(error: HelperClientError) -> Self {
+            Self {
+                dispatch: RefCell::new(Some(Err(error))),
+                ..Self::default()
+            }
+        }
+
+        fn acts(&self) -> Vec<Act> {
+            self.acts.borrow().clone()
+        }
+
+        fn did(&self, act: Act) {
+            self.acts.borrow_mut().push(act);
+        }
+    }
+
+    impl ApplyEnvironment for World {
+        fn preference(&self) -> Result<HelperPreference, String> {
+            self.preference.clone()
+        }
+
+        fn displacement(&self) -> Option<String> {
+            self.displacement.clone()
+        }
+
+        fn registration_status(&self) -> Result<RegistrationStatus, String> {
+            self.status.clone()
+        }
+
+        fn dispatch_activation(&self, activate_path: &str) -> Result<HelperReply, DispatchFailure> {
+            assert_eq!(activate_path, ACTIVATE_PATH);
+            self.did(Act::Dispatched);
+            if self.unusable {
+                return Err(DispatchFailure::Unusable(anyhow::anyhow!(
+                    "not a store activation path"
+                )));
+            }
+            self.dispatch
+                .borrow_mut()
+                .take()
+                .expect("one dispatch, and only where the table dispatches")
+                .map_err(DispatchFailure::Exchange)
+        }
+
+        fn observe_listener(&self) -> ListenerObservation {
+            self.did(Act::Probed);
+            self.listener.clone()
+        }
+
+        fn password_activate(&self, activate_path: &str) -> PasswordActivation {
+            assert_eq!(activate_path, ACTIVATE_PATH);
+            if self.replacement_in_flight {
+                // The record and the refusal are one step in the real
+                // implementation, which is why nothing is recorded here.
+                return PasswordActivation::HelperBeingReplaced;
+            }
+            self.did(Act::Prompted);
+            PasswordActivation::Ran(Ok(ActivateResult {
+                success: true,
+                code: 0,
+                stdout: "activated with an administrator password".to_string(),
+                stderr: String::new(),
+            }))
+        }
+    }
+
+    fn activation() -> ActivationInfo {
+        ActivationInfo {
+            request_id: "request-1".to_string(),
+            script_path: ACTIVATE_PATH.to_string(),
+            client_kind: ClientKind::SyncAgent,
+        }
+    }
+
+    fn apply(world: &World) -> ActivateResult {
+        activate(world, ACTIVATE_PATH).expect("the fake password path cannot fail to run")
+    }
+
+    /// Refused: nothing activated, and — the part that matters — no prompt.
+    fn assert_refused(world: &World, result: &ActivateResult) {
+        assert!(!result.success, "a refusal is not a successful activation");
+        assert_eq!(result.code, -1);
+        assert!(
+            !world.acts().contains(&Act::Prompted),
+            "a refusal must never fall back to the administrator-password prompt: {}",
+            result.stderr
+        );
+    }
+
+    // ── the table ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn granted_and_enabled_is_the_only_pairing_that_dispatches() {
+        assert_eq!(
+            route(&HelperUse::Permitted, Ok(RegistrationStatus::Enabled)),
+            Route::Dispatch
+        );
+    }
+
+    #[test]
+    fn every_proven_quiet_observation_takes_the_password_path() {
+        // The closed set of eligibility observations: nothing registered, a
+        // registration pending approval (which has no process), and a broken
+        // service definition. Under either column — the password path itself
+        // needs no grant.
+        for helper in [
+            HelperUse::Permitted,
+            HelperUse::Withheld { note: None },
+            HelperUse::Withheld {
+                note: Some("move it".to_string()),
+            },
+        ] {
+            for status in [
+                RegistrationStatus::NotRegistered,
+                RegistrationStatus::RequiresApproval,
+                RegistrationStatus::NotFound,
+            ] {
+                assert_eq!(route(&helper, Ok(status)), Route::Password, "{status}");
+            }
+        }
+    }
+
+    #[test]
+    fn an_enabled_registration_this_apply_may_not_use_refuses_instead() {
+        // Never the password path: that registration could still admit a
+        // scheduled sync-agent activation, and nixmac does not activate
+        // underneath one.
+        for note in [None, Some("restart nixmac".to_string())] {
+            assert_eq!(
+                route(
+                    &HelperUse::Withheld { note },
+                    Ok(RegistrationStatus::Enabled)
+                ),
+                Route::Refuse(Reason::HelperStillInstalled)
+            );
+        }
+    }
+
+    #[test]
+    fn an_unreadable_registration_refuses_rather_than_guessing_quiet() {
+        assert_eq!(
+            route(&HelperUse::Permitted, Err("no service".to_string())),
+            Route::Refuse(Reason::RegistrationUnreadable("no service".to_string()))
+        );
+    }
+
+    #[test]
+    fn nothing_about_managed_app_bundles_can_divert_a_granted_helper_apply() {
+        // The decision's inputs are the stored decision, the displacement gates
+        // and the registration status — a closed set. An apply that touches
+        // managed app bundles (App Management) therefore dispatches through the
+        // helper like any other: skipping the helper for those was a silent
+        // password-path substitution, and the preflight already refuses the
+        // apply outright when the permission is missing.
+        let world = World::answering(HelperReply::ActivationResult(ActivationResult {
+            ok: true,
+            code: 0,
+            stdout: "activated".to_string(),
+            error: None,
+        }));
+
+        let result = apply(&world);
+
+        assert!(result.success);
+        assert_eq!(world.acts(), vec![Act::Dispatched]);
+    }
+
+    // ── what a copy that may not touch a helper does ───────────────────────
+
+    #[test]
+    fn a_displaced_copy_is_withheld_whatever_the_stored_decision_says() {
+        for preference in [
+            Ok(HelperPreference::Granted),
+            Ok(HelperPreference::Unset),
+            Ok(HelperPreference::Disabled),
+            Err("unreadable".to_string()),
+        ] {
+            assert_eq!(
+                helper_use(preference, Some("move it to /Applications".to_string())),
+                HelperUse::Withheld {
+                    note: Some("move it to /Applications".to_string())
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_granted_decision_permits_a_helper() {
+        assert_eq!(
+            helper_use(Ok(HelperPreference::Granted), None),
+            HelperUse::Permitted
+        );
+        for preference in [HelperPreference::Unset, HelperPreference::Disabled] {
+            assert_eq!(
+                helper_use(Ok(preference), None),
+                HelperUse::Withheld { note: None }
+            );
+        }
+    }
+
+    #[test]
+    fn an_unreadable_decision_is_withheld_and_says_so() {
+        let HelperUse::Withheld { note: Some(note) } =
+            helper_use(Err("store missing".to_string()), None)
+        else {
+            panic!("an unreadable decision must not permit a helper");
+        };
+        assert!(note.contains("store missing"));
+    }
+
+    #[test]
+    fn a_displaced_copy_carries_its_guidance_into_the_refusal() {
+        let world = World {
+            displacement: Some("Move nixmac to /Applications.".to_string()),
+            ..World::default()
+        };
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains("Move nixmac to /Applications."));
+        assert!(
+            world.acts().is_empty(),
+            "a displaced copy touches no helper at all"
+        );
+    }
+
+    #[test]
+    fn a_displaced_copy_still_uses_the_password_path_when_nothing_is_registered() {
+        // The password path itself requires no canonical install.
+        let world = World {
+            displacement: Some("Move nixmac to /Applications.".to_string()),
+            status: Ok(RegistrationStatus::NotRegistered),
+            ..World::default()
+        };
+
+        let result = apply(&world);
+
+        assert!(result.success);
+        assert_eq!(world.acts(), vec![Act::Prompted]);
+    }
+
+    // ── what came back from a dispatch ─────────────────────────────────────
+
+    #[test]
+    fn an_activation_result_is_the_applys_own_result() {
+        for (ok, code, error) in [
+            (true, 0, None),
+            (false, 1, Some("activation script failed".to_string())),
+        ] {
+            let world = World::answering(HelperReply::ActivationResult(ActivationResult {
+                ok,
+                code,
+                stdout: "log".to_string(),
+                error: error.clone(),
+            }));
+
+            let result = apply(&world);
+
+            assert_eq!(result.success, ok);
+            assert_eq!(result.code, code);
+            assert_eq!(result.stdout, "log");
+            assert_eq!(result.stderr, error.unwrap_or_default());
+            assert_eq!(world.acts(), vec![Act::Dispatched]);
+        }
+    }
+
+    #[test]
+    fn every_reply_that_is_not_a_result_refuses() {
+        // The complete reply set, minus the activation result above. None of
+        // them is permission to activate some other way.
+        let replies = [
+            (
+                HelperReply::Busy {
+                    activation: activation(),
+                },
+                Reason::ActivationRunning(activation()),
+            ),
+            (
+                HelperReply::Retired { activation: None },
+                Reason::HelperBeingReplaced,
+            ),
+            (
+                HelperReply::Retired {
+                    activation: Some(activation()),
+                },
+                Reason::HelperBeingReplaced,
+            ),
+            (
+                HelperReply::BuildMismatch {
+                    helper_build_id: "build-previous".to_string(),
+                },
+                Reason::HelperUpdateRequired(
+                    "the installed helper is from a different nixmac build (build build-previous)"
+                        .to_string(),
+                ),
+            ),
+            (
+                HelperReply::RequestNotUnderstood,
+                Reason::HelperUpdateRequired(HelperReply::RequestNotUnderstood.summary()),
+            ),
+            (
+                HelperReply::CallerNotPermitted,
+                Reason::HelperRefused(HelperReply::CallerNotPermitted.summary()),
+            ),
+            (
+                HelperReply::Status {
+                    state: crate::privileged_helper::protocol::HelperStateName::Idle,
+                    helper_build_id: "build-current".to_string(),
+                    activation: None,
+                },
+                Reason::HelperRefused(
+                    HelperReply::Status {
+                        state: crate::privileged_helper::protocol::HelperStateName::Idle,
+                        helper_build_id: "build-current".to_string(),
+                        activation: None,
+                    }
+                    .summary(),
+                ),
+            ),
+        ];
+
+        for (reply, expected) in replies {
+            assert_eq!(reply_refusal(reply.clone()), expected, "{reply:?}");
+
+            let world = World::answering(reply);
+            let result = apply(&world);
+
+            assert_refused(&world, &result);
+            assert_eq!(world.acts(), vec![Act::Dispatched]);
+        }
+    }
+
+    #[test]
+    fn a_build_mismatch_reports_the_helper_build_it_found() {
+        let world = World::answering(HelperReply::BuildMismatch {
+            helper_build_id: "build-previous".to_string(),
+        });
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains("build-previous"));
+    }
+
+    #[test]
+    fn a_running_activation_is_reported_with_the_script_and_the_client_that_submitted_it() {
+        let world = World::answering(HelperReply::Busy {
+            activation: activation(),
+        });
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains(ACTIVATE_PATH));
+        assert!(result.stderr.contains("sync agent"));
+    }
+
+    // ── what a failed exchange means ───────────────────────────────────────
+
+    #[test]
+    fn only_a_connection_that_was_never_established_dispatched_nothing() {
+        assert_eq!(
+            exchange_failure(HelperClientError::Unreachable(std::io::Error::from(
+                std::io::ErrorKind::ConnectionRefused
+            ))),
+            ExchangeFailure::NeverConnected(
+                std::io::Error::from(std::io::ErrorKind::ConnectionRefused).to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn every_other_exchange_failure_is_reported_and_never_falls_back() {
+        // An authentication failure is the one that most invites a fallback: it
+        // is where an unsigned local build lands. Under the contract it is a
+        // refusal — something unidentified holds the socket, so nixmac cannot
+        // establish that no activation is running.
+        // Built twice rather than cloned: a client error carries an
+        // `anyhow::Error` and an `io::Error`, neither of which clones.
+        let failures: [fn() -> HelperClientError; 4] = [
+            || HelperClientError::AuthenticationFailed(anyhow::anyhow!("unsigned")),
+            || HelperClientError::ClosedBeforeReply,
+            || HelperClientError::Io(std::io::Error::from(std::io::ErrorKind::TimedOut)),
+            || HelperClientError::UnparseableReply("not json".to_string()),
+        ];
+        for failure in failures {
+            assert!(
+                matches!(exchange_failure(failure()), ExchangeFailure::Refused(_)),
+                "{}",
+                failure()
+            );
+
+            let world = World::failing(failure());
+            let result = apply(&world);
+
+            assert_refused(&world, &result);
+            assert_eq!(
+                world.acts(),
+                vec![Act::Dispatched],
+                "an attempted exchange is never followed by an absence probe"
+            );
+        }
+    }
+
+    #[test]
+    fn a_socket_with_no_listener_at_all_takes_the_password_path() {
+        // Positive absence is the fourth eligibility observation, and nothing
+        // was dispatched: the connection was never established.
+        let world = World::failing(HelperClientError::Unreachable(std::io::Error::from(
+            std::io::ErrorKind::ConnectionRefused,
+        )));
+
+        let result = apply(&world);
+
+        assert!(result.success);
+        assert_eq!(
+            world.acts(),
+            vec![Act::Dispatched, Act::Probed, Act::Prompted]
+        );
+    }
+
+    #[test]
+    fn an_absence_that_could_not_be_established_refuses() {
+        for listener in [
+            ListenerObservation::Listening,
+            ListenerObservation::Ambiguous("timed out".to_string()),
+        ] {
+            let world = World {
+                listener,
+                dispatch: RefCell::new(Some(Err(HelperClientError::Unreachable(
+                    std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+                )))),
+                ..World::default()
+            };
+
+            let result = apply(&world);
+
+            assert_refused(&world, &result);
+            assert_eq!(world.acts(), vec![Act::Dispatched, Act::Probed]);
+        }
+    }
+
+    #[test]
+    fn an_activation_body_that_cannot_be_assembled_fails_the_apply() {
+        // Not a refusal and not an outcome: the apply itself cannot be
+        // expressed, so it fails rather than looking for another path.
+        let world = World {
+            unusable: true,
+            ..World::default()
+        };
+
+        let error = activate(&world, ACTIVATE_PATH).expect_err("an unusable path cannot activate");
+
+        assert!(error.to_string().contains("store activation path"));
+        assert_eq!(world.acts(), vec![Act::Dispatched]);
+    }
+
+    // ── the race with the replacement function ─────────────────────────────
+
+    #[test]
+    fn an_apply_during_a_replacement_refuses_rather_than_reading_the_gap_as_quiet() {
+        // Between the replacement's unregister and its register, `SMAppService`
+        // transiently reports `notRegistered`. Reading that as "no helper, the
+        // password path is safe" is exactly what the shared record prevents:
+        // the prompt and the record are one step, and it refuses.
+        let world = World {
+            status: Ok(RegistrationStatus::NotRegistered),
+            replacement_in_flight: true,
+            ..World::default()
+        };
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains("being replaced"));
+        assert!(world.acts().is_empty());
+    }
+
+    #[test]
+    fn an_apply_that_dispatches_into_a_replacement_is_refused_by_the_helper_itself() {
+        // The dispatch branch of the same race. A replacement that has retired
+        // the old helper but not yet unregistered it leaves `SMAppService`
+        // reporting `enabled`, so this apply dispatches — and the helper it
+        // reaches answers `Retired`, which is a refusal and never a licence to
+        // use the password path. The slot is not consulted before dispatch,
+        // deliberately: `TryActivate` is the admission check, and the reply is
+        // what says the helper is on its way out.
+        let world = World::answering(HelperReply::Retired { activation: None });
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains("being replaced"));
+        assert_eq!(world.acts(), vec![Act::Dispatched]);
+    }
+
+    #[test]
+    fn an_apply_during_a_replacement_refuses_on_the_absence_path_too() {
+        // The same gap, reached the other way: an `enabled` registration whose
+        // helper has already been killed by the replacement's unregister.
+        let world = World {
+            replacement_in_flight: true,
+            dispatch: RefCell::new(Some(Err(HelperClientError::Unreachable(
+                std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+            )))),
+            ..World::default()
+        };
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains("being replaced"));
+    }
+}

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -4,9 +4,11 @@
 
 use crate::ai::log_summarizer;
 use crate::privileged_helper::{
-    client as helper_client, protocol as helper_protocol, root_activation,
-    service as helper_service,
+    client as helper_client, protocol as helper_protocol, reconcile, root_activation,
+    service as helper_service, socket_probe,
 };
+use crate::rebuild::activation_path;
+use crate::system::helper_permission;
 use crate::utils::nix_string_literal;
 use chrono::Local;
 use log::{error, info, warn};
@@ -353,7 +355,8 @@ fn app_management_error_payload(
 /// Runs the equivalent of `darwin-rebuild switch` with streaming output in two steps:
 /// 1. `nix build` of the system closure as the user (no sudo), with the
 ///    out-link in app-support so the config dir stays clean
-/// 2. `<store path>/activate` as root via native macOS authentication dialog (supports Touch ID)
+/// 2. `<store path>/activate` as root — through the privileged helper when one is
+///    installed and enabled, otherwise via the native macOS admin password prompt
 ///
 /// This pattern avoids Git ownership issues by keeping all file operations
 /// under the user's permissions during the build phase while still making system
@@ -474,11 +477,16 @@ struct BuildResult {
 }
 
 /// Result of the activation step.
-struct ActivateResult {
-    success: bool,
-    code: i32,
-    stdout: String,
-    stderr: String,
+///
+/// Also how a refused activation is reported: `success: false` with the reason
+/// in `stderr`, which is the shape every consumer already renders (see
+/// [`super::activation_path`]).
+#[derive(Debug)]
+pub(crate) struct ActivateResult {
+    pub(crate) success: bool,
+    pub(crate) code: i32,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
 }
 
 /// Run the build step as the current user (no sudo).
@@ -607,39 +615,21 @@ fn run_build_step(
     })
 }
 
-/// Run the activation step as root using native macOS authentication dialog.
-/// Uses `osascript` to show Touch ID / password dialog on compatible hardware.
-///
-/// Root cause of the "updating apps over SSH" error:
-///   `osascript do shell script ... with administrator privileges` spawns the
-///   privileged process in the *system* bootstrap domain (root context), not
-///   the user's Aqua GUI session domain.  The nix-darwin activation script
-///   calls `launchctl managername` and aborts with the "over SSH" error
-///   whenever the result is not "Aqua" — even when called from a GUI app.
-///
-/// Fix: the elevated step uses `launchctl asuser <uid>` to re-enter the
-///   user's Aqua bootstrap domain before exec'ing the activation script.
-///   fork()/exec() inherits the bootstrap port, so the activation script
-///   sees `launchctl managername == "Aqua"` and the App Management check
-///   proceeds correctly.
-///
-///   The elevated command is this binary re-executed in root-activation
-///   mode (`privileged_helper::root_activation`): fixed Rust code with the
-///   same hardening rules as the helper daemon — no shell script, no
-///   sudoers rules, no EXIT traps, absolute programs, and a fixed root-owned
-///   environment.
+/// Run the activation step, by whichever of the two paths is allowed — the
+/// privileged helper, or one native authentication dialog (see
+/// [`password_activation`]).
 fn run_activate_step(
+    app: &AppHandle,
     system_store_path: &Path,
-    allow_helper: bool,
 ) -> Result<ActivateResult, anyhow::Error> {
     let activate_path = system_store_path.join("activate");
-    run_activate_with_path(&activate_path.to_string_lossy(), allow_helper)
+    run_activate_with_path(app, &activate_path.to_string_lossy())
 }
 
 /// Activate a specific nix store path directly
-fn activate_store_path(store_path: &str) -> Result<ActivateResult, anyhow::Error> {
+fn activate_store_path(app: &AppHandle, store_path: &str) -> Result<ActivateResult, anyhow::Error> {
     let activate_path = format!("{}/activate", store_path);
-    run_activate_with_path(&activate_path, true)
+    run_activate_with_path(app, &activate_path)
 }
 
 /// Classify an activation failure into (error_type, error_message).
@@ -706,7 +696,7 @@ pub fn activate_store_path_stream(
             serde_json::json!({"chunk": "Activating previous nix store...\n"}),
         );
 
-        match activate_store_path(&store_path) {
+        match activate_store_path(&app_handle, &store_path) {
             Ok(result) => {
                 for line in result.stdout.lines() {
                     if !line.is_empty() {
@@ -761,8 +751,8 @@ pub fn activate_store_path_stream(
 }
 
 fn run_activate_with_path(
+    app: &AppHandle,
     activate_path: &str,
-    allow_helper: bool,
 ) -> Result<ActivateResult, anyhow::Error> {
     // Resolve the symlink to the real nix store path: the privileged step
     // only ever accepts canonical /nix/store activation paths.
@@ -770,19 +760,106 @@ fn run_activate_with_path(
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| activate_path.to_owned());
 
-    if allow_helper {
-        if let Some(result) = try_activate_with_helper(&real_activate) {
-            return result;
-        }
-    } else {
-        info!("[darwin] Skipping privileged helper for App Management-sensitive activation");
+    // Which path this apply may use is decided there, before any bytes reach
+    // the helper. Nothing in this module chooses between them.
+    activation_path::activate(&AppActivation { app }, &real_activate)
+}
+
+/// The observations and effects [`activation_path`] decides over. Nothing here
+/// decides anything; the two gates come from the replacement function's own, so
+/// Apply and reconciliation cannot disagree about where this copy runs from.
+struct AppActivation<'a> {
+    app: &'a AppHandle,
+}
+
+impl activation_path::ApplyEnvironment for AppActivation<'_> {
+    fn preference(&self) -> Result<crate::shared_types::HelperPreference, String> {
+        crate::state::preferences::read_helper_preference(self.app)
+            .map_err(|error| format!("{error:#}"))
     }
 
-    // Interactive fallback: one native admin prompt (Touch ID capable), then
-    // re-execute this binary in root-activation mode. The privileged step is
-    // fixed Rust code mirroring the helper daemon — direct exec of absolute
-    // programs with a fixed root-owned environment. No sudoers rules, EXIT
-    // traps, or requester-controlled PATH/HOME reach root.
+    fn displacement(&self) -> Option<String> {
+        reconcile::gates(&reconcile::LiveEnvironment::new(self.app))
+            .err()
+            .map(|report| helper_permission::describe(&report))
+    }
+
+    fn registration_status(&self) -> Result<helper_service::RegistrationStatus, String> {
+        helper_service::registration_status().map_err(|error| format!("{error:#}"))
+    }
+
+    fn dispatch_activation(
+        &self,
+        activate_path: &str,
+    ) -> Result<helper_protocol::HelperReply, activation_path::DispatchFailure> {
+        let request =
+            helper_protocol::activation_request(Path::new(activate_path)).map_err(|error| {
+                activation_path::DispatchFailure::Unusable(
+                    error.context("failed to build helper activation request"),
+                )
+            })?;
+        // The result arrives on this connection when the activation completes,
+        // under the client's one generous bound rather than the short leashes
+        // the other exchanges use (`client::ACTIVATION_TIMEOUT`). An activation
+        // still running when that expires is reported as an unknown outcome and
+        // never compensated. The connection itself is dropped with the exchange:
+        // only the replacement function holds one open.
+        helper_client::activate_store_path(&request)
+            .map(|exchange| exchange.reply)
+            .map_err(activation_path::DispatchFailure::Exchange)
+    }
+
+    fn observe_listener(&self) -> socket_probe::ListenerObservation {
+        socket_probe::observe_listener()
+    }
+
+    fn password_activate(&self, activate_path: &str) -> activation_path::PasswordActivation {
+        // The record and the prompt are one step: while this guard lives, the
+        // replacement function's register step ends its run rather than putting
+        // an activation-capable helper underneath this activation. `Err` is the
+        // other order — a replacement already holds the slot.
+        match reconcile::shared().start_password_activation() {
+            Ok(_recorded) => {
+                activation_path::PasswordActivation::Ran(password_activation(activate_path))
+            }
+            Err(reconcile::ReplacementInFlight) => {
+                activation_path::PasswordActivation::HelperBeingReplaced
+            }
+        }
+    }
+}
+
+/// The administrator-password path: one native macOS authentication dialog, then
+/// this binary re-executed in root-activation mode.
+///
+/// `osascript ... with administrator privileges` shows the legacy Security Agent
+/// dialog, which is password-only — macOS does not offer Touch ID there. Avoiding
+/// that prompt is what the privileged helper exists for.
+///
+/// Root cause of the "updating apps over SSH" error:
+///   `osascript do shell script ... with administrator privileges` spawns the
+///   privileged process in the *system* bootstrap domain (root context), not
+///   the user's Aqua GUI session domain.  The nix-darwin activation script
+///   calls `launchctl managername` and aborts with the "over SSH" error
+///   whenever the result is not "Aqua" — even when called from a GUI app.
+///
+/// Fix: the elevated step uses `launchctl asuser <uid>` to re-enter the
+///   user's Aqua bootstrap domain before exec'ing the activation script.
+///   fork()/exec() inherits the bootstrap port, so the activation script
+///   sees `launchctl managername == "Aqua"` and the App Management check
+///   proceeds correctly.
+///
+///   The elevated command is this binary re-executed in root-activation
+///   mode (`privileged_helper::root_activation`): fixed Rust code with the
+///   same hardening rules as the helper daemon — no shell script, no
+///   sudoers rules, no EXIT traps, absolute programs, and a fixed root-owned
+///   environment.
+///
+/// Reached only through [`activation_path::ApplyEnvironment::password_activate`],
+/// which records that a password activation is running for as long as this
+/// takes.
+fn password_activation(real_activate: &str) -> Result<ActivateResult, anyhow::Error> {
+    let real_activate = real_activate.to_owned();
     let root_args = root_activation::RootActivationArgs {
         // SAFETY: `getuid` is thread-safe, has no preconditions, and cannot fail.
         uid: unsafe { libc::getuid() },
@@ -824,113 +901,6 @@ fn run_activate_with_path(
         stdout: stdout_str,
         stderr: stderr_str,
     })
-}
-
-fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult, anyhow::Error>> {
-    let status = helper_service::status();
-    if !status.authorized || !status.socket_available {
-        return None;
-    }
-    // `responding` is the authenticated `Status` round-trip
-    // `helper_service::status` already performed. Requiring it here is what
-    // keeps a helper from a previous release from failing the apply: it cannot
-    // answer this build's probe with a reply this build parses, so the
-    // osascript path takes over instead of the activation request coming back
-    // refused. This is transitional: the contract forbids a `Status` preflight
-    // from gating activation dispatch, and the wiring change that replaces this
-    // whole function with the Apply decision tables removes it.
-    if !status.responding {
-        info!(
-            "[darwin] privileged helper did not answer an authenticated status probe; falling back to osascript: {}",
-            status.detail.unwrap_or_default()
-        );
-        return None;
-    }
-
-    let request = match helper_protocol::activation_request(Path::new(activate_path)) {
-        Ok(request) => request,
-        Err(error) => {
-            return Some(Err(
-                error.context("failed to build helper activation request")
-            ));
-        }
-    };
-
-    match helper_client::activate_store_path(&request) {
-        Ok(exchange) => match exchange.reply {
-            helper_protocol::HelperReply::ActivationResult(result) => Some(Ok(ActivateResult {
-                success: result.ok,
-                code: result.code,
-                stdout: result.stdout,
-                // The result has no stderr: the activation log arrives
-                // merged into stdout, so only a helper-level error belongs
-                // in the stderr slot consumers show for failures.
-                stderr: result.error.unwrap_or_default(),
-            })),
-            // Every other reply means the helper did not start this
-            // activation: report rather than silently substituting the
-            // password path. No typed refusal is permission to activate some
-            // other way — a build mismatch says the installed helper must be
-            // upgraded or disabled, and a request-not-understood (which an
-            // alien peer could answer with) says even less. Do not "fix" any
-            // of these into a password-path fallback.
-            reply => Some(Ok(ActivateResult {
-                success: false,
-                code: -1,
-                stdout: String::new(),
-                stderr: format!(
-                    "Privileged helper did not start the activation: {}. nixmac did not fall back to the password prompt.",
-                    reply.summary()
-                ),
-            })),
-        },
-        Err(error) if helper_error_allows_password_fallback(&error) => {
-            // These failures happen before the client writes any request
-            // bytes, so this flow knows it did not dispatch an activation.
-            match &error {
-                helper_client::HelperClientError::Unreachable(_) => info!(
-                    "[darwin] privileged helper socket was stale; falling back to osascript: {error}"
-                ),
-                helper_client::HelperClientError::AuthenticationFailed(_) => warn!(
-                    "[darwin] process at helper socket failed signature validation; falling back to osascript: {error}"
-                ),
-                // Whatever the gate admits is by definition pre-dispatch; log
-                // it rather than panicking inside a privileged apply if that
-                // list ever grows.
-                _ => info!("[darwin] falling back to osascript: {error}"),
-            }
-            None
-        }
-        // Once the activation exchange starts writing, a close, malformed
-        // reply, or other I/O failure cannot prove that the helper did not
-        // run the request. The outcome is unknown; this flow stops without
-        // compensating through the administrator-password path.
-        Err(error) => Some(Ok(ActivateResult {
-            success: false,
-            code: -1,
-            stdout: String::new(),
-            stderr: format!(
-                "Privileged helper activation did not return a trustworthy result: {error}. Activation may have completed or may still be running; nixmac did not fall back to the password prompt."
-            ),
-        })),
-    }
-}
-
-/// Only failures proven to precede all request bytes may select the
-/// administrator-password fallback. Every other exchange error follows the
-/// contract's unknown-outcome rule.
-///
-/// Transitional, like the status-probe gate above: the contract decides
-/// password eligibility before dispatch from reconciled service state and lets
-/// no helper-exchange error select it — including this authentication failure,
-/// which is where unsigned development builds land today. The wiring change
-/// that brings in the Apply decision tables removes this function.
-fn helper_error_allows_password_fallback(error: &helper_client::HelperClientError) -> bool {
-    matches!(
-        error,
-        helper_client::HelperClientError::Unreachable(_)
-            | helper_client::HelperClientError::AuthenticationFailed(_)
-    )
 }
 
 /// Handle activation failures and determine the appropriate error response.
@@ -1165,11 +1135,15 @@ fn run_darwin_rebuild(
     // =========================================================================
     // Step 1c: proactively detect App Management denial for Home Manager
     // copyApps. This mirrors Home Manager's own harmless `.DS_Store` update
-    // probe, but does it before the admin activation prompt. When existing app
-    // bundles are involved, avoid the unattended helper path so macOS attributes
-    // the TCC decision to the foreground app flow more consistently.
+    // probe, but does it before the admin activation prompt.
+    //
+    // A denial refuses the apply here. A pass says the bundle writes succeed,
+    // and the activation path is chosen the same way it is for every other
+    // apply: managed app bundles used to divert this flow to the password
+    // prompt, which was a silent substitution while an enabled registration
+    // could still admit a scheduled sync-agent activation of the same
+    // generation.
     // =========================================================================
-    let mut allow_activation_helper = true;
     match preflight_app_management(config_dir, host_attr) {
         Ok(result) if !result.ok => {
             log_and_emit!(
@@ -1180,7 +1154,6 @@ fn run_darwin_rebuild(
         }
         Ok(result) => {
             if result.checked > 0 {
-                allow_activation_helper = false;
                 log_and_emit!(format!(
                     "Preflight: App Management check passed for {} managed app bundle(s).",
                     result.checked
@@ -1213,17 +1186,16 @@ fn run_darwin_rebuild(
         }));
     };
 
-    let activate_result =
-        run_activate_step(system_store_path, allow_activation_helper).map_err(|e| {
-            serde_json::json!({
-                "ok": false,
-                "code": -1,
-                "log_file": log_path.to_string_lossy(),
-                "error_type": "generic_error",
-                "system_untouched": true,
-                "error": format!("Activation step failed to execute: {}", e),
-            })
-        })?;
+    let activate_result = run_activate_step(app, system_store_path).map_err(|e| {
+        serde_json::json!({
+            "ok": false,
+            "code": -1,
+            "log_file": log_path.to_string_lossy(),
+            "error_type": "generic_error",
+            "system_untouched": true,
+            "error": format!("Activation step failed to execute: {}", e),
+        })
+    })?;
 
     if !activate_result.success {
         summarizer.complete(false);
@@ -1373,7 +1345,6 @@ fn run_darwin_rebuild(
 mod activation_safety_tests {
     use super::{
         ActivateResult, activation_failure_left_system_untouched, classify_activate_error,
-        helper_error_allows_password_fallback,
     };
 
     fn failed_activation(stdout: &str, stderr: &str) -> ActivateResult {
@@ -1417,29 +1388,5 @@ mod activation_safety_tests {
             "authorization_denied"
         ));
         assert!(!activation_failure_left_system_untouched("generic_error"));
-    }
-
-    #[test]
-    fn only_proven_pre_dispatch_helper_errors_allow_password_fallback() {
-        use crate::privileged_helper::client::HelperClientError;
-
-        let unreachable = HelperClientError::Unreachable(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "no listener",
-        ));
-        let authentication = HelperClientError::AuthenticationFailed(anyhow::anyhow!("wrong peer"));
-        assert!(helper_error_allows_password_fallback(&unreachable));
-        assert!(helper_error_allows_password_fallback(&authentication));
-
-        let mid_exchange = HelperClientError::Io(std::io::Error::new(
-            std::io::ErrorKind::ConnectionReset,
-            "result lost",
-        ));
-        let malformed = HelperClientError::UnparseableReply("future shape".to_string());
-        assert!(!helper_error_allows_password_fallback(
-            &HelperClientError::ClosedBeforeReply
-        ));
-        assert!(!helper_error_allows_password_fallback(&mid_exchange));
-        assert!(!helper_error_allows_password_fallback(&malformed));
     }
 }

--- a/apps/native/src-tauri/src/rebuild/mod.rs
+++ b/apps/native/src-tauri/src/rebuild/mod.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 //! Darwin-rebuild pipeline: build, activate, finalize, and rollback.
 
+pub mod activation_path;
 pub mod darwin;
 pub mod finalize_apply;
 pub mod finalize_restore;

--- a/apps/native/src-tauri/src/shared_types/system.rs
+++ b/apps/native/src-tauri/src/shared_types/system.rs
@@ -69,7 +69,14 @@ pub struct Permission {
     pub description: String,
     /// Whether onboarding requires this permission.
     pub required: bool,
-    /// Whether the app can trigger the system prompt directly.
+    /// Whether the app can trigger the system prompt directly. False means the
+    /// row's action can only deep-link into System Settings and wait for the
+    /// user, which is what the UI renders it as.
+    ///
+    /// Fixed per row for the TCC permissions, but not a capability in general:
+    /// the unattended sync helper reports it per observation, and it is false
+    /// only while macOS holds the registration pending approval in Login Items.
+    /// Read it as "is System Settings where the user finishes this, right now".
     pub can_request_programmatically: bool,
     /// Current permission status.
     pub status: PermissionStatus,

--- a/apps/native/src-tauri/src/state/permissions_state.rs
+++ b/apps/native/src-tauri/src/state/permissions_state.rs
@@ -8,7 +8,7 @@
 use tauri::{AppHandle, Manager, Runtime};
 
 use crate::observable::Observable;
-use crate::shared_types::PermissionsState;
+use crate::shared_types::{Permission, PermissionsState};
 use crate::system::permissions;
 
 pub const PERMISSIONS_CHANGED_EVENT: &str = "permissions_changed";
@@ -28,8 +28,38 @@ pub fn get<R: Runtime>(app: &AppHandle<R>) -> Option<PermissionsState> {
 /// Probe all permissions and record the result; the cell write emits
 /// `permissions_changed`.
 pub fn refresh<R: Runtime>(app: &AppHandle<R>) -> PermissionsState {
-    let state = permissions::check_all_permissions();
+    let state = permissions::check_all_permissions(app);
     let observable = app.state::<Observable<Option<PermissionsState>>>();
     *observable.write_sync() = Some(state.clone());
     state
+}
+
+/// Replace one permission's row in the last-known state and re-emit.
+///
+/// The convergence loop cannot use [`refresh`] to publish: that re-probes every
+/// permission, and its helper row runs a *second* reconciliation of its own. So
+/// the loop reconciles once, turns that report into a row, and drops it in here.
+///
+/// Does nothing when nothing has been probed yet — startup reconciles before any
+/// full probe has run, and inventing the other five rows here would be worse than
+/// waiting for the panel's own refresh.
+pub fn replace_row<R: Runtime>(app: &AppHandle<R>, row: Permission) {
+    // A build with the permission skip on reports every row Granted, and the
+    // onboarding gate depends on that fiction. A real helper row dropped in here
+    // would flip `all_required_granted` back to false and close the gate the
+    // flag exists to open.
+    if permissions::skip_enabled() {
+        return;
+    }
+    let observable = app.state::<Observable<Option<PermissionsState>>>();
+    let mut cell = observable.write_sync();
+    let Some(state) = cell.as_mut() else { return };
+    let Some(slot) = state.permissions.iter_mut().find(|p| p.id == row.id) else {
+        return;
+    };
+    *slot = row;
+    state.all_required_granted = state
+        .permissions
+        .iter()
+        .all(|p| !p.required || p.status == crate::shared_types::PermissionStatus::Granted);
 }

--- a/apps/native/src-tauri/src/system/helper_permission.rs
+++ b/apps/native/src-tauri/src/system/helper_permission.rs
@@ -1,0 +1,650 @@
+//! The unattended sync helper, as the app's permission surface sees it.
+//!
+//! One reconciliation function decides everything about the installed helper
+//! (`privileged_helper::reconcile`). This module is the only place the GUI calls
+//! it from, and it holds nothing but the wiring:
+//!
+//!   * [`observe`] for startup and status refreshes, [`grant`] and [`disable`]
+//!     for the two explicit user actions;
+//!   * [`describe`] and [`row`], which turn one run's report into the sentence
+//!     and the permission state the UI shows;
+//!   * an [`Environment`] that is the live one plus a display-only note about
+//!     the activation a `Retire` is waiting on.
+//!
+//! Opening Login Items lives here too, and only in [`grant`]: startup and
+//! refreshes run the same reconciliation function, so no report opens System
+//! Settings except through the click whose run produced it — however pending the
+//! approval a report describes, a run no click is waiting on opens nothing.
+
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, PoisonError};
+use std::time::Duration;
+
+use tauri::{AppHandle, Runtime};
+
+use crate::privileged_helper::protocol::ActivationInfo;
+use crate::privileged_helper::reconcile::{
+    self, Environment, LiveEnvironment, PeerReply, Reconciled, Stopped,
+};
+use crate::privileged_helper::service::{
+    self, RegisterFailure, RegistrationStatus, ReplaceFailure,
+};
+use crate::privileged_helper::socket_probe::ListenerObservation;
+use crate::shared_types::{HelperDecision, HelperPreference, PermissionStatus};
+use crate::state::permissions_state;
+use crate::system::install_location::InstallLocation;
+use crate::system::permissions;
+
+const APPROVE_IN_LOGIN_ITEMS: &str = "Approve nixmac in System Settings → General → Login Items & Extensions to finish enabling the unattended sync helper.";
+
+/// Reconciles the installed helper with this build, and reports.
+///
+/// Cheap on its normal path (one `Status` exchange), so startup and every
+/// status refresh run it. It opens System Settings for nothing it observes: only
+/// [`grant`] does that, from what the click itself saw.
+///
+/// Must not run on the main thread: the register and replace calls it may make
+/// are issued *on* the main queue and awaited, so a main-thread caller would
+/// starve the queue that has to make them. Those two refuse up front rather than
+/// wait out the call window and misreport the silence. The other two,
+/// `registration_status` and `unregister`, are issued inline and would proceed —
+/// so a main-thread run that only has to read a status or remove a helper is not
+/// caught by that refusal.
+pub fn observe<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    reconcile::reconcile(&GuiEnvironment::new(app))
+}
+
+/// The explicit Grant action: record the decision, reconcile under it, and open
+/// Login Items when macOS is waiting on the user there.
+///
+/// This function is the only thing in nixmac that opens System Settings for the
+/// helper, which is what keeps startup and refreshes from ever doing it: they
+/// call [`observe`], and no report can open anything on its own account however
+/// pending the approval it describes.
+///
+/// It opens the pane in the two places a click can learn that macOS is waiting,
+/// so which one fires depends only on what this call saw — never on which pass
+/// happened to report first:
+///
+///   * **before the run**, when the registration is already waiting for
+///     approval. The row's button says "Open Settings" in that state, so opening
+///     it is the click's own action and does not depend on the run at all — the
+///     run may report something else, or be answered `Busy` by one already in
+///     flight, and neither is a reason for the click to do nothing visible.
+///   * **after the run**, when this run is the one that registered and macOS now
+///     wants approval for it. That is the first-time Enable path, where nothing
+///     was waiting when the click landed.
+///
+/// The gap between them: a click answered `Busy` *before* anything is registered
+/// leaves the in-flight run to register, and its `PendingApproval` is reported to
+/// nobody's click, so no pane opens. The row then says to approve in Login Items
+/// and offers the button that opens them, which is one click and deterministic.
+pub fn grant<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    let env = GuiEnvironment::new(app);
+    // Read before the run, because the run is what changes it, and read through
+    // the same seam the run uses rather than the platform directly — one place
+    // says what the registration status is.
+    let awaiting_approval_already = matches!(
+        env.registration_status(),
+        Ok(RegistrationStatus::RequiresApproval)
+    );
+    if awaiting_approval_already {
+        service::open_login_items_settings();
+    }
+    let report = reconcile::grant(&env);
+    if !awaiting_approval_already && matches!(report, Reconciled::PendingApproval) {
+        service::open_login_items_settings();
+    }
+    start_converging(app);
+    report
+}
+
+/// The explicit Disable action: record the decision, then reconcile under it —
+/// retire the helper if it is running, unregister, done.
+pub fn disable<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    let report = reconcile::disable(&GuiEnvironment::new(app));
+    start_converging(app);
+    report
+}
+
+/// The permission row for one report: only a helper of this build, ready, is
+/// granted, and every report says what it found.
+pub fn row(report: &Reconciled) -> (PermissionStatus, String) {
+    let status = match report {
+        Reconciled::AtThisBuild => PermissionStatus::Granted,
+        _ => PermissionStatus::Pending,
+    };
+    (status, describe(report))
+}
+
+/// Whether a pane of System Settings is where the user finishes this report.
+///
+/// `PendingApproval` is the one report where it is: the registration exists and
+/// macOS is waiting for the user to approve it in Login Items, and nothing else
+/// makes it go. So the row offers the same "Open Settings" action as the other
+/// rows that deep-link into System Settings, rather than one more attempt or a
+/// way to hand the helper back. [`grant`] is still what the button calls — it
+/// records the decision and opens that pane, and does nothing to a registration
+/// already waiting there.
+///
+/// Not "can a later run change this": several reports are equally terminal
+/// without a run — a displaced copy has to be moved or restarted (see
+/// [`nothing_more_to_do`], which classifies those as final for that reason). What
+/// separates this one is *where* the remedy is. The others are answered by a run,
+/// or by the user doing something to the app itself, not in System Settings.
+pub fn can_request_programmatically(report: &Reconciled) -> bool {
+    !matches!(report, Reconciled::PendingApproval)
+}
+
+/// What one report says, in a sentence for the user.
+///
+/// The vocabulary is the report's own wherever the report carries text of its
+/// own (the displaced and stopped-short cases); the resting states have none, so
+/// they are phrased here.
+pub fn describe(report: &Reconciled) -> String {
+    match report {
+        Reconciled::AtThisBuild => {
+            "The unattended sync helper is installed and answering.".to_string()
+        }
+        Reconciled::PendingApproval => APPROVE_IN_LOGIN_ITEMS.to_string(),
+        Reconciled::NoHelper => {
+            "The unattended sync helper is not installed. Enable it to activate builds without a password prompt.".to_string()
+        }
+        Reconciled::Removed => {
+            "The unattended sync helper is disabled and has been removed.".to_string()
+        }
+        Reconciled::Busy => match waiting_on() {
+            // The activation another run is waiting out. This is the only place
+            // a user learns why enabling or disabling is taking minutes.
+            Some(note) => format!("nixmac is still reconciling the unattended sync helper: {note}."),
+            None => "nixmac is still reconciling the unattended sync helper.".to_string(),
+        },
+        Reconciled::Displaced(displacement) => sentence(displacement),
+        Reconciled::Stopped(stopped) => sentence(stopped),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Converging on the stored decision.
+// ---------------------------------------------------------------------------
+//
+// One reconciliation run is often not enough, and nothing else re-runs it: the
+// platform refuses a register for about a second after any unregister, and
+// approving in Login Items neither starts the helper nor tells anyone. So a
+// launch, and each explicit user action, drives the function until the stored
+// decision is carried out. Measured on real hardware: one launch, one Login
+// Items toggle, ~30 s, no relaunch.
+
+/// Spacing between attempts, and how many working ones are made at the shorter
+/// one.
+///
+/// The short spacing covers the platform's refusal window — measured at about a
+/// second — and the settling that follows a replacement. These are counts of
+/// *working* attempts, not wall clock: a run that has to prove the socket absent
+/// costs about five seconds of its own, so thirty of them is minutes rather than
+/// half a minute.
+const FAST_INTERVAL: Duration = Duration::from_secs(1);
+const SLOW_INTERVAL: Duration = Duration::from_secs(60);
+const FAST_ATTEMPTS: u32 = 30;
+
+/// Spacing while nothing is being attempted. Not derived from the counters
+/// above, because a wait is not a streak of failures: it may last weeks, so it
+/// must not sit at the short spacing, and it should still notice an approval
+/// promptly once it comes.
+///
+/// Not free, either. Every pass runs the gates first, and those resolve the app
+/// bundle twice — `current_exe` and two `canonicalize` each — and parse
+/// `Info.plist` for the stamped build id, before the `SMAppService` read. All
+/// page-cached and cheap in absolute terms, but this is the app's steady state
+/// for as long as an approval is outstanding, so it is a poll rather than a
+/// glance.
+const WAITING_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Working attempts one loop makes before giving up and leaving repair to the
+/// next launch or the next click.
+///
+/// Only attempts that are *trying to change something* count. Waiting on a human
+/// is not failing at anything — see [`drive`] — so this bounds the repetition
+/// that could churn a registration, and nothing else.
+const MAX_ATTEMPTS: u32 = 100;
+
+/// Whether re-running could still change anything.
+fn nothing_more_to_do(report: &Reconciled) -> bool {
+    matches!(
+        report,
+        // The stored decision is carried out — one success state per goal.
+        Reconciled::AtThisBuild | Reconciled::Removed | Reconciled::NoHelper
+        // Or nothing this loop can do will change the answer. A displaced copy
+        // must be moved or restarted, and neither takes effect in a running
+        // process: `current_exe` reports the path the process was launched from,
+        // and the realistic route here is a quarantined copy, which macOS runs
+        // from a read-only mount that is never under /Applications. A broken
+        // service definition is a property of the bundle, read identically every
+        // time.
+            | Reconciled::Displaced(_)
+            | Reconciled::Stopped(Stopped::ServiceDefinitionBroken)
+    )
+}
+
+/// The one loop, as a flag rather than a handle: nothing waits on it, cancels
+/// it, or asks it anything.
+static CONVERGING: AtomicBool = AtomicBool::new(false);
+
+/// Held for a loop's lifetime, and released by `Drop` on every way out
+/// including a panic — a leaked flag is permanent, since nothing else clears it.
+///
+/// A unit struct on purpose. An earlier version passed a value carrying the flag
+/// into `bool::then_some`, which evaluates its argument eagerly: the guard was
+/// built and dropped on the *refused* path too, releasing the running loop's
+/// flag, and loops doubled every tick until the process ran out of threads.
+/// There is nothing here for a claim to construct speculatively.
+struct Converging;
+
+impl Drop for Converging {
+    fn drop(&mut self) {
+        CONVERGING.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Starts a loop unless one is already running.
+///
+/// Startup calls this, and so does every explicit user action — a click has to
+/// keep trying if its first attempt stops short, not wait for the next launch.
+/// A loop already running needs no help: every pass re-reads the stored decision,
+/// so it picks up a Grant or a Disable by itself.
+pub fn start_converging<R: Runtime>(app: &AppHandle<R>) {
+    // A build that reports every permission granted without probing must not go
+    // and register a real helper behind that fiction. `replace_row` refuses too,
+    // but this is the one that keeps `SMAppService` untouched.
+    if permissions::skip_enabled() {
+        return;
+    }
+    if CONVERGING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    // Built only after the claim succeeded, and moved into the closure — so a
+    // `spawn` that fails drops it and gives the flag back.
+    let guard = Converging;
+    let app = app.clone();
+    // Off the calling thread for two reasons. It must not be the main thread:
+    // the ServiceManagement calls are issued *on* the main queue and awaited, so
+    // a main-thread caller would starve the queue it is waiting on, and the
+    // adapter refuses outright. And its own thread rather than the blocking
+    // pool, because this one sleeps for as long as an approval takes — a pool
+    // slot it would never give back.
+    std::thread::spawn(move || {
+        let _guard = guard;
+        drive(
+            || {
+                let report = observe(&app);
+                permissions_state::replace_row(&app, permissions::helper_row(&report));
+                report
+            },
+            std::thread::sleep,
+        );
+    });
+}
+
+/// Run, publish, stop when there is nothing left to do, otherwise wait and go
+/// again.
+fn drive(mut attempt: impl FnMut() -> Reconciled, mut wait: impl FnMut(Duration)) {
+    let mut working = 0;
+    loop {
+        let report = attempt();
+        if nothing_more_to_do(&report) {
+            return;
+        }
+        // Neither of these attempted anything. `PendingApproval` is macOS
+        // waiting on the user — §8.6 says that may be weeks — and `Busy` is
+        // another run holding the single-flight slot, so this pass did not even
+        // begin. Both are cheap, both can persist, and neither changed what is
+        // registered, so they are neither counted nor hurried, and the loop
+        // watches for as long as the app runs.
+        //
+        // The subtlety, because the report alone does not carry it: a *mutating*
+        // pass can also end at `PendingApproval`, when `verify` finds the
+        // registration it just created parked at `requiresApproval`. What keeps
+        // that from recurring uncounted is the world, not the report — after it,
+        // the registration *is* at `requiresApproval`, so the next pass takes the
+        // status × goal table's row and touches nothing. Getting back to a
+        // mutating pass takes an external event: an approval, or a removal in
+        // Login Items. Every such cycle is therefore paced by a human.
+        if matches!(report, Reconciled::PendingApproval | Reconciled::Busy) {
+            wait(WAITING_INTERVAL);
+            continue;
+        }
+        working += 1;
+        if working >= MAX_ATTEMPTS {
+            log::warn!(
+                "helper convergence: giving up after {working} attempts, last report {report:?}; \
+                 repair is left to the next launch or user action"
+            );
+            return;
+        }
+        wait(if working < FAST_ATTEMPTS {
+            FAST_INTERVAL
+        } else {
+            SLOW_INTERVAL
+        });
+    }
+}
+
+/// One report, terminated.
+///
+/// The reports are written as clauses and carry no full stop; several of them
+/// start with "nixmac", so the first letter is left exactly as the report wrote
+/// it rather than upper-cased into a different product name.
+fn sentence(report: &impl std::fmt::Display) -> String {
+    let report = report.to_string();
+    if report.ends_with(['.', '!', '?']) {
+        report
+    } else {
+        format!("{report}.")
+    }
+}
+
+/// The activation a `Retire` loop is currently waiting on, for display only.
+///
+/// Not state: nothing decides anything from it, it is never persisted, and a run
+/// that ends clears it. It exists because a run that waits — legitimately, for
+/// as long as an activation takes — is otherwise silent to a second caller,
+/// which is exactly the caller that has a UI to update.
+static WAITING_ON: Mutex<Option<String>> = Mutex::new(None);
+
+fn waiting_on() -> Option<String> {
+    WAITING_ON
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone()
+}
+
+fn set_waiting_on(note: Option<String>) {
+    *WAITING_ON.lock().unwrap_or_else(PoisonError::into_inner) = note;
+}
+
+/// The live environment, plus the display-only note above.
+///
+/// Everything else is delegated verbatim: this is not a second reconciliation
+/// procedure, and it holds no decision of its own.
+struct GuiEnvironment<'a, R: Runtime> {
+    live: LiveEnvironment<'a, R>,
+}
+
+impl<'a, R: Runtime> GuiEnvironment<'a, R> {
+    fn new(app: &'a AppHandle<R>) -> Self {
+        Self {
+            live: LiveEnvironment::new(app),
+        }
+    }
+}
+
+impl<R: Runtime> Environment for GuiEnvironment<'_, R> {
+    type Held = UnixStream;
+
+    fn install_location(&self) -> InstallLocation {
+        self.live.install_location()
+    }
+
+    fn compiled_build_id(&self) -> &str {
+        self.live.compiled_build_id()
+    }
+
+    fn bundle_build_id(&self) -> Result<String, String> {
+        self.live.bundle_build_id()
+    }
+
+    fn registration_status(&self) -> Result<RegistrationStatus, String> {
+        self.live.registration_status()
+    }
+
+    fn preference(&self) -> Result<HelperPreference, String> {
+        self.live.preference()
+    }
+
+    fn store_decision(&self, decision: HelperDecision) -> Result<(), String> {
+        self.live.store_decision(decision)
+    }
+
+    fn observe_listener(&self) -> ListenerObservation {
+        self.live.observe_listener()
+    }
+
+    fn status_exchange(&self) -> PeerReply<Self::Held> {
+        self.live.status_exchange()
+    }
+
+    fn retire_exchange(&self) -> PeerReply<Self::Held> {
+        self.live.retire_exchange()
+    }
+
+    fn peer_still_open(&self, held: &Self::Held) -> bool {
+        self.live.peer_still_open(held)
+    }
+
+    fn unregister(&self) -> Result<(), String> {
+        self.live.unregister()
+    }
+
+    fn replace_helper(
+        &self,
+        commit_to_register: &dyn Fn() -> Result<reconcile::Committed, Reconciled>,
+    ) -> Result<(), ReplaceFailure<Reconciled>> {
+        self.live.replace_helper(commit_to_register)
+    }
+
+    fn register(&self, committed: reconcile::Committed) -> Result<(), RegisterFailure> {
+        self.live.register(committed)
+    }
+
+    fn wait(&self, interval: Duration) {
+        self.live.wait(interval);
+    }
+
+    fn waiting_on_activation(&self, activation: &ActivationInfo) {
+        set_waiting_on(Some(format!(
+            "waiting for a running activation to finish ({} submitted by the {})",
+            activation.script_path, activation.client_kind
+        )));
+        self.live.waiting_on_activation(activation);
+    }
+
+    fn reported(&self, outcome: &Reconciled) {
+        // A pass that ended is no longer waiting on anything. `Busy` is the one
+        // report that does not end a pass — it comes from a *caller* that found
+        // one in flight, and that pass may still be waiting.
+        //
+        // Nothing else happens here, and in particular nothing opens System
+        // Settings: a report is the same value whether a startup, a refresh or a
+        // click produced it, so a pane opened from here would be one no user
+        // asked for. [`grant`] opens it, from what the click itself saw.
+        if !matches!(outcome, Reconciled::Busy) {
+            set_waiting_on(None);
+        }
+        self.live.reported(outcome);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privileged_helper::reconcile::Displacement;
+
+    fn stopped(reason: Stopped) -> Reconciled {
+        Reconciled::Stopped(reason)
+    }
+
+    #[test]
+    fn the_loop_stops_on_a_goal_and_on_nothing_else_it_can_fix() {
+        for done in [
+            Reconciled::AtThisBuild,
+            Reconciled::Removed,
+            Reconciled::NoHelper,
+            Reconciled::Displaced(Displacement::NotInstalledInApplications(None)),
+            stopped(Stopped::ServiceDefinitionBroken),
+        ] {
+            assert!(nothing_more_to_do(&done), "{done:?}");
+        }
+        // Everything else is worth another go — the refusal window, the
+        // approval wait, a caller turned away, a helper that has not answered
+        // yet.
+        for keep_going in [
+            Reconciled::PendingApproval,
+            Reconciled::Busy,
+            stopped(Stopped::RegisterFailed("not permitted".to_string())),
+            stopped(Stopped::VerifyNeverAnswered),
+            stopped(Stopped::UnregisterFailed("refused".to_string())),
+            stopped(Stopped::PasswordActivationRunning),
+        ] {
+            assert!(!nothing_more_to_do(&keep_going), "{keep_going:?}");
+        }
+    }
+
+    #[test]
+    fn only_a_pending_approval_hands_the_row_to_the_user() {
+        // The one report whose remedy is in System Settings, so the row offers
+        // the Login Items deep link rather than an action of nixmac's own.
+        assert!(!can_request_programmatically(&Reconciled::PendingApproval));
+        // Everything else is answered by a run, or by the user doing something to
+        // the app itself — including the reports that ask for a move or a restart,
+        // which no pane of System Settings can help with.
+        for ours in [
+            Reconciled::AtThisBuild,
+            Reconciled::NoHelper,
+            Reconciled::Removed,
+            Reconciled::Busy,
+            Reconciled::Displaced(Displacement::NotInstalledInApplications(None)),
+            stopped(Stopped::RegisterFailed("not permitted".to_string())),
+            stopped(Stopped::UnregisterFailed("refused".to_string())),
+            stopped(Stopped::VerifyNeverAnswered),
+        ] {
+            assert!(can_request_programmatically(&ours), "{ours:?}");
+        }
+    }
+
+    #[test]
+    fn it_stops_as_soon_as_the_decision_is_carried_out() {
+        let mut attempts = 0;
+        let mut waited = Vec::new();
+        drive(
+            || {
+                attempts += 1;
+                if attempts < 3 {
+                    stopped(Stopped::RegisterFailed("not permitted".to_string()))
+                } else {
+                    Reconciled::AtThisBuild
+                }
+            },
+            |interval| waited.push(interval),
+        );
+        assert_eq!(attempts, 3);
+        // Waited between attempts, and not after the last one.
+        assert_eq!(waited, vec![FAST_INTERVAL; 2]);
+    }
+
+    #[test]
+    fn waiting_on_a_human_is_never_counted_against_the_bound() {
+        // §8.6 says the approval may arrive weeks later, and the poll that
+        // observes it registers nothing. So the loop must still be watching long
+        // after a bound on working attempts would have stopped it.
+        let mut attempts = 0;
+        let mut waited = Vec::new();
+        drive(
+            || {
+                attempts += 1;
+                if attempts <= MAX_ATTEMPTS * 10 {
+                    Reconciled::PendingApproval
+                } else {
+                    Reconciled::AtThisBuild
+                }
+            },
+            |interval| waited.push(interval),
+        );
+        assert_eq!(attempts, MAX_ATTEMPTS * 10 + 1, "the loop stopped watching");
+        // And it waits at the waiting spacing throughout — the working counter
+        // never moves, so it must not be what picks the interval.
+        assert!(waited.iter().all(|i| *i == WAITING_INTERVAL));
+    }
+
+    #[test]
+    fn a_wait_that_turns_into_work_is_still_bounded() {
+        // The pending polls are free, but the moment the approval lands and the
+        // repair starts failing, the bound applies to those attempts.
+        let mut attempts = 0;
+        let mut working = 0;
+        drive(
+            || {
+                attempts += 1;
+                if attempts <= 500 {
+                    Reconciled::PendingApproval
+                } else {
+                    working += 1;
+                    stopped(Stopped::RegisterFailed("not permitted".to_string()))
+                }
+            },
+            |_| {},
+        );
+        assert_eq!(working, MAX_ATTEMPTS);
+    }
+
+    #[test]
+    fn it_gives_up_rather_than_running_for_ever() {
+        let mut attempts = 0;
+        let mut waited = Vec::new();
+        drive(
+            || {
+                attempts += 1;
+                stopped(Stopped::RegisterFailed("not permitted".to_string()))
+            },
+            |interval| waited.push(interval),
+        );
+        assert_eq!(attempts, MAX_ATTEMPTS);
+        assert_eq!(waited.len(), (MAX_ATTEMPTS - 1) as usize);
+        // Quick while the platform might still be settling, patient afterwards.
+        assert!(
+            waited[..(FAST_ATTEMPTS - 1) as usize]
+                .iter()
+                .all(|i| *i == FAST_INTERVAL)
+        );
+        assert!(
+            waited[(FAST_ATTEMPTS - 1) as usize..]
+                .iter()
+                .all(|i| *i == SLOW_INTERVAL)
+        );
+    }
+
+    #[test]
+    fn the_claim_primitives_hold_one_loop_and_survive_a_panic() {
+        // Note this drives `CONVERGING` and `Converging` directly, not
+        // `start_converging` — the claim/spawn/guard *sequencing* in that
+        // function is what once had the doubling bug, and it is not covered
+        // here.
+        assert!(
+            CONVERGING
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+        );
+        assert!(
+            CONVERGING
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err(),
+            "a second loop claimed a taken flag"
+        );
+        // A refused claim must not release what the holder has — the bug that
+        // spawned loops until the process ran out of threads.
+        assert!(CONVERGING.load(Ordering::SeqCst));
+
+        let outcome = std::panic::catch_unwind(|| {
+            let _guard = Converging;
+            panic!("the run panicked");
+        });
+        assert!(outcome.is_err());
+        assert!(
+            !CONVERGING.load(Ordering::SeqCst),
+            "the flag was leaked by a panic"
+        );
+    }
+}

--- a/apps/native/src-tauri/src/system/mod.rs
+++ b/apps/native/src-tauri/src/system/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod app_management_preflight;
 pub mod etc_preflight;
+pub mod helper_permission;
 pub mod install_location;
 pub mod launchd_scanner;
 pub mod nix;

--- a/apps/native/src-tauri/src/system/permissions.rs
+++ b/apps/native/src-tauri/src/system/permissions.rs
@@ -10,12 +10,15 @@
 //! - App Management - recommended so activation can update managed apps
 //! - Administrator privileges (sudo access)
 
+use crate::privileged_helper::reconcile::Reconciled;
 pub(crate) use crate::shared_types::{Permission, PermissionStatus, PermissionsState};
+use crate::system::helper_permission;
 use anyhow::Result;
 use log::{debug, info, warn};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use tauri::{AppHandle, Runtime};
 
 impl Default for PermissionsState {
     fn default() -> Self {
@@ -82,6 +85,9 @@ fn get_default_permissions() -> Vec<Permission> {
         privileged_helper_permission(
             default_status,
             "Enable this once per device to allow nixmac to activate already-built system generations unattended.",
+            // No report yet, so nothing says macOS is waiting on the user. Every
+            // path that has one replaces this row whole (`helper_row`).
+            true,
         ),
     ]
 }
@@ -104,6 +110,11 @@ fn e2e_skip_permissions_enabled() -> bool {
 #[cfg(not(debug_assertions))]
 fn vite_skip_permissions_enabled() -> bool {
     false
+}
+
+/// Whether this build reports every permission granted without probing.
+pub(crate) fn skip_enabled() -> bool {
+    skip_permissions_enabled()
 }
 
 fn skip_permissions_enabled() -> bool {
@@ -140,7 +151,11 @@ fn granted_folder_permission(id: &str, name: &str, description: &str) -> Permiss
     }
 }
 
-fn privileged_helper_permission(status: PermissionStatus, instructions: &str) -> Permission {
+fn privileged_helper_permission(
+    status: PermissionStatus,
+    instructions: &str,
+    can_request_programmatically: bool,
+) -> Permission {
     Permission {
         id: "privileged-helper".to_string(),
         name: "Unattended Sync Helper".to_string(),
@@ -148,7 +163,7 @@ fn privileged_helper_permission(status: PermissionStatus, instructions: &str) ->
             "Required for unattended device sync to activate builds without a password prompt"
                 .to_string(),
         required: true,
-        can_request_programmatically: true,
+        can_request_programmatically,
         status,
         instructions: Some(instructions.to_string()),
     }
@@ -348,8 +363,12 @@ fn check_admin_privileges() -> PermissionStatus {
     }
 }
 
-/// Check all permissions and return the current state
-pub fn check_all_permissions() -> PermissionsState {
+/// Check all permissions and return the current state.
+///
+/// The helper row is one run of the reconciliation function, which is also how
+/// a routine refresh converges the installed helper on this build. It must not
+/// run on the main thread — see [`helper_permission::observe`].
+pub fn check_all_permissions<R: Runtime>(app: &AppHandle<R>) -> PermissionsState {
     // Debug/test environments may not have TCC permissions granted and cannot
     // obtain them programmatically, so the skip flags satisfy the whole gate.
     if skip_permissions_enabled() {
@@ -362,43 +381,43 @@ pub fn check_all_permissions() -> PermissionsState {
 
     // Fill in each permission status and update all_required_granted on the fly
     for perm in &mut permissions {
-        perm.status = match perm.id.as_str() {
-            "desktop" => check_desktop_access(),
-            "documents" => check_documents_access(),
-            "admin" => check_admin_privileges(),
-            "full-disk" => {
-                let (status, detail) = check_full_disk_access();
-                // Keep the default "how to grant it" text unless the probe has
-                // something more accurate to say.
-                if let Some(detail) = detail {
-                    perm.instructions = Some(detail);
+        // The helper row is the one row a report produces whole — its status, the
+        // sentence that tells the user what is true, and whether nixmac can still
+        // get anywhere on its own — so it is replaced rather than patched field by
+        // field, and `helper_row` stays the only place a report becomes a row.
+        if perm.id == "privileged-helper" {
+            *perm = helper_row(&check_privileged_helper(app));
+        } else {
+            perm.status = match perm.id.as_str() {
+                "desktop" => check_desktop_access(),
+                "documents" => check_documents_access(),
+                "admin" => check_admin_privileges(),
+                "full-disk" => {
+                    let (status, detail) = check_full_disk_access();
+                    // Keep the default "how to grant it" text unless the probe
+                    // has something more accurate to say.
+                    if let Some(detail) = detail {
+                        perm.instructions = Some(detail);
+                    }
+                    // A probe that could not decide must not keep the gate shut
+                    // — the same reasoning that makes app-management Recommended
+                    // rather than Required (see `app_management_permission`),
+                    // except discovered at runtime. Requiring access we cannot
+                    // verify shows a permissions banner to users who may well
+                    // have granted it. Only this row relaxes: every other
+                    // `Unknown` still blocks.
+                    if status == PermissionStatus::Unknown {
+                        perm.required = false;
+                    }
+                    status
                 }
-                // A probe that could not decide must not keep the gate shut —
-                // the same reasoning that makes app-management Recommended
-                // rather than Required (see `app_management_permission`), except
-                // discovered at runtime. Requiring access we cannot verify shows
-                // a permissions banner to users who may well have granted it.
-                // Only this row relaxes: every other `Unknown` still blocks.
-                if status == PermissionStatus::Unknown {
-                    perm.required = false;
+                "app-management" => check_app_management(),
+                other => {
+                    debug_assert!(false, "no probe for permission id {other:?}");
+                    PermissionStatus::Unknown
                 }
-                status
-            }
-            "app-management" => check_app_management(),
-            "privileged-helper" => {
-                let (status, detail) = check_privileged_helper();
-                // Keep the default instructions when healthy; surface what is
-                // actually wrong otherwise.
-                if let Some(detail) = detail {
-                    perm.instructions = Some(detail);
-                }
-                status
-            }
-            other => {
-                debug_assert!(false, "no probe for permission id {other:?}");
-                PermissionStatus::Unknown
-            }
-        };
+            };
+        }
 
         // If this permission is required and not granted, mark all_required_granted as false
         if perm.required && perm.status != PermissionStatus::Granted {
@@ -430,7 +449,10 @@ pub fn check_all_permissions() -> PermissionsState {
 /// Request a specific permission
 /// For programmatic permissions (desktop, documents), this triggers the OS prompt
 /// For manual permissions (FDA, admin), this returns instructions
-pub fn request_permission(permission_id: &str) -> Result<Permission> {
+pub fn request_permission<R: Runtime>(
+    app: &AppHandle<R>,
+    permission_id: &str,
+) -> Result<Permission> {
     info!("Requesting permission: {}", permission_id);
 
     match permission_id {
@@ -569,225 +591,44 @@ pub fn request_permission(permission_id: &str) -> Result<Permission> {
 
             Ok(app_management_permission(check_app_management()))
         }
-        "privileged-helper" => {
-            // SMAppService registration requires the helper binary and its
-            // LaunchDaemon plist to be embedded inside the .app bundle
-            // (Contents/MacOS/nixmac-helper and
-            // Contents/Library/LaunchDaemons/com.darkmatter.nixmac.helper.plist).
-            // Those assets are only staged by `bun run desktop:build[:local]`
-            // (externalBin in package.json). Under `tauri dev` the app runs as
-            // a bare binary from target/debug with no bundle, so
-            // registerAndReturnError: fails with an opaque "Operation not
-            // permitted". Detect that up front and surface a clear Pending
-            // state instead of propagating the OS error to the UI.
-            let install = crate::system::install_location::check_install_location();
-
-            const APPROVE_INSTRUCTIONS: &str = "Approve nixmac in System Settings → General → Login Items & Extensions if macOS asks for background item approval.";
-
-            let (status, instructions) = if install.bundle_path.is_none() {
-                warn!(
-                    "privileged helper registration skipped: nixmac is not running from a .app bundle"
-                );
-                (
-                    PermissionStatus::Pending,
-                    "Build a signed .app with `bun run desktop:build:local`, drag it into /Applications, and launch it from there to install the unattended sync helper. It cannot be installed from a dev build."
-                        .to_string(),
-                )
-            } else if cfg!(debug_assertions) && !install.in_applications_dir {
-                // Debug builds run out of the build tree, never /Applications.
-                // Registering from there would pin the LaunchDaemon to that
-                // bundle path, so only connect to a helper that an
-                // /Applications install already registered. Release builds
-                // keep the normal register flow regardless of location.
-                warn!(
-                    "privileged helper registration skipped: nixmac is running outside /Applications"
-                );
-                let (status, detail) = probe_installed_helper();
-                (
-                    status,
-                    detail.unwrap_or_else(|| APPROVE_INSTRUCTIONS.to_string()),
-                )
-            } else {
-                match crate::privileged_helper::service::register() {
-                    // Registration alone is not a working helper: wait briefly
-                    // for the freshly launched daemon to answer a status
-                    // round-trip before reporting Granted.
-                    Ok(status) if status.authorized => match await_helper_ready() {
-                        Ok(()) => (PermissionStatus::Granted, APPROVE_INSTRUCTIONS.to_string()),
-                        Err(error) => (
-                            PermissionStatus::Pending,
-                            format!(
-                                "The helper is registered but did not answer a status probe: {error:#}."
-                            ),
-                        ),
-                    },
-                    Ok(_) => {
-                        crate::privileged_helper::service::open_login_items_settings();
-                        (PermissionStatus::Pending, APPROVE_INSTRUCTIONS.to_string())
-                    }
-                    Err(error) => {
-                        warn!("privileged helper registration failed: {error:#}");
-                        crate::privileged_helper::service::open_login_items_settings();
-                        (PermissionStatus::Pending, APPROVE_INSTRUCTIONS.to_string())
-                    }
-                }
-            };
-            Ok(privileged_helper_permission(status, &instructions))
-        }
+        // Grant: record the decision, then reconcile under it. First-time
+        // registration and repairing a half-finished one are the same step, and
+        // the write is idempotent. Grant is the only action that may open Login
+        // Items; `darwin.helperGrant` is this same action.
+        "privileged-helper" => Ok(helper_row(&helper_permission::grant(app))),
         _ => Err(anyhow::anyhow!("Unknown permission: {}", permission_id)),
     }
 }
 
-/// Wait for a freshly registered helper daemon to come up and answer a
-/// `Status` round-trip. launchd starts it asynchronously after approval, so
-/// the socket appears a moment after `register()` returns.
-fn await_helper_ready() -> Result<()> {
-    const ATTEMPTS: u32 = 10;
-    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
-
-    let mut last_error = anyhow::anyhow!("helper socket never appeared");
-    for attempt in 0..ATTEMPTS {
-        if attempt > 0 {
-            std::thread::sleep(RETRY_DELAY);
-        }
-        if !crate::privileged_helper::client::socket_available() {
-            continue;
-        }
-        match probe_helper_status() {
-            Ok(()) => return Ok(()),
-            Err(error) => last_error = error,
-        }
-    }
-    Err(last_error)
-}
-
-/// One authenticated `Status` round-trip, reduced to ok-or-why-not. A reply
-/// naming a state is the helper working; a typed refusal, an unparseable
-/// reply, and every exchange failure are reported as-is.
-fn probe_helper_status() -> Result<()> {
-    match crate::privileged_helper::client::status() {
-        Ok(exchange) => match exchange.reply {
-            crate::privileged_helper::protocol::HelperReply::Status { .. } => Ok(()),
-            reply => Err(anyhow::anyhow!("{}", reply.summary())),
-        },
-        Err(error) => Err(anyhow::anyhow!("{error}")),
-    }
-}
-
-/// One authenticated status round-trip to an already-installed helper
-/// daemon, bypassing SMAppService entirely. Used when the app is not running
-/// from /Applications: it must never install the helper from there (the
-/// LaunchDaemon would point at the wrong bundle path), but if a signed
-/// /Applications copy already installed one, mutual code-signature
-/// validation is what decides whether this copy may use it.
-fn probe_installed_helper() -> (PermissionStatus, Option<String>) {
-    const INSTALL_FROM_APPLICATIONS: &str = "nixmac is not running from /Applications, so it cannot install the unattended sync helper itself. Install it by launching a signed nixmac from /Applications; a correctly signed copy running elsewhere can then connect to it.";
-
-    if !crate::privileged_helper::client::socket_available() {
-        return (
-            PermissionStatus::Pending,
-            Some(INSTALL_FROM_APPLICATIONS.to_string()),
-        );
-    }
-    match crate::privileged_helper::client::status() {
-        Ok(exchange) => match exchange.reply {
-            crate::privileged_helper::protocol::HelperReply::Status { .. } => {
-                (PermissionStatus::Granted, None)
-            }
-            reply => (
-                PermissionStatus::Pending,
-                Some(format!(
-                    "The helper is running but did not answer a status probe: {}. {INSTALL_FROM_APPLICATIONS}",
-                    reply.summary()
-                )),
-            ),
-        },
-        // A close before any reply is deliberately ambiguous: the helper sends
-        // it both for a client it will not serve and for a connection dropped
-        // at its concurrency cap, and a helper that died mid-exchange looks
-        // the same. Report all of that, not just the refusal.
-        Err(crate::privileged_helper::client::HelperClientError::ClosedBeforeReply) => (
-            PermissionStatus::Pending,
-            Some(format!(
-                "The helper closed the connection without answering: it declined this app, is busy with other connections, or stopped. {INSTALL_FROM_APPLICATIONS}"
-            )),
-        ),
-        Err(error) => (
-            PermissionStatus::Pending,
-            Some(format!(
-                "The helper did not answer a status probe: {error}. {INSTALL_FROM_APPLICATIONS}"
-            )),
-        ),
-    }
-}
-
-/// Status of the unattended sync helper, with a detail message when it is
-/// not fully working.
+/// Status of the unattended sync helper: one run of the reconciliation
+/// function, as a permission row.
 ///
-/// `SMAppService` registration alone is not proof of a working helper: the
-/// approval persists in the BackgroundTaskManagement database even after the
-/// helper binary is gone or replaced. Granted therefore additionally requires
-/// a live status round-trip through the socket, which also exercises both
-/// code-signature checks (client validates the daemon, daemon validates this
-/// client).
-fn check_privileged_helper() -> (PermissionStatus, Option<String>) {
-    // Debug builds run outside /Applications (bare dev binaries or a locally
-    // built .app), where SMAppService describes this bundle copy rather than
-    // the daemon that an /Applications install registered. Skip it there and
-    // rely on the authenticated socket round-trip alone: a correctly signed
-    // copy can talk to an installed helper from anywhere. Release builds
-    // always go through the full SMAppService check below.
-    if cfg!(debug_assertions)
-        && !crate::system::install_location::check_install_location().in_applications_dir
-    {
-        return probe_installed_helper();
-    }
+/// Only a helper of this build answering an authenticated `Status` is granted.
+/// An `SMAppService` registration alone proves nothing — the approval outlives
+/// the binary it was granted for — and neither does a socket. Everything else is
+/// a report, and the report is what tells the user what to do: approve in Login
+/// Items, move the app to /Applications, restart the app, or wait out a running
+/// activation.
+fn check_privileged_helper<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    let report = helper_permission::observe(app);
+    // A refresh is how a user comes back to this — opening the panel, or
+    // pressing Check again — and one run is usually not enough: the platform
+    // refuses a register for about a second after any unregister, so the run
+    // that repairs a helper typically reports a failure and needs a successor.
+    // Starting the loop here means the visit converges instead of handing back a
+    // scary report. A loop already running ignores this.
+    helper_permission::start_converging(app);
+    report
+}
 
-    let status = crate::privileged_helper::service::status();
-    if !status.available {
-        return (PermissionStatus::Unknown, status.detail);
-    }
-    if !status.authorized {
-        return (PermissionStatus::Pending, None);
-    }
-    if !status.socket_available {
-        return (
-            PermissionStatus::Pending,
-            Some(
-                "The helper is approved in Login Items, but its daemon is not running (no socket). Use Grant to re-register it, or toggle nixmac off and on in System Settings → General → Login Items & Extensions."
-                    .to_string(),
-            ),
-        );
-    }
-    match crate::privileged_helper::client::status() {
-        Ok(exchange) => match exchange.reply {
-            crate::privileged_helper::protocol::HelperReply::Status { .. } => {
-                (PermissionStatus::Granted, None)
-            }
-            reply => (
-                PermissionStatus::Pending,
-                Some(format!(
-                    "The helper is registered but did not answer a status probe: {}. Unattended sync will fall back to password prompts until a matching signed build talks to it.",
-                    reply.summary()
-                )),
-            ),
-        },
-        // Ambiguous by design, as above: declined client, connection cap, or a
-        // helper that stopped all close the same way.
-        Err(crate::privileged_helper::client::HelperClientError::ClosedBeforeReply) => (
-            PermissionStatus::Pending,
-            Some(
-                "The helper closed the connection without answering: it declined this app, is busy with other connections, or stopped. Unattended sync will fall back to password prompts until a matching signed build talks to it."
-                    .to_string(),
-            ),
-        ),
-        Err(error) => (
-            PermissionStatus::Pending,
-            Some(format!(
-                "The helper is registered but did not answer a status probe: {error}."
-            )),
-        ),
-    }
+/// One report as the permission row it produces.
+pub(crate) fn helper_row(report: &Reconciled) -> Permission {
+    let (status, detail) = helper_permission::row(report);
+    privileged_helper_permission(
+        status,
+        &detail,
+        helper_permission::can_request_programmatically(report),
+    )
 }
 
 /// Best-effort App Management status.
@@ -804,6 +645,29 @@ fn check_app_management() -> PermissionStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::privileged_helper::reconcile::Reconciled;
+
+    /// The row a report produces has to carry the report's own answer to "is
+    /// System Settings where the user finishes this", or the panel offers the
+    /// wrong action: an approval waiting in Login Items would get a button that
+    /// hands the helper back instead of one that opens the pane. Asserted through
+    /// `helper_row` rather than on the predicate alone, because the wiring between
+    /// them is what the UI actually reads and nothing else pins it.
+    #[test]
+    fn the_row_takes_its_deep_link_from_the_report() {
+        assert!(!helper_row(&Reconciled::PendingApproval).can_request_programmatically);
+        assert!(helper_row(&Reconciled::AtThisBuild).can_request_programmatically);
+        assert!(helper_row(&Reconciled::NoHelper).can_request_programmatically);
+    }
+
+    /// A bare app handle. The skip flags below short-circuit before anything
+    /// reads app state, which is what keeps these tests from probing the real
+    /// helper.
+    fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
+        tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds")
+    }
 
     #[cfg(debug_assertions)]
     #[test]
@@ -946,7 +810,8 @@ mod tests {
         unsafe { std::env::remove_var("NIXMAC_SKIP_PERMISSIONS") };
         unsafe { std::env::set_var("VITE_NIXMAC_SKIP_PERMISSIONS", "true") };
 
-        let state = check_all_permissions();
+        let app = mock_app();
+        let state = check_all_permissions(app.handle());
 
         assert!(state.all_required_granted);
         assert!(
@@ -969,7 +834,8 @@ mod tests {
         unsafe { std::env::set_var("NIXMAC_SKIP_PERMISSIONS", "true") };
         unsafe { std::env::remove_var("VITE_NIXMAC_SKIP_PERMISSIONS") };
 
-        let state = check_all_permissions();
+        let app = mock_app();
+        let state = check_all_permissions(app.handle());
 
         assert!(state.all_required_granted);
         assert!(

--- a/apps/native/src/components/widget/permissions/permissions-panel.test.tsx
+++ b/apps/native/src/components/widget/permissions/permissions-panel.test.tsx
@@ -1,0 +1,345 @@
+import type { Permission, PermissionStatus } from "@/ipc/types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The helper row is the one permission nixmac installs rather than asks macOS
+ * for, so it is the one row that can hand it back — as one button, a toggle of
+ * the standing decision. Everything else the row shows comes from the backend's
+ * reconciliation report: the status decides whether "Granted" is shown, and
+ * `instructions` is the sentence.
+ */
+
+const mockRefresh = vi.fn();
+const mockRequest = vi.fn();
+const mockDisableHelper = vi.fn();
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    permissions: {
+      refresh: (...args: unknown[]) => mockRefresh(...args),
+      request: (...args: unknown[]) => mockRequest(...args),
+      requestFullDiskAccess: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/orpc", () => ({
+  client: {
+    darwin: {
+      helperDisable: (...args: unknown[]) => mockDisableHelper(...args),
+    },
+  },
+  orpc: {
+    system: {
+      installLocation: {
+        queryOptions: () => ({
+          queryKey: ["installLocation"],
+          queryFn: async () => ({ bundlePath: null, inApplicationsDir: false }),
+        }),
+      },
+    },
+  },
+}));
+
+const permissionsState = vi.fn();
+const helperPreference = vi.fn();
+vi.mock("@nixmac/state", () => ({
+  useViewModel: (select: (state: { permissions: unknown; preferences: unknown }) => unknown) =>
+    select({
+      permissions: permissionsState(),
+      preferences: { helperPreference: helperPreference() },
+    }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: { bundlePath: null, inApplicationsDir: false } }),
+}));
+
+const APPROVE_IN_LOGIN_ITEMS =
+  "Approve nixmac in System Settings → General → Login Items & Extensions to finish enabling the unattended sync helper.";
+
+function helperPermission(overrides: Partial<Permission>) {
+  return {
+    id: "privileged-helper",
+    name: "Unattended Sync Helper",
+    description: "Required for unattended device sync",
+    required: true,
+    canRequestProgrammatically: true,
+    status: "pending",
+    instructions: "a report",
+    ...overrides,
+  };
+}
+
+function helperRow(status: PermissionStatus, instructions: string, ...others: unknown[]) {
+  return {
+    permissions: [helperPermission({ status, instructions }), ...others],
+    allRequiredGranted: status === "granted",
+    checkedAt: null,
+  };
+}
+
+/**
+ * The row the backend sends while macOS holds the registration pending approval
+ * in Login Items: the sentence names the pane, and `canRequestProgrammatically`
+ * is false because no run nixmac makes can finish it — only the user can.
+ */
+function awaitingApprovalRow() {
+  return {
+    permissions: [
+      helperPermission({
+        instructions: APPROVE_IN_LOGIN_ITEMS,
+        canRequestProgrammatically: false,
+      }),
+    ],
+    allRequiredGranted: false,
+    checkedAt: null,
+  };
+}
+
+/**
+ * A second row, to check that one row's action leaves the other's alone.
+ *
+ * `admin` specifically: its grant takes `handleGrant`'s plain
+ * `permissions.request` branch, so the mocked request is what holds the action in
+ * flight. The `full-disk` and `app-management` branches wait out a `setTimeout`
+ * of their own, which would settle the row after the test body and take its
+ * running label with it.
+ */
+const adminRow = {
+  id: "admin",
+  name: "Administrator Privileges",
+  description: "Required to install system packages and modify system configurations",
+  required: true,
+  canRequestProgrammatically: false,
+  status: "pending",
+  instructions: "You will be prompted for your password when needed",
+};
+
+async function panel() {
+  const { PermissionsPanel } = await import("./permissions-panel");
+  const rendered = render(<PermissionsPanel />);
+  // The store is mocked as a bare selector call, so nothing re-renders on its
+  // own when a mocked value changes: a test that flips one mid-flight has to ask
+  // for the render itself, or it asserts against the pre-flip markup.
+  return { ...rendered, repaint: () => rendered.rerender(<PermissionsPanel />) };
+}
+
+describe("PermissionsPanel — the unattended sync helper row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefresh.mockResolvedValue(undefined);
+    helperPreference.mockReturnValue("unset");
+  });
+
+  it("offers Enable, and only Enable, while no helper is wanted", async () => {
+    for (const preference of ["unset", "disabled"]) {
+      helperPreference.mockReturnValue(preference);
+      permissionsState.mockReturnValue(
+        helperRow("pending", "The unattended sync helper is not installed."),
+      );
+
+      const { unmount } = await panel();
+
+      expect(screen.getByRole("button", { name: "Enable" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+      unmount();
+    }
+  });
+
+  it("offers Disable in every state the helper is wanted in, granted or not", async () => {
+    // A row that is not granted is still one nixmac keeps reconciling towards on
+    // its own, so the only thing left for the user to decide is whether they
+    // still want it — and offering Disable only on a granted row would leave a
+    // helper this build cannot use with no way out but Enable, which records the
+    // opposite. The reports that want the user to act say so in `instructions`.
+    // The one exception is approval pending, which has its own test below.
+    helperPreference.mockReturnValue("granted");
+    for (const status of ["granted", "pending", "denied", "unknown"] as const) {
+      permissionsState.mockReturnValue(helperRow(status, "a report"));
+
+      const { unmount } = await panel();
+
+      expect(screen.getByRole("button", { name: "Disable" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+      unmount();
+    }
+  });
+
+  it("offers the Login Items deep link, not Disable, while approval is pending", async () => {
+    // macOS is holding the registration and nothing nixmac does next makes that
+    // go, so the row offers the same "Open Settings" action as the other rows
+    // that send the user into System Settings — the pane the sentence names,
+    // which is where macOS asks for the approval. Disable would be answering a
+    // question the user has not been asked yet, and Enable would run a
+    // reconciliation that can only report the same thing again.
+    for (const preference of ["unset", "granted"]) {
+      helperPreference.mockReturnValue(preference);
+      permissionsState.mockReturnValue(awaitingApprovalRow());
+
+      const { unmount } = await panel();
+
+      expect(screen.getByRole("button", { name: /Open Settings/ })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+      expect(screen.getByText(APPROVE_IN_LOGIN_ITEMS)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it("opens Login Items through the same grant action the row always used", async () => {
+    // The deep link is not a new backend call: it is `permissions.request` for
+    // this row, which records the decision and reconciles, and is the only action
+    // allowed to open Login Items. In this state it opens them before it
+    // reconciles at all — the registration is already waiting for approval, so
+    // the pane does not depend on what the run goes on to report.
+    helperPreference.mockReturnValue("granted");
+    permissionsState.mockReturnValue(awaitingApprovalRow());
+    mockRequest.mockResolvedValue({ id: "privileged-helper", status: "pending" });
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: /Open Settings/ }));
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith("privileged-helper");
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+    expect(mockDisableHelper).not.toHaveBeenCalled();
+  });
+
+  it("offers Disable on a granted row whose decision was never recorded", async () => {
+    // An adopted registration: the reconciliation run records `granted` before
+    // it reports, so this is the window before the mirrored preference catches
+    // up. A granted row must never offer to enable what is already enabled.
+    helperPreference.mockReturnValue("unset");
+    permissionsState.mockReturnValue(helperRow("granted", "installed and answering"));
+
+    await panel();
+
+    expect(screen.getByRole("button", { name: "Disable" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+  });
+
+  it("renders every report the backend can send for a row that is not granted", async () => {
+    // The vocabulary: move the app, restart it, wait out a running activation, a
+    // possible interruption, and plain failures. Each arrives as the row's
+    // instructions and is shown verbatim — the UI never re-words a report. All of
+    // them are reachable with the helper wanted, which is what this row is. The
+    // sixth report, approval pending, comes with a row of its own and is asserted
+    // in the Login Items test above.
+    helperPreference.mockReturnValue("granted");
+    for (const report of [
+      "nixmac runs from /Volumes/nixmac/nixmac.app — move it to /Applications.",
+      "this app was replaced while running (build a is running, b is installed) — restart nixmac.",
+      "nixmac is still reconciling the unattended sync helper: waiting for a running activation to finish (/nix/store/abc/activate submitted by the sync agent).",
+      "the helper process ended while running /nix/store/abc/activate — that activation may have been interrupted and the system may be partially changed.",
+      "the helper could not be unregistered: SMAppService 1 refused.",
+    ]) {
+      permissionsState.mockReturnValue(helperRow("pending", report));
+
+      const { unmount } = await panel();
+
+      expect(screen.getByText(report)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it("keeps the clicked action's button until it finishes", async () => {
+    // Both actions record the decision before the run they start, so the
+    // preference this row picks its button from flips while the run is still
+    // going. The button must not: an Enable click that turned into "Disable"
+    // mid-run would offer to undo an action still in flight, and the row would
+    // be labelling the opposite of what was asked.
+    helperPreference.mockReturnValue("unset");
+    permissionsState.mockReturnValue(helperRow("pending", "a report"));
+    let finishGrant: () => void = () => {};
+    mockRequest.mockReturnValue(
+      new Promise((resolve) => {
+        finishGrant = () => resolve({ id: "privileged-helper", status: "pending" });
+      }),
+    );
+
+    const { getByRole, repaint } = await panel();
+    fireEvent.click(getByRole("button", { name: "Enable" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    });
+    // The decision the click recorded, now mirrored back mid-run.
+    helperPreference.mockReturnValue("granted");
+    repaint();
+
+    expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+
+    finishGrant();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /Enabling/ })).toBeNull();
+    });
+  });
+
+  it("leaves another row's in-flight button alone", async () => {
+    // The in-flight action is keyed by row for this: only the row that owns an
+    // action is disabled, so a click on any other row is expected at any moment.
+    // With one slot for the whole panel it would evict this row's, and the row
+    // would fall back to the decision its own running Enable already recorded —
+    // offering to disable a helper it is still enabling.
+    helperPreference.mockReturnValue("unset");
+    permissionsState.mockReturnValue(helperRow("pending", "a report", adminRow));
+    mockRequest.mockReturnValue(new Promise(() => {}));
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: "Enable" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    });
+    helperPreference.mockReturnValue("granted");
+    // No `repaint` needed: this click starts the second row's action, and that
+    // state change is the render which reads the flipped preference back.
+    fireEvent.click(getByRole("button", { name: /Open Settings/ }));
+
+    expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+    // And the row that was clicked second reports its own action, not the first.
+    expect(screen.getByRole("button", { name: /Waiting/ })).toBeTruthy();
+  });
+
+  it("keeps the label rendered while the action runs, and says the running word", async () => {
+    // What fixes the button's width is that the idle label stays in the layout,
+    // hidden, with the spinner over it. jsdom has no layout, so what is asserted
+    // here is the testable half — the label is still rendered, and the running
+    // word is the accessible name meanwhile, so the button is never nameless
+    // while its label is hidden.
+    helperPreference.mockReturnValue("granted");
+    permissionsState.mockReturnValue(helperRow("granted", "installed and answering"));
+    mockDisableHelper.mockReturnValue(new Promise(() => {}));
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: "Disable" }));
+
+    const running = await waitFor(() => screen.getByRole("button", { name: "Disabling…" }));
+    expect(screen.getByText("Disable")).toBeTruthy();
+    // The running label and `disabled` come from the same input, so a button
+    // that says it is working cannot still be taking clicks.
+    expect(running).toBeDisabled();
+  });
+
+  it("disabling reports what the run did and re-probes", async () => {
+    permissionsState.mockReturnValue(helperRow("granted", "installed and answering"));
+    mockDisableHelper.mockResolvedValue({
+      atThisBuild: false,
+      detail: "The unattended sync helper is disabled and has been removed.",
+    });
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(mockDisableHelper).toHaveBeenCalledTimes(1);
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+    expect(screen.getByText("The unattended sync helper is disabled and has been removed.")).toBeTruthy();
+  });
+});

--- a/apps/native/src/components/widget/permissions/permissions-panel.tsx
+++ b/apps/native/src/components/widget/permissions/permissions-panel.tsx
@@ -3,12 +3,104 @@
 import { Button } from "@/components/ui/button";
 import { tauriAPI } from "@/ipc/api";
 import type { Permission } from "@/ipc/types";
-import { orpc } from "@/lib/orpc";
+import { client, orpc } from "@/lib/orpc";
 import { cn } from "@/lib/utils";
 import { useViewModel } from "@nixmac/state";
 import { useQuery } from "@tanstack/react-query";
 import { AppWindow, Check, ExternalLink, Folder, HardDrive, KeyRound, Loader2, ShieldCheck, Terminal } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type ComponentProps, type ReactNode, useEffect, useState } from "react";
+
+type ActionButtonProps = {
+  idle: ReactNode;
+  busy: string;
+  isBusy: boolean;
+  /** Taken from the Button itself, so this cannot drift from the design system. */
+  variant?: ComponentProps<typeof Button>["variant"];
+  onClick: () => void;
+};
+
+/**
+ * One row's action: a button that neither resizes nor dims when it starts.
+ *
+ * `isBusy` is the only input for both the running label and `disabled`, because
+ * those two must never disagree — a button that says it is working while still
+ * accepting clicks, or the reverse, is the bug this shape rules out.
+ *
+ * Not resizing: the idle label stays in the layout and goes `invisible`, and the
+ * spinner is laid over it, so the button is the width of that label in every
+ * state and starting the action cannot change it — which, with `transition-all`
+ * on every Button, would animate the resize and reflow the whole row. The running
+ * word is the accessible name rather than a second label in the box, because in
+ * Settings → Permissions the row is only about 350px wide: a button sized for
+ * "Disabling…" instead of "Disable" takes those pixels out of the description for
+ * as long as the app runs, to say something the spinner already says. The spinner
+ * is wrapped rather than a direct child for a related reason: `size="sm"` carries
+ * `has-[>svg]:px-2.5`, so a top-level icon would shrink the padding mid-flight.
+ *
+ * Not dimming: `disabled:opacity-100` is a preference, not a fix. Here `disabled`
+ * means exactly "this action is running", and a half-faded spinner is a weaker
+ * cue than a solid one; `disabled:pointer-events-none` in the base is what
+ * actually refuses the click. Deliberately unlike the feedback dialog's footer,
+ * which keeps the dim: there `disabled` means the whole footer is inert and the
+ * spinner only marks which button caused it, so dimming says something true. (The
+ * blurred *text* that first sent us here cannot happen either way now — no label
+ * is visible while the action runs, so nothing is left in the opacity layer to
+ * lose its antialiasing.)
+ *
+ * `invisible` hides the label without giving up its box; `aria-label` is what
+ * says the running word while it is hidden, so the button is never nameless and
+ * never named twice.
+ */
+function ActionButton({ idle, busy, isBusy, variant, onClick }: ActionButtonProps) {
+  return (
+    <Button
+      size="sm"
+      variant={variant}
+      onClick={onClick}
+      disabled={isBusy}
+      aria-label={isBusy ? busy : undefined}
+      aria-busy={isBusy}
+      className="relative disabled:opacity-100"
+    >
+      <span className={cn("inline-flex items-center gap-1.5", isBusy && "invisible")}>{idle}</span>
+      {isBusy ? (
+        <span className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        </span>
+      ) : null}
+    </Button>
+  );
+}
+
+/**
+ * What one row's grant button says, which is the only thing that differs between
+ * them.
+ *
+ * A row nixmac cannot get anywhere on by itself only deep-links into System
+ * Settings and waits for the user, so it comes first and is secondary — that
+ * includes the helper while macOS holds its registration pending approval in
+ * Login Items, which is the state its sentence describes and the pane this
+ * button opens. Of the rest, nixmac installs the helper, so that row is enabled
+ * rather than requested, and everything else is a macOS prompt nixmac can raise.
+ */
+function grantLabel(perm: Permission): Pick<ActionButtonProps, "idle" | "busy" | "variant"> {
+  if (!perm.canRequestProgrammatically) {
+    return {
+      idle: (
+        <>
+          Open Settings
+          <ExternalLink className="size-3.5" aria-hidden="true" />
+        </>
+      ),
+      busy: "Waiting…",
+      variant: "secondary",
+    };
+  }
+  if (perm.id === "privileged-helper") {
+    return { idle: "Enable", busy: "Enabling…" };
+  }
+  return { idle: "Request", busy: "Requesting…" };
+}
 
 /**
  * The macOS permission list: status rows plus grant/request actions. Real
@@ -19,8 +111,40 @@ import { useEffect, useState } from "react";
  */
 export function PermissionsPanel() {
   const permissionsState = useViewModel((s) => s.permissions);
-  const [requesting, setRequesting] = useState<string | null>(null);
+  // The user's standing decision about the helper, which is what picks the one
+  // action its row offers (see the row below). Unless the write itself is refused
+  // — a gate on this copy of nixmac, or a store that cannot be written — both
+  // actions record the decision before the reconciliation run they start, so this
+  // flips while that run is still going, which is why an action in flight pins
+  // the button rather than re-deriving it from here.
+  const helperPreference = useViewModel((s) => s.preferences?.helperPreference ?? null);
+  // The action in flight, per row: the one that row shows until it finishes, and
+  // the one labelled as running. Keyed by row rather than one slot for the whole
+  // panel because only the row that owns an action is disabled — with a single
+  // slot, a click on any other row evicts this row's entry, and the row then
+  // re-derives its button from the decision its own running action has already
+  // recorded, offering to undo an action that is still in flight. A `Map` rather
+  // than an object keyed by id, so a lookup can only find an action this panel
+  // put there and never an inherited property of a plain object.
+  const [requesting, setRequesting] = useState<ReadonlyMap<string, "grant" | "disable">>(
+    () => new Map(),
+  );
   const [notice, setNotice] = useState<{ tone: "info" | "error"; message: string } | null>(null);
+
+  // Both take the updater form: two rows can start or settle in the same tick,
+  // and each has to apply to the map the other just produced rather than to the
+  // one its own render closed over.
+  function startAction(id: string, action: "grant" | "disable") {
+    setRequesting((inFlight) => new Map(inFlight).set(id, action));
+  }
+
+  function finishAction(id: string) {
+    setRequesting((inFlight) => {
+      const next = new Map(inFlight);
+      next.delete(id);
+      return next;
+    });
+  }
 
   // Refresh permissions when the panel mounts.
   useEffect(() => {
@@ -41,7 +165,7 @@ export function PermissionsPanel() {
     installLocation?.bundlePath != null && !installLocation.inApplicationsDir;
 
   async function handleGrant(permission: Permission) {
-    setRequesting(permission.id);
+    startAction(permission.id, "grant");
     setNotice(null);
     try {
       if (permission.id === "full-disk") {
@@ -62,17 +186,24 @@ export function PermissionsPanel() {
         });
         await new Promise((resolve) => setTimeout(resolve, 1000));
       } else if (permission.id === "privileged-helper") {
-        // Registers the bundled SMAppService LaunchDaemon. macOS may require
-        // one-time approval in Login Items & Extensions before status is granted.
+        // Grant: the backend records the decision and reconciles the installed
+        // helper with this build. It is the only action that may open Login
+        // Items, and it does so when macOS is waiting for approval there.
+        //
+        // The notice carries what *this* run reported, which the refresh below
+        // can overwrite in the row with a later run's answer — so it is worth
+        // showing only when the two differ. A run that reports what the row
+        // already said, which is every click while approval is pending, would
+        // otherwise print the same sentence twice on the same screen.
         const result = await tauriAPI.permissions.request(permission.id);
-        if (result.status !== "granted") {
+        if (result.status !== "granted" && result.instructions !== permission.instructions) {
           setNotice({
             tone: "info",
             message:
-              "nixmac opened Login Items & Extensions. Enable nixmac there, then return here and click Enable again if this row is still pending.",
+              result.instructions ??
+              "nixmac could not finish enabling the unattended sync helper.",
           });
         }
-        await new Promise((resolve) => setTimeout(resolve, 1500));
       } else {
         // deprecated(orpc): replace with client/orpc from @/lib/orpc
         await tauriAPI.permissions.request(permission.id);
@@ -86,7 +217,34 @@ export function PermissionsPanel() {
         message: `Permission request failed: ${error instanceof Error ? error.message : String(error)}`,
       });
     } finally {
-      setRequesting(null);
+      finishAction(permission.id);
+    }
+  }
+
+  /**
+   * Disable: the backend records the decision, retires a running helper,
+   * unregisters it, and registers nothing. It is the helper row's action whenever
+   * the helper is the standing decision *and* nixmac can still act on it — a
+   * granted row, and equally one whose report only a later run can change. Not
+   * while macOS holds the registration pending approval: that row sends the user
+   * to Login Items instead (see the row below).
+   */
+  async function handleDisableHelper() {
+    startAction("privileged-helper", "disable");
+    setNotice(null);
+    try {
+      const report = await client.darwin.helperDisable();
+      setNotice({ tone: "info", message: report.detail });
+      // deprecated(orpc): replace with client/orpc from @/lib/orpc
+      await tauriAPI.permissions.refresh();
+    } catch (error) {
+      console.error("Failed to disable the unattended sync helper:", error);
+      setNotice({
+        tone: "error",
+        message: `Disabling the unattended sync helper failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    } finally {
+      finishAction("privileged-helper");
     }
   }
 
@@ -124,8 +282,45 @@ export function PermissionsPanel() {
       <ul className="flex flex-col gap-3">
         {permissions.map((perm) => {
           const isGranted = perm.status === "granted";
-          const isRequesting = requesting === perm.id;
-          const canRequest = perm.canRequestProgrammatically;
+          const pendingAction = requesting.get(perm.id) ?? null;
+          const isGranting = pendingAction === "grant";
+          const isDisabling = pendingAction === "disable";
+          // The one action this row offers.
+          //
+          // The helper is the one permission nixmac installs rather than asks
+          // macOS for, so it is the one row that can hand it back — as a toggle
+          // of the standing decision, not of the row's status: with the helper
+          // wanted, every startup and refresh reconciles towards it on its own,
+          // and a report the user has to act on (move the app, restart) says so
+          // in `instructions`. What no automatic run can do is change their mind,
+          // so that is the button.
+          //
+          // Except while macOS holds the registration pending approval, which the
+          // backend reports by clearing `canRequestProgrammatically` on this row.
+          // Nothing nixmac does next makes that go, so the row offers the same
+          // deep link as the other rows that send the user into System Settings —
+          // the Login Items pane its sentence names, which is where macOS asks
+          // for the approval.
+          //
+          // An action in flight keeps its own button: it has already recorded the
+          // opposite decision.
+          const offersDisable =
+            perm.id === "privileged-helper" &&
+            perm.canRequestProgrammatically &&
+            (helperPreference === "granted" || isGranted);
+          const action: "grant" | "disable" | null =
+            pendingAction ?? (offersDisable ? "disable" : isGranted ? null : "grant");
+          // A fresh DOM node whenever the button changes shape, because the base
+          // `transition-all` cross-fades a reused one: a helper row that goes from
+          // waiting on approval to a failed register would animate secondary
+          // "Open Settings ↗" into primary "Enable", easing both the fill and the
+          // width. The feedback dialog's footer keys its buttons for this.
+          const buttonKey =
+            action === "disable"
+              ? "disable"
+              : perm.canRequestProgrammatically
+                ? "grant"
+                : "open-settings";
           const icon = (() => {
             if (isGranted) {
               return <ShieldCheck className="size-5" />;
@@ -156,7 +351,11 @@ export function PermissionsPanel() {
                 isGranted ? "border-success/30" : "border-border",
               )}
             >
-              <div className="flex items-start gap-3">
+              {/* `min-w-0 flex-1` so the text takes the width the actions do not:
+                  the action column is `shrink-0`, so without this every pixel the
+                  row is short of comes out of this side and the description wraps
+                  two words at a time. */}
+              <div className="flex min-w-0 flex-1 items-start gap-3">
                 <span
                   className={cn(
                     "mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg",
@@ -183,44 +382,55 @@ export function PermissionsPanel() {
                   <p className="mt-1 text-muted-foreground text-sm leading-relaxed">
                     {perm.description}
                   </p>
+                  {/* `wrap-anywhere` because these sentences quote paths: the
+                      helper's reports name `/nix/store/…` activations and
+                      `/Volumes/…` bundles, one unbreakable token of 60-odd monospace
+                      characters — wider than the row, so without this they run out
+                      of the box. Not `break-all`, which would also break the
+                      ordinary words around them at the edge of every line. */}
                   {perm.instructions ? (
-                    <p className="mt-2 rounded-md border border-border bg-secondary/50 p-2 font-mono text-muted-foreground text-xs">
+                    <p className="mt-2 wrap-anywhere rounded-md border border-border bg-secondary/50 p-2 font-mono text-muted-foreground text-xs">
                       {perm.instructions}
                     </p>
                   ) : null}
                 </div>
               </div>
 
-              <div className="shrink-0 self-start sm:self-center">
+              {/* Stacked, not side by side: the status and the action are as wide
+                  as their own text, and a row wide enough for both of them next to
+                  each other is width the description does not get.
+
+                  No minimum width. In Settings → Permissions the row is only about
+                  350px wide, so a column sized for the widest button would spend a
+                  third of it on empty space in every row that only says "Granted".
+
+                  `self-end` for the stacked layout the narrowest windows fall back
+                  to: the cross axis is horizontal there, so `self-start` would put
+                  the actions under the text on the *left*. */}
+              <div className="flex shrink-0 flex-col items-end gap-1.5 self-end sm:self-center">
                 {isGranted ? (
                   <span className="inline-flex items-center gap-1.5 font-medium text-success text-sm">
                     <Check className="size-4" aria-hidden="true" />
                     Granted
                   </span>
-                ) : (
-                  <Button
-                    size="sm"
-                    variant={canRequest ? "default" : "secondary"}
+                ) : null}
+                {action === "disable" ? (
+                  <ActionButton
+                    key={buttonKey}
+                    idle="Disable"
+                    busy="Disabling…"
+                    isBusy={isDisabling}
+                    variant="ghost"
+                    onClick={handleDisableHelper}
+                  />
+                ) : action === "grant" ? (
+                  <ActionButton
+                    key={buttonKey}
+                    {...grantLabel(perm)}
+                    isBusy={isGranting}
                     onClick={() => handleGrant(perm)}
-                    disabled={isRequesting}
-                  >
-                    {isRequesting ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                        {canRequest ? "Requesting…" : "Waiting…"}
-                      </>
-                    ) : perm.id === "privileged-helper" ? (
-                      "Enable"
-                    ) : canRequest ? (
-                      "Request"
-                    ) : (
-                      <>
-                        Open Settings
-                        <ExternalLink className="size-3.5" aria-hidden="true" />
-                      </>
-                    )}
-                  </Button>
-                )}
+                  />
+                ) : null}
               </div>
             </li>
           );

--- a/apps/native/src/components/widget/repair/lib.test.ts
+++ b/apps/native/src/components/widget/repair/lib.test.ts
@@ -1,6 +1,11 @@
+import type { Permission } from "@/ipc/types";
 import { describe, expect, it } from "vitest";
 import { makeGrantedPermissions } from "@/utils/test-fixtures";
 import { computeRepairPlan, type RepairInputs } from "./lib";
+
+/** What the backend reports while macOS holds the registration for approval. */
+const APPROVE_IN_LOGIN_ITEMS =
+  "Approve nixmac in System Settings → General → Login Items & Extensions to finish enabling the unattended sync helper.";
 
 function makeInputs(overrides: Partial<RepairInputs> = {}): RepairInputs {
   return {
@@ -9,8 +14,24 @@ function makeInputs(overrides: Partial<RepairInputs> = {}): RepairInputs {
     flakeExists: true,
     nixInstalled: true,
     permissions: makeGrantedPermissions(),
+    helperRow: null,
+    helperPreference: "unset",
+    helperGraceElapsed: false,
     skipPermissions: false,
     nixInstalledOverride: false,
+    ...overrides,
+  };
+}
+
+function makeHelperRow(overrides: Partial<Permission> = {}): Permission {
+  return {
+    id: "privileged-helper",
+    name: "Unattended Sync Helper",
+    description: "",
+    required: true,
+    canRequestProgrammatically: false,
+    status: "pending",
+    instructions: APPROVE_IN_LOGIN_ITEMS,
     ...overrides,
   };
 }
@@ -82,6 +103,103 @@ describe("computeRepairPlan", () => {
     ]);
   });
 
+  it("says nothing about a helper the user never asked for", () => {
+    for (const helperPreference of ["unset", "disabled"] as const) {
+      const plan = computeRepairPlan(
+        makeInputs({
+          helperPreference,
+          helperRow: makeHelperRow(),
+          helperGraceElapsed: true,
+        }),
+      );
+      expect(plan.banners).toEqual([]);
+    }
+  });
+
+  it("says nothing about a helper that is answering", () => {
+    const plan = computeRepairPlan(
+      makeInputs({
+        helperPreference: "granted",
+        helperRow: makeHelperRow({ status: "granted" }),
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([]);
+  });
+
+  it("waits for the grace period before naming the helper", () => {
+    const plan = computeRepairPlan(
+      makeInputs({
+        helperPreference: "granted",
+        helperRow: makeHelperRow(),
+        helperGraceElapsed: false,
+      }),
+    );
+    expect(plan.banners).toEqual([]);
+  });
+
+  it("banners the wanted-but-silent helper with the row's own sentence", () => {
+    const plan = computeRepairPlan(
+      makeInputs({
+        helperPreference: "granted",
+        helperRow: makeHelperRow(),
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
+  it("leaves the helper out of the revoked-permissions list", () => {
+    const helperRow = makeHelperRow();
+    const plan = computeRepairPlan(
+      makeInputs({
+        permissions: {
+          permissions: [
+            {
+              id: "full-disk",
+              name: "Full Disk Access",
+              description: "",
+              required: true,
+              canRequestProgrammatically: true,
+              status: "denied",
+            },
+            helperRow,
+          ],
+          allRequiredGranted: false,
+          checkedAt: 1,
+        },
+        helperPreference: "granted",
+        helperRow,
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([
+      { kind: "permissions-revoked", missing: [{ id: "full-disk", name: "Full Disk Access" }] },
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
+  it("produces exactly one banner when only the helper is missing", () => {
+    const helperRow = makeHelperRow();
+    const plan = computeRepairPlan(
+      makeInputs({
+        permissions: {
+          permissions: [helperRow],
+          allRequiredGranted: false,
+          checkedAt: 1,
+        },
+        helperPreference: "granted",
+        helperRow,
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
   it("honors the dev-profile skip overrides", () => {
     const plan = computeRepairPlan(
       makeInputs({
@@ -93,6 +211,9 @@ describe("computeRepairPlan", () => {
           allRequiredGranted: false,
           checkedAt: 1,
         },
+        helperPreference: "granted",
+        helperRow: makeHelperRow(),
+        helperGraceElapsed: true,
       }),
     );
     expect(plan).toEqual({ blocking: null, banners: [] });

--- a/apps/native/src/components/widget/repair/lib.ts
+++ b/apps/native/src/components/widget/repair/lib.ts
@@ -1,10 +1,18 @@
-import type { PermissionsState } from "@/ipc/types";
+import type { HelperPreference, Permission, PermissionsState } from "@/ipc/types";
+
+/**
+ * The one permission nixmac installs itself instead of asking macOS for, and so
+ * the one row whose state nixmac keeps working on after the probe returns.
+ */
+export const HELPER_PERMISSION_ID = "privileged-helper";
 
 /** A prerequisite that regressed after onboarding completed. */
 export type RepairIssue =
   | { kind: "config-missing"; configDir: string }
   | { kind: "nix-missing" }
-  | { kind: "permissions-revoked"; missing: { id: string; name: string }[] };
+  | { kind: "permissions-revoked"; missing: { id: string; name: string }[] }
+  /** The user asked for the unattended sync helper and it is not answering. */
+  | { kind: "helper-inactive"; instructions: string | null };
 
 export interface RepairInputs {
   /** Onboarding completion latch; repair is a post-completion concept. */
@@ -14,6 +22,17 @@ export interface RepairInputs {
   flakeExists: boolean | null;
   nixInstalled: boolean | null;
   permissions: PermissionsState | null;
+  /**
+   * The helper's row as it stands *now*, not as the snapshot in `permissions`
+   * had it; null before the first probe. Read live because this row is expected
+   * to be wrong for the first seconds of a launch and to then come right on its
+   * own — see the header comment.
+   */
+  helperRow: Permission | null;
+  /** The user's standing decision about the helper; null before hydration. */
+  helperPreference: HelperPreference | null;
+  /** Whether the helper condition has held long enough to be worth saying. */
+  helperGraceElapsed: boolean;
   /** Dev-profile overrides; a skipped gate must not resurface as a repair. */
   skipPermissions: boolean;
   nixInstalledOverride: boolean;
@@ -28,13 +47,26 @@ export interface RepairPlan {
 
 /**
  * Classify post-completion prerequisite regressions (design decision D7 of
- * docs/2026-07-08-onboarding-state-ownership.md). Evaluated once at launch —
- * the window is never swapped mid-session by a background event — and
- * re-evaluated only through the explicit "Check again" action.
+ * docs/2026-07-08-onboarding-state-ownership.md).
  *
  * Only a missing configuration blocks: every main surface (evolve, git,
  * build) operates on it. A missing Nix install or a revoked permission
  * degrades specific actions but leaves the app browsable, so they banner.
+ *
+ * Every input except the three helper ones is snapshotted when the widget mounts
+ * and re-read only through the explicit "Check again" action, so the blocking
+ * card is still decided once per launch: D7's rule is that a prerequisite is
+ * "evaluated at launch and surfaced in place — the window is never swapped
+ * mid-session by a background event", and replacing the step content is that
+ * swap.
+ *
+ * The helper's inputs are live because a snapshot of that row says nothing
+ * durable. A launch that upgrades the helper re-registers it, macOS may hold the
+ * new registration until the user approves it in Login Items, and the backend
+ * keeps reconciling until it converges — all of it after the probe the snapshot
+ * came from. So a snapshot would banner a launch that is about to be fine, and
+ * keep bannering after it became fine. A banner is the surface D7 allows to
+ * change: it appears above the content and takes nothing over.
  */
 export function computeRepairPlan(inputs: RepairInputs): RepairPlan {
   // Pre-completion gating belongs to the onboarding wizard, not repair.
@@ -52,12 +84,47 @@ export function computeRepairPlan(inputs: RepairInputs): RepairPlan {
   }
 
   if (!inputs.skipPermissions && inputs.permissions && !inputs.permissions.allRequiredGranted) {
+    // The helper is left out of this list unconditionally, and gets the banner
+    // below instead. Two reasons, both structural: this list is a snapshot and
+    // its row is not, and "revoked" is false for a registration that is waiting
+    // for an approval the user has not given yet. Leaving it out cannot produce
+    // an empty banner — `allRequiredGranted` still counts the helper, so it still
+    // goes false, and the `missing.length > 0` guard is what decides.
     const missing = inputs.permissions.permissions
-      .filter((p) => p.required && p.status !== "granted")
+      .filter((p) => p.required && p.status !== "granted" && p.id !== HELPER_PERMISSION_ID)
       .map((p) => ({ id: p.id, name: p.name }));
     if (missing.length > 0) {
       banners.push({ kind: "permissions-revoked", missing });
     }
+  }
+
+  // The user asked for the helper and the helper is not answering.
+  //
+  // The condition is exactly that: the standing decision is `granted` and the row
+  // is not. It covers a registration waiting for approval in Login Items, a copy
+  // of nixmac running from a folder macOS will not register, and a register that
+  // failed — and it deliberately cannot tell them apart, because the row carries
+  // no marker to tell them apart by. Hence one headline for all of them, stating
+  // the condition rather than any one cause, and the row's own `instructions` as
+  // the sentence that says what is actually true right now.
+  //
+  // The same lack of a marker is why the banner's button is the row's Grant
+  // action for every one of those states. When macOS is waiting for approval,
+  // that click opens the pane where the user gives it, which is the case this
+  // banner exists for. In the states no run can fix, the click re-runs and
+  // re-reports the same sentence: honest, and no help. That is the accepted cost
+  // of having nothing to branch on — not a gap to close by inventing a marker.
+  if (
+    !inputs.skipPermissions &&
+    inputs.helperPreference === "granted" &&
+    inputs.helperRow !== null &&
+    inputs.helperRow.status !== "granted" &&
+    inputs.helperGraceElapsed
+  ) {
+    banners.push({
+      kind: "helper-inactive",
+      instructions: inputs.helperRow.instructions ?? null,
+    });
   }
 
   return { blocking, banners };

--- a/apps/native/src/components/widget/repair/repair.test.tsx
+++ b/apps/native/src/components/widget/repair/repair.test.tsx
@@ -1,0 +1,181 @@
+import type { HelperPreference, Permission } from "@/ipc/types";
+import {
+  makeCompletedOnboardingState,
+  makeGlobalPreferences,
+  makeNixInstallState,
+} from "@/utils/test-fixtures";
+import { initialViewModelState, useViewModel } from "@nixmac/state";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HELPER_GRACE_MS, useRepair } from "./repair";
+
+/**
+ * The helper's banner is the one part of the repair plan that follows live state,
+ * so what is worth testing is the timing: it must stay quiet while the backend is
+ * still converging, speak once the condition has outlasted that, and go when the
+ * helper answers — without a churning report ever holding it back.
+ */
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    permissions: { refresh: vi.fn(async () => {}), request: vi.fn(async () => {}) },
+  },
+}));
+
+vi.mock("@/lib/orpc", () => ({
+  client: { flake: { exists: vi.fn(async () => true) } },
+}));
+
+vi.mock("@/lib/env", () => ({ settings: {} }));
+vi.mock("@/router", () => ({ nav: { openSettings: vi.fn() } }));
+vi.mock("@/components/widget/onboarding/restart-setup", () => ({
+  RestartSetupConfirmation: () => null,
+}));
+
+const APPROVE_IN_LOGIN_ITEMS =
+  "Approve nixmac in System Settings → General → Login Items & Extensions to finish enabling the unattended sync helper.";
+
+function makeHelperRow(overrides: Partial<Permission> = {}): Permission {
+  return {
+    id: "privileged-helper",
+    name: "Unattended Sync Helper",
+    description: "",
+    required: true,
+    canRequestProgrammatically: false,
+    status: "pending",
+    instructions: APPROVE_IN_LOGIN_ITEMS,
+    ...overrides,
+  };
+}
+
+/** A completed profile whose only unsettled prerequisite is the helper row. */
+function seedStore(helperRow: Permission, helperPreference: HelperPreference) {
+  useViewModel.setState({
+    hydrated: true,
+    onboardingState: makeCompletedOnboardingState(),
+    preferences: makeGlobalPreferences({
+      configDir: "/Users/demo/.darwin",
+      helperPreference,
+    }),
+    nixInstall: makeNixInstallState(),
+    permissions: {
+      permissions: [helperRow],
+      allRequiredGranted: helperRow.status === "granted",
+      checkedAt: 1,
+    },
+  });
+}
+
+/** What the backend publishes on a later reconciliation pass. */
+function publishHelperRow(helperRow: Permission) {
+  useViewModel.setState({
+    permissions: {
+      permissions: [helperRow],
+      allRequiredGranted: helperRow.status === "granted",
+      checkedAt: 2,
+    },
+  });
+}
+
+describe("useRepair", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    useViewModel.setState(initialViewModelState);
+  });
+
+  /** Mount and let the launch snapshot (an async flake probe) settle. */
+  async function mount() {
+    const view = renderHook(() => useRepair());
+    await act(async () => {});
+    return view;
+  }
+
+  it("stays quiet until the condition has outlasted the grace period", async () => {
+    seedStore(makeHelperRow(), "granted");
+    const { result } = await mount();
+
+    expect(result.current.plan.banners).toEqual([]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+
+    expect(result.current.plan.banners).toEqual([
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
+  it("does not restart the clock when a still-failing report changes", async () => {
+    seedStore(makeHelperRow(), "granted");
+    const { result } = await mount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS * 0.6);
+      publishHelperRow(
+        makeHelperRow({
+          canRequestProgrammatically: true,
+          instructions: "nixmac could not register the unattended sync helper.",
+        }),
+      );
+    });
+    expect(result.current.plan.banners).toEqual([]);
+
+    // Past the grace period counted from the first report, not the second.
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS * 0.6);
+    });
+    expect(result.current.plan.banners).toEqual([
+      {
+        kind: "helper-inactive",
+        instructions: "nixmac could not register the unattended sync helper.",
+      },
+    ]);
+  });
+
+  it("clears the banner and the clock once the helper answers", async () => {
+    seedStore(makeHelperRow(), "granted");
+    const { result } = await mount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+    expect(result.current.plan.banners).toHaveLength(1);
+
+    await act(async () => {
+      publishHelperRow(
+        makeHelperRow({
+          status: "granted",
+          canRequestProgrammatically: true,
+          instructions: "The unattended sync helper is installed and answering.",
+        }),
+      );
+    });
+    expect(result.current.plan.banners).toEqual([]);
+
+    // The clock was cleared with the banner, so a later regression waits again.
+    await act(async () => {
+      publishHelperRow(makeHelperRow());
+    });
+    expect(result.current.plan.banners).toEqual([]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+    expect(result.current.plan.banners).toHaveLength(1);
+  });
+
+  it("says nothing about a helper the user did not ask for", async () => {
+    seedStore(makeHelperRow(), "unset");
+    const { result } = await mount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+
+    expect(result.current.plan.banners).toEqual([]);
+  });
+});

--- a/apps/native/src/components/widget/repair/repair.tsx
+++ b/apps/native/src/components/widget/repair/repair.tsx
@@ -7,32 +7,87 @@ import { settings } from "@/lib/env";
 import { client } from "@/lib/orpc";
 import { nav } from "@/router";
 import { useViewModel } from "@nixmac/state";
-import { CircleAlert, FolderX, RotateCcw, X } from "lucide-react";
+import { CircleAlert, FolderX, Loader2, RotateCcw, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { computeRepairPlan, type RepairIssue, type RepairPlan } from "./lib";
+import {
+  computeRepairPlan,
+  HELPER_PERMISSION_ID,
+  type RepairInputs,
+  type RepairIssue,
+  type RepairPlan,
+} from "./lib";
+
+/** The inputs read once, when the (hydrated) widget mounts. */
+type LaunchSnapshot = Omit<
+  RepairInputs,
+  "helperRow" | "helperPreference" | "helperGraceElapsed"
+>;
 
 /**
- * Launch-time evaluation of post-completion prerequisite regressions.
+ * How long "the helper was asked for and is not answering" must hold before the
+ * banner says so.
  *
- * Runs once when the (hydrated) widget mounts and only again through the
- * returned `recheck` — mid-session backend events never add or swap a repair
- * surface, mirroring how the onboarding takeover is entered only at
- * well-defined moments.
+ * Not a cosmetic debounce: at the moment the widget mounts the condition is true
+ * on any launch that has to re-register the helper, and the backend is already
+ * working on it. Waiting lets those launches finish in silence, and leaves only
+ * the ones that are still stuck once the user has had time to look at the window
+ * — which is when there is something for them to do.
  */
-export function useLaunchRepair(): {
+export const HELPER_GRACE_MS = 10_000;
+
+/**
+ * Post-completion prerequisite regressions: what to block on, what to banner.
+ *
+ * The plan is decided from a launch snapshot, re-taken only by the returned
+ * `recheck`, with one exception: the unattended sync helper's banner follows the
+ * live row and the live standing decision. `computeRepairPlan` documents why that
+ * one row is different and why a banner may change mid-session where the blocking
+ * card may not.
+ */
+export function useRepair(): {
   plan: RepairPlan;
   recheck: () => Promise<void>;
   dismissBanner: (kind: RepairIssue["kind"]) => void;
 } {
-  const [plan, setPlan] = useState<RepairPlan>({ blocking: null, banners: [] });
+  const [snapshot, setSnapshot] = useState<LaunchSnapshot | null>(null);
   const [dismissed, setDismissed] = useState<RepairIssue["kind"][]>([]);
   // The widget renders a neutral shell until hydration; the launch evaluation
   // must read post-hydration values (probes have run, latch is mirrored).
   const hydrated = useViewModel((s) => s.hydrated);
 
+  // The two live inputs. `find` hands back the row object the store holds rather
+  // than building a new one, so a re-render can never come from the selector
+  // itself. Every publish is one, though: each `permissions_changed` mirrors a
+  // freshly deserialized state, so even a report identical to the last one is a
+  // new object — which is why the grace clock below keys on the condition rather
+  // than on the row.
+  const helperRow = useViewModel(
+    (s) => s.permissions?.permissions.find((p) => p.id === HELPER_PERMISSION_ID) ?? null,
+  );
+  const helperPreference = useViewModel((s) => s.preferences?.helperPreference ?? null);
+
+  // The grace clock keys on the condition, not on the report that reveals it: a
+  // helper whose registration keeps failing publishes a new row every pass, and
+  // restarting the clock on each one would keep the banner off the screen for
+  // exactly as long as the failure lasts. So the effect depends on this boolean
+  // and nothing else — a report that changes while still not granted does not
+  // touch the timer, and the row reaching granted clears the banner and the clock
+  // together.
+  const helperWanted =
+    helperPreference === "granted" && helperRow !== null && helperRow.status !== "granted";
+  const [helperGraceElapsed, setHelperGraceElapsed] = useState(false);
+  useEffect(() => {
+    if (!helperWanted) {
+      setHelperGraceElapsed(false);
+      return;
+    }
+    const timer = setTimeout(() => setHelperGraceElapsed(true), HELPER_GRACE_MS);
+    return () => clearTimeout(timer);
+  }, [helperWanted]);
+
   const evaluate = useCallback(async () => {
-    // Snapshot the store rather than subscribing: repair is launch-scoped
-    // by design, not reactive.
+    // Snapshot the store rather than subscribing: everything here is
+    // launch-scoped by design (the helper's live inputs are read above).
     const vm = useViewModel.getState();
     const configDir = vm.preferences?.configDir ?? null;
 
@@ -46,17 +101,15 @@ export function useLaunchRepair(): {
       }
     }
 
-    setPlan(
-      computeRepairPlan({
-        completedAt: vm.onboardingState?.completedAt ?? null,
-        configDir,
-        flakeExists,
-        nixInstalled: vm.nixInstall?.installed ?? null,
-        permissions: vm.permissions,
-        skipPermissions: settings.skipPermissions === true,
-        nixInstalledOverride: settings.nixInstalledOverride === true,
-      }),
-    );
+    setSnapshot({
+      completedAt: vm.onboardingState?.completedAt ?? null,
+      configDir,
+      flakeExists,
+      nixInstalled: vm.nixInstall?.installed ?? null,
+      permissions: vm.permissions,
+      skipPermissions: settings.skipPermissions === true,
+      nixInstalledOverride: settings.nixInstalledOverride === true,
+    });
   }, []);
 
   useEffect(() => {
@@ -72,6 +125,10 @@ export function useLaunchRepair(): {
     await evaluate();
   }, [evaluate]);
 
+  const plan = snapshot
+    ? computeRepairPlan({ ...snapshot, helperRow, helperPreference, helperGraceElapsed })
+    : { blocking: null, banners: [] };
+
   return {
     plan: {
       blocking: plan.blocking,
@@ -80,6 +137,55 @@ export function useLaunchRepair(): {
     recheck,
     dismissBanner: (kind) => setDismissed((prev) => [...prev, kind]),
   };
+}
+
+/**
+ * The helper banner's one action: the same Grant the helper's row in Settings →
+ * Permissions offers. It records the decision and reconciles towards it, and it
+ * is the only action that opens Login Items — which it does when macOS is waiting
+ * for the approval there.
+ *
+ * No re-probe afterwards, unlike the "Check again" button on the snapshot-based
+ * banner: this banner reads the row live, and the backend publishes it on every
+ * reconciliation pass. A failed call leaves the banner and the row's sentence
+ * standing, which is already the truth, so it is logged rather than surfaced.
+ *
+ * The label keeps its box under `invisible` with the spinner laid over it, as the
+ * helper's row does, because the Button base carries `transition-all`: a label
+ * swapped for a shorter one would animate the width and shift the dismiss button
+ * next to it. The spinner is nested rather than a direct child because `size="sm"`
+ * carries `has-[>svg]:px-2.5`, which a top-level icon would trigger.
+ */
+function HelperGrantButton() {
+  const [granting, setGranting] = useState(false);
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={granting}
+      aria-label={granting ? "Enabling…" : undefined}
+      aria-busy={granting}
+      className="relative disabled:opacity-100"
+      onClick={async () => {
+        setGranting(true);
+        try {
+          // deprecated(orpc): replace with client/orpc from @/lib/orpc
+          await tauriAPI.permissions.request(HELPER_PERMISSION_ID);
+        } catch (error) {
+          console.error("Failed to enable the unattended sync helper:", error);
+        } finally {
+          setGranting(false);
+        }
+      }}
+    >
+      <span className={granting ? "invisible" : undefined}>Enable</span>
+      {granting ? (
+        <span className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        </span>
+      ) : null}
+    </Button>
+  );
 }
 
 /** Non-blocking repair notices, rendered above the main content. */
@@ -121,6 +227,20 @@ export function RepairBanners({
                   permissions in Settings → Permissions.
                 </p>
               </>
+            ) : issue.kind === "helper-inactive" ? (
+              <>
+                {/* States the condition and nothing more: which of the states
+                    behind it this is cannot be known here, and the sentence
+                    below is the row's own report of it. */}
+                <p className="font-medium">Unattended sync helper is not active</p>
+                {/* `wrap-anywhere` because these sentences quote paths — a
+                    `/Volumes/…` bundle is one unbreakable token wider than the
+                    banner. Not `break-all`, which would also break the ordinary
+                    words at the end of every line. */}
+                {issue.instructions ? (
+                  <p className="mt-0.5 wrap-anywhere text-xs opacity-70">{issue.instructions}</p>
+                ) : null}
+              </>
             ) : null}
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -140,6 +260,7 @@ export function RepairBanners({
                 </Button>
               </>
             )}
+            {issue.kind === "helper-inactive" && <HelperGrantButton />}
             <button
               type="button"
               onClick={() => onDismiss(issue.kind)}

--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -18,7 +18,7 @@ import { useOnboardingFlow } from "@/components/widget/onboarding/use-onboarding
 import {
   RepairBanners,
   RepairBlockingCard,
-  useLaunchRepair,
+  useRepair,
 } from "@/components/widget/repair/repair";
 import { uiActions } from "@nixmac/state";
 import {
@@ -187,9 +187,11 @@ export function DarwinWidget() {
   // explicit "Restart setup", never because a preference fact regressed
   // mid-session. In-flow step routing still derives from durable facts.
   const { showFlow: showOnboarding } = useOnboardingFlow();
-  // Post-completion prerequisite regressions surface as repair cards/banners
-  // (evaluated once at launch), never by re-entering the wizard.
-  const repair = useLaunchRepair();
+  // Post-completion prerequisite regressions surface as repair cards/banners,
+  // never by re-entering the wizard. Evaluated from a launch snapshot; the
+  // unattended sync helper's banner is the one part that follows live state,
+  // because that row is expected to settle after the launch probe.
+  const repair = useRepair();
   // Suppress the boot flash: before the ViewModel hydrates, every gate input
   // is a default (null preferences/nixInstall), so both OnboardingFlow and the
   // main widget would render against stale state for a frame. Hold a neutral

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -1214,14 +1214,12 @@ helperPreference: HelperPreference }
  */
 export type HelperPreference = "unset" | "granted" | "disabled"
 
-export type HelperServiceStatus = { label: string; available: boolean; registered: boolean; authorized: boolean; socketAvailable: boolean; 
 /**
- * The daemon answered an authenticated `Status` round-trip naming a
- * state: the client validated the daemon's signature and the daemon
- * accepted this client. A typed refusal or an unparseable reply never
- * sets this.
+ * What one reconciliation run found, for a client that only has to display it:
+ * whether the helper is installed and answering at this build, and the sentence
+ * that says what else is true.
  */
-responding: boolean; detail: string | null }
+export type HelperReport = { atThisBuild: boolean; detail: string }
 
 /**
  * A commit entry combining git log data, tag-derived flags, optional DB metadata, and raw diff changes.
@@ -1604,7 +1602,14 @@ description: string;
  */
 required: boolean; 
 /**
- * Whether the app can trigger the system prompt directly.
+ * Whether the app can trigger the system prompt directly. False means the
+ * row's action can only deep-link into System Settings and wait for the
+ * user, which is what the UI renders it as.
+ * 
+ * Fixed per row for the TCC permissions, but not a capability in general:
+ * the unattended sync helper reports it per observation, and it is false
+ * only while macOS holds the registration pending approval in Login Items.
+ * Read it as "is System Settings where the user finishes this, right now".
  */
 canRequestProgrammatically: boolean; 
 /**
@@ -2058,9 +2063,9 @@ export type Procedures = {
     finalizeRestore: Client<Record<never, never>, RestoreTargetInput, void, Error>
     finalizeRollback: Client<Record<never, never>, FinalizeRollbackInput, void, Error>
     fixWithAi: Client<Record<never, never>, FixWithAiInput, void, Error>
-    helperRegister: Client<Record<never, never>, void, HelperServiceStatus, Error>
-    helperStatus: Client<Record<never, never>, void, HelperServiceStatus, Error>
-    helperUnregister: Client<Record<never, never>, void, HelperServiceStatus, Error>
+    helperDisable: Client<Record<never, never>, void, HelperReport, Error>
+    helperGrant: Client<Record<never, never>, void, HelperReport, Error>
+    helperStatus: Client<Record<never, never>, void, HelperReport, Error>
     prepareRestore: Client<Record<never, never>, RestoreTargetInput, void, Error>
     rebuildStatus: Client<Record<never, never>, void, RebuildStatus, Error>
     rollbackErase: Client<Record<never, never>, void, RollbackResult, Error>

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1873,7 +1873,14 @@ description: string;
  */
 required: boolean; 
 /**
- * Whether the app can trigger the system prompt directly.
+ * Whether the app can trigger the system prompt directly. False means the
+ * row's action can only deep-link into System Settings and wait for the
+ * user, which is what the UI renders it as.
+ * 
+ * Fixed per row for the TCC permissions, but not a capability in general:
+ * the unattended sync helper reports it per observation, and it is false
+ * only while macOS holds the registration pending approval in Login Items.
+ * Read it as "is System Settings where the user finishes this, right now".
  */
 canRequestProgrammatically: boolean; 
 /**


### PR DESCRIPTION
# not done yet
- after the helper upgrade, it might (very likely) need to be re-approved by the user. This should show a banner in the main app.

## Summary

- activates all the E1 commits which enable automatic helper upgrade
internal code `E1d`

## Test Plan

- [ ] Manual testing of a CI-build artifact
- [x] Dev-built and signed version replaces the current prod helper

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
