### PR TITLE
fix(search_packages): relax nix package search constraints and score on the tool side

### DIFF
--- a/apps/native/src-tauri/src/evolve/search_packages.rs
+++ b/apps/native/src-tauri/src/evolve/search_packages.rs
@@ -80,8 +80,7 @@ fn channel_is_registered(registry_list: &str, channel: &str) -> bool {
 /// Splits the query terms into the appropriate argument(s) for the nix search command, handling regex vs. non-regex searches.
 fn build_search_queries(query: &str, use_regex: bool) -> Result<Vec<String>> {
     if use_regex {
-        let escaped_regex = regex::escape(query);
-        return Ok(vec![escaped_regex]);
+        return Ok(vec![query.to_string()]);
     }
 
     let terms = query
@@ -252,6 +251,7 @@ fn relevance_score(result: &SearchPackageResult, query: &str) -> i32 {
 /// Processes the given results by scoring them, then appending unique results to the structured list up to the limit.
 fn process_results(
     results: Vec<SearchPackageResult>,
+    query: &str,
     limit: u64,
 ) -> Result<Vec<SearchPackageResult>> {
     let mut unique_results = Vec::new();
@@ -266,8 +266,8 @@ fn process_results(
 
     // Sort by relevance score in descending order.
     unique_results.sort_by(|a, b| {
-        let score_a = relevance_score(a, &a.name);
-        let score_b = relevance_score(b, &b.name);
+        let score_a = relevance_score(a, query);
+        let score_b = relevance_score(b, query);
         score_b.cmp(&score_a)
     });
 
@@ -310,7 +310,11 @@ pub fn execute_search_packages(
     }
 
     // 2. Process the full results.
-    let processed = process_results(results.into_iter().flat_map(|(_, r)| r).collect(), limit)?;
+    let processed = process_results(
+        results.into_iter().flat_map(|(_, r)| r).collect(),
+        query,
+        limit,
+    )?;
     Ok(processed)
 }
 
@@ -538,7 +542,7 @@ mod tests {
         }];
 
         let all_results = [channel1_results.clone(), channel2_results.clone()].concat();
-        let processed_results = process_results(all_results, 10).unwrap();
+        let processed_results = process_results(all_results, "emacs", 10).unwrap();
 
         assert_eq!(
             processed_results.len(),
@@ -572,15 +576,6 @@ mod tests {
         let query = "google chrome";
         let use_regex = true;
         let expected = vec!["google chrome"];
-        let result = build_search_queries(query, use_regex).unwrap();
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn build_search_queries_regex_special_characters() {
-        let query = "foo.bar+baz";
-        let use_regex = true;
-        let expected = vec!["foo\\.bar\\+baz"];
         let result = build_search_queries(query, use_regex).unwrap();
         assert_eq!(result, expected);
     }
@@ -697,7 +692,38 @@ mod tests {
         ];
 
         let limit = 2;
-        let processed = process_results(results, limit).unwrap();
+        let processed = process_results(results, "pkg", limit).unwrap();
         assert_eq!(processed.len(), limit as usize);
+    }
+
+    #[test]
+    fn process_results_ranks_by_user_query() {
+        let emacs = SearchPackageResult {
+            name: "emacs".to_string(),
+            attr_path: "legacyPackages.aarch64-darwin.emacs".to_string(),
+            channel: "test-channel".to_string(),
+            version: "30.2".to_string(),
+            description: "Extensible text editor".to_string(),
+            install_via: SearchResultInstallTarget::Either,
+            additional_info: None,
+        };
+        let vim = SearchPackageResult {
+            name: "vim".to_string(),
+            attr_path: "legacyPackages.aarch64-darwin.vim".to_string(),
+            channel: "test-channel".to_string(),
+            version: "9.1".to_string(),
+            description: "Vi IMproved text editor".to_string(),
+            install_via: SearchResultInstallTarget::Either,
+            additional_info: None,
+        };
+
+        // Keep the non-matching package first in the input so this fails if
+        // equal self-match scores merely preserve the original order.
+        let results = vec![emacs.clone(), vim.clone()];
+        let ranked_for_vim = process_results(results.clone(), "vim", 10).unwrap();
+        let ranked_for_emacs = process_results(results, "emacs", 10).unwrap();
+
+        assert_eq!(ranked_for_vim[0], vim);
+        assert_eq!(ranked_for_emacs[0], emacs);
     }
 }

--- a/apps/native/src-tauri/src/evolve/search_packages.rs
+++ b/apps/native/src-tauri/src/evolve/search_packages.rs
@@ -5,11 +5,6 @@ use anyhow::Result;
 use log::info;
 use std::process::Command;
 
-/// Most packages we will consider from a single channel search.
-/// This is useful if the agent decides to search on a super-generic term
-/// and we don't want to score thousands of results.
-const CHANNEL_LIMIT: u64 = 100;
-
 /// Indicates whether this package looks like something that we think should be
 /// installed via Homebrew vs. Nix. This is just a heuristic to help users avoid installing things like
 /// GUI apps via Nix when they might be better off with Homebrew Cask, etc.
@@ -38,6 +33,52 @@ pub struct SearchPackageResult {
     pub description: String,
     pub install_via: SearchResultInstallTarget,
     pub additional_info: Option<String>,
+}
+
+/// Package metadata returned by `nix search`, before the comparatively expensive
+/// derivation classification step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SearchPackageCandidate {
+    name: String,
+    attr_path: String,
+    channel: String,
+    version: String,
+    description: String,
+}
+
+/// Package metadata common to both `SearchPackageCandidate` (pre-classification) and `SearchPackageResult` (post).
+trait PackageMetadata {
+    fn name(&self) -> &str;
+    fn attr_path(&self) -> &str;
+    fn description(&self) -> &str;
+}
+
+impl PackageMetadata for SearchPackageCandidate {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn attr_path(&self) -> &str {
+        &self.attr_path
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+impl PackageMetadata for SearchPackageResult {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn attr_path(&self) -> &str {
+        &self.attr_path
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
 }
 
 /// Wrapper for `nix registry list` that returns the raw output as a string, or an error if the command fails.
@@ -77,16 +118,28 @@ fn channel_is_registered(registry_list: &str, channel: &str) -> bool {
     })
 }
 
+/// Escape a literal for the POSIX ERE syntax used by `nix search`.
+/// Do not use `regex::escape`: it targets Rust regex syntax and escapes
+/// additional characters whose backslash-escaped forms are not valid
+/// portable POSIX ERE.
+fn ere_escape(term: &str) -> String {
+    let mut out = String::with_capacity(term.len() + 2);
+    for c in term.chars() {
+        if r#"\.[(){}*+?^$|"#.contains(c) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 /// Splits the query terms into the appropriate argument(s) for the nix search command, handling regex vs. non-regex searches.
 fn build_search_queries(query: &str, use_regex: bool) -> Result<Vec<String>> {
     if use_regex {
         return Ok(vec![query.to_string()]);
     }
 
-    let terms = query
-        .split_whitespace()
-        .map(regex::escape)
-        .collect::<Vec<_>>();
+    let terms = query.split_whitespace().map(ere_escape).collect::<Vec<_>>();
 
     if terms.is_empty() {
         anyhow::bail!("package search query cannot be empty");
@@ -95,14 +148,13 @@ fn build_search_queries(query: &str, use_regex: bool) -> Result<Vec<String>> {
     Ok(terms)
 }
 
-/// Search a single channel and return a list of SearchPackageResult
-/// results.
+/// Search a single channel and return its unclassified package candidates.
 fn search_single_channel(
     config_dir: &str,
     query_term: &str,
     use_regex: bool,
     channel: &str,
-) -> Result<Vec<SearchPackageResult>> {
+) -> Result<Vec<SearchPackageCandidate>> {
     let search_queries = build_search_queries(query_term, use_regex)?;
 
     let mut cmd = Command::new("nix");
@@ -128,16 +180,14 @@ fn search_single_channel(
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    process_search_output(&stdout, channel, None, CHANNEL_LIMIT)
+    process_search_output(&stdout, channel)
 }
 
-/// Process the JSON output from a nix search command and return a list of SearchPackageResult.
+/// Parse all candidates from the JSON output of a nix search command.
 fn process_search_output(
     search_cmd_output: &str,
     channel: &str,
-    package_classifier: Option<&dyn Fn(&str) -> SearchResultInstallTarget>,
-    limit: u64,
-) -> Result<Vec<SearchPackageResult>> {
+) -> Result<Vec<SearchPackageCandidate>> {
     let parsed = serde_json::from_str::<serde_json::Value>(search_cmd_output)
         .map_err(|e| anyhow::anyhow!("Failed to parse JSON output from nix search: {}", e))?;
 
@@ -150,22 +200,9 @@ fn process_search_output(
                 .next_back()
                 .unwrap_or(attr_path)
                 .to_string();
-            let (package_type, additional_info) = if let Some(classifier) = package_classifier {
-                (classifier(&name), None)
-            } else {
-                let (pkg_type, info) = classify_package(channel, attr_path);
-                (pkg_type, info)
-            };
-
-            // If the package is unavailable on the host platform, skip it.
-            if package_type == SearchResultInstallTarget::UnavailableOnHostPlatform {
-                continue;
-            }
-
-            results.push(SearchPackageResult {
+            results.push(SearchPackageCandidate {
                 name,
                 attr_path: attr_path.clone(),
-                install_via: package_type,
                 channel: channel.to_string(),
                 version: pkg
                     .get("version")
@@ -177,33 +214,44 @@ fn process_search_output(
                     .and_then(|v| v.as_str())
                     .unwrap_or("No description")
                     .to_string(),
-                additional_info,
             });
-
-            // Respect the channel limit to avoid overwhelming the scoring system with too many results.
-            if results.len() as u64 >= limit {
-                break;
-            }
         }
     }
 
     Ok(results)
 }
 
-/// Compute a relevance score for a given search result based on the query terms.
-fn relevance_score(result: &SearchPackageResult, query: &str) -> i32 {
+/// Computes a relevance bonus for package attribute names with fewer terms.
+/// A top-level package is a particularly strong signal that it is the package a
+/// user intended, while deeper package-set entries receive progressively less.
+fn fewer_terms_relevance_bonus(terms: &[&str]) -> i32 {
+    match terms.len() {
+        0 => 0,
+        1 => 200,
+        2 => 100,
+        num_terms => 100 / num_terms as i32,
+    }
+}
+
+/// Compute a relevance score for package metadata based on the query terms.
+fn relevance_score(result: &impl PackageMetadata, query: &str) -> i32 {
     let query = query.to_lowercase();
     let terms = query.split_whitespace().collect::<Vec<_>>();
 
-    let name = result.name.to_lowercase();
-    let attr = result.attr_path.to_lowercase();
-    let description = result.description.to_lowercase();
+    let name = result.name().to_lowercase();
+    let attr = result.attr_path().to_lowercase();
+    let description = result.description().to_lowercase();
+
+    // `nix search` prefixes attribute paths with `legacyPackages.<system>`.
+    // Score the remaining package attribute, so `spotify` gets a larger bonus
+    // than a nested package such as `haskellPackages.spotify`.
+    let package_attr_terms = attr.split('.').skip(2).collect::<Vec<_>>();
 
     let normalized_query = query.replace([' ', '_'], "-");
 
     let mut score = 0;
 
-    // Exact-ish package identity should dominate.
+    // Exact-ish package identity should dominate, but give a bonus to fewer terms in the name.
     if name == query || attr.ends_with(&format!(".{query}")) {
         score += 1000;
     }
@@ -245,15 +293,22 @@ fn relevance_score(result: &SearchPackageResult, query: &str) -> i32 {
         }
     }
 
+    score += fewer_terms_relevance_bonus(&package_attr_terms);
+
     score
 }
 
-/// Processes the given results by scoring them, then appending unique results to the structured list up to the limit.
-fn process_results(
-    results: Vec<SearchPackageResult>,
+/// Deduplicate and rank all lightweight candidates, truncate them to the requested
+/// limit, and only then run the expensive derivation classifier.
+fn process_results<F>(
+    results: Vec<SearchPackageCandidate>,
     query: &str,
     limit: u64,
-) -> Result<Vec<SearchPackageResult>> {
+    package_classifier: &F,
+) -> Result<Vec<SearchPackageResult>>
+where
+    F: Fn(&str, &str) -> (SearchResultInstallTarget, Option<String>),
+{
     let mut unique_results = Vec::new();
     let mut seen_attr_paths = std::collections::HashSet::new();
 
@@ -276,7 +331,27 @@ fn process_results(
         unique_results.truncate(limit as usize);
     }
 
-    Ok(unique_results)
+    Ok(unique_results
+        .into_iter()
+        .filter_map(|candidate| {
+            let (install_via, additional_info) =
+                package_classifier(&candidate.channel, &candidate.attr_path);
+
+            if install_via == SearchResultInstallTarget::UnavailableOnHostPlatform {
+                return None;
+            }
+
+            Some(SearchPackageResult {
+                name: candidate.name,
+                attr_path: candidate.attr_path,
+                channel: candidate.channel,
+                version: candidate.version,
+                description: candidate.description,
+                install_via,
+                additional_info,
+            })
+        })
+        .collect())
 }
 
 /// Execute a search_packages tool call
@@ -314,6 +389,7 @@ pub fn execute_search_packages(
         results.into_iter().flat_map(|(_, r)| r).collect(),
         query,
         limit,
+        &classify_package,
     )?;
     Ok(processed)
 }
@@ -425,6 +501,31 @@ fn classify_package(channel: &str, attr_path: &str) -> (SearchResultInstallTarge
 mod tests {
     use super::*;
 
+    fn candidate_from_result(result: SearchPackageResult) -> SearchPackageCandidate {
+        SearchPackageCandidate {
+            name: result.name,
+            attr_path: result.attr_path,
+            channel: result.channel,
+            version: result.version,
+            description: result.description,
+        }
+    }
+
+    fn process_test_results(
+        results: Vec<SearchPackageResult>,
+        query: &str,
+        limit: u64,
+    ) -> Vec<SearchPackageResult> {
+        let candidates = results
+            .into_iter()
+            .map(candidate_from_result)
+            .collect::<Vec<_>>();
+        process_results(candidates, query, limit, &|_, _| {
+            (SearchResultInstallTarget::Either, None)
+        })
+        .unwrap()
+    }
+
     fn load_classifier_fixture(name: &str) -> &'static str {
         match name {
             "firefox" => include_str!("../../tests/fixtures/derivations/firefox.json"),
@@ -479,17 +580,9 @@ mod tests {
             install_via: SearchResultInstallTarget::Either,
             additional_info: None,
         })), ("empty", 0, None )];
-        let fake_package_classifier = |_package_name: &str| SearchResultInstallTarget::Either;
-
         for (name, expected_count, first_result) in cases {
             let output = load_search_fixture(name);
-            let results = process_search_output(
-                output,
-                "test-channel",
-                Some(&fake_package_classifier),
-                CHANNEL_LIMIT,
-            )
-            .unwrap();
+            let results = process_search_output(output, "test-channel").unwrap();
             assert_eq!(
                 results.len(),
                 expected_count,
@@ -499,12 +592,48 @@ mod tests {
             if let Some(expected_first) = first_result {
                 assert_eq!(
                     results.first(),
-                    Some(&expected_first),
+                    Some(&candidate_from_result(expected_first)),
                     "unexpected first result for {}",
                     name
                 );
             }
         }
+    }
+
+    #[test]
+    fn ranks_all_candidates_before_limiting_and_classifying() {
+        let mut packages = serde_json::Map::new();
+        for index in 0..150 {
+            packages.insert(
+                format!("legacyPackages.aarch64-darwin.androidenv.pkg{index:03}.google"),
+                serde_json::json!({
+                    "version": "1.0",
+                    "description": "Android Google API image"
+                }),
+            );
+        }
+        packages.insert(
+            "legacyPackages.aarch64-darwin.go".to_string(),
+            serde_json::json!({
+                "version": "1.25",
+                "description": "The Go programming language"
+            }),
+        );
+
+        let output = serde_json::Value::Object(packages).to_string();
+        let candidates = process_search_output(&output, "nixpkgs").unwrap();
+        assert_eq!(candidates.len(), 151);
+
+        let classification_count = std::cell::Cell::new(0);
+        let results = process_results(candidates, "go", 2, &|_, _| {
+            classification_count.set(classification_count.get() + 1);
+            (SearchResultInstallTarget::System, None)
+        })
+        .unwrap();
+
+        assert_eq!(classification_count.get(), 2);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].attr_path, "legacyPackages.aarch64-darwin.go");
     }
 
     #[test]
@@ -542,7 +671,7 @@ mod tests {
         }];
 
         let all_results = [channel1_results.clone(), channel2_results.clone()].concat();
-        let processed_results = process_results(all_results, "emacs", 10).unwrap();
+        let processed_results = process_test_results(all_results, "emacs", 10);
 
         assert_eq!(
             processed_results.len(),
@@ -560,6 +689,21 @@ mod tests {
             registry_list,
             "unregistered-channel"
         ));
+    }
+
+    #[test]
+    fn build_search_queries_ere_escape() {
+        let query = "google-chrome";
+        let use_regex = false;
+        let expected = vec!["google-chrome"];
+        let result = build_search_queries(query, use_regex).unwrap();
+        assert_eq!(result, expected);
+
+        let query = "c++";
+        let use_regex = false;
+        let expected = vec!["c\\+\\+"];
+        let result = build_search_queries(query, use_regex).unwrap();
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -660,6 +804,45 @@ mod tests {
     }
 
     #[test]
+    fn fewer_terms_bonus_favors_short_package_attributes() {
+        assert_eq!(fewer_terms_relevance_bonus(&[]), 0);
+        assert_eq!(fewer_terms_relevance_bonus(&["spotify"]), 200);
+        assert_eq!(
+            fewer_terms_relevance_bonus(&["haskellPackages", "spotify"]),
+            100
+        );
+        assert_eq!(
+            fewer_terms_relevance_bonus(&["packageSet", "nested", "spotify"]),
+            33
+        );
+    }
+
+    #[test]
+    fn relevance_score_prefers_top_level_package_attributes() {
+        let spotify = SearchPackageResult {
+            name: "spotify".to_string(),
+            attr_path: "legacyPackages.aarch64-darwin.spotify".to_string(),
+            channel: "test-channel".to_string(),
+            version: "1.0".to_string(),
+            description: "Spotify client".to_string(),
+            install_via: SearchResultInstallTarget::Either,
+            additional_info: None,
+        };
+        let haskell_spotify = SearchPackageResult {
+            attr_path: "legacyPackages.aarch64-darwin.haskellPackages.spotify".to_string(),
+            ..spotify.clone()
+        };
+
+        assert_eq!(
+            relevance_score(&spotify, "spotify") - relevance_score(&haskell_spotify, "spotify"),
+            100
+        );
+
+        let ranked = process_test_results(vec![haskell_spotify, spotify.clone()], "spotify", 10);
+        assert_eq!(ranked[0], spotify);
+    }
+
+    #[test]
     fn process_limit() {
         let results = vec![
             SearchPackageResult {
@@ -692,7 +875,7 @@ mod tests {
         ];
 
         let limit = 2;
-        let processed = process_results(results, "pkg", limit).unwrap();
+        let processed = process_test_results(results, "pkg", limit);
         assert_eq!(processed.len(), limit as usize);
     }
 
@@ -720,8 +903,8 @@ mod tests {
         // Keep the non-matching package first in the input so this fails if
         // equal self-match scores merely preserve the original order.
         let results = vec![emacs.clone(), vim.clone()];
-        let ranked_for_vim = process_results(results.clone(), "vim", 10).unwrap();
-        let ranked_for_emacs = process_results(results, "emacs", 10).unwrap();
+        let ranked_for_vim = process_test_results(results.clone(), "vim", 10);
+        let ranked_for_emacs = process_test_results(results, "emacs", 10);
 
         assert_eq!(ranked_for_vim[0], vim);
         assert_eq!(ranked_for_emacs[0], emacs);

--- a/apps/native/src-tauri/src/evolve/search_packages.rs
+++ b/apps/native/src-tauri/src/evolve/search_packages.rs
@@ -5,6 +5,11 @@ use anyhow::Result;
 use log::info;
 use std::process::Command;
 
+/// Most packages we will consider from a single channel search.
+/// This is useful if the agent decides to search on a super-generic term
+/// and we don't want to score thousands of results.
+const CHANNEL_LIMIT: u64 = 100;
+
 /// Indicates whether this package looks like something that we think should be
 /// installed via Homebrew vs. Nix. This is just a heuristic to help users avoid installing things like
 /// GUI apps via Nix when they might be better off with Homebrew Cask, etc.
@@ -74,24 +79,14 @@ fn channel_is_registered(registry_list: &str, channel: &str) -> bool {
 
 /// Splits the query terms into the appropriate argument(s) for the nix search command, handling regex vs. non-regex searches.
 fn build_search_queries(query: &str, use_regex: bool) -> Result<Vec<String>> {
-    // Nix search supports regex implicitly. So if the user wants non-"regex"
-    // search, we need to pin with ^$.
-    // It also returns search results for both name and description so there
-    // is no point to have separate "search types".
-    // It also treats multiple regex arguments as separate search terms.
-    // Anchor the overall search while allowing punctuation, such as "-",
-    // between terms:
-    //
-    // "google chrome" -> ["^google", "chrome$"]
     if use_regex {
-        return Ok(vec![query.to_string()]);
+        let escaped_regex = regex::escape(query);
+        return Ok(vec![escaped_regex]);
     }
 
-    // Anchor the first and last terms to avoid partial matches, but allow punctuation between terms.
-    let anchored_query = format!("^{}$", query);
-    let terms = anchored_query
+    let terms = query
         .split_whitespace()
-        .map(|s| s.to_string())
+        .map(regex::escape)
         .collect::<Vec<_>>();
 
     if terms.is_empty() {
@@ -134,7 +129,7 @@ fn search_single_channel(
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    process_search_output(&stdout, channel, None)
+    process_search_output(&stdout, channel, None, CHANNEL_LIMIT)
 }
 
 /// Process the JSON output from a nix search command and return a list of SearchPackageResult.
@@ -142,6 +137,7 @@ fn process_search_output(
     search_cmd_output: &str,
     channel: &str,
     package_classifier: Option<&dyn Fn(&str) -> SearchResultInstallTarget>,
+    limit: u64,
 ) -> Result<Vec<SearchPackageResult>> {
     let parsed = serde_json::from_str::<serde_json::Value>(search_cmd_output)
         .map_err(|e| anyhow::anyhow!("Failed to parse JSON output from nix search: {}", e))?;
@@ -184,71 +180,103 @@ fn process_search_output(
                     .to_string(),
                 additional_info,
             });
+
+            // Respect the channel limit to avoid overwhelming the scoring system with too many results.
+            if results.len() as u64 >= limit {
+                break;
+            }
         }
     }
 
     Ok(results)
 }
 
-/// Adds the search results from a single channel to the structured results list, ensuring uniqueness by attr_path and respecting the limit.
-fn process_channel_results(
-    structured: &mut Vec<SearchPackageResult>,
-    channel_results: Vec<SearchPackageResult>,
-    limit: u64,
-) -> Result<bool> {
-    for result in channel_results {
-        if structured.len() >= limit as usize {
-            return Ok(true);
-        };
+/// Compute a relevance score for a given search result based on the query terms.
+fn relevance_score(result: &SearchPackageResult, query: &str) -> i32 {
+    let query = query.to_lowercase();
+    let terms = query.split_whitespace().collect::<Vec<_>>();
 
-        let _map_key = result
-            .attr_path
-            .split('.')
-            .next_back()
-            .unwrap_or(&result.attr_path);
-        if !structured
-            .iter()
-            .any(|item| item.attr_path == result.attr_path)
-        {
-            structured.push(result);
+    let name = result.name.to_lowercase();
+    let attr = result.attr_path.to_lowercase();
+    let description = result.description.to_lowercase();
+
+    let normalized_query = query.replace([' ', '_'], "-");
+
+    let mut score = 0;
+
+    // Exact-ish package identity should dominate.
+    if name == query || attr.ends_with(&format!(".{query}")) {
+        score += 1000;
+    }
+
+    if name == normalized_query || attr.ends_with(&format!(".{normalized_query}")) {
+        score += 900;
+    }
+
+    // Strong prefix matches.
+    if name.starts_with(&query) {
+        score += 500;
+    }
+
+    if name.starts_with(&normalized_query) {
+        score += 450;
+    }
+
+    // All terms in package name is much stronger than description-only.
+    if terms.iter().all(|term| name.contains(term)) {
+        score += 300;
+    }
+
+    if terms.iter().all(|term| attr.contains(term)) {
+        score += 200;
+    }
+
+    // Individual term weighting.
+    for term in &terms {
+        if name.contains(term) {
+            score += 50;
+        }
+
+        if attr.contains(term) {
+            score += 25;
+        }
+
+        if description.contains(term) {
+            score += 5;
         }
     }
-    Ok(structured.len() >= limit as usize)
+
+    score
 }
 
-/// Search channels in order for a given query/type and append unique results up to `limit`.
-fn collect_from_channels(
-    config_dir: &str,
-    channels: &[String],
-    query_term: &str,
-    use_regex: bool,
+/// Processes the given results by scoring them, then appending unique results to the structured list up to the limit.
+fn process_results(
+    results: Vec<SearchPackageResult>,
     limit: u64,
-    structured: &mut Vec<SearchPackageResult>,
-) -> Result<bool> {
-    let registry_list = nix_registry_list(config_dir)?;
+) -> Result<Vec<SearchPackageResult>> {
+    let mut unique_results = Vec::new();
+    let mut seen_attr_paths = std::collections::HashSet::new();
 
-    for channel in channels {
-        if structured.len() >= limit as usize {
-            return Ok(true);
-        }
-
-        if !channel_is_registered(&registry_list, channel) {
-            // CONSIDER: Whether we need to surface this to the agent somehow.
-            log::warn!(
-                "Channel '{}' is not registered, skipping search for this channel",
-                channel
-            );
-            continue;
-        }
-
-        let channel_results = search_single_channel(config_dir, query_term, use_regex, channel)?;
-        let complete = process_channel_results(structured, channel_results, limit)?;
-        if complete {
-            return Ok(true);
+    for result in results {
+        if !seen_attr_paths.contains(&result.attr_path) {
+            seen_attr_paths.insert(result.attr_path.clone());
+            unique_results.push(result);
         }
     }
 
-    Ok(structured.len() >= limit as usize)
+    // Sort by relevance score in descending order.
+    unique_results.sort_by(|a, b| {
+        let score_a = relevance_score(a, &a.name);
+        let score_b = relevance_score(b, &b.name);
+        score_b.cmp(&score_a)
+    });
+
+    // Limit the number of results.
+    if unique_results.len() > limit as usize {
+        unique_results.truncate(limit as usize);
+    }
+
+    Ok(unique_results)
 }
 
 /// Execute a search_packages tool call
@@ -263,21 +291,27 @@ pub fn execute_search_packages(
         "Searching for packages matching: '{}' (regex: {}, channels: {:?})",
         query, use_regex, channels
     );
+    let registry_list = nix_registry_list(config_dir)?;
 
-    let mut structured = Vec::new();
+    // 1. Collect results from each channel.
+    let mut results = Vec::new();
+    for channel in channels {
+        if !channel_is_registered(&registry_list, channel) {
+            // CONSIDER: Whether we need to surface this to the agent somehow.
+            log::warn!(
+                "Channel '{}' is not registered, skipping search for this channel",
+                channel
+            );
+            continue;
+        }
 
-    // Try primary search across channels, collecting up to limit.
-    let mut _complete = collect_from_channels(
-        config_dir,
-        channels,
-        query,
-        use_regex,
-        limit,
-        &mut structured,
-    )?;
+        let channel_results = search_single_channel(config_dir, query, use_regex, channel)?;
+        results.push((channel.clone(), channel_results));
+    }
 
-    // Return JSON result
-    Ok(structured)
+    // 2. Process the full results.
+    let processed = process_results(results.into_iter().flat_map(|(_, r)| r).collect(), limit)?;
+    Ok(processed)
 }
 
 /// Heuristically classify a nix derivation to determine if it looks like a GUI app (Homebrew Cask-like)
@@ -445,9 +479,13 @@ mod tests {
 
         for (name, expected_count, first_result) in cases {
             let output = load_search_fixture(name);
-            let results =
-                process_search_output(output, "test-channel", Some(&fake_package_classifier))
-                    .unwrap();
+            let results = process_search_output(
+                output,
+                "test-channel",
+                Some(&fake_package_classifier),
+                CHANNEL_LIMIT,
+            )
+            .unwrap();
             assert_eq!(
                 results.len(),
                 expected_count,
@@ -467,7 +505,6 @@ mod tests {
 
     #[test]
     fn multiple_channels_are_deduped() {
-        let mut structured = Vec::new();
         let channel1_results = vec![
             SearchPackageResult {
                 name: "emacs".to_string(),
@@ -500,10 +537,14 @@ mod tests {
             additional_info: None,
         }];
 
-        process_channel_results(&mut structured, channel1_results, 10).unwrap();
-        process_channel_results(&mut structured, channel2_results, 10).unwrap();
+        let all_results = [channel1_results.clone(), channel2_results.clone()].concat();
+        let processed_results = process_results(all_results, 10).unwrap();
 
-        assert_eq!(structured.len(), 2, "expected deduplication by attr_path");
+        assert_eq!(
+            processed_results.len(),
+            2,
+            "expected deduplication by attr_path"
+        );
     }
 
     #[test]
@@ -521,7 +562,7 @@ mod tests {
     fn build_search_queries_no_regex() {
         let query = "google chrome";
         let use_regex = false;
-        let expected = vec!["^google", "chrome$"];
+        let expected = vec!["google", "chrome"];
         let result = build_search_queries(query, use_regex).unwrap();
         assert_eq!(result, expected);
     }
@@ -533,5 +574,130 @@ mod tests {
         let expected = vec!["google chrome"];
         let result = build_search_queries(query, use_regex).unwrap();
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn build_search_queries_regex_special_characters() {
+        let query = "foo.bar+baz";
+        let use_regex = true;
+        let expected = vec!["foo\\.bar\\+baz"];
+        let result = build_search_queries(query, use_regex).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn relevance_score_basic() {
+        let result = SearchPackageResult {
+            name: "emacs".to_string(),
+            attr_path: "legacyPackages.aarch64-darwin.emacs".to_string(),
+            channel: "test-channel".to_string(),
+            version: "30.2".to_string(),
+            description: "Extensible, customizable GNU text editor".to_string(),
+            install_via: SearchResultInstallTarget::Either,
+            additional_info: None,
+        };
+
+        let score_exact = relevance_score(&result, "emacs");
+        let score_partial = relevance_score(&result, "em");
+        let score_unrelated = relevance_score(&result, "vim");
+
+        assert!(score_exact > score_partial);
+        assert!(score_partial > score_unrelated);
+    }
+
+    #[test]
+    fn relevance_score_with_normalization() {
+        let result = SearchPackageResult {
+            name: "google-chrome".to_string(),
+            attr_path: "legacyPackages.aarch64-darwin.google-chrome".to_string(),
+            channel: "test-channel".to_string(),
+            version: "90.0".to_string(),
+            description: "Web browser".to_string(),
+            install_via: SearchResultInstallTarget::Either,
+            additional_info: None,
+        };
+        let score_exact = relevance_score(&result, "google-chrome");
+        let score_partial = relevance_score(&result, "google");
+        let score_unrelated = relevance_score(&result, "firefox");
+
+        assert!(score_exact > score_partial);
+        assert!(score_partial > score_unrelated);
+    }
+
+    #[test]
+    fn relevance_score_with_description() {
+        let result = SearchPackageResult {
+            name: "vim".to_string(),
+            attr_path: "legacyPackages.aarch64-darwin.vim".to_string(),
+            channel: "test-channel".to_string(),
+            version: "8.2".to_string(),
+            description: "Vi IMproved, a highly configurable text editor".to_string(),
+            install_via: SearchResultInstallTarget::Either,
+            additional_info: None,
+        };
+
+        let score_exact = relevance_score(&result, "vim");
+        let score_description = relevance_score(&result, "text editor");
+        let score_unrelated = relevance_score(&result, "emacs");
+
+        assert!(score_exact > score_description);
+        assert!(score_description > score_unrelated);
+    }
+
+    #[test]
+    fn relevance_score_with_multiple_terms() {
+        let result = SearchPackageResult {
+            name: "python".to_string(),
+            attr_path: "legacyPackages.aarch64-darwin.python".to_string(),
+            channel: "test-channel".to_string(),
+            version: "3.9".to_string(),
+            description: "Python programming language".to_string(),
+            install_via: SearchResultInstallTarget::Either,
+            additional_info: None,
+        };
+
+        let score_exact = relevance_score(&result, "python");
+        let score_partial = relevance_score(&result, "programming language");
+        let score_unrelated = relevance_score(&result, "java");
+
+        assert!(score_exact > score_partial);
+        assert!(score_partial > score_unrelated);
+    }
+
+    #[test]
+    fn process_limit() {
+        let results = vec![
+            SearchPackageResult {
+                name: "pkg1".to_string(),
+                attr_path: "legacyPackages.aarch64-darwin.pkg1".to_string(),
+                channel: "test-channel".to_string(),
+                version: "1.0".to_string(),
+                description: "Package 1".to_string(),
+                install_via: SearchResultInstallTarget::Either,
+                additional_info: None,
+            },
+            SearchPackageResult {
+                name: "pkg2".to_string(),
+                attr_path: "legacyPackages.aarch64-darwin.pkg2".to_string(),
+                channel: "test-channel".to_string(),
+                version: "2.0".to_string(),
+                description: "Package 2".to_string(),
+                install_via: SearchResultInstallTarget::Either,
+                additional_info: None,
+            },
+            SearchPackageResult {
+                name: "pkg3".to_string(),
+                attr_path: "legacyPackages.aarch64-darwin.pkg3".to_string(),
+                channel: "test-channel".to_string(),
+                version: "3.0".to_string(),
+                description: "Package 3".to_string(),
+                install_via: SearchResultInstallTarget::Either,
+                additional_info: None,
+            },
+        ];
+
+        let limit = 2;
+        let processed = process_results(results, limit).unwrap();
+        assert_eq!(processed.len(), limit as usize);
     }
 }

--- a/apps/native/src-tauri/src/evolve/tools/search_packages.rs
+++ b/apps/native/src-tauri/src/evolve/tools/search_packages.rs
@@ -7,6 +7,9 @@ use crate::evolve::search_packages::execute_search_packages;
 
 use super::{ToolCtx, ToolResult};
 
+const DEFAULT_SEARCH_LIMIT: u64 = 20;
+const MAX_SEARCH_LIMIT: u64 = 50;
+
 pub(crate) fn definition() -> Tool {
     Tool {
         name: "search_packages".to_string(),
@@ -55,9 +58,12 @@ pub(crate) fn execute(ctx: &ToolCtx) -> Result<ToolResult> {
     let query = args["query"]
         .as_str()
         .ok_or_else(|| anyhow!("search_packages: missing query"))?;
-    // Clamp `limit` between 1 and 50 (default 20). Use as_i64 so negative
+    // Clamp `limit` between 1 and MAX_SEARCH_LIMIT (default DEFAULT_SEARCH_LIMIT). Use as_i64 so negative
     // and crazy-large values provided by callers are handled gracefully.
-    let limit = args["limit"].as_i64().unwrap_or(20).clamp(1, 50) as u64;
+    let limit = args["limit"]
+        .as_i64()
+        .unwrap_or(DEFAULT_SEARCH_LIMIT as i64)
+        .clamp(1, MAX_SEARCH_LIMIT as i64) as u64;
     let use_regex = args["use_regex"].as_bool().unwrap_or(false);
 
     // Clamp to at most 5 channels to prevent abuse since each channel adds latency


### PR DESCRIPTION
## Summary

This is for issue 617 -- another try at making the `search_packages` tool return good results with less churn (my white whale).

The ^ and $ anchors overconstrain the nix search so you can see this kind of churn:

<img width="788" height="719" alt="Screenshot 2026-08-07 at 1 36 35 PM" src="https://github.com/user-attachments/assets/7500b96e-5189-4bef-9505-ecb190134e50" />

With this change:

1. We no longer anchor but just let the query term tokens pass through to nix search. This gets us a lot more candidate results. So...
2. Then we collect those across _all_ channels (no longer just each channel individually).
3. And do some heuristics to score them. We can improve these heuristics later, do Manhattan distances or other kinds of spelling/sounds-like correction, let an LLM do the scoring, or whatever -- but I think what's here is pretty effective and also fast/easy.

Then you can see much happier results more like this (note the scoring implied in the agent's evolution logs in the UI):

<img width="788" height="719" alt="Screenshot 2026-08-07 at 3 39 44 PM" src="https://github.com/user-attachments/assets/c1138050-7e04-408a-b509-11516b7d6023" />

In addition to not missing pretty obvious things, by return just MORE results, we give the agent the opportunity to make better decisions in future search and edit steps.

## Test Plan

Some new unit tests, plus manual testing.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed