### PR TITLE
fix: obsolete comment and add test for double-escaping hostname in `nix_eval_homebrew_attr`

### DIFF
--- a/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
+++ b/apps/native/src-tauri/src/managed_edits/homebrew_adopt.rs
@@ -32,9 +32,8 @@ const NIX_EVAL_HOMEBREW_APPLY: &str = r#"cfg: {
 }"#;
 
 fn nix_eval_homebrew_attr(hostname: &str) -> Result<String> {
-    // serde_json::to_string already wraps the hostname in quotes and escapes
-    // internals — do not also embed quote chars in the format string or we
-    // produce malformed attrs like .#darwinConfigurations.""host"".config…
+    // nix_string_literal returns a fully quoted Nix string literal, so the
+    // format string must not add another layer of quotes around the hostname.
     let host_attr = nix_string_literal(hostname);
     Ok(format!(
         ".#darwinConfigurations.{}.config.homebrew",
@@ -900,6 +899,12 @@ mod tests {
         assert_eq!(
             nix_eval_homebrew_attr(r#"office"mac"#).expect("attr should escape hostname"),
             r#".#darwinConfigurations."office\"mac".config.homebrew"#
+        );
+
+        // Make sure we don't double-escape the hostname if it already has quotes.
+        assert_eq!(
+            nix_eval_homebrew_attr(r#""quoted-host""#).expect("attr should escape hostname"),
+            r#".#darwinConfigurations."\"quoted-host\"".config.homebrew"#
         );
     }
 


### PR DESCRIPTION
## Summary

Saw this while reviewing https://github.com/darkmatter/nixmac/pull/652 (which I think should be closed without merging, at least for the homebrew_adopt.rs change).

<!-- What does this PR do? Why? -->

## Test Plan

Enhanced unit test.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed