### PR TITLE
feat: add SOPS secret add/delete with darwin-rebuild verification and commit

### DIFF
--- a/apps/native/src-tauri/src/evolve/ensure_secret.rs
+++ b/apps/native/src-tauri/src/evolve/ensure_secret.rs
@@ -1,5 +1,5 @@
 use crate::evolve::age::ensure_age_key;
-use crate::evolve::file_ops::join_in_dir;
+use crate::evolve::file_ops::{join_in_dir, relative_path_between, repo_relative_path};
 use crate::evolve::nix_file_editor::{
     apply_semantic_edit, nix_builtins_path_meta_value, nix_expr_meta_value,
 };
@@ -9,9 +9,9 @@ use crate::evolve::sops::{
 use crate::evolve::types::{FileEditAction, SemanticFileEdit};
 
 use super::gitignore::GitignoreChecker;
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -319,55 +319,26 @@ fn secret_path_relative_to_target_file(
     })?;
     let secret_abs = join_in_dir(base, secret_path)?;
 
-    let from = target_dir.strip_prefix(base).map_err(|_| {
-        anyhow!(
+    let from = repo_relative_path(base, target_dir).with_context(|| {
+        format!(
             "ensure_secret: target file '{}' resolved outside config root",
             target_file
         )
     })?;
-    let to = secret_abs.strip_prefix(base).map_err(|_| {
-        anyhow!(
+    let to = repo_relative_path(base, &secret_abs).with_context(|| {
+        format!(
             "ensure_secret: secret path '{}' resolved outside config root",
             secret_path
         )
     })?;
 
-    let relative = relative_path(from, to);
+    let relative = relative_path_between(&from, &to)?;
     let rendered = relative.to_string_lossy().replace('\\', "/");
 
     if rendered.starts_with("../") || rendered.starts_with("./") {
         Ok(rendered)
     } else {
         Ok(format!("./{}", rendered))
-    }
-}
-
-fn relative_path(from: &Path, to: &Path) -> PathBuf {
-    let from_components: Vec<Component<'_>> = from.components().collect();
-    let to_components: Vec<Component<'_>> = to.components().collect();
-
-    let mut common_len = 0usize;
-    while common_len < from_components.len()
-        && common_len < to_components.len()
-        && from_components[common_len] == to_components[common_len]
-    {
-        common_len += 1;
-    }
-
-    let mut relative = PathBuf::new();
-
-    for _ in common_len..from_components.len() {
-        relative.push("..");
-    }
-
-    for component in &to_components[common_len..] {
-        relative.push(component.as_os_str());
-    }
-
-    if relative.as_os_str().is_empty() {
-        PathBuf::from(".")
-    } else {
-        relative
     }
 }
 

--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -24,6 +24,64 @@ pub(crate) fn join_in_dir(base: &Path, rel: &str) -> anyhow::Result<PathBuf> {
     Ok(base.join(normalized))
 }
 
+/// Return `path` relative to a repository root.
+pub(crate) fn repo_relative_path(repo_root: &Path, path: &Path) -> anyhow::Result<PathBuf> {
+    path.strip_prefix(repo_root)
+        .map(Path::to_path_buf)
+        .with_context(|| {
+            format!(
+                "{} is outside repository {}",
+                path.display(),
+                repo_root.display()
+            )
+        })
+}
+
+/// Return a repository-relative path using `/` separators for Git and Nix APIs.
+pub(crate) fn repo_relative_path_string(repo_root: &Path, path: &Path) -> anyhow::Result<String> {
+    Ok(repo_relative_path(repo_root, path)?
+        .to_string_lossy()
+        .replace('\\', "/"))
+}
+
+/// Compute a lexical path from directory `from` to `to`.
+///
+/// Both inputs must be either relative paths or absolute paths on the same
+/// root. Parent components are rejected because callers should normalize
+/// scoped paths before calculating a relative reference.
+pub(crate) fn relative_path_between(from: &Path, to: &Path) -> anyhow::Result<PathBuf> {
+    if from.is_absolute() != to.is_absolute() {
+        anyhow::bail!("cannot relativize an absolute path against a relative path");
+    }
+
+    let from_components = from.components().collect::<Vec<_>>();
+    let to_components = to.components().collect::<Vec<_>>();
+    let common = from_components
+        .iter()
+        .zip(&to_components)
+        .take_while(|(left, right)| left == right)
+        .count();
+    if from_components[common..]
+        .iter()
+        .chain(&to_components[common..])
+        .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        anyhow::bail!("cannot relativize paths with different roots or parent components");
+    }
+
+    let mut relative = PathBuf::new();
+    for _ in common..from_components.len() {
+        relative.push("..");
+    }
+    for component in &to_components[common..] {
+        relative.push(component.as_os_str());
+    }
+    if relative.as_os_str().is_empty() {
+        relative.push(".");
+    }
+    Ok(relative)
+}
+
 /// Canonicalize and validate a path exists under `base`.
 pub(crate) fn resolve_existing_path_in_dir(base: &Path, rel: &str) -> anyhow::Result<PathBuf> {
     let full_path = join_in_dir(base, rel)?;
@@ -465,10 +523,46 @@ fn reject_gitignored_edit_path(
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_file_edits, rewrite_existing_file_in_dir};
+    use super::{
+        apply_file_edits, relative_path_between, repo_relative_path, repo_relative_path_string,
+        rewrite_existing_file_in_dir,
+    };
     use crate::evolve::gitignore::GitignoreChecker;
     use crate::shared_types::FileEdit;
-    use std::fs;
+    use std::{fs, path::Path};
+
+    #[test]
+    fn repository_path_helpers_share_consistent_relative_semantics() {
+        let root = Path::new("/config");
+        let file = Path::new("/config/modules/darwin/sops-secrets.nix");
+        assert_eq!(
+            repo_relative_path(root, file).expect("make repository-relative"),
+            Path::new("modules/darwin/sops-secrets.nix")
+        );
+        assert_eq!(
+            repo_relative_path_string(root, file).expect("render repository-relative"),
+            "modules/darwin/sops-secrets.nix"
+        );
+        assert_eq!(
+            relative_path_between(
+                Path::new("modules/darwin"),
+                Path::new("secrets/secrets.yaml")
+            )
+            .expect("compute relative path"),
+            Path::new("../../secrets/secrets.yaml")
+        );
+        assert_eq!(
+            relative_path_between(Path::new("modules"), Path::new("modules"))
+                .expect("compute identity path"),
+            Path::new(".")
+        );
+    }
+
+    #[test]
+    fn repository_path_helpers_reject_incompatible_paths() {
+        assert!(repo_relative_path(Path::new("/config"), Path::new("/other/file.nix")).is_err());
+        assert!(relative_path_between(Path::new("relative"), Path::new("/absolute")).is_err());
+    }
 
     #[test]
     fn empty_search_overwrites_existing_file() {

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -8,6 +8,7 @@ mod context_budget;
 mod ensure_secret;
 pub(crate) mod file_ops;
 mod gitignore;
+pub(crate) use gitignore::GitignoreChecker;
 pub(crate) mod isolation;
 pub mod messages;
 pub(crate) mod nix_file_editor;

--- a/apps/native/src-tauri/src/evolve/mod.rs
+++ b/apps/native/src-tauri/src/evolve/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod isolation;
 pub mod messages;
 pub(crate) mod nix_file_editor;
 mod nixmac_ignore;
+pub(crate) use nixmac_ignore::NixmacIgnoreChecker;
 pub mod providers;
 mod search_code;
 pub mod search_docs;

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -905,6 +905,83 @@ fn remove(content: &str, attrpath: &str, values: &[String]) -> Result<String> {
     Ok(content.to_string())
 }
 
+/// Remove an attribute assignment and any flat descendant assignments from Nix source.
+///
+/// The attrpath is resolved structurally, so this handles flat declarations such as
+/// `sops.secrets.foo = { ... };`, nested attrsets, and a mixture of both. Empty parent
+/// attrsets are intentionally preserved. An absent attrpath is reported as an error so
+/// callers performing destructive operations do not silently succeed.
+pub(crate) fn remove_attrpath(content: &str, attrpath: &str) -> Result<String> {
+    let target = attrpath
+        .split('.')
+        .map(normalize_attrpath_for_match)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    if target.is_empty() {
+        return Err(anyhow::anyhow!("Nix attrpath must not be empty"));
+    }
+
+    let root = Root::parse(content)
+        .ok()
+        .context("Failed to parse Nix content when removing an attrpath")?;
+    let top = AttrSet::cast(root.syntax().clone())
+        .or_else(|| root.syntax().descendants().find_map(AttrSet::cast))
+        .context("Cannot find top-level attribute set when removing an attrpath")?;
+    let mut ranges = Vec::new();
+    collect_attrpath_assignment_ranges(&top, &target, &mut ranges);
+    if ranges.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Nix attrpath '{}' does not exist",
+            attrpath
+        ));
+    }
+
+    ranges.sort_unstable_by_key(|range| range.start);
+    let mut updated = content.to_string();
+    for range in ranges.into_iter().rev() {
+        let mut start = range.start;
+        while start > 0 && matches!(updated.as_bytes()[start - 1], b' ' | b'\t') {
+            start -= 1;
+        }
+        let mut end = range.end;
+        while end < updated.len() && matches!(updated.as_bytes()[end], b' ' | b'\t') {
+            end += 1;
+        }
+        if end < updated.len() && updated.as_bytes()[end] == b'\n' {
+            end += 1;
+        }
+        updated.replace_range(start..end, "");
+    }
+    Ok(updated)
+}
+
+/// Helper to recursively collect the byte ranges of all assignments that match a given attrpath prefix, including nested attrsets.
+fn collect_attrpath_assignment_ranges(
+    attrset: &AttrSet,
+    target: &[String],
+    ranges: &mut Vec<std::ops::Range<usize>>,
+) {
+    for entry in attrset.attrpath_values() {
+        let Some(attrpath) = entry.attrpath() else {
+            continue;
+        };
+        let keys = attrpath
+            .attrs()
+            .map(|attr| normalize_attrpath_for_match(&attr.syntax().text().to_string()))
+            .collect::<Vec<_>>();
+
+        if target.len() <= keys.len() && keys[..target.len()] == target[..] {
+            ranges.push(text_range_to_usize_range(entry.syntax().text_range()));
+        } else if keys.len() < target.len()
+            && keys[..] == target[..keys.len()]
+            && let Some(value) = entry.value()
+            && let Some(nested) = AttrSet::cast(value.syntax().clone())
+        {
+            collect_attrpath_assignment_ranges(&nested, &target[keys.len()..], ranges);
+        }
+    }
+}
+
 /// Reject string values that are Nix source in disguise. A value like
 /// `"{ url = …; }"` would be spliced as a *quoted string literal* — observed
 /// with gpt-oss-120b setting `inputs.home-manager` to a stringified attrset,
@@ -1379,6 +1456,41 @@ environment.systemPackages = with pkgs; [
             1,
             "should not duplicate assignment during remove"
         );
+    }
+
+    #[test]
+    fn remove_attrpath_handles_flat_and_nested_assignments() {
+        let flat = r#"{
+  sops.secrets."github-token".sopsFile = ./secrets.yaml;
+  sops.secrets."github-token".key = "github-token";
+  sops.secrets.other = { key = "other"; };
+}
+"#;
+        let flat = remove_attrpath(flat, "sops.secrets.\"github-token\"")
+            .expect("remove flat descendant assignments");
+        assert!(!flat.contains("github-token"));
+        assert!(flat.contains("sops.secrets.other"));
+
+        let nested = r#"{
+  sops = {
+    secrets = {
+      "github-token" = { key = "github-token"; };
+      other = { key = "other"; };
+    };
+  };
+}
+"#;
+        let nested = remove_attrpath(nested, "sops.secrets.\"github-token\"")
+            .expect("remove nested assignment");
+        assert!(!nested.contains("github-token"));
+        assert!(nested.contains("other = { key = \"other\"; };"));
+    }
+
+    #[test]
+    fn remove_attrpath_errors_when_assignment_is_missing() {
+        let error = remove_attrpath("{ services.foo.enable = true; }", "sops.secrets.foo")
+            .expect_err("missing attrpath must not silently succeed");
+        assert!(error.to_string().contains("does not exist"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/git/exec.rs
+++ b/apps/native/src-tauri/src/git/exec.rs
@@ -188,8 +188,13 @@ pub fn commit_all(dir: &str, message: &str) -> Result<CommitInfo> {
 /// uncommitted. The index is reset to HEAD so only `path` is included, then the
 /// path is staged (or its deletion staged) and a commit is created.
 pub fn commit_file(dir: &str, path: &str, message: &str) -> Result<CommitInfo> {
+    commit_files(dir, &[path], message)
+}
+
+/// Commit only the requested repository-relative files, leaving unrelated
+/// worktree changes out of the commit.
+pub fn commit_files(dir: &str, paths: &[&str], message: &str) -> Result<CommitInfo> {
     let repo = git2::Repository::discover(dir)?;
-    let rel = Path::new(path);
 
     let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
 
@@ -204,15 +209,20 @@ pub fn commit_file(dir: &str, path: &str, message: &str) -> Result<CommitInfo> {
         index.clear().context("git2 clear index")?;
     }
 
-    let workdir = repo.workdir().context("commit_file in a bare repository")?;
-    if workdir.join(rel).exists() {
-        index
-            .add_path(rel)
-            .with_context(|| format!("git2 stage `{path}`"))?;
-    } else {
-        index
-            .remove_path(rel)
-            .with_context(|| format!("git2 stage deletion of `{path}`"))?;
+    let workdir = repo
+        .workdir()
+        .context("commit_files in a bare repository")?;
+    for path in paths {
+        let rel = Path::new(path);
+        if workdir.join(rel).exists() {
+            index
+                .add_path(rel)
+                .with_context(|| format!("git2 stage `{path}`"))?;
+        } else {
+            index
+                .remove_path(rel)
+                .with_context(|| format!("git2 stage deletion of `{path}`"))?;
+        }
     }
     index.write().context("git2 write staged index")?;
 
@@ -864,6 +874,41 @@ mod tests {
         assert_eq!(
             run_git_ok(&repo_dir, &["show", "-s", "--format=%s", "HEAD"]).trim(),
             "initial"
+        );
+    }
+
+    #[test]
+    fn test_commit_files_commits_only_requested_paths() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        init_repo(&repo_dir_str).unwrap();
+
+        fs::write(repo_dir.join("one.txt"), "initial one\n").unwrap();
+        fs::write(repo_dir.join("two.txt"), "initial two\n").unwrap();
+        fs::write(repo_dir.join("unrelated.txt"), "initial unrelated\n").unwrap();
+        commit_all(&repo_dir_str, "initial").unwrap();
+
+        fs::write(repo_dir.join("one.txt"), "changed one\n").unwrap();
+        fs::write(repo_dir.join("two.txt"), "changed two\n").unwrap();
+        fs::write(repo_dir.join("unrelated.txt"), "working change\n").unwrap();
+        commit_files(&repo_dir_str, &["one.txt", "two.txt"], "selected").unwrap();
+
+        assert_eq!(
+            run_git_ok(&repo_dir, &["show", "HEAD:one.txt"]),
+            "changed one\n"
+        );
+        assert_eq!(
+            run_git_ok(&repo_dir, &["show", "HEAD:two.txt"]),
+            "changed two\n"
+        );
+        assert_eq!(
+            run_git_ok(&repo_dir, &["show", "HEAD:unrelated.txt"]),
+            "initial unrelated\n"
+        );
+        assert_eq!(
+            fs::read_to_string(repo_dir.join("unrelated.txt")).unwrap(),
+            "working change\n"
         );
     }
 

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -12,9 +12,9 @@ mod repo_files;
 // `crate::git::some_fn()` without change.
 #[allow(unused_imports)]
 pub use exec::{
-    checkout_files_at_commit, commit_all, commit_file, commit_files, commit_hunk, 
+    CommitInfo, checkout_files_at_commit, commit_all, commit_file, commit_files, commit_hunk,
     create_evolution_backup, intent_add_untracked, restore_all, restore_file,
-    restore_from_branch_ref, restore_hunk, tag_commit, CommitInfo,
+    restore_from_branch_ref, restore_hunk, tag_commit,
 };
 
 #[allow(unused_imports)]

--- a/apps/native/src-tauri/src/git/mod.rs
+++ b/apps/native/src-tauri/src/git/mod.rs
@@ -12,9 +12,9 @@ mod repo_files;
 // `crate::git::some_fn()` without change.
 #[allow(unused_imports)]
 pub use exec::{
-    CommitInfo, checkout_files_at_commit, commit_all, commit_file, commit_hunk,
+    checkout_files_at_commit, commit_all, commit_file, commit_files, commit_hunk, 
     create_evolution_backup, intent_add_untracked, restore_all, restore_file,
-    restore_from_branch_ref, restore_hunk, tag_commit,
+    restore_from_branch_ref, restore_hunk, tag_commit, CommitInfo,
 };
 
 #[allow(unused_imports)]

--- a/apps/native/src-tauri/src/orpc/secrets.rs
+++ b/apps/native/src-tauri/src/orpc/secrets.rs
@@ -1,7 +1,7 @@
 //! Secrets management procedures.
 
 use super::{OrpcCtx, helpers::internal_err};
-use crate::shared_types::SecretsVaultState;
+use crate::shared_types::{AddSecretResult, DeleteSecretResult, SecretsVaultState};
 use crate::state::secrets_vault;
 use crate::{commands::helpers::get_hostname_and_config_dir, shared_types::SecretBackend};
 use orpc::*;
@@ -11,6 +11,21 @@ use specta::Type;
 #[derive(Debug, Deserialize, Serialize, Type)]
 #[serde(rename_all = "camelCase")]
 struct DecryptSecretInput {
+    secret_id: String,
+    backend: SecretBackend,
+}
+
+#[derive(Debug, Deserialize, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+struct AddSecretInput {
+    secret_id: String,
+    value: String,
+    backend: SecretBackend,
+}
+
+#[derive(Debug, Deserialize, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+struct DeleteSecretInput {
     secret_id: String,
     backend: SecretBackend,
 }
@@ -47,6 +62,53 @@ async fn decrypt_secret(ctx: OrpcCtx, input: DecryptSecretInput) -> Result<Strin
     })
 }
 
+async fn add_secret(ctx: OrpcCtx, input: AddSecretInput) -> Result<AddSecretResult, ORPCError> {
+    let (host_attr, config_dir) = get_hostname_and_config_dir(&ctx.app, "secrets.addSecret")
+        .map_err(|error| internal_err("secrets.addSecret", error))?;
+    let result = crate::secrets::secrets_management::add_secret(
+        &host_attr,
+        &config_dir,
+        &input.secret_id,
+        &input.value,
+        input.backend,
+    )
+    .map_err(|error| internal_err("secrets.addSecret", error))?;
+    refresh_state_after_mutation(&ctx, &config_dir, "secrets.addSecret");
+    Ok(result)
+}
+
+async fn delete_secret(
+    ctx: OrpcCtx,
+    input: DeleteSecretInput,
+) -> Result<DeleteSecretResult, ORPCError> {
+    let (host_attr, config_dir) = get_hostname_and_config_dir(&ctx.app, "secrets.deleteSecret")
+        .map_err(|error| internal_err("secrets.deleteSecret", error))?;
+    let result = crate::secrets::secrets_management::delete_secret(
+        &host_attr,
+        &config_dir,
+        &input.secret_id,
+        input.backend,
+    )
+    .map_err(|error| internal_err("secrets.deleteSecret", error))?;
+    refresh_state_after_mutation(&ctx, &config_dir, "secrets.deleteSecret");
+    Ok(result)
+}
+
+/// Record the commit in the shared Git snapshot and let that state transition
+/// invalidate the derived vault. Without updating Git state here, the explicit
+/// vault refresh completes first and the polling watcher notices the same HEAD
+/// change a few seconds later, causing a second refresh.
+fn refresh_state_after_mutation(ctx: &OrpcCtx, config_dir: &str, operation: &str) {
+    if let Err(error) = crate::git::query::status_and_cache(config_dir, &ctx.app) {
+        // The mutation and commit already succeeded, so don't report a false
+        // operation failure just because the auxiliary Git snapshot failed.
+        // Fall back to the direct invalidation used before this state was
+        // synchronized here.
+        log::warn!("[{operation}] Failed to refresh Git state: {error}");
+        secrets_vault::refresh(&ctx.app);
+    }
+}
+
 pub fn routes() -> Router<OrpcCtx> {
     router! {
         "getState" => os::<OrpcCtx>()
@@ -58,5 +120,13 @@ pub fn routes() -> Router<OrpcCtx> {
             .input(orpc_specta::specta::<DecryptSecretInput>())
             .output(orpc_specta::specta::<String>())
             .handler(decrypt_secret),
+        "addSecret" => os::<OrpcCtx>()
+            .input(orpc_specta::specta::<AddSecretInput>())
+            .output(orpc_specta::specta::<AddSecretResult>())
+            .handler(add_secret),
+        "deleteSecret" => os::<OrpcCtx>()
+            .input(orpc_specta::specta::<DeleteSecretInput>())
+            .output(orpc_specta::specta::<DeleteSecretResult>())
+            .handler(delete_secret),
     }
 }

--- a/apps/native/src-tauri/src/orpc/secrets.rs
+++ b/apps/native/src-tauri/src/orpc/secrets.rs
@@ -65,6 +65,7 @@ async fn decrypt_secret(ctx: OrpcCtx, input: DecryptSecretInput) -> Result<Strin
 async fn add_secret(ctx: OrpcCtx, input: AddSecretInput) -> Result<AddSecretResult, ORPCError> {
     let (host_attr, config_dir) = get_hostname_and_config_dir(&ctx.app, "secrets.addSecret")
         .map_err(|error| internal_err("secrets.addSecret", error))?;
+    let _refresh_guard = secrets_vault::begin_mutation(&ctx.app);
     let result = crate::secrets::secrets_management::add_secret(
         &host_attr,
         &config_dir,
@@ -83,6 +84,7 @@ async fn delete_secret(
 ) -> Result<DeleteSecretResult, ORPCError> {
     let (host_attr, config_dir) = get_hostname_and_config_dir(&ctx.app, "secrets.deleteSecret")
         .map_err(|error| internal_err("secrets.deleteSecret", error))?;
+    let _refresh_guard = secrets_vault::begin_mutation(&ctx.app);
     let result = crate::secrets::secrets_management::delete_secret(
         &host_attr,
         &config_dir,

--- a/apps/native/src-tauri/src/secrets/secrets_management.rs
+++ b/apps/native/src-tauri/src/secrets/secrets_management.rs
@@ -1,6 +1,6 @@
 use crate::{
     evolve::{
-        GitignoreChecker,
+        GitignoreChecker, NixmacIgnoreChecker,
         file_ops::{
             relative_path_between, repo_relative_path, repo_relative_path_string,
             resolve_existing_path_in_dir,
@@ -29,12 +29,13 @@ use std::{
     process::Stdio,
 };
 
-/// The path to the managed SOPS secrets file in the repository.
-/// By convention, this is a single YAML file that contains all SOPS-managed secrets, and is encrypted with SOPS.
-const MANAGED_SOPS_FILE: &str = "secrets/secrets.yaml";
-
 /// The path to the standard nix-darwin module that declares SOPS secrets.
 const STANDARD_SOPS_MODULE: &str = "modules/darwin/sops-secrets.nix";
+
+/// Returns the repository-relative path used for a SOPS secret.
+fn managed_sops_file(secret_id: &str) -> String {
+    format!("secrets/{secret_id}.yaml")
+}
 
 /// Deletes a secret from the configured repo, returning the result.
 pub fn delete_secret(
@@ -82,34 +83,25 @@ fn delete_sops_secret(
 
         log::info!("Deleting SOPS secret declaration {secret_id} from config dir {config_dir}");
 
-        let secret = load_sops_secrets(host_attr, config_dir)
+        load_sops_secrets(host_attr, config_dir)
             .map_err(|error| anyhow!(error))?
             .into_iter()
             .find(|secret| secret.id == secret_id)
             .ok_or_else(|| anyhow!("Secret declaration '{secret_id}' does not exist"))?;
-        let sops_key = secret
-            .sops_key
-            .as_deref()
-            .ok_or_else(|| anyhow!("SOPS secret '{secret_id}' has no key"))?;
 
         let base = Path::new(config_dir);
-        let encrypted_path = resolve_existing_path_in_dir(base, MANAGED_SOPS_FILE)
-            .with_context(|| format!("resolve {MANAGED_SOPS_FILE}"))?;
+        let encrypted_file = managed_sops_file(secret_id);
+        let encrypted_path = resolve_existing_path_in_dir(base, &encrypted_file)
+            .with_context(|| format!("resolve {encrypted_file}"))?;
         let declaration_file = find_sops_declaration_file(base)?;
         let declaration_rel = repo_relative_path_string(base, &declaration_file)?;
-        let plaintext = decrypt_sops_file(host_attr, config_dir, &encrypted_path)?;
-        let remaining = remove_sops_key(&plaintext, sops_key)?;
 
         // Steps:
-        // 1. Remove the secret from the SOPS YAML file.
+        // 1. Remove the secret's SOPS YAML file.
         // 2. Remove the secret declaration from the nix-darwin module.
         // 3. Run a dry build to verify that the secret is no longer present.
         let operation = (|| -> anyhow::Result<crate::shared_types::DeleteSecretResult> {
-            if remaining.is_empty() {
-                std::fs::remove_file(&encrypted_path).context("remove empty SOPS secrets file")?;
-            } else {
-                encrypt_sops_yaml(config_dir, MANAGED_SOPS_FILE, remaining.as_bytes())?;
-            }
+            std::fs::remove_file(&encrypted_path).context("remove SOPS secret file")?;
             remove_sops_declaration(base, &declaration_rel, secret_id)?;
 
             let (passed, stdout, stderr) =
@@ -133,7 +125,7 @@ fn delete_sops_secret(
 
             let commit = crate::git::commit_files(
                 config_dir,
-                &[MANAGED_SOPS_FILE, &declaration_rel],
+                &[&encrypted_file, &declaration_rel],
                 &format!("secrets: delete {secret_id} (sops)"),
             )
             .context("commit deleted SOPS secret")?;
@@ -145,63 +137,12 @@ fn delete_sops_secret(
         })();
 
         if operation.is_err() {
-            let _ = crate::git::restore_file(config_dir, MANAGED_SOPS_FILE);
+            let _ = crate::git::restore_file(config_dir, &encrypted_file);
             let _ = crate::git::restore_file(config_dir, &declaration_rel);
         }
         operation
     })()
     .map_err(|error| error.to_string())
-}
-
-/// Removes a SOPS key from the decrypted YAML document, returning the updated YAML as a string.
-fn remove_sops_key(plaintext: &str, sops_key: &str) -> anyhow::Result<String> {
-    let mut document: serde_yaml::Value =
-        serde_yaml::from_str(plaintext).context("parse decrypted secrets YAML")?;
-    let mut parts = sops_key.split('/').peekable();
-    let removed = remove_yaml_path(&mut document, &mut parts)?;
-    if !removed {
-        anyhow::bail!("SOPS key '{sops_key}' does not exist in {MANAGED_SOPS_FILE}");
-    }
-    let empty = document
-        .as_mapping()
-        .is_some_and(serde_yaml::Mapping::is_empty);
-    if empty {
-        Ok(String::new())
-    } else {
-        serde_yaml::to_string(&document).context("serialize secrets YAML")
-    }
-}
-
-/// Recursively removes a path from a YAML document, returning true if the path was found and removed.
-fn remove_yaml_path<'a, I>(
-    value: &mut serde_yaml::Value,
-    parts: &mut std::iter::Peekable<I>,
-) -> anyhow::Result<bool>
-where
-    I: Iterator<Item = &'a str>,
-{
-    let part = parts
-        .next()
-        .ok_or_else(|| anyhow!("SOPS key must not be empty"))?;
-    let mapping = value
-        .as_mapping_mut()
-        .ok_or_else(|| anyhow!("SOPS key path '{part}' does not refer to a YAML mapping"))?;
-    let key = serde_yaml::Value::String(part.to_string());
-    if parts.peek().is_none() {
-        return Ok(mapping.remove(&key).is_some());
-    }
-    let Some(child) = mapping.get_mut(&key) else {
-        return Ok(false);
-    };
-    let removed = remove_yaml_path(child, parts)?;
-    if removed
-        && child
-            .as_mapping()
-            .is_some_and(serde_yaml::Mapping::is_empty)
-    {
-        mapping.remove(&key);
-    }
-    Ok(removed)
 }
 
 /// Removes a SOPS secret declaration from the nix-darwin module, returning an error if the declaration was not found.
@@ -223,7 +164,7 @@ fn remove_sops_declaration(
     Ok(())
 }
 
-/// Add one value to the repository's shared SOPS YAML file, declare it in the
+/// Add one value to its own SOPS YAML file, declare it in the
 /// nix-darwin module, run a dry build, and commit only the two managed files.
 /// Plaintext is kept in memory and sent to SOPS over stdin; it is never written
 /// to the repository.
@@ -256,11 +197,15 @@ fn add_sops_secret(
     }
 
     let declaration_file = find_sops_declaration_file(base)?;
-    let plaintext = updated_sops_plaintext(host_attr, config_dir, secret_id, value)?;
+    let encrypted_file = managed_sops_file(secret_id);
+    if base.join(&encrypted_file).exists() {
+        anyhow::bail!("SOPS file '{encrypted_file}' already exists");
+    }
+    let plaintext = sops_plaintext(secret_id, value)?;
 
     let operation = (|| -> anyhow::Result<AddSecretResult> {
-        encrypt_sops_yaml(config_dir, MANAGED_SOPS_FILE, plaintext.as_bytes())?;
-        declare_sops_secret(base, &declaration_file, secret_id)?;
+        encrypt_sops_yaml(config_dir, &encrypted_file, plaintext.as_bytes())?;
+        declare_sops_secret(base, &declaration_file, secret_id, &encrypted_file)?;
 
         let (passed, stdout, stderr) =
             crate::rebuild::dry_run_build_check(config_dir, host_attr, false)
@@ -287,14 +232,14 @@ fn add_sops_secret(
         let declaration_rel = repo_relative_path_string(base, &declaration_file)?;
         let commit = crate::git::commit_files(
             config_dir,
-            &[MANAGED_SOPS_FILE, &declaration_rel],
+            &[&encrypted_file, &declaration_rel],
             &format!("secrets: add {secret_id} (sops)"),
         )
         .context("commit SOPS secret")?;
 
         Ok(AddSecretResult {
             secret_id: secret_id.to_string(),
-            encrypted_file: MANAGED_SOPS_FILE.to_string(),
+            encrypted_file: encrypted_file.clone(),
             declaration_file: declaration_rel,
             runtime_path: format!("/run/secrets/{secret_id}"),
             commit_hash: commit.hash,
@@ -304,7 +249,7 @@ fn add_sops_secret(
     if operation.is_err() {
         // The repository was clean at entry, so restoring these exact paths is
         // sufficient and cannot discard unrelated user work.
-        let _ = crate::git::restore_file(config_dir, MANAGED_SOPS_FILE);
+        let _ = crate::git::restore_file(config_dir, &encrypted_file);
         if let Ok(declaration_rel) = repo_relative_path_string(base, &declaration_file) {
             let _ = crate::git::restore_file(config_dir, &declaration_rel);
         }
@@ -330,71 +275,15 @@ fn validate_new_secret(secret_id: &str, value: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Updates the SOPS plaintext document with a new secret entry, returning the updated YAML as a string.
-fn updated_sops_plaintext(
-    host_attr: &str,
-    config_dir: &str,
-    secret_id: &str,
-    value: &str,
-) -> anyhow::Result<String> {
-    let base = Path::new(config_dir);
-    let encrypted_path = base.join(MANAGED_SOPS_FILE);
-    let existing = if encrypted_path.exists() {
-        let encrypted_path = resolve_existing_path_in_dir(base, MANAGED_SOPS_FILE)
-            .with_context(|| format!("resolve {MANAGED_SOPS_FILE}"))?;
-        decrypt_sops_file(host_attr, config_dir, &encrypted_path)?
-    } else {
-        String::new()
-    };
-    let mut document: serde_yaml::Value = if existing.trim().is_empty() {
-        serde_yaml::Value::Mapping(Default::default())
-    } else {
-        serde_yaml::from_str(&existing).context("parse decrypted secrets YAML")?
-    };
-    let mapping = document
-        .as_mapping_mut()
-        .ok_or_else(|| anyhow!("{MANAGED_SOPS_FILE} must contain a YAML mapping"))?;
-    let key = serde_yaml::Value::String(secret_id.to_string());
-    if mapping.contains_key(&key) {
-        anyhow::bail!("SOPS key '{secret_id}' already exists in {MANAGED_SOPS_FILE}");
-    }
-    mapping.insert(key, serde_yaml::Value::String(value.to_string()));
+/// Renders the plaintext for a one-secret SOPS YAML file.
+fn sops_plaintext(secret_id: &str, value: &str) -> anyhow::Result<String> {
+    let mut mapping = serde_yaml::Mapping::new();
+    mapping.insert(
+        serde_yaml::Value::String(secret_id.to_string()),
+        serde_yaml::Value::String(value.to_string()),
+    );
+    let document = serde_yaml::Value::Mapping(mapping);
     serde_yaml::to_string(&document).context("serialize secrets YAML")
-}
-
-/// Decrypts a SOPS file using the available identities, returning the plaintext as a string.
-fn decrypt_sops_file(host_attr: &str, config_dir: &str, path: &Path) -> anyhow::Result<String> {
-    let (_, identities, _) =
-        load_recipients(host_attr, config_dir, &[], false).map_err(|error| anyhow!(error))?;
-    let attempts = identities
-        .iter()
-        .filter(|identity| identity.available)
-        .map(Some)
-        .chain(std::iter::once(None));
-    let mut last_error = None;
-    for identity in attempts {
-        let mut command = nix_command(config_dir);
-        command
-            .args([
-                "shell",
-                "nixpkgs#sops",
-                "-c",
-                "sops",
-                "--decrypt",
-                "--output-type",
-                "yaml",
-            ])
-            .arg(path);
-        apply_sops_identity(&mut command, identity);
-        let output = command.output().context("execute sops decrypt")?;
-        if output.status.success() {
-            return String::from_utf8(output.stdout).context("sops returned invalid UTF-8");
-        }
-        last_error = Some(String::from_utf8_lossy(&output.stderr).trim().to_string());
-    }
-    Err(anyhow!(
-        last_error.unwrap_or_else(|| "SOPS decryption failed".to_string())
-    ))
 }
 
 /// Encrypts a SOPS YAML file using the available identities, writing the encrypted file to the given relative path.
@@ -481,11 +370,13 @@ fn find_sops_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
     let visible = GitignoreChecker::new(base)?
         .map(|checker| checker.visible_files())
         .transpose()?;
+    let nixmac_ignore = NixmacIgnoreChecker::new(base)?;
     let standard = base.join(STANDARD_SOPS_MODULE);
     if standard.is_file()
         && visible
             .as_ref()
             .is_none_or(|files| files.contains_file(Path::new(STANDARD_SOPS_MODULE)))
+        && !nixmac_ignore.is_ignored(Path::new(STANDARD_SOPS_MODULE), false)
     {
         resolve_existing_path_in_dir(base, STANDARD_SOPS_MODULE)
             .with_context(|| format!("resolve {STANDARD_SOPS_MODULE}"))?;
@@ -500,13 +391,15 @@ fn find_sops_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
             let Ok(relative) = entry.path().strip_prefix(base) else {
                 return false;
             };
-            visible.as_ref().is_none_or(|files| {
-                if entry.file_type().is_dir() {
-                    files.contains_dir(relative)
-                } else {
-                    files.contains_file(relative)
-                }
-            })
+            let is_dir = entry.file_type().is_dir();
+            !nixmac_ignore.is_ignored(relative, is_dir)
+                && visible.as_ref().is_none_or(|files| {
+                    if is_dir {
+                        files.contains_dir(relative)
+                    } else {
+                        files.contains_file(relative)
+                    }
+                })
         })
         .filter_map(Result::ok)
         .filter(|entry| {
@@ -533,10 +426,11 @@ fn declare_sops_secret(
     base: &Path,
     declaration_file: &Path,
     secret_id: &str,
+    encrypted_file: &str,
 ) -> anyhow::Result<()> {
     let declaration_rel = repo_relative_path_string(base, declaration_file)?;
     let from = repo_relative_path(base, declaration_file.parent().unwrap_or(base))?;
-    let secret_path = relative_path_between(&from, Path::new(MANAGED_SOPS_FILE))?;
+    let secret_path = relative_path_between(&from, Path::new(encrypted_file))?;
     let rendered_path = secret_path.to_string_lossy().replace('\\', "/");
     let rendered_path = if rendered_path.starts_with('.') {
         rendered_path
@@ -547,10 +441,6 @@ fn declare_sops_secret(
     attrs.insert(
         "sopsFile".to_string(),
         crate::evolve::nix_file_editor::nix_builtins_path_meta_value(&rendered_path),
-    );
-    attrs.insert(
-        "key".to_string(),
-        serde_json::Value::String(secret_id.to_string()),
     );
     crate::evolve::nix_file_editor::apply_semantic_edit(
         base,
@@ -971,9 +861,10 @@ fn secret(
 mod tests {
     use super::{
         AGENIX_DECRYPTION_FAILED, SOPS_DECRYPTION_FAILED, age_decrypt_command,
-        find_sops_declaration_file, readable_agenix_identity_paths, relative_path_between,
-        resolve_secret_file_path, sanitized_subprocess_error, sops_decrypt_command,
-        sops_extract_path, ssh_to_age_decrypt_command, updated_sops_plaintext, validate_new_secret,
+        find_sops_declaration_file, managed_sops_file, readable_agenix_identity_paths,
+        relative_path_between, resolve_secret_file_path, sanitized_subprocess_error,
+        sops_decrypt_command, sops_extract_path, sops_plaintext, ssh_to_age_decrypt_command,
+        validate_new_secret,
     };
     use crate::shared_types::{
         DecryptionIdentity, DecryptionIdentityKind, DecryptionIdentityLocality,
@@ -1196,19 +1087,19 @@ mod tests {
 
     #[test]
     fn new_sops_plaintext_is_a_yaml_mapping_and_preserves_multiline_values() {
-        let config_dir = TempDir::new().expect("create config dir");
-        let encrypted_path = config_dir.path().join("secrets/secrets.yaml");
-        let rendered = updated_sops_plaintext(
-            "test-host",
-            config_dir.path().to_str().unwrap(),
-            "github-token",
-            "line one\nline two",
-        )
-        .expect("render plaintext");
+        let rendered =
+            sops_plaintext("github-token", "line one\nline two").expect("render plaintext");
         let parsed: serde_yaml::Value = serde_yaml::from_str(&rendered).expect("parse YAML");
 
         assert_eq!(parsed["github-token"], "line one\nline two");
-        assert!(!encrypted_path.exists(), "plaintext must never touch disk");
+    }
+
+    #[test]
+    fn sops_secrets_use_one_file_per_secret() {
+        assert_eq!(
+            managed_sops_file("github-token"),
+            "secrets/github-token.yaml"
+        );
     }
 
     #[test]
@@ -1258,14 +1149,37 @@ mod tests {
     }
 
     #[test]
+    fn declaration_discovery_excludes_nixmac_ignored_modules() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let standard = config_dir.path().join("modules/darwin/sops-secrets.nix");
+        fs::create_dir_all(standard.parent().unwrap()).expect("create standard module dir");
+        fs::write(&standard, "{ sops.secrets = {}; }").expect("write ignored standard module");
+        let ignored = config_dir.path().join("private/secrets.nix");
+        fs::create_dir_all(ignored.parent().unwrap()).expect("create ignored module dir");
+        fs::write(&ignored, "{ sops.secrets = {}; }").expect("write ignored module");
+        fs::write(
+            config_dir.path().join(".nixmacignore"),
+            "modules/darwin/sops-secrets.nix\nprivate/\n",
+        )
+        .expect("write nixmacignore");
+        let visible = config_dir.path().join("visible.nix");
+        fs::write(&visible, "{ sops.secrets = {}; }").expect("write visible module");
+
+        assert_eq!(
+            find_sops_declaration_file(config_dir.path()).expect("find visible module"),
+            visible
+        );
+    }
+
+    #[test]
     fn relative_sops_path_is_computed_from_the_declaration_directory() {
         assert_eq!(
             relative_path_between(
                 Path::new("modules/darwin"),
-                Path::new("secrets/secrets.yaml")
+                Path::new("secrets/github-token.yaml")
             )
             .expect("compute relative path"),
-            Path::new("../../secrets/secrets.yaml")
+            Path::new("../../secrets/github-token.yaml")
         );
     }
 

--- a/apps/native/src-tauri/src/secrets/secrets_management.rs
+++ b/apps/native/src-tauri/src/secrets/secrets_management.rs
@@ -528,7 +528,7 @@ fn find_sops_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
     }
 }
 
-/// Declares a SOPS secret in the nix-darwin module, creating the module if it does not exist.
+/// Declares a SOPS secret in the existing nix-darwin module identified by `declaration_file`.
 fn declare_sops_secret(
     base: &Path,
     declaration_file: &Path,

--- a/apps/native/src-tauri/src/secrets/secrets_management.rs
+++ b/apps/native/src-tauri/src/secrets/secrets_management.rs
@@ -1,4 +1,11 @@
 use crate::{
+    evolve::{
+        GitignoreChecker,
+        file_ops::{
+            relative_path_between, repo_relative_path, repo_relative_path_string,
+            resolve_existing_path_in_dir,
+        },
+    },
     secrets::{
         identities::load_secret_identities,
         is_readable_file,
@@ -9,12 +16,555 @@ use crate::{
         resolve_secret_file_path, sanitized_subprocess_error,
     },
     shared_types::{
-        DecryptionIdentity, DecryptionIdentityKind, SecretBackend, SecretEntry, SecretsVault,
+        AddSecretResult, DecryptionIdentity, DecryptionIdentityKind, FileEditAction, SecretBackend,
+        SecretEntry, SecretsVault, SemanticFileEdit,
     },
     system::nix::nix_command,
     utils::nix_string_literal,
 };
-use std::path::Path;
+use anyhow::{Context, anyhow};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+
+/// The path to the managed SOPS secrets file in the repository.
+/// By convention, this is a single YAML file that contains all SOPS-managed secrets, and is encrypted with SOPS.
+const MANAGED_SOPS_FILE: &str = "secrets/secrets.yaml";
+
+/// The path to the standard nix-darwin module that declares SOPS secrets.
+const STANDARD_SOPS_MODULE: &str = "modules/darwin/sops-secrets.nix";
+
+/// Deletes a secret from the configured repo, returning the result.
+pub fn delete_secret(
+    host_attr: &str,
+    config_dir: &str,
+    secret_id: &str,
+    backend: SecretBackend,
+) -> Result<crate::shared_types::DeleteSecretResult, String> {
+    match backend {
+        SecretBackend::Sops => delete_sops_secret(host_attr, config_dir, secret_id),
+        SecretBackend::Agenix => Err("Deleting agenix secrets is not yet implemented".to_string()),
+    }
+}
+
+/// Add a secret to the configured repo, returning the result.
+pub fn add_secret(
+    host_attr: &str,
+    config_dir: &str,
+    secret_id: &str,
+    value: &str,
+    backend: SecretBackend,
+) -> Result<AddSecretResult, String> {
+    match backend {
+        SecretBackend::Sops => add_sops_secret(host_attr, config_dir, secret_id, value)
+            .map_err(|error| error.to_string()),
+        SecretBackend::Agenix => Err("Adding agenix secrets is not yet implemented".to_string()),
+    }
+}
+
+/// Deletes a SOPS secret from the configured repo, returning the result.
+/// Requires that the repository is clean and that the secret exists.
+/// If the operation fails, it attempts to restore the repository to its original state.
+fn delete_sops_secret(
+    host_attr: &str,
+    config_dir: &str,
+    secret_id: &str,
+) -> Result<crate::shared_types::DeleteSecretResult, String> {
+    (|| -> anyhow::Result<crate::shared_types::DeleteSecretResult> {
+        let status = crate::git::status(config_dir).context("inspect repository status")?;
+        if !status.clean_head {
+            anyhow::bail!(
+                "The repository has uncommitted changes. Commit or stash them before deleting a secret so nixmac can roll back safely if verification fails."
+            );
+        }
+
+        log::info!("Deleting SOPS secret declaration {secret_id} from config dir {config_dir}");
+
+        let secret = load_sops_secrets(host_attr, config_dir)
+            .map_err(|error| anyhow!(error))?
+            .into_iter()
+            .find(|secret| secret.id == secret_id)
+            .ok_or_else(|| anyhow!("Secret declaration '{secret_id}' does not exist"))?;
+        let sops_key = secret
+            .sops_key
+            .as_deref()
+            .ok_or_else(|| anyhow!("SOPS secret '{secret_id}' has no key"))?;
+
+        let base = Path::new(config_dir);
+        let encrypted_path = resolve_existing_path_in_dir(base, MANAGED_SOPS_FILE)
+            .with_context(|| format!("resolve {MANAGED_SOPS_FILE}"))?;
+        let declaration_file = find_sops_declaration_file(base)?;
+        let declaration_rel = repo_relative_path_string(base, &declaration_file)?;
+        let plaintext = decrypt_sops_file(host_attr, config_dir, &encrypted_path)?;
+        let remaining = remove_sops_key(&plaintext, sops_key)?;
+
+        // Steps:
+        // 1. Remove the secret from the SOPS YAML file.
+        // 2. Remove the secret declaration from the nix-darwin module.
+        // 3. Run a dry build to verify that the secret is no longer present.
+        let operation = (|| -> anyhow::Result<crate::shared_types::DeleteSecretResult> {
+            if remaining.is_empty() {
+                std::fs::remove_file(&encrypted_path).context("remove empty SOPS secrets file")?;
+            } else {
+                encrypt_sops_yaml(config_dir, MANAGED_SOPS_FILE, remaining.as_bytes())?;
+            }
+            remove_sops_declaration(base, &declaration_rel, secret_id)?;
+
+            let (passed, stdout, stderr) =
+                crate::rebuild::dry_run_build_check(config_dir, host_attr, false)
+                    .context("run darwin build check")?;
+            if !passed {
+                anyhow::bail!(
+                    "darwin build check failed after deleting the secret:\n{}{}",
+                    stdout,
+                    stderr
+                );
+            }
+
+            if load_sops_secrets(host_attr, config_dir)
+                .map_err(|error| anyhow!(error))?
+                .iter()
+                .any(|secret| secret.id == secret_id)
+            {
+                anyhow::bail!("The SOPS declaration is still present after editing the module");
+            }
+
+            let commit = crate::git::commit_files(
+                config_dir,
+                &[MANAGED_SOPS_FILE, &declaration_rel],
+                &format!("secrets: delete {secret_id} (sops)"),
+            )
+            .context("commit deleted SOPS secret")?;
+
+            Ok(crate::shared_types::DeleteSecretResult {
+                secret_id: secret_id.to_string(),
+                commit_hash: commit.hash,
+            })
+        })();
+
+        if operation.is_err() {
+            let _ = crate::git::restore_file(config_dir, MANAGED_SOPS_FILE);
+            let _ = crate::git::restore_file(config_dir, &declaration_rel);
+        }
+        operation
+    })()
+    .map_err(|error| error.to_string())
+}
+
+/// Removes a SOPS key from the decrypted YAML document, returning the updated YAML as a string.
+fn remove_sops_key(plaintext: &str, sops_key: &str) -> anyhow::Result<String> {
+    let mut document: serde_yaml::Value =
+        serde_yaml::from_str(plaintext).context("parse decrypted secrets YAML")?;
+    let mut parts = sops_key.split('/').peekable();
+    let removed = remove_yaml_path(&mut document, &mut parts)?;
+    if !removed {
+        anyhow::bail!("SOPS key '{sops_key}' does not exist in {MANAGED_SOPS_FILE}");
+    }
+    let empty = document
+        .as_mapping()
+        .is_some_and(serde_yaml::Mapping::is_empty);
+    if empty {
+        Ok(String::new())
+    } else {
+        serde_yaml::to_string(&document).context("serialize secrets YAML")
+    }
+}
+
+/// Recursively removes a path from a YAML document, returning true if the path was found and removed.
+fn remove_yaml_path<'a, I>(
+    value: &mut serde_yaml::Value,
+    parts: &mut std::iter::Peekable<I>,
+) -> anyhow::Result<bool>
+where
+    I: Iterator<Item = &'a str>,
+{
+    let part = parts
+        .next()
+        .ok_or_else(|| anyhow!("SOPS key must not be empty"))?;
+    let mapping = value
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow!("SOPS key path '{part}' does not refer to a YAML mapping"))?;
+    let key = serde_yaml::Value::String(part.to_string());
+    if parts.peek().is_none() {
+        return Ok(mapping.remove(&key).is_some());
+    }
+    let Some(child) = mapping.get_mut(&key) else {
+        return Ok(false);
+    };
+    let removed = remove_yaml_path(child, parts)?;
+    if removed
+        && child
+            .as_mapping()
+            .is_some_and(serde_yaml::Mapping::is_empty)
+    {
+        mapping.remove(&key);
+    }
+    Ok(removed)
+}
+
+/// Removes a SOPS secret declaration from the nix-darwin module, returning an error if the declaration was not found.
+fn remove_sops_declaration(
+    base: &Path,
+    relative_file: &str,
+    secret_id: &str,
+) -> anyhow::Result<()> {
+    let path = crate::evolve::file_ops::resolve_existing_path_in_dir(base, relative_file)?;
+    let content = std::fs::read_to_string(&path).context("read SOPS declaration module")?;
+    let attrpath = format!("sops.secrets.\"{secret_id}\"");
+    let updated = crate::evolve::nix_file_editor::remove_attrpath(&content, &attrpath)
+        .with_context(|| format!("remove SOPS declaration '{secret_id}'"))?;
+    std::fs::write(&path, updated).context("write SOPS declaration module")?;
+    let config_dir = base.to_string_lossy();
+    if let Err(error) = crate::system::nix::nix_format(&config_dir, relative_file) {
+        log::warn!("Failed to format {relative_file} after deleting a secret: {error}");
+    }
+    Ok(())
+}
+
+/// Add one value to the repository's shared SOPS YAML file, declare it in the
+/// nix-darwin module, run a dry build, and commit only the two managed files.
+/// Plaintext is kept in memory and sent to SOPS over stdin; it is never written
+/// to the repository.
+fn add_sops_secret(
+    host_attr: &str,
+    config_dir: &str,
+    secret_id: &str,
+    value: &str,
+) -> anyhow::Result<AddSecretResult> {
+    validate_new_secret(secret_id, value)?;
+    let status = crate::git::status(config_dir).context("inspect repository status")?;
+    if !status.clean_head {
+        anyhow::bail!(
+            "The repository has uncommitted changes. Commit or stash them before adding a secret so nixmac can roll back safely if verification fails."
+        );
+    }
+
+    let base = Path::new(config_dir);
+    if !base.join(".sops.yaml").is_file() && !base.join("sops.yaml").is_file() {
+        anyhow::bail!("No .sops.yaml or sops.yaml was found in the repository root");
+    }
+
+    // Make sure the secret does not already exist in the vault.
+    if load_sops_secrets(host_attr, config_dir)
+        .map_err(|error| anyhow!(error))?
+        .iter()
+        .any(|secret| secret.id == secret_id)
+    {
+        anyhow::bail!("Secret declaration '{secret_id}' already exists");
+    }
+
+    let declaration_file = find_sops_declaration_file(base)?;
+    let plaintext = updated_sops_plaintext(host_attr, config_dir, secret_id, value)?;
+
+    let operation = (|| -> anyhow::Result<AddSecretResult> {
+        encrypt_sops_yaml(config_dir, MANAGED_SOPS_FILE, plaintext.as_bytes())?;
+        declare_sops_secret(base, &declaration_file, secret_id)?;
+
+        let (passed, stdout, stderr) =
+            crate::rebuild::dry_run_build_check(config_dir, host_attr, false)
+                .context("run darwin build check")?;
+        if !passed {
+            anyhow::bail!(
+                "darwin build check failed after adding the secret:\n{}{}",
+                stdout,
+                stderr
+            );
+        }
+
+        // Reload the secrets vault to verify that the new secret is present and has the expected SOPS key.
+        let declared = load_sops_secrets(host_attr, config_dir)
+            .map_err(|error| anyhow!(error))?
+            .into_iter()
+            .any(|secret| secret.id == secret_id && secret.sops_key.as_deref() == Some(secret_id));
+        if !declared {
+            anyhow::bail!(
+                "The edited SOPS declaration was not present in the evaluated host configuration"
+            );
+        }
+
+        let declaration_rel = repo_relative_path_string(base, &declaration_file)?;
+        let commit = crate::git::commit_files(
+            config_dir,
+            &[MANAGED_SOPS_FILE, &declaration_rel],
+            &format!("secrets: add {secret_id} (sops)"),
+        )
+        .context("commit SOPS secret")?;
+
+        Ok(AddSecretResult {
+            secret_id: secret_id.to_string(),
+            encrypted_file: MANAGED_SOPS_FILE.to_string(),
+            declaration_file: declaration_rel,
+            runtime_path: format!("/run/secrets/{secret_id}"),
+            commit_hash: commit.hash,
+        })
+    })();
+
+    if operation.is_err() {
+        // The repository was clean at entry, so restoring these exact paths is
+        // sufficient and cannot discard unrelated user work.
+        let _ = crate::git::restore_file(config_dir, MANAGED_SOPS_FILE);
+        if let Ok(declaration_rel) = repo_relative_path_string(base, &declaration_file) {
+            let _ = crate::git::restore_file(config_dir, &declaration_rel);
+        }
+    }
+    operation
+}
+
+/// Validates that a new secret ID and value are acceptable for adding to the repository.
+/// Rules:
+/// - Secret IDs must be lowercase slugs containing only a-z, 0-9, and '-'.
+/// - Secret values must not be empty.
+fn validate_new_secret(secret_id: &str, value: &str) -> anyhow::Result<()> {
+    if secret_id.is_empty()
+        || !secret_id
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        anyhow::bail!("Secret names must be lowercase slugs containing only a-z, 0-9, and '-'");
+    }
+    if value.is_empty() {
+        anyhow::bail!("Secret value must not be empty");
+    }
+    Ok(())
+}
+
+/// Updates the SOPS plaintext document with a new secret entry, returning the updated YAML as a string.
+fn updated_sops_plaintext(
+    host_attr: &str,
+    config_dir: &str,
+    secret_id: &str,
+    value: &str,
+) -> anyhow::Result<String> {
+    let base = Path::new(config_dir);
+    let encrypted_path = base.join(MANAGED_SOPS_FILE);
+    let existing = if encrypted_path.exists() {
+        let encrypted_path = resolve_existing_path_in_dir(base, MANAGED_SOPS_FILE)
+            .with_context(|| format!("resolve {MANAGED_SOPS_FILE}"))?;
+        decrypt_sops_file(host_attr, config_dir, &encrypted_path)?
+    } else {
+        String::new()
+    };
+    let mut document: serde_yaml::Value = if existing.trim().is_empty() {
+        serde_yaml::Value::Mapping(Default::default())
+    } else {
+        serde_yaml::from_str(&existing).context("parse decrypted secrets YAML")?
+    };
+    let mapping = document
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow!("{MANAGED_SOPS_FILE} must contain a YAML mapping"))?;
+    let key = serde_yaml::Value::String(secret_id.to_string());
+    if mapping.contains_key(&key) {
+        anyhow::bail!("SOPS key '{secret_id}' already exists in {MANAGED_SOPS_FILE}");
+    }
+    mapping.insert(key, serde_yaml::Value::String(value.to_string()));
+    serde_yaml::to_string(&document).context("serialize secrets YAML")
+}
+
+/// Decrypts a SOPS file using the available identities, returning the plaintext as a string.
+fn decrypt_sops_file(host_attr: &str, config_dir: &str, path: &Path) -> anyhow::Result<String> {
+    let (_, identities, _) =
+        load_recipients(host_attr, config_dir, &[], false).map_err(|error| anyhow!(error))?;
+    let attempts = identities
+        .iter()
+        .filter(|identity| identity.available)
+        .map(Some)
+        .chain(std::iter::once(None));
+    let mut last_error = None;
+    for identity in attempts {
+        let mut command = nix_command(config_dir);
+        command
+            .args([
+                "shell",
+                "nixpkgs#sops",
+                "-c",
+                "sops",
+                "--decrypt",
+                "--output-type",
+                "yaml",
+            ])
+            .arg(path);
+        apply_sops_identity(&mut command, identity);
+        let output = command.output().context("execute sops decrypt")?;
+        if output.status.success() {
+            return String::from_utf8(output.stdout).context("sops returned invalid UTF-8");
+        }
+        last_error = Some(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Err(anyhow!(
+        last_error.unwrap_or_else(|| "SOPS decryption failed".to_string())
+    ))
+}
+
+/// Encrypts a SOPS YAML file using the available identities, writing the encrypted file to the given relative path.
+fn encrypt_sops_yaml(
+    config_dir: &str,
+    relative_path: &str,
+    plaintext: &[u8],
+) -> anyhow::Result<()> {
+    let mut command = nix_command(config_dir);
+    command.args([
+        "shell",
+        "nixpkgs#sops",
+        "-c",
+        "sops",
+        "--encrypt",
+        "--input-type",
+        "yaml",
+        "--output-type",
+        "yaml",
+        "--filename-override",
+        relative_path,
+        "/dev/stdin",
+    ]);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().context("execute sops encrypt")?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("open sops stdin"))?
+        .write_all(plaintext)
+        .context("send plaintext to sops")?;
+    let output = child.wait_with_output().context("wait for sops encrypt")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "sops encryption failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let target = crate::evolve::file_ops::resolve_path_in_dir_allow_create(
+        Path::new(config_dir),
+        relative_path,
+    )?;
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(target, output.stdout).context("write encrypted SOPS file")
+}
+
+/// Make one explicit local age identity available to a SOPS decryption attempt.
+///
+/// These environment variables are optional: without them, SOPS still uses
+/// identities available through its inherited environment, default age key
+/// locations, agents, plugins, PGP, or cloud KMS providers. We set one here
+/// because nixmac also discovers identity paths from the evaluated host
+/// configuration, and SOPS cannot otherwise know about an arbitrary key file.
+/// `Command::env` affects only this child command; it does not modify nixmac's
+/// process environment.
+///
+/// Passing `None` deliberately sets nothing and lets SOPS perform its normal
+/// ambient discovery. Passing `Some` overrides only the matching environment
+/// variable for this attempt; other inherited identity mechanisms remain
+/// available.
+fn apply_sops_identity(command: &mut std::process::Command, identity: Option<&DecryptionIdentity>) {
+    if let Some(identity) = identity {
+        match identity.kind {
+            DecryptionIdentityKind::AgeKeyFile => {
+                command.env("SOPS_AGE_KEY_FILE", &identity.path);
+            }
+            DecryptionIdentityKind::SshKeyPath => {
+                command.env("SOPS_AGE_SSH_PRIVATE_KEY_FILE", &identity.path);
+            }
+        }
+    }
+}
+
+/// Finds the nix-darwin module that declares SOPS secrets.
+/// If the standard module exists, it is returned.
+/// Otherwise, the repository is searched for a module that contains `sops.secrets`.
+/// If multiple modules are found, an error is returned.
+fn find_sops_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
+    let visible = GitignoreChecker::new(base)?
+        .map(|checker| checker.visible_files())
+        .transpose()?;
+    let standard = base.join(STANDARD_SOPS_MODULE);
+    if standard.is_file()
+        && visible
+            .as_ref()
+            .is_none_or(|files| files.contains_file(Path::new(STANDARD_SOPS_MODULE)))
+    {
+        resolve_existing_path_in_dir(base, STANDARD_SOPS_MODULE)
+            .with_context(|| format!("resolve {STANDARD_SOPS_MODULE}"))?;
+        return Ok(standard);
+    }
+    let candidates = walkdir::WalkDir::new(base)
+        .into_iter()
+        .filter_entry(|entry| {
+            if entry.depth() == 0 {
+                return true;
+            }
+            let Ok(relative) = entry.path().strip_prefix(base) else {
+                return false;
+            };
+            visible.as_ref().is_none_or(|files| {
+                if entry.file_type().is_dir() {
+                    files.contains_dir(relative)
+                } else {
+                    files.contains_file(relative)
+                }
+            })
+        })
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry.file_type().is_file() && entry.path().extension().is_some_and(|ext| ext == "nix")
+        })
+        .filter_map(|entry| {
+            std::fs::read_to_string(entry.path())
+                .ok()
+                .filter(|text| text.contains("sops.secrets"))
+                .map(|_| entry.into_path())
+        })
+        .collect::<Vec<_>>();
+    match candidates.as_slice() {
+        [path] => Ok(path.clone()),
+        [] => anyhow::bail!("Could not find a Nix module containing sops.secrets"),
+        _ => anyhow::bail!(
+            "Found multiple Nix modules containing sops.secrets; expected {STANDARD_SOPS_MODULE}"
+        ),
+    }
+}
+
+/// Declares a SOPS secret in the nix-darwin module, creating the module if it does not exist.
+fn declare_sops_secret(
+    base: &Path,
+    declaration_file: &Path,
+    secret_id: &str,
+) -> anyhow::Result<()> {
+    let declaration_rel = repo_relative_path_string(base, declaration_file)?;
+    let from = repo_relative_path(base, declaration_file.parent().unwrap_or(base))?;
+    let secret_path = relative_path_between(&from, Path::new(MANAGED_SOPS_FILE))?;
+    let rendered_path = secret_path.to_string_lossy().replace('\\', "/");
+    let rendered_path = if rendered_path.starts_with('.') {
+        rendered_path
+    } else {
+        format!("./{rendered_path}")
+    };
+    let mut attrs = serde_json::Map::new();
+    attrs.insert(
+        "sopsFile".to_string(),
+        crate::evolve::nix_file_editor::nix_builtins_path_meta_value(&rendered_path),
+    );
+    attrs.insert(
+        "key".to_string(),
+        serde_json::Value::String(secret_id.to_string()),
+    );
+    crate::evolve::nix_file_editor::apply_semantic_edit(
+        base,
+        &SemanticFileEdit {
+            path: declaration_rel,
+            action: FileEditAction::SetAttrs {
+                path: format!("sops.secrets.\"{secret_id}\""),
+                attrs,
+            },
+        },
+        true,
+        None,
+    )
+}
 
 const AGENIX_DECRYPTION_FAILED: &str = "Failed to decrypt agenix secret";
 const SOPS_DECRYPTION_FAILED: &str = "Failed to decrypt SOPS secret";
@@ -235,16 +785,7 @@ fn sops_decrypt_command(
             "binary",
         ])
         .arg(secret_file_path);
-    if let Some(identity) = identity {
-        match identity.kind {
-            DecryptionIdentityKind::AgeKeyFile => {
-                command.env("SOPS_AGE_KEY_FILE", &identity.path);
-            }
-            DecryptionIdentityKind::SshKeyPath => {
-                command.env("SOPS_AGE_SSH_PRIVATE_KEY_FILE", &identity.path);
-            }
-        }
-    }
+    apply_sops_identity(&mut command, identity);
     command
 }
 
@@ -430,8 +971,9 @@ fn secret(
 mod tests {
     use super::{
         AGENIX_DECRYPTION_FAILED, SOPS_DECRYPTION_FAILED, age_decrypt_command,
-        readable_agenix_identity_paths, resolve_secret_file_path, sanitized_subprocess_error,
-        sops_decrypt_command, sops_extract_path, ssh_to_age_decrypt_command,
+        find_sops_declaration_file, readable_agenix_identity_paths, relative_path_between,
+        resolve_secret_file_path, sanitized_subprocess_error, sops_decrypt_command,
+        sops_extract_path, ssh_to_age_decrypt_command, updated_sops_plaintext, validate_new_secret,
     };
     use crate::shared_types::{
         DecryptionIdentity, DecryptionIdentityKind, DecryptionIdentityLocality,
@@ -649,6 +1191,81 @@ mod tests {
         assert_eq!(
             sops_extract_path(r#"nested/a"key"#),
             r#"["nested"]["a\"key"]"#
+        );
+    }
+
+    #[test]
+    fn new_sops_plaintext_is_a_yaml_mapping_and_preserves_multiline_values() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let encrypted_path = config_dir.path().join("secrets/secrets.yaml");
+        let rendered = updated_sops_plaintext(
+            "test-host",
+            config_dir.path().to_str().unwrap(),
+            "github-token",
+            "line one\nline two",
+        )
+        .expect("render plaintext");
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&rendered).expect("parse YAML");
+
+        assert_eq!(parsed["github-token"], "line one\nline two");
+        assert!(!encrypted_path.exists(), "plaintext must never touch disk");
+    }
+
+    #[test]
+    fn add_secret_validation_accepts_only_lowercase_slugs() {
+        assert!(validate_new_secret("github-token-2", "value").is_ok());
+        assert!(validate_new_secret("GitHub token", "value").is_err());
+        assert!(validate_new_secret("github-token", "").is_err());
+    }
+
+    #[test]
+    fn declaration_discovery_prefers_the_standard_module() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let standard = config_dir.path().join("modules/darwin/sops-secrets.nix");
+        fs::create_dir_all(standard.parent().unwrap()).expect("create module dir");
+        fs::write(&standard, "{ sops.secrets = {}; }").expect("write standard module");
+        fs::write(
+            config_dir.path().join("other.nix"),
+            "{ sops.secrets = {}; }",
+        )
+        .expect("write other module");
+
+        assert_eq!(
+            find_sops_declaration_file(config_dir.path()).expect("find module"),
+            standard
+        );
+    }
+
+    #[test]
+    fn declaration_discovery_excludes_gitignored_modules() {
+        let config_dir = TempDir::new().expect("create config dir");
+        git2::Repository::init(config_dir.path()).expect("initialize git repository");
+        let standard = config_dir.path().join("modules/darwin/sops-secrets.nix");
+        fs::create_dir_all(standard.parent().unwrap()).expect("create module dir");
+        fs::write(&standard, "{ sops.secrets = {}; }").expect("write ignored module");
+        fs::write(
+            config_dir.path().join(".gitignore"),
+            "modules/darwin/sops-secrets.nix\n",
+        )
+        .expect("write gitignore");
+        let visible = config_dir.path().join("visible.nix");
+        fs::write(&visible, "{ sops.secrets = {}; }").expect("write visible module");
+
+        assert_eq!(
+            find_sops_declaration_file(config_dir.path()).expect("find visible module"),
+            visible
+        );
+    }
+
+    #[test]
+    fn relative_sops_path_is_computed_from_the_declaration_directory() {
+        assert_eq!(
+            relative_path_between(
+                Path::new("modules/darwin"),
+                Path::new("secrets/secrets.yaml")
+            )
+            .expect("compute relative path"),
+            Path::new("../../secrets/secrets.yaml")
         );
     }
 

--- a/apps/native/src-tauri/src/shared_types/secrets_management.rs
+++ b/apps/native/src-tauri/src/shared_types/secrets_management.rs
@@ -143,6 +143,25 @@ pub struct SecretsVault {
     pub decryption_identities: Vec<DecryptionIdentity>,
 }
 
+/// Result of encrypting, declaring, verifying, and committing a secret.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AddSecretResult {
+    pub secret_id: String,
+    pub encrypted_file: String,
+    pub declaration_file: String,
+    pub runtime_path: String,
+    pub commit_hash: String,
+}
+
+/// Result of removing a secret from the repo and committing the change.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteSecretResult {
+    pub secret_id: String,
+    pub commit_hash: String,
+}
+
 /// Backend-owned lifecycle for the derived secrets vault.
 /// The vault is potentially very expensive to derive (it evaluates the configured flake), so
 /// Rust refreshes it when its inputs change and the frontend only mirrors this

--- a/apps/native/src-tauri/src/state/secrets_vault.rs
+++ b/apps/native/src-tauri/src/state/secrets_vault.rs
@@ -4,7 +4,10 @@
 //! source re-check prevent an older evaluation from publishing after the
 //! config directory or host has changed.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 
 use tauri::{AppHandle, Manager, Runtime};
 
@@ -15,6 +18,51 @@ use crate::{secrets, storage::store, system::nix};
 pub const SECRETS_VAULT_STATE_CHANGED_EVENT: &str = "secrets_vault_state_changed";
 
 static REFRESH_GENERATION: AtomicU64 = AtomicU64::new(0);
+static REFRESH_GATE: Mutex<RefreshGate> = Mutex::new(RefreshGate {
+    mutations_in_flight: 0,
+    refresh_pending: false,
+});
+
+struct RefreshGate {
+    mutations_in_flight: usize,
+    refresh_pending: bool,
+}
+
+/// Defers vault refreshes until a secrets mutation has either committed or
+/// rolled back, so an evaluation can never publish a half-applied worktree.
+pub struct MutationGuard<R: Runtime + 'static> {
+    app: AppHandle<R>,
+}
+
+pub fn begin_mutation<R: Runtime + 'static>(app: &AppHandle<R>) -> MutationGuard<R> {
+    let mut gate = REFRESH_GATE.lock().unwrap();
+    gate.mutations_in_flight += 1;
+    // Always reload once the final mutation finishes. This also replaces any
+    // in-progress refresh invalidated below, even when the mutation exits
+    // before changing files and therefore produces no watcher event.
+    gate.refresh_pending = true;
+    // Prevent an evaluation started just before the mutation from publishing
+    // a snapshot read while the working tree is being edited.
+    REFRESH_GENERATION.fetch_add(1, Ordering::SeqCst);
+    MutationGuard { app: app.clone() }
+}
+
+impl<R: Runtime + 'static> Drop for MutationGuard<R> {
+    fn drop(&mut self) {
+        let should_refresh = {
+            let mut gate = REFRESH_GATE.lock().unwrap();
+            gate.mutations_in_flight -= 1;
+            let should_refresh = gate.mutations_in_flight == 0 && gate.refresh_pending;
+            if should_refresh {
+                gate.refresh_pending = false;
+            }
+            should_refresh
+        };
+        if should_refresh {
+            refresh(&self.app);
+        }
+    }
+}
 
 pub fn load_observable<R: Runtime>(app: &AppHandle<R>) -> Observable<SecretsVaultState> {
     Observable::new(SecretsVaultState::default()).emit_to(app, SECRETS_VAULT_STATE_CHANGED_EVENT)
@@ -41,6 +89,18 @@ fn current_source<R: Runtime>(app: &AppHandle<R>) -> Result<(String, String), St
 /// This is deliberately a no-op when the observable is not managed, which
 /// keeps lower-level config helpers usable in isolated tests and early startup.
 pub fn refresh<R: Runtime + 'static>(app: &AppHandle<R>) {
+    let mut gate = REFRESH_GATE.lock().unwrap();
+    if gate.mutations_in_flight > 0 {
+        gate.refresh_pending = true;
+        return;
+    }
+
+    // Keep the gate locked until the generation is claimed and the worker is
+    // started. A mutation that begins concurrently will then invalidate it.
+    refresh_now(app);
+}
+
+fn refresh_now<R: Runtime + 'static>(app: &AppHandle<R>) {
     let Some(observable) = app.try_state::<Observable<SecretsVaultState>>() else {
         return;
     };

--- a/apps/native/src/components/widget/secrets/add-secret-view.tsx
+++ b/apps/native/src/components/widget/secrets/add-secret-view.tsx
@@ -2,57 +2,37 @@ import { CornerDownRight, Lock } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import type { SecretBackend, SecretsVault } from "@/ipc/orpc-bindings";
 import { cn } from "@/lib/utils";
 import { recipientKindLabel, RecipientKindIcon, ViewHeader } from "./shared";
-import {
-  type ApplyRequest,
-  backendLabel,
-  recipientHasLocalIdentity,
-  slugifySecretName,
-} from "./types";
+import { type ApplyRequest, slugifySecretName } from "./types";
 
-function buildAddRequest(slug: string, backend: SecretBackend, recipientLabels: string[]): ApplyRequest {
-  if (backend === "agenix") {
-    return {
-      origin: "add",
-      title: "Encrypt & commit",
-      subtitle: `New secret · ${slug}`,
-      files: [{ path: `secrets/${slug}.age`, note: "· new", mark: "+" }],
-      diffFile: "secrets/secrets.nix",
-      diff: [
-        { kind: "meta", text: "@@ agenix recipients @@" },
-        { kind: "context", text: "  age.secrets = {" },
-        { kind: "added", text: `+   "${slug}.age".publicKeys = [ ${recipientLabels.join(" ")} ];` },
-        { kind: "context", text: "  };" },
-      ],
-      commit: "a1b2c3d",
-      commitMsg: `secrets: add ${slug}`,
-    };
-  }
+function buildAddRequest(slug: string): ApplyRequest {
   return {
     origin: "add",
     title: "Encrypt & commit",
     subtitle: `New secret · ${slug}`,
-    files: [{ path: "secrets/secrets.yaml", note: "· updated", mark: "~" }],
+    files: [
+      { path: "secrets/secrets.yaml", note: "· encrypted update", mark: "~" },
+      { path: "sops secrets module", note: "· declaration added", mark: "~" },
+    ],
     diffFile: "secrets/secrets.yaml",
     diff: [
       { kind: "meta", text: "@@ sops-nix @@" },
       { kind: "context", text: "  # encrypted with .sops.yaml creation rules" },
       { kind: "added", text: `+ ${slug}: ENC[AES256_GCM,data:••••••,type:str]` },
     ],
-    commit: "a1b2c3d",
+    commit: "",
     commitMsg: `secrets: add ${slug} (sops)`,
   };
 }
 
 /**
- * The add-secret form: name, backend choice, value, runtime path preview,
- * agent-tool exposure, and the recipient checklist. Submitting hands a
- * ready-to-review {@link ApplyRequest} to the apply sheet.
+ * The SOPS add-secret form: name, value, runtime path preview, and the
+ * recipients derived from repository configuration. Submitting hands a
+ * ready-to-review {@link ApplyRequest} and plaintext payload to the caller.
  */
 export function AddSecretView({
   vault,
@@ -60,36 +40,23 @@ export function AddSecretView({
   onBack,
 }: {
   vault: SecretsVault;
-  onSubmit: (request: ApplyRequest) => void;
+  onSubmit: (request: ApplyRequest, secret: { secretId: string; value: string, backend: SecretBackend }) => void;
   onBack: () => void;
 }) {
   const committedRecipients = vault.recipients.filter((r) => r.inUse);
 
   const [name, setName] = useState("");
   const [value, setValue] = useState("");
-  const [backend, setBackend] = useState<SecretBackend>("sops");
   const [hidden, setHidden] = useState(true);
-  // Every committed local decryption identity is a recipient by default.
-  const [recipientIds, setRecipientIds] = useState<string[]>(
-    committedRecipients.filter((r) => recipientHasLocalIdentity(vault, r)).map((r) => r.id),
-  );
 
   const slug = slugifySecretName(name);
-  const encryptTarget = backend === "agenix" ? `secrets/${slug}.age` : `secrets/secrets.yaml  ›  ${slug}`;
-  const runtimePath = (backend === "agenix" ? "/run/agenix/" : "/run/secrets/") + slug;
+  const encryptTarget = `secrets/secrets.yaml  ›  ${slug}`;
+  const runtimePath = `/run/secrets/${slug}`;
   const invalid = !name.trim() || !value.trim();
-
-  const toggleRecipient = (id: string) => {
-    if (id === vault.primaryDecryptionIdentityId) return;
-    setRecipientIds((ids) => (ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id]));
-  };
 
   const submit = () => {
     if (invalid) return;
-    const labels = committedRecipients
-      .filter((r) => recipientIds.includes(r.id))
-      .map((r) => r.label);
-    onSubmit(buildAddRequest(slug, backend, labels));
+    onSubmit(buildAddRequest(slug), { secretId: slug, value, backend: "sops" });
   };
 
   return (
@@ -111,28 +78,12 @@ export function AddSecretView({
       <div>
         <div className="mb-1.5 flex items-center justify-between">
           <span className="font-medium text-xs">Backend</span>
-          <div className="inline-flex gap-0.5 rounded-md border border-border bg-background/60 p-0.5">
-            {(["sops", "agenix"] as const).map((option) => (
-              <button
-                key={option}
-                type="button"
-                onClick={() => setBackend(option)}
-                className={cn(
-                  "cursor-pointer rounded-[5px] px-2.5 py-1 font-medium font-mono text-[11px] transition-colors",
-                  backend === option
-                    ? "bg-muted text-foreground"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                {backendLabel(option)}
-              </button>
-            ))}
+          <div className="inline-flex rounded-md border border-border bg-muted px-2.5 py-1 font-medium font-mono text-[11px]">
+            sops-nix
           </div>
         </div>
         <p className="text-[11px] text-muted-foreground">
-          {backend === "sops"
-            ? "Recommended — YAML file with .sops.yaml rules; decrypts to a runtime path and can be exposed to the agent."
-            : "Per-file age recipients in secrets.nix."}
+          YAML encrypted with the repository&apos;s SOPS creation rules. Agenix support will be added later.
         </p>
       </div>
 
@@ -174,43 +125,20 @@ export function AddSecretView({
       </div>
 
       <div>
-        <span className="mb-2 block font-medium text-xs">Recipients — who can decrypt</span>
+        <span className="mb-1 block font-medium text-xs">Recipients — who can decrypt</span>
+        <p className="mb-2 text-[11px] text-muted-foreground">
+          Encryption uses the recipients in the matching <code className="font-mono">.sops.yaml</code> creation rule.
+        </p>
         <div className="flex flex-col gap-1.5">
           {committedRecipients.map((recipient) => {
-            const checked = recipientIds.includes(recipient.id);
-            const locked = recipient.id === vault.primaryDecryptionIdentityId;
             return (
               <div
                 key={recipient.id}
-                role="checkbox"
-                aria-checked={checked}
-                aria-disabled={locked}
                 aria-label={`Recipient ${recipient.label}`}
-                tabIndex={0}
-                onClick={() => toggleRecipient(recipient.id)}
-                onKeyDown={(e) => {
-                  if (e.key === " " || e.key === "Enter") {
-                    e.preventDefault();
-                    toggleRecipient(recipient.id);
-                  }
-                }}
-                className={cn(
-                  "flex cursor-pointer items-center gap-2.5 rounded-[9px] border border-border px-3 py-2 text-left",
-                  checked && "bg-primary/5",
-                )}
+                className="flex items-center gap-2.5 rounded-[9px] border border-border px-3 py-2 text-left"
               >
-                <Checkbox
-                  checked={checked}
-                  disabled={locked}
-                  aria-hidden="true"
-                  tabIndex={-1}
-                  className="pointer-events-none"
-                />
                 <RecipientKindIcon kind={recipient.kind} className="text-muted-foreground" />
                 <span className="font-medium font-mono text-[13px]">{recipient.label}</span>
-                {locked && (
-                  <span className="text-[10.5px] text-brand">required — primary identity</span>
-                )}
                 <span className="ml-auto text-[11px] text-muted-foreground">
                   {recipientKindLabel(recipient.kind)}
                 </span>

--- a/apps/native/src/components/widget/secrets/apply-sheet.tsx
+++ b/apps/native/src/components/widget/secrets/apply-sheet.tsx
@@ -36,12 +36,14 @@ export function ApplySheet({
   onCancel,
   onApply,
   onDone,
+  error,
 }: {
   request: ApplyRequest;
   phase: ApplyPhase;
   onCancel: () => void;
   onApply: () => void;
   onDone: () => void;
+  error?: string | null;
 }) {
   return (
     /* backdrop click-to-dismiss mirrors the app's overlay pattern */
@@ -115,7 +117,7 @@ export function ApplySheet({
             <div className="flex items-center justify-between gap-3 pt-0.5">
               <span className="inline-flex items-center gap-1.5 text-muted-foreground text-xs">
                 <Shield className="size-3.5" aria-hidden="true" />
-                Encrypted with age, then verified with darwin-rebuild before anything is applied.
+                Encrypted with SOPS, then verified with darwin-rebuild before anything is committed.
               </span>
               <div className="flex items-center gap-2">
                 <Button variant="ghost" size="sm" onClick={onCancel}>
@@ -127,6 +129,11 @@ export function ApplySheet({
                 </ButtonGlow>
               </div>
             </div>
+            {error && (
+              <p role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive text-xs">
+                {error}
+              </p>
+            )}
           </div>
         )}
 
@@ -136,7 +143,7 @@ export function ApplySheet({
             <div className="text-center">
               <div className="font-semibold text-[15px]">Applying changes</div>
               <div className="mt-1 text-[13px] text-muted-foreground">
-                Encrypting with age · running{" "}
+                Encrypting with SOPS · running{" "}
                 <code className="font-mono text-foreground">darwin-rebuild check</code>
               </div>
             </div>

--- a/apps/native/src/components/widget/secrets/secret-detail-view.tsx
+++ b/apps/native/src/components/widget/secrets/secret-detail-view.tsx
@@ -98,7 +98,7 @@ export function SecretDetailView({
   };
 
   const onDelete = async () => {
-    if (isDeleting) return;
+    if (capability === "unavailable" || isDeleting) return;
     setIsDeleting(true);
     setDeleteError(null);
     try {
@@ -282,6 +282,7 @@ export function SecretDetailView({
           variant="ghost"
           size="sm"
           className="text-destructive"
+          disabled={capability === "unavailable" || isDeleting}
           onClick={() => {
             setDeleteError(null);
             setDeleteOpen(true);
@@ -314,7 +315,7 @@ export function SecretDetailView({
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              disabled={isDeleting}
+              disabled={capability === "unavailable" || isDeleting}
               onClick={(event) => {
                 event.preventDefault();
                 void onDelete();

--- a/apps/native/src/components/widget/secrets/secret-detail-view.tsx
+++ b/apps/native/src/components/widget/secrets/secret-detail-view.tsx
@@ -11,6 +11,16 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
@@ -39,12 +49,19 @@ export function SecretDetailView({
   onBack: () => void;
 }) {
   const MASKED_SECRET_VALUE = "****************";
-  const readOnly = true; // TODO: implement edit flow
   const capability = secret.decryptionCapability;
   const [isDecrypting, setIsDecrypting] = useState(false);
   const [decryptedValue, setDecryptedValue] = useState<string | null>(null);
   const [revealError, setRevealError] = useState<string | null>(null);
   const [isRevealed, setIsRevealed] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // TODO: Implement these
+  const canEdit = false;
+  const canRotate = false;
+  const canUseAgentTool = false;
 
   // Secrets are always readable at their runtime path; an agent tool is a
   // deliberate, per-secret opt-in.
@@ -77,6 +94,26 @@ export function SecretDetailView({
       setRevealError(error instanceof Error ? error.message : "Failed to decrypt secret");
     } finally {
       setIsDecrypting(false);
+    }
+  };
+
+  const onDelete = async () => {
+    if (isDeleting) return;
+    setIsDeleting(true);
+    setDeleteError(null);
+    try {
+      await client.secrets.deleteSecret({
+        secretId: secret.id,
+        backend: secret.backend,
+      });
+      setDecryptedValue(null);
+      setIsRevealed(false);
+      setDeleteOpen(false);
+      onBack();
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : "Failed to delete secret");
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -189,67 +226,107 @@ export function SecretDetailView({
           })}
         </div>
       </div>
-
-      {!readOnly && (
-        <>
-          <div
-            className={cn(
-              "flex items-start gap-3 rounded-[9px] border border-border px-3 py-2.5",
-              !toolSupported && "opacity-55",
-              toolSupported && toolEnabled && "bg-primary/5",
-            )}
-          >
-            <Switch
-              checked={toolSupported && toolEnabled}
-              disabled={!toolSupported}
-              onCheckedChange={setToolEnabled}
-              aria-label="Agent tool"
-              className="mt-0.5"
-            />
-            <div className="flex-1">
-              <div className="flex items-center gap-2 font-medium text-[13px]">
-                Agent tool
-                {!toolSupported && (
-                  <span className="rounded border border-border px-1 text-[10px] text-muted-foreground">
-                    sops-nix only
-                  </span>
-                )}
-              </div>
-              <div className="mt-0.5 text-[11.5px] text-muted-foreground leading-relaxed">
-                {toolSupported && toolEnabled ? (
-                  <>
-                    nixmac's agent can call{" "}
-                    <code className="font-mono text-foreground">use_secret.{secret.id}</code> to
-                    read this value at its runtime path — without ever printing the plaintext.
-                  </>
-                ) : (
-                  "Off by default. Enable to generate a scoped tool the agent can call to use this value — without ever printing the plaintext."
-                )}
-              </div>
+      {canUseAgentTool && (
+        <div
+          className={cn(
+            "flex items-start gap-3 rounded-[9px] border border-border px-3 py-2.5",
+            !toolSupported && "opacity-55",
+            toolSupported && toolEnabled && "bg-primary/5",
+          )}
+        >
+          <Switch
+            checked={toolSupported && toolEnabled}
+            disabled={!toolSupported}
+            onCheckedChange={setToolEnabled}
+            aria-label="Agent tool"
+            className="mt-0.5"
+          />
+          <div className="flex-1">
+            <div className="flex items-center gap-2 font-medium text-[13px]">
+              Agent tool
+              {!toolSupported && (
+                <span className="rounded border border-border px-1 text-[10px] text-muted-foreground">
+                  sops-nix only
+                </span>
+              )}
+            </div>
+            <div className="mt-0.5 text-[11.5px] text-muted-foreground leading-relaxed">
+              {toolSupported && toolEnabled ? (
+                <>
+                  nixmac's agent can call{" "}
+                  <code className="font-mono text-foreground">use_secret.{secret.id}</code> to
+                  read this value at its runtime path — without ever printing the plaintext.
+                </>
+              ) : (
+                "Off by default. Enable to generate a scoped tool the agent can call to use this value — without ever printing the plaintext."
+              )}
             </div>
           </div>
-
-          <div className="flex gap-2 pt-0.5">
-            <Button variant="outline" size="sm" onClick={onNotImplemented}>
-              <Pencil aria-hidden="true" />
-              Edit value
-            </Button>
-            <Button variant="outline" size="sm" onClick={onRotate}>
-              <RefreshCw aria-hidden="true" />
-              Rotate &amp; re-key
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-destructive"
-              onClick={onNotImplemented}
-            >
-              <Trash2 aria-hidden="true" />
-              Delete
-            </Button>
-          </div>
-        </>
+        </div>
       )}
+
+      <div className="flex gap-2 pt-0.5">
+        { canEdit && (
+          <Button variant="outline" size="sm" onClick={onNotImplemented}>
+            <Pencil aria-hidden="true" />
+            Edit value
+          </Button>
+        )}
+        { canRotate && (
+          <Button variant="outline" size="sm" onClick={onRotate}>
+            <RefreshCw aria-hidden="true" />
+            Rotate &amp; re-key
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive"
+          onClick={() => {
+            setDeleteError(null);
+            setDeleteOpen(true);
+          }}
+        >
+          <Trash2 aria-hidden="true" />
+          Delete
+        </Button>
+      </div>
+
+      <AlertDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          if (!isDeleting) setDeleteOpen(open);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {secret.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the encrypted value and Nix declaration, verifies the configuration,
+              and commits the change. You can restore it later from Git history.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deleteError && (
+            <p role="alert" className="text-destructive text-xs">
+              {deleteError}
+            </p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isDeleting}
+              onClick={(event) => {
+                event.preventDefault();
+                void onDelete();
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? <Loader2 className="animate-spin" aria-hidden="true" /> : <Trash2 />}
+              {isDeleting ? "Deleting…" : "Delete & commit"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/native/src/components/widget/secrets/secrets-management-route.test.tsx
+++ b/apps/native/src/components/widget/secrets/secrets-management-route.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SecretsVaultState } from "@/ipc/orpc-bindings";
+import { MOCK_VAULT } from "./mock-data";
+import { SecretsManagementRoute } from "./secrets-management";
+
+const mocks = vi.hoisted(() => ({
+  state: { current: null as SecretsVaultState | null },
+}));
+
+vi.mock("@nixmac/state", () => ({
+  selectSecretsVaultState: vi.fn<(state: unknown) => unknown>(),
+  useViewModel: vi.fn<(_selector: unknown) => SecretsVaultState | null>(
+    () => mocks.state.current,
+  ),
+}));
+
+vi.mock("@/viewmodel/secrets-vault", () => ({
+  startSecretsVaultSync: vi.fn<() => Promise<() => void>>(async () => () => {}),
+}));
+
+vi.mock("@/lib/orpc", () => ({
+  client: { secrets: { refresh: vi.fn<() => Promise<void>>() } },
+}));
+
+describe("SecretsManagementRoute", () => {
+  it("keeps the current screen mounted while the vault refreshes", () => {
+    mocks.state.current = {
+      vault: MOCK_VAULT,
+      activated: true,
+      loading: false,
+      error: null,
+    };
+    const { rerender } = render(<SecretsManagementRoute />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add secret" }));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "demo2" } });
+
+    mocks.state.current = {
+      vault: null,
+      activated: true,
+      loading: true,
+      error: null,
+    };
+    rerender(<SecretsManagementRoute />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("demo2");
+    expect(screen.queryByText("Loading secrets…")).not.toBeInTheDocument();
+  });
+});

--- a/apps/native/src/components/widget/secrets/secrets-management.test.tsx
+++ b/apps/native/src/components/widget/secrets/secrets-management.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { SecretsVault } from "@/ipc/orpc-bindings";
+import { client } from "@/lib/orpc";
 import { MOCK_VAULT } from "./mock-data";
 import { SecretsManagement } from "./secrets-management";
 
@@ -9,13 +10,14 @@ vi.mock("@/lib/orpc", () => ({
   client: {
     secrets: {
       decryptSecret: vi.fn<() => Promise<string>>(),
+      deleteSecret: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
       refresh: vi.fn<() => Promise<void>>(),
     },
   },
 }));
 
 describe("SecretsManagement secret selection", () => {
-  it("selects secrets by backend and id when backends contain the same id", () => {
+  it("deletes secrets by backend and id when backends contain the same id", async () => {
     const sharedEntries: SecretsVault["entries"] = [
       {
         ...MOCK_VAULT.entries[3]!,
@@ -43,5 +45,15 @@ describe("SecretsManagement secret selection", () => {
     expect(screen.getByText("secrets/shared.age")).toBeInTheDocument();
     expect(screen.getByText("agenix")).toBeInTheDocument();
     expect(screen.queryByText("secrets/shared.yaml")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete & commit" }));
+
+    await waitFor(() => {
+      expect(client.secrets.deleteSecret).toHaveBeenCalledWith({
+        secretId: "shared-secret",
+        backend: "agenix",
+      });
+    });
   });
 });

--- a/apps/native/src/components/widget/secrets/secrets-management.tsx
+++ b/apps/native/src/components/widget/secrets/secrets-management.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type {
+  SecretBackend,
   SecretRecipient,
   SecretsVault,
 } from "@/ipc/orpc-bindings";
@@ -149,8 +150,9 @@ export function SecretsManagementRoute() {
  * recipient keys that can open them, and add/detail/rotate flows that all
  * funnel through the review → darwin-rebuild check → commit sheet.
  *
- * The vault is loaded from Rust by {@link SecretsManagementRoute}. Mutating
- * flows are still local simulations until their commands are implemented.
+ * The vault is loaded from Rust by {@link SecretsManagementRoute}. The secret
+ * add flow is backend-owned; the remaining mutating flows are still
+ * local simulations until their commands are implemented.
  */
 export function SecretsManagement({
   vault,
@@ -166,11 +168,14 @@ export function SecretsManagement({
   const [extraRecipients, setExtraRecipients] = useState<SecretRecipient[]>([]);
   const [apply, setApply] = useState<ApplyRequest | null>(null);
   const [applyPhase, setApplyPhase] = useState<ApplyPhase>("review");
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [pendingSecret, setPendingSecret] = useState<{ secretId: string; value: string; backend: SecretBackend } | null>(null);
   const [prompt, setPrompt] = useState("");
   const [toast, setToast] = useState<string | null>(null);
 
   const toastTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const buildTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const applyInFlight = useRef(false);
   useEffect(
     () => () => {
       clearTimeout(toastTimer.current);
@@ -195,10 +200,30 @@ export function SecretsManagement({
   const openApply = (request: ApplyRequest) => {
     setApply(request);
     setApplyPhase("review");
+    setApplyError(null);
   };
 
-  const runApply = () => {
+  const runApply = async () => {
+    if (applyInFlight.current) return;
     setApplyPhase("building");
+    setApplyError(null);
+    if (apply?.origin === "add" && pendingSecret) {
+      applyInFlight.current = true;
+      try {
+        const result = await client.secrets.addSecret(pendingSecret);
+        setApply((request) =>
+          request ? { ...request, commit: result.commitHash.slice(0, 7) } : request,
+        );
+        setPendingSecret(null);
+        setApplyPhase("done");
+      } catch (error) {
+        setApplyError(error instanceof Error ? error.message : "Failed to add SOPS secret");
+        setApplyPhase("review");
+      } finally {
+        applyInFlight.current = false;
+      }
+      return;
+    }
     clearTimeout(buildTimer.current);
     buildTimer.current = setTimeout(() => setApplyPhase("done"), BUILD_SIMULATION_MS);
   };
@@ -214,6 +239,12 @@ export function SecretsManagement({
     setTab(registered ? "keys" : "vault");
     setPrompt("");
     flash("Committed to your config");
+  };
+
+  const cancelApply = () => {
+    if (apply?.origin === "add") setPendingSecret(null);
+    setApplyError(null);
+    setApply(null);
   };
 
   const browse = () => setView({ kind: "browse" });
@@ -247,8 +278,7 @@ export function SecretsManagement({
             </TabsTrigger>
           </TabsList>
         </Tabs>
-        {/* TODO: the add-secret button is hidden until we implement the write flow */}
-        <Button size="sm" onClick={() => setView({ kind: "add" })} className="hidden">
+        <Button size="sm" onClick={() => setView({ kind: "add" })}>
           <Plus aria-hidden="true" />
           Add secret
         </Button>
@@ -270,7 +300,14 @@ export function SecretsManagement({
           />
         )}
         {view.kind === "add" && (
-          <AddSecretView vault={effectiveVault} onSubmit={openApply} onBack={browse} />
+          <AddSecretView
+            vault={effectiveVault}
+            onSubmit={(request, secret) => {
+              setPendingSecret(secret);
+              openApply(request);
+            }}
+            onBack={browse}
+          />
         )}
         {view.kind === "detail" && selectedSecret && (
           <SecretDetailView
@@ -332,9 +369,10 @@ export function SecretsManagement({
         <ApplySheet
           request={apply}
           phase={applyPhase}
-          onCancel={() => setApply(null)}
+          onCancel={cancelApply}
           onApply={runApply}
           onDone={finishApply}
+          error={applyError}
         />
       )}
     </div>

--- a/apps/native/src/components/widget/secrets/secrets-management.tsx
+++ b/apps/native/src/components/widget/secrets/secrets-management.tsx
@@ -98,6 +98,10 @@ export interface SecretsManagementProps {
 /** Mirrors the backend-owned vault state from the Zustand view model. */
 export function SecretsManagementRoute() {
   const state = useViewModel(selectSecretsVaultState);
+  const lastVault = useRef<SecretsVault | null>(null);
+
+  if (state?.vault) lastVault.current = state.vault;
+  const vault = state?.vault ?? (state?.loading ? lastVault.current : null);
 
   useEffect(() => {
     let disposed = false;
@@ -115,7 +119,7 @@ export function SecretsManagementRoute() {
     };
   }, []);
 
-  if (!state || !state.activated || state.loading) {
+  if (!state || !state.activated || (state.loading && !vault)) {
     return (
       <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
         <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
@@ -124,7 +128,7 @@ export function SecretsManagementRoute() {
     );
   }
 
-  if (state.error || !state.vault) {
+  if (state.error || !vault) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
         <TriangleAlert className="size-5 text-destructive" aria-hidden="true" />
@@ -142,7 +146,7 @@ export function SecretsManagementRoute() {
     );
   }
 
-  return <SecretsManagement vault={state.vault} />;
+  return <SecretsManagement vault={vault} />;
 }
 
 /**

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -14,6 +14,13 @@ export type AddInput = { prompt: string }
 
 export type AddItemsInput = { items: HomebrewItem[] }
 
+export type AddSecretInput = { secretId: string; value: string; backend: SecretBackend }
+
+/**
+ * Result of encrypting, declaring, verifying, and committing a secret.
+ */
+export type AddSecretResult = { secretId: string; encryptedFile: string; declarationFile: string; runtimePath: string; commitHash: string }
+
 export type AdoptManualChangesResult = { evolutionId: number }
 
 /**
@@ -386,6 +393,13 @@ export type DecryptionIdentityLocality =
  * Found at a conventional path on this machine.
  */
 "machine"
+
+export type DeleteSecretInput = { secretId: string; backend: SecretBackend }
+
+/**
+ * Result of removing a secret from the repo and committing the change.
+ */
+export type DeleteSecretResult = { secretId: string; commitHash: string }
 
 export type EnumVariant = { value: string; label: string }
 
@@ -2183,7 +2197,9 @@ export type Procedures = {
     scanDefaults: Client<Record<never, never>, void, SystemDefaultsScan, Error>
   }
   secrets: {
+    addSecret: Client<Record<never, never>, AddSecretInput, AddSecretResult, Error>
     decryptSecret: Client<Record<never, never>, DecryptSecretInput, string, Error>
+    deleteSecret: Client<Record<never, never>, DeleteSecretInput, DeleteSecretResult, Error>
     getState: Client<Record<never, never>, void, SecretsVaultState, Error>
     refresh: Client<Record<never, never>, void, void, Error>
   }


### PR DESCRIPTION
## Summary

Hooks up the original storybook mocks end-to-end for SOP secret add and delete operations. (Age will be forthcoming.)

Includes some fileops and nix editor refactorings and enhancements for reusable/recurring patterns.

Screenshots:

<img width="791" height="574" alt="Screenshot 2026-08-11 at 3 08 33 PM" src="https://github.com/user-attachments/assets/f5a6d48f-e404-4350-af44-1065eaa7dec3" />

<img width="788" height="762" alt="Screenshot 2026-08-11 at 2 58 26 PM" src="https://github.com/user-attachments/assets/8c94aaaa-abb8-45a3-9001-46dfa413689d" />

<img width="781" height="321" alt="image" src="https://github.com/user-attachments/assets/8684643a-d812-4d61-9e6a-6f2c24841c6c" />

<img width="788" height="360" alt="image" src="https://github.com/user-attachments/assets/57e43f1f-4ffe-4b04-b314-303ea377a0d1" />

<img width="472" height="138" alt="Screenshot 2026-08-11 at 3 00 39 PM" src="https://github.com/user-attachments/assets/912ebed2-e309-4a25-a9d6-0500fa19787c" />

<img width="553" height="264" alt="image" src="https://github.com/user-attachments/assets/b761c1b5-5bb8-42a2-85de-4eafd4ab9129" />

## Test Plan

New unit tests as appropriate, plus manual testing e2e.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed