### PR TITLE
feat: add agenix secret add/delete support

### DIFF
--- a/apps/native/src-tauri/src/evolve/file_ops.rs
+++ b/apps/native/src-tauri/src/evolve/file_ops.rs
@@ -82,6 +82,21 @@ pub(crate) fn relative_path_between(from: &Path, to: &Path) -> anyhow::Result<Pa
     Ok(relative)
 }
 
+/// Compute a lexical relative path rendered as a portable Nix path literal.
+///
+/// Unlike a plain filesystem path, a same-directory or child Nix path must
+/// start with `./` so it is parsed as a path rather than an identifier.
+pub(crate) fn relative_nix_path_between(from: &Path, to: &Path) -> anyhow::Result<String> {
+    let rendered = relative_path_between(from, to)?
+        .to_string_lossy()
+        .replace('\\', "/");
+    Ok(if rendered.starts_with('.') {
+        rendered
+    } else {
+        format!("./{rendered}")
+    })
+}
+
 /// Canonicalize and validate a path exists under `base`.
 pub(crate) fn resolve_existing_path_in_dir(base: &Path, rel: &str) -> anyhow::Result<PathBuf> {
     let full_path = join_in_dir(base, rel)?;
@@ -524,8 +539,8 @@ fn reject_gitignored_edit_path(
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_file_edits, relative_path_between, repo_relative_path, repo_relative_path_string,
-        rewrite_existing_file_in_dir,
+        apply_file_edits, relative_nix_path_between, relative_path_between, repo_relative_path,
+        repo_relative_path_string, rewrite_existing_file_in_dir,
     };
     use crate::evolve::gitignore::GitignoreChecker;
     use crate::shared_types::FileEdit;
@@ -555,6 +570,16 @@ mod tests {
             relative_path_between(Path::new("modules"), Path::new("modules"))
                 .expect("compute identity path"),
             Path::new(".")
+        );
+        assert_eq!(
+            relative_nix_path_between(Path::new("modules"), Path::new("secrets/token.age"))
+                .expect("render parent Nix path"),
+            "../secrets/token.age"
+        );
+        assert_eq!(
+            relative_nix_path_between(Path::new(""), Path::new("secrets/token.age"))
+                .expect("render child Nix path"),
+            "./secrets/token.age"
         );
     }
 

--- a/apps/native/src-tauri/src/evolve/nix_file_editor.rs
+++ b/apps/native/src-tauri/src/evolve/nix_file_editor.rs
@@ -73,6 +73,46 @@ fn normalize_attrpath_for_match(input: &str) -> String {
         .collect()
 }
 
+/// Split a Nix attribute path without treating dots inside quoted attribute
+/// names as separators (for example `age.secrets."api.token"`).
+fn split_attrpath_for_match(attrpath: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quoted = false;
+    let mut escaped = false;
+    for ch in attrpath.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        if quoted && ch == '\\' {
+            current.push(ch);
+            escaped = true;
+            continue;
+        }
+        if ch == '"' {
+            quoted = !quoted;
+            current.push(ch);
+            continue;
+        }
+        if ch == '.' && !quoted {
+            let normalized = normalize_attrpath_for_match(&current);
+            if !normalized.is_empty() {
+                segments.push(normalized);
+            }
+            current.clear();
+        } else {
+            current.push(ch);
+        }
+    }
+    let normalized = normalize_attrpath_for_match(&current);
+    if !normalized.is_empty() {
+        segments.push(normalized);
+    }
+    segments
+}
+
 fn render_nix_string(value: &str) -> String {
     let mut rendered = String::from("\"");
     for ch in value.chars() {
@@ -631,17 +671,8 @@ pub(crate) fn infer_single_list_attrpath(content: &str) -> Result<Option<String>
 /// This is the structural counterpart to `find_assignment_value_range`, which
 /// matches only a flat dotted LHS and so cannot see a leaf nested inside an
 /// attrset literal — the case that let `add()` insert a duplicate assignment.
-///
-/// Known limitation: a quoted key containing dots (e.g.
-/// `NSGlobalDomain."com.apple.sound.beep.feedback"`) is one AST segment but
-/// splits into several here, so such paths won't resolve. That matches the
-/// existing dot-splitting behaviour elsewhere in this module.
 fn find_attrpath_value_node(root: &SyntaxNode, attrpath: &str) -> Option<SyntaxNode> {
-    let target: Vec<String> = attrpath
-        .split('.')
-        .map(normalize_attrpath_for_match)
-        .filter(|segment| !segment.is_empty())
-        .collect();
+    let target = split_attrpath_for_match(attrpath);
     if target.is_empty() {
         return None;
     }
@@ -912,11 +943,7 @@ fn remove(content: &str, attrpath: &str, values: &[String]) -> Result<String> {
 /// attrsets are intentionally preserved. An absent attrpath is reported as an error so
 /// callers performing destructive operations do not silently succeed.
 pub(crate) fn remove_attrpath(content: &str, attrpath: &str) -> Result<String> {
-    let target = attrpath
-        .split('.')
-        .map(normalize_attrpath_for_match)
-        .filter(|segment| !segment.is_empty())
-        .collect::<Vec<_>>();
+    let target = split_attrpath_for_match(attrpath);
     if target.is_empty() {
         return Err(anyhow::anyhow!("Nix attrpath must not be empty"));
     }
@@ -953,6 +980,37 @@ pub(crate) fn remove_attrpath(content: &str, attrpath: &str) -> Result<String> {
         updated.replace_range(start..end, "");
     }
     Ok(updated)
+}
+
+/// Remove an attribute path from an existing Nix file and optionally format it.
+///
+/// This is the filesystem counterpart to [`remove_attrpath`]. Keeping it here
+/// ensures callers share the same path-safety, read-modify-write, and formatting
+/// behavior instead of implementing their own Nix file mutation wrappers.
+pub(crate) fn remove_attrpath_in_file(
+    base: &Path,
+    relative_file: &str,
+    attrpath: &str,
+    auto_format: bool,
+) -> Result<()> {
+    rewrite_existing_file_in_dir(
+        base,
+        relative_file,
+        "remove Nix attribute path",
+        None,
+        |content| remove_attrpath(content, attrpath),
+    )?;
+
+    if auto_format {
+        let config_dir = base.to_string_lossy();
+        if let Err(error) = nix_format(&config_dir, relative_file) {
+            log::warn!(
+                "Removed Nix attrpath '{attrpath}', but formatting {relative_file} failed: {error}"
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// Helper to recursively collect the byte ranges of all assignments that match a given attrpath prefix, including nested attrsets.
@@ -1491,6 +1549,45 @@ environment.systemPackages = with pkgs; [
         let error = remove_attrpath("{ services.foo.enable = true; }", "sops.secrets.foo")
             .expect_err("missing attrpath must not silently succeed");
         assert!(error.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn remove_attrpath_preserves_dots_inside_quoted_segments() {
+        let rules = r#"{
+  "api.token.age".publicKeys = [ "age1example" ];
+  "other.age".publicKeys = [ "age1example" ];
+}
+"#;
+        let updated =
+            remove_attrpath(rules, "\"api.token.age\"").expect("remove quoted agenix rule");
+
+        assert!(!updated.contains("api.token.age"));
+        assert!(updated.contains("other.age"));
+    }
+
+    #[test]
+    fn remove_attrpath_in_file_rewrites_only_the_target_assignment() {
+        let repo = tempfile::tempdir().expect("create temporary repository");
+        let relative_file = "secrets/secrets.nix";
+        let directory = repo.path().join("secrets");
+        std::fs::create_dir(&directory).expect("create secrets directory");
+        let file = directory.join("secrets.nix");
+        std::fs::write(
+            &file,
+            r#"{
+  "api.token.age".publicKeys = [ "age1example" ];
+  "other.age".publicKeys = [ "age1example" ];
+}
+"#,
+        )
+        .expect("write Nix fixture");
+
+        remove_attrpath_in_file(repo.path(), relative_file, "\"api.token.age\"", false)
+            .expect("remove attrpath from file");
+
+        let updated = std::fs::read_to_string(file).expect("read updated Nix file");
+        assert!(!updated.contains("api.token.age"));
+        assert!(updated.contains("other.age"));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/secrets/recipients.rs
+++ b/apps/native/src-tauri/src/secrets/recipients.rs
@@ -402,6 +402,19 @@ pub(crate) fn load_recipients(
     ))
 }
 
+/// Resolve the repository's active SOPS config file. The repo root is treated as
+/// the source of truth, so a single helper keeps discovery stable for both the
+/// `.sops.yaml` and `sops.yaml` conventions.
+fn sops_config_path(config_dir: &Path) -> Option<PathBuf> {
+    if config_dir.join(".sops.yaml").exists() {
+        Some(config_dir.join(".sops.yaml"))
+    } else if config_dir.join("sops.yaml").exists() {
+        Some(config_dir.join("sops.yaml"))
+    } else {
+        None
+    }
+}
+
 /// Load the public recipients declared by the repository's SOPS config.
 ///
 /// YAML aliases resolve to their scalar values during deserialization, but their
@@ -410,11 +423,7 @@ pub(crate) fn load_recipients(
 /// source scan recovers optional friendly names such as `&build-server`.
 /// If this doesn't make sense, see the unit tests.
 fn load_sops_config_recipients(config_dir: &Path) -> Result<Vec<ConfigRecipient>, String> {
-    let config_path = if config_dir.join(".sops.yaml").exists() {
-        config_dir.join(".sops.yaml")
-    } else if config_dir.join("sops.yaml").exists() {
-        config_dir.join("sops.yaml")
-    } else {
+    let Some(config_path) = sops_config_path(config_dir) else {
         return Ok(Vec::new());
     };
     let source = fs::read_to_string(&config_path)
@@ -688,6 +697,38 @@ fn handle_agenix_rules_result(
     }
 }
 
+/// Resolve which evaluated agenix secret declarations match a rule entry.
+/// We prefer an exact path match and fall back to a unique basename match only
+/// when the rules file cannot preserve the directory layout (for example when
+/// builtins.path expands to a store path).
+fn match_agenix_secret_entries<'a>(
+    secret_file: &str,
+    secret_entries: &'a [SecretEntry],
+) -> Vec<&'a SecretEntry> {
+    let exact_matching_entries: Vec<&SecretEntry> = secret_entries
+        .iter()
+        .filter(|entry| {
+            entry.backend == SecretBackend::Agenix && Path::new(&entry.file).ends_with(secret_file)
+        })
+        .collect();
+    if !exact_matching_entries.is_empty() {
+        return exact_matching_entries;
+    }
+
+    let Some(basename) = Path::new(secret_file)
+        .file_name()
+        .and_then(|name| name.to_str())
+    else {
+        return Vec::new();
+    };
+    secret_entries
+        .iter()
+        .filter(|entry| {
+            entry.backend == SecretBackend::Agenix && agenix_filename_matches(&entry.file, basename)
+        })
+        .collect()
+}
+
 /// Build the per-secret recipient inventory and repository-level recipient registrations from the evaluated agenix rules.
 fn build_agenix_rules(
     config_dir: &Path,
@@ -776,44 +817,21 @@ fn build_agenix_rules(
                 direct_match_count += 1;
             }
         }
-        let exact_matching_entries: Vec<&SecretEntry> = secret_entries
-            .iter()
-            .filter(|entry| {
-                entry.backend == SecretBackend::Agenix
-                    && Path::new(&entry.file).ends_with(&secret_file)
-            })
-            .collect();
-        // builtins.path commonly produces /nix/store/<hash>-<basename>, which
-        // cannot retain the rules file's directory suffix. Fall back to a
-        // unique filename match, allowing that Nix store hash prefix, but
-        // never guess when multiple agenix declarations share the basename.
-        let basename = Path::new(&secret_file)
+        let matching_entries = match_agenix_secret_entries(&secret_file, secret_entries);
+        let basename_for_debug = Path::new(&secret_file)
             .file_name()
-            .and_then(|name| name.to_str());
-        let basename_matching_entries: Vec<&SecretEntry> = if exact_matching_entries.is_empty() {
-            basename
-                .map(|basename| {
-                    secret_entries
-                        .iter()
-                        .filter(|entry| {
-                            entry.backend == SecretBackend::Agenix
-                                && agenix_filename_matches(&entry.file, basename)
-                        })
-                        .collect()
-                })
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-        let matching_entries = if exact_matching_entries.is_empty() {
-            &basename_matching_entries
-        } else {
-            &exact_matching_entries
-        };
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
         log::debug!(
             "Agenix rule '{secret_file}': repository_path_matches={direct_match_count}, evaluated_exact_matches={}, evaluated_basename_matches={}",
-            exact_matching_entries.len(),
-            basename_matching_entries.len()
+            matching_entries
+                .iter()
+                .filter(|entry| Path::new(&entry.file).ends_with(&secret_file))
+                .count(),
+            matching_entries
+                .iter()
+                .filter(|entry| agenix_filename_matches(&entry.file, basename_for_debug))
+                .count()
         );
         if matching_entries.len() == 1
             && let Ok(path) = resolve_secret_file_path(

--- a/apps/native/src-tauri/src/secrets/recipients.rs
+++ b/apps/native/src-tauri/src/secrets/recipients.rs
@@ -806,7 +806,6 @@ fn build_agenix_rules(
                 .collect()
         };
         let mut matched = false;
-        let mut direct_match_count = 0;
         for path in candidates.into_iter().flatten() {
             if path.is_file() {
                 inventory
@@ -814,25 +813,9 @@ fn build_agenix_rules(
                     .or_default()
                     .extend(encrypted_for.iter().cloned());
                 matched = true;
-                direct_match_count += 1;
             }
         }
         let matching_entries = match_agenix_secret_entries(&secret_file, secret_entries);
-        let basename_for_debug = Path::new(&secret_file)
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or_default();
-        log::debug!(
-            "Agenix rule '{secret_file}': repository_path_matches={direct_match_count}, evaluated_exact_matches={}, evaluated_basename_matches={}",
-            matching_entries
-                .iter()
-                .filter(|entry| Path::new(&entry.file).ends_with(&secret_file))
-                .count(),
-            matching_entries
-                .iter()
-                .filter(|entry| agenix_filename_matches(&entry.file, basename_for_debug))
-                .count()
-        );
         if matching_entries.len() == 1
             && let Ok(path) = resolve_secret_file_path(
                 config_dir.to_string_lossy().as_ref(),

--- a/apps/native/src-tauri/src/secrets/recipients.rs
+++ b/apps/native/src-tauri/src/secrets/recipients.rs
@@ -562,19 +562,14 @@ fn load_agenix_rules(
         config_dir.display(),
         rules_override.is_some()
     );
-    let rules_path = if let Some(rules_override) = rules_override {
-        let configured_path = PathBuf::from(rules_override);
-        match resolve_agenix_rules_path(config_dir, &configured_path) {
-            Ok(path) => Some(path),
-            Err(error) => {
-                return handle_agenix_rules_result(&configured_path, true, Err(error));
-            }
+    let rules_path = match discover_agenix_rules_path(config_dir) {
+        Ok(path) => path,
+        Err(error) => {
+            let configured_path = rules_override
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("$RULES"));
+            return handle_agenix_rules_result(&configured_path, true, Err(error));
         }
-    } else {
-        ["secrets.nix", "secrets/secrets.nix"]
-            .into_iter()
-            .map(|path| config_dir.join(path))
-            .find(|path| path.is_file())
     };
     let Some(rules_path) = rules_path else {
         log::debug!(
@@ -584,6 +579,19 @@ fn load_agenix_rules(
     };
     let result = evaluate_agenix_rules(config_dir, &rules_path, secret_entries);
     handle_agenix_rules_result(&rules_path, explicitly_configured, result)
+}
+
+/// Discover the classic agenix rules path using the same precedence as agenix:
+/// `$RULES`, `secrets.nix`, then `secrets/secrets.nix`.
+pub(crate) fn discover_agenix_rules_path(config_dir: &Path) -> Result<Option<PathBuf>, String> {
+    if let Some(rules_override) = std::env::var_os("RULES").filter(|value| !value.is_empty()) {
+        return resolve_agenix_rules_path(config_dir, &PathBuf::from(rules_override)).map(Some);
+    }
+
+    Ok(["secrets.nix", "secrets/secrets.nix"]
+        .into_iter()
+        .map(|path| config_dir.join(path))
+        .find(|path| path.is_file()))
 }
 
 /// Resolve an inherited rules override without allowing a relative path or
@@ -846,7 +854,7 @@ fn build_agenix_rules(
 
 /// Check if the given entry file name matches the expected basename according to the Agenix naming convention.
 /// This includes the convention where the filename may have a 32-character store hash prefix followed by a hyphen and the basename.
-fn agenix_filename_matches(entry_file: &str, basename: &str) -> bool {
+pub(super) fn agenix_filename_matches(entry_file: &str, basename: &str) -> bool {
     let Some(filename) = Path::new(entry_file)
         .file_name()
         .and_then(|name| name.to_str())

--- a/apps/native/src-tauri/src/secrets/secrets_management.rs
+++ b/apps/native/src-tauri/src/secrets/secrets_management.rs
@@ -2,8 +2,8 @@ use crate::{
     evolve::{
         GitignoreChecker, NixmacIgnoreChecker,
         file_ops::{
-            relative_path_between, repo_relative_path, repo_relative_path_string,
-            resolve_existing_path_in_dir,
+            relative_nix_path_between, relative_path_between, repo_relative_path,
+            repo_relative_path_string, resolve_existing_path_in_dir,
         },
     },
     secrets::{
@@ -681,13 +681,7 @@ fn declare_agenix_secret(
 ) -> anyhow::Result<()> {
     let declaration_rel = repo_relative_path_string(base, declaration_file)?;
     let from = repo_relative_path(base, declaration_file.parent().unwrap_or(base))?;
-    let secret_path = relative_path_between(&from, Path::new(encrypted_relative))?;
-    let rendered_path = secret_path.to_string_lossy().replace('\\', "/");
-    let rendered_path = if rendered_path.starts_with('.') {
-        rendered_path
-    } else {
-        format!("./{rendered_path}")
-    };
+    let rendered_path = relative_nix_path_between(&from, Path::new(encrypted_relative))?;
     let mut attrs = serde_json::Map::new();
     attrs.insert(
         "file".to_string(),
@@ -781,7 +775,6 @@ fn add_sops_secret(
         // and prevents accidentally discarding unrelated user work.
         let declaration_rel = repo_relative_path_string(base, &declaration_file)
             .ok()
-            .map(|path| path as String)
             .unwrap_or_default();
         restore_repo_files_on_failure(
             config_dir,
@@ -964,13 +957,7 @@ fn declare_sops_secret(
 ) -> anyhow::Result<()> {
     let declaration_rel = repo_relative_path_string(base, declaration_file)?;
     let from = repo_relative_path(base, declaration_file.parent().unwrap_or(base))?;
-    let secret_path = relative_path_between(&from, Path::new(encrypted_file))?;
-    let rendered_path = secret_path.to_string_lossy().replace('\\', "/");
-    let rendered_path = if rendered_path.starts_with('.') {
-        rendered_path
-    } else {
-        format!("./{rendered_path}")
-    };
+    let rendered_path = relative_nix_path_between(&from, Path::new(encrypted_file))?;
     let mut attrs = serde_json::Map::new();
     attrs.insert(
         "sopsFile".to_string(),
@@ -1246,9 +1233,23 @@ pub fn load_secrets_vault(host_attr: &str, config_dir: &str) -> Result<SecretsVa
         .iter()
         .find(|recipient| recipient_has_local_identity(recipient, &decryption_identities))
         .map(|recipient| recipient.id.clone());
+    let base = Path::new(config_dir);
+    let agenix_rules_file = find_agenix_rules_file(base)
+        .and_then(|path| repo_relative_path_string(base, &path))
+        .ok();
+    let agenix_declaration_path = find_agenix_declaration_file(base).ok();
+    let agenix_encrypted_directory_from_declaration = agenix_declaration_path
+        .as_ref()
+        .and_then(|path| repo_relative_path(base, path.parent().unwrap_or(base)).ok())
+        .and_then(|from| relative_nix_path_between(&from, Path::new("secrets")).ok());
+    let agenix_declaration_file =
+        agenix_declaration_path.and_then(|path| repo_relative_path_string(base, &path).ok());
 
     Ok(SecretsVault {
         primary_decryption_identity_id,
+        agenix_rules_file,
+        agenix_declaration_file,
+        agenix_encrypted_directory_from_declaration,
         entries,
         recipients,
         decryption_identities,
@@ -1397,9 +1398,9 @@ mod tests {
         AGENIX_DECRYPTION_FAILED, SOPS_DECRYPTION_FAILED, age_decrypt_command, age_encrypt_command,
         find_agenix_declaration_file, find_agenix_rules_file, find_sops_declaration_file,
         managed_sops_file, matching_agenix_rule_key, readable_agenix_identity_paths,
-        relative_path_between, resolve_secret_file_path, sanitized_subprocess_error, secret,
-        sops_decrypt_command, sops_extract_path, sops_plaintext, ssh_to_age_decrypt_command,
-        validate_new_secret,
+        relative_nix_path_between, relative_path_between, repo_relative_path_string,
+        resolve_secret_file_path, sanitized_subprocess_error, secret, sops_decrypt_command,
+        sops_extract_path, sops_plaintext, ssh_to_age_decrypt_command, validate_new_secret,
     };
     use crate::shared_types::{
         DecryptionIdentity, DecryptionIdentityKind, DecryptionIdentityLocality,
@@ -1748,6 +1749,31 @@ mod tests {
         assert_eq!(
             find_agenix_declaration_file(config_dir.path()).expect("find agenix module"),
             module
+        );
+    }
+
+    #[test]
+    fn agenix_discovery_preserves_a_nonstandard_declaration_location() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let rules = config_dir.path().join("secrets.nix");
+        fs::write(&rules, "{ }").expect("write agenix rules");
+        let module = config_dir
+            .path()
+            .join("hosts/workstation/modules/security.nix");
+        fs::create_dir_all(module.parent().unwrap()).expect("create module dir");
+        fs::write(&module, "{ age.secrets = {}; }").expect("write agenix module");
+
+        let discovered =
+            find_agenix_declaration_file(config_dir.path()).expect("find agenix module");
+        assert_eq!(
+            repo_relative_path_string(config_dir.path(), &discovered)
+                .expect("render repository-relative module path"),
+            "hosts/workstation/modules/security.nix"
+        );
+        assert_eq!(
+            relative_nix_path_between(Path::new("hosts/workstation/modules"), Path::new("secrets"))
+                .expect("render encrypted directory from declaration"),
+            "../../../secrets"
         );
     }
 

--- a/apps/native/src-tauri/src/secrets/secrets_management.rs
+++ b/apps/native/src-tauri/src/secrets/secrets_management.rs
@@ -37,6 +37,55 @@ fn managed_sops_file(secret_id: &str) -> String {
     format!("secrets/{secret_id}.yaml")
 }
 
+const UNCOMMITTED_REPO_ERROR: &str = "The repository has uncommitted changes. Commit or stash them before editing secrets so nixmac can roll back safely if verification fails.";
+
+/// Require a clean repository before mutating a secret. This is a safety check,
+/// not a formatting policy: the add/delete flows verify each edit with a dry
+/// build and then commit only the files they touched. If verification fails, we
+/// restore the exact paths we edited rather than guessing about unrelated work.
+fn ensure_clean_repo(config_dir: &str) -> anyhow::Result<()> {
+    let status = crate::git::status(config_dir).context("inspect repository status")?;
+    if status.clean_head {
+        Ok(())
+    } else {
+        anyhow::bail!(UNCOMMITTED_REPO_ERROR)
+    }
+}
+
+/// Best-effort rollback for the small set of repository files touched by a secret
+/// mutation. The clean-repo guard above ensures we only restore the exact files
+/// owned by this operation; restoring unrelated user changes would be unsafe.
+fn restore_repo_files_on_failure(config_dir: &str, paths: &[&str]) {
+    for path in paths {
+        if path.is_empty() {
+            continue;
+        }
+        let _ = crate::git::restore_file(config_dir, path);
+    }
+}
+
+/// Shared validation for the secret-edit flow: after a file mutation, we rerun
+/// the host dry build before committing. The build acts as the final safety
+/// gate, and if it fails we undo just the files touched in this operation.
+fn verify_dry_build_for_secret_edit(
+    config_dir: &str,
+    host_attr: &str,
+    action: &str,
+) -> anyhow::Result<()> {
+    let (passed, stdout, stderr) =
+        crate::rebuild::dry_run_build_check(config_dir, host_attr, false)
+            .context("run darwin build check")?;
+    if passed {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "darwin build check failed after {action}:\n{}{}",
+            stdout,
+            stderr
+        )
+    }
+}
+
 /// Deletes a secret from the configured repo, returning the result.
 pub fn delete_secret(
     host_attr: &str,
@@ -46,7 +95,7 @@ pub fn delete_secret(
 ) -> Result<crate::shared_types::DeleteSecretResult, String> {
     match backend {
         SecretBackend::Sops => delete_sops_secret(host_attr, config_dir, secret_id),
-        SecretBackend::Agenix => Err("Deleting agenix secrets is not yet implemented".to_string()),
+        SecretBackend::Agenix => delete_age_secret(host_attr, config_dir, secret_id),
     }
 }
 
@@ -61,8 +110,197 @@ pub fn add_secret(
     match backend {
         SecretBackend::Sops => add_sops_secret(host_attr, config_dir, secret_id, value)
             .map_err(|error| error.to_string()),
-        SecretBackend::Agenix => Err("Adding agenix secrets is not yet implemented".to_string()),
+        SecretBackend::Agenix => add_age_secret(host_attr, config_dir, secret_id, value)
+            .map_err(|error| error.to_string()),
     }
+}
+
+/// Deletes an agenix secret from the configured repo, returning the result.
+/// Requires that the repository is clean and that the secret exists.
+/// If the operation fails, it attempts to restore the repository to its original state.
+fn delete_age_secret(
+    host_attr: &str,
+    config_dir: &str,
+    secret_id: &str,
+) -> Result<crate::shared_types::DeleteSecretResult, String> {
+    (|| -> anyhow::Result<crate::shared_types::DeleteSecretResult> {
+        ensure_clean_repo(config_dir)?;
+
+        log::info!("Deleting agenix secret declaration {secret_id} from config dir {config_dir}");
+
+        let secret = load_agenix_secrets(host_attr, config_dir)
+            .map_err(|error| anyhow!(error))?
+            .into_iter()
+            .find(|secret| secret.id == secret_id)
+            .ok_or_else(|| anyhow!("Secret declaration '{secret_id}' does not exist"))?;
+
+        let base = Path::new(config_dir);
+        let rules_file = find_agenix_rules_file(base)?;
+        let declaration_file = find_agenix_declaration_file(base)?;
+        let rules_rel = repo_relative_path_string(base, &rules_file)?;
+        let declaration_rel = repo_relative_path_string(base, &declaration_file)?;
+        let (rule_key, encrypted_path) =
+            resolve_agenix_rule_file(config_dir, &rules_file, &secret)?;
+        let encrypted_rel = repo_relative_path_string(base, &encrypted_path)?;
+
+        let operation = (|| -> anyhow::Result<crate::shared_types::DeleteSecretResult> {
+            std::fs::remove_file(&encrypted_path).context("remove encrypted agenix secret")?;
+            remove_agenix_rule(base, &rules_rel, &rule_key)?;
+            remove_agenix_declaration(base, &declaration_rel, secret_id)?;
+
+            verify_dry_build_for_secret_edit(config_dir, host_attr, "deleting the secret")?;
+
+            if load_agenix_secrets(host_attr, config_dir)
+                .map_err(|error| anyhow!(error))?
+                .iter()
+                .any(|secret| secret.id == secret_id)
+            {
+                anyhow::bail!("The agenix declaration is still present after editing the module");
+            }
+            if load_agenix_rule_keys(config_dir, &rules_file)?.contains(&rule_key) {
+                anyhow::bail!("The agenix rule '{rule_key}' is still present after editing");
+            }
+
+            let commit = crate::git::commit_files(
+                config_dir,
+                &[&encrypted_rel, &rules_rel, &declaration_rel],
+                &format!("secrets: delete {secret_id} (agenix)"),
+            )
+            .context("commit deleted agenix secret")?;
+
+            Ok(crate::shared_types::DeleteSecretResult {
+                secret_id: secret_id.to_string(),
+                commit_hash: commit.hash,
+            })
+        })();
+
+        if operation.is_err() {
+            restore_repo_files_on_failure(
+                config_dir,
+                &[
+                    encrypted_rel.as_str(),
+                    rules_rel.as_str(),
+                    declaration_rel.as_str(),
+                ],
+            );
+        }
+        operation
+    })()
+    .map_err(|error| error.to_string())
+}
+
+/// Load the evaluated agenix rule names from the rules file, returning an error if evaluation fails or the output is not valid JSON for some reason.
+fn load_agenix_rule_keys(config_dir: &str, rules_file: &Path) -> anyhow::Result<Vec<String>> {
+    let output = nix_command(config_dir)
+        .args([
+            "eval",
+            "--json",
+            "--file",
+            rules_file.to_string_lossy().as_ref(),
+            "--apply",
+            "rules: builtins.attrNames rules",
+        ])
+        .output()
+        .context("evaluate agenix rules")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "Agenix rules evaluation failed with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    serde_json::from_slice(&output.stdout).context("parse evaluated agenix rule names")
+}
+
+/// Resolve the agenix rule key and the path to the encrypted file for a given secret entry,
+/// returning an error if the rule cannot be resolved or the file does not exist.
+fn resolve_agenix_rule_file(
+    config_dir: &str,
+    rules_file: &Path,
+    secret: &SecretEntry,
+) -> anyhow::Result<(String, PathBuf)> {
+    let base = Path::new(config_dir);
+    let rules_dir = rules_file.parent().unwrap_or(base);
+    let rule_keys = load_agenix_rule_keys(config_dir, rules_file)?;
+    let rule_key = matching_agenix_rule_key(&rule_keys, secret)?;
+
+    let mut candidates = [rules_dir.join(&rule_key), base.join(&rule_key)]
+        .into_iter()
+        .filter_map(|path| path.canonicalize().ok())
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.dedup();
+    let resolved = match candidates.as_slice() {
+        [path] => path,
+        [] => anyhow::bail!("Encrypted file for agenix rule '{rule_key}' does not exist"),
+        _ => anyhow::bail!(
+            "Agenix rule '{rule_key}' resolves to multiple repository files; refusing to guess"
+        ),
+    };
+    let base_resolved = base.canonicalize().context("resolve repository")?;
+    let relative = repo_relative_path(&base_resolved, resolved).with_context(|| {
+        format!(
+            "Encrypted agenix file {} is outside the repository and cannot be deleted",
+            resolved.display()
+        )
+    })?;
+    Ok((rule_key, base.join(relative)))
+}
+
+/// Find the agenix rule key that matches a given secret entry, preferring an exact path match and falling back to a unique basename match if necessary.
+fn matching_agenix_rule_key(rule_keys: &[String], secret: &SecretEntry) -> anyhow::Result<String> {
+    let evaluated_path = Path::new(&secret.file);
+    let exact = rule_keys
+        .iter()
+        .filter(|key| evaluated_path.ends_with(Path::new(key)))
+        .cloned()
+        .collect::<Vec<_>>();
+    let matching = if exact.is_empty() {
+        rule_keys
+            .iter()
+            .filter(|key| {
+                Path::new(key)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|basename| secret.file.ends_with(basename))
+            })
+            .cloned()
+            .collect::<Vec<_>>()
+    } else {
+        exact
+    };
+    match matching.as_slice() {
+        [key] => Ok(key.clone()),
+        [] => anyhow::bail!(
+            "Could not find an agenix rule matching secret '{}' at {}",
+            secret.id,
+            secret.file
+        ),
+        _ => anyhow::bail!(
+            "Found multiple agenix rules matching secret '{}' at {}; refusing to guess",
+            secret.id,
+            secret.file
+        ),
+    }
+}
+
+/// Remove an agenix rule from the rules file, returning an error if the rule was not found.
+fn remove_agenix_rule(base: &Path, relative_file: &str, rule_key: &str) -> anyhow::Result<()> {
+    let attrpath = serde_json::to_string(rule_key).expect("serialize agenix rule key");
+    crate::evolve::nix_file_editor::remove_attrpath_in_file(base, relative_file, &attrpath, true)
+        .with_context(|| format!("remove agenix rule '{attrpath}'"))
+}
+
+/// Remove an agenix declaration for a specific secret from the rules file, returning an error if the declaration was not found.
+fn remove_agenix_declaration(
+    base: &Path,
+    relative_file: &str,
+    secret_id: &str,
+) -> anyhow::Result<()> {
+    let attrpath = format!("age.secrets.\"{secret_id}\"");
+    crate::evolve::nix_file_editor::remove_attrpath_in_file(base, relative_file, &attrpath, true)
+        .with_context(|| format!("remove agenix declaration '{attrpath}'"))
 }
 
 /// Deletes a SOPS secret from the configured repo, returning the result.
@@ -74,12 +312,7 @@ fn delete_sops_secret(
     secret_id: &str,
 ) -> Result<crate::shared_types::DeleteSecretResult, String> {
     (|| -> anyhow::Result<crate::shared_types::DeleteSecretResult> {
-        let status = crate::git::status(config_dir).context("inspect repository status")?;
-        if !status.clean_head {
-            anyhow::bail!(
-                "The repository has uncommitted changes. Commit or stash them before deleting a secret so nixmac can roll back safely if verification fails."
-            );
-        }
+        ensure_clean_repo(config_dir)?;
 
         log::info!("Deleting SOPS secret declaration {secret_id} from config dir {config_dir}");
 
@@ -104,16 +337,7 @@ fn delete_sops_secret(
             std::fs::remove_file(&encrypted_path).context("remove SOPS secret file")?;
             remove_sops_declaration(base, &declaration_rel, secret_id)?;
 
-            let (passed, stdout, stderr) =
-                crate::rebuild::dry_run_build_check(config_dir, host_attr, false)
-                    .context("run darwin build check")?;
-            if !passed {
-                anyhow::bail!(
-                    "darwin build check failed after deleting the secret:\n{}{}",
-                    stdout,
-                    stderr
-                );
-            }
+            verify_dry_build_for_secret_edit(config_dir, host_attr, "deleting the secret")?;
 
             if load_sops_secrets(host_attr, config_dir)
                 .map_err(|error| anyhow!(error))?
@@ -137,8 +361,10 @@ fn delete_sops_secret(
         })();
 
         if operation.is_err() {
-            let _ = crate::git::restore_file(config_dir, &encrypted_file);
-            let _ = crate::git::restore_file(config_dir, &declaration_rel);
+            restore_repo_files_on_failure(
+                config_dir,
+                &[encrypted_file.as_str(), declaration_rel.as_str()],
+            );
         }
         operation
     })()
@@ -151,17 +377,334 @@ fn remove_sops_declaration(
     relative_file: &str,
     secret_id: &str,
 ) -> anyhow::Result<()> {
-    let path = crate::evolve::file_ops::resolve_existing_path_in_dir(base, relative_file)?;
-    let content = std::fs::read_to_string(&path).context("read SOPS declaration module")?;
     let attrpath = format!("sops.secrets.\"{secret_id}\"");
-    let updated = crate::evolve::nix_file_editor::remove_attrpath(&content, &attrpath)
-        .with_context(|| format!("remove SOPS declaration '{secret_id}'"))?;
-    std::fs::write(&path, updated).context("write SOPS declaration module")?;
-    let config_dir = base.to_string_lossy();
-    if let Err(error) = crate::system::nix::nix_format(&config_dir, relative_file) {
-        log::warn!("Failed to format {relative_file} after deleting a secret: {error}");
+    crate::evolve::nix_file_editor::remove_attrpath_in_file(base, relative_file, &attrpath, true)
+        .with_context(|| format!("remove SOPS declaration '{attrpath}'"))
+}
+
+/// Add an agenix secret to the configured repo, returning the result.
+/// Requires that the repository is clean and that the secret does not already exist.
+/// If the operation fails, it attempts to restore the repository to its original state.
+fn add_age_secret(
+    host_attr: &str,
+    config_dir: &str,
+    secret_id: &str,
+    value: &str,
+) -> anyhow::Result<AddSecretResult> {
+    validate_new_secret(secret_id, value)?;
+    ensure_clean_repo(config_dir)?;
+
+    let base = Path::new(config_dir);
+    let vault = load_secrets_vault(host_attr, config_dir).map_err(|error| anyhow!(error))?;
+    if vault.entries.iter().any(|secret| secret.id == secret_id) {
+        anyhow::bail!("Secret declaration '{secret_id}' already exists");
     }
-    Ok(())
+
+    // Steps:
+    // 1. Encrypt the secret value with age and write it to a new file in the repository.
+    // 2. Add a new rule to the agenix rules file that points to the encrypted file and lists the recipients.
+    // 3. Add a new declaration to the agenix declaration module that points to the encrypted file.
+
+    let rules_file = find_agenix_rules_file(base)?;
+    let declaration_file = find_agenix_declaration_file(base)?;
+    let rules_rel = repo_relative_path_string(base, &rules_file)?;
+    let declaration_rel = repo_relative_path_string(base, &declaration_file)?;
+    let encrypted_rel = format!("secrets/{secret_id}.age");
+    let encrypted_path = base.join(&encrypted_rel);
+    if encrypted_path.exists() {
+        anyhow::bail!("Encrypted file '{encrypted_rel}' already exists");
+    }
+
+    let recipients = vault
+        .recipients
+        .iter()
+        .filter(|recipient| {
+            recipient
+                .registrations
+                .iter()
+                .any(|registration| registration.backend == SecretBackend::Agenix)
+        })
+        .map(|recipient| recipient.public_key.clone())
+        .collect::<Vec<_>>();
+    if recipients.is_empty() {
+        anyhow::bail!(
+            "No agenix recipients were found in {}. Register at least one public key before adding a secret.",
+            rules_rel
+        );
+    }
+
+    let operation = (|| -> anyhow::Result<AddSecretResult> {
+        encrypt_age_secret(config_dir, &encrypted_rel, value.as_bytes(), &recipients)?;
+        declare_agenix_rule(base, &rules_file, &encrypted_rel, &recipients)?;
+        declare_agenix_secret(base, &declaration_file, secret_id, &encrypted_rel)?;
+
+        verify_dry_build_for_secret_edit(config_dir, host_attr, "adding the secret")?;
+
+        let reloaded_vault =
+            load_secrets_vault(host_attr, config_dir).map_err(|error| anyhow!(error))?;
+        let declared = reloaded_vault
+            .entries
+            .iter()
+            .find(|secret| secret.backend == SecretBackend::Agenix && secret.id == secret_id);
+        let Some(declared) = declared else {
+            anyhow::bail!(
+                "The edited agenix declaration was not present in the evaluated host configuration"
+            );
+        };
+        if !declared.public_recipients_resolved
+            || !recipients
+                .iter()
+                .all(|recipient| declared.public_recipients.contains(recipient))
+        {
+            anyhow::bail!(
+                "The new agenix rule did not resolve to every recipient used for encryption"
+            );
+        }
+
+        let commit = crate::git::commit_files(
+            config_dir,
+            &[&encrypted_rel, &rules_rel, &declaration_rel],
+            &format!("secrets: add {secret_id} (agenix)"),
+        )
+        .context("commit agenix secret")?;
+
+        Ok(AddSecretResult {
+            secret_id: secret_id.to_string(),
+            encrypted_file: encrypted_rel.clone(),
+            declaration_file: declaration_rel.clone(),
+            runtime_path: format!("/run/agenix/{secret_id}"),
+            commit_hash: commit.hash,
+        })
+    })();
+
+    if operation.is_err() {
+        restore_repo_files_on_failure(
+            config_dir,
+            &[
+                encrypted_rel.as_str(),
+                rules_rel.as_str(),
+                declaration_rel.as_str(),
+            ],
+        );
+    }
+    operation
+}
+
+/// Locate the classic agenix rules file that nixmac can safely edit and commit.
+fn find_agenix_rules_file(base: &Path) -> anyhow::Result<PathBuf> {
+    let configured = std::env::var_os("RULES").filter(|value| !value.is_empty());
+    let candidate = configured
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                base.join(path)
+            }
+        })
+        .or_else(|| {
+            ["secrets.nix", "secrets/secrets.nix"]
+                .into_iter()
+                .map(|path| base.join(path))
+                .find(|path| path.is_file())
+        })
+        .ok_or_else(|| {
+            anyhow!("Could not find classic agenix rules at secrets.nix or secrets/secrets.nix")
+        })?;
+    let resolved = candidate
+        .canonicalize()
+        .with_context(|| format!("resolve agenix rules file {}", candidate.display()))?;
+    if !resolved.is_file() {
+        anyhow::bail!(
+            "Agenix rules path {} is not a regular file",
+            resolved.display()
+        );
+    }
+    let base_resolved = base
+        .canonicalize()
+        .with_context(|| format!("resolve repository {}", base.display()))?;
+    let relative = repo_relative_path(&base_resolved, &resolved).with_context(|| {
+        format!(
+            "Agenix rules file {} is outside the repository and cannot be committed",
+            resolved.display()
+        )
+    })?;
+    Ok(base.join(relative))
+}
+
+/// Find the Nix module that owns `age.secrets` declarations.
+fn find_agenix_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
+    const STANDARD_AGENIX_MODULE: &str = "modules/darwin/agenix-secrets.nix";
+    find_secret_declaration_file(base, STANDARD_AGENIX_MODULE, "age.secrets", "agenix")
+}
+
+/// Find a Nix module that contains a specific secret declaration, preferring the standard module path if it exists and is visible.
+fn find_secret_declaration_file(
+    base: &Path,
+    standard_relative: &str,
+    declaration_marker: &str,
+    backend_name: &str,
+) -> anyhow::Result<PathBuf> {
+    let visible = GitignoreChecker::new(base)?
+        .map(|checker| checker.visible_files())
+        .transpose()?;
+    let standard = base.join(standard_relative);
+    if standard.is_file()
+        && visible
+            .as_ref()
+            .is_none_or(|files| files.contains_file(Path::new(standard_relative)))
+    {
+        resolve_existing_path_in_dir(base, standard_relative)
+            .with_context(|| format!("resolve {standard_relative}"))?;
+        return Ok(standard);
+    }
+    let candidates = walkdir::WalkDir::new(base)
+        .into_iter()
+        .filter_entry(|entry| {
+            if entry.depth() == 0 {
+                return true;
+            }
+            let Ok(relative) = entry.path().strip_prefix(base) else {
+                return false;
+            };
+            visible.as_ref().is_none_or(|files| {
+                if entry.file_type().is_dir() {
+                    files.contains_dir(relative)
+                } else {
+                    files.contains_file(relative)
+                }
+            })
+        })
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry.file_type().is_file() && entry.path().extension().is_some_and(|ext| ext == "nix")
+        })
+        .filter_map(|entry| {
+            std::fs::read_to_string(entry.path())
+                .ok()
+                .filter(|text| text.contains(declaration_marker))
+                .map(|_| entry.into_path())
+        })
+        .collect::<Vec<_>>();
+    match candidates.as_slice() {
+        [path] => Ok(path.clone()),
+        [] => anyhow::bail!("Could not find a Nix module containing {declaration_marker}"),
+        _ => anyhow::bail!(
+            "Found multiple Nix modules containing {declaration_marker}; expected one {backend_name} declaration module"
+        ),
+    }
+}
+
+/// Encrypt a plaintext secret with age and write it to the specified relative path in the repository.
+/// The plaintext is sent to age over stdin and is never written to disk.
+fn encrypt_age_secret(
+    config_dir: &str,
+    relative_path: &str,
+    plaintext: &[u8],
+    recipients: &[String],
+) -> anyhow::Result<()> {
+    let mut command = age_encrypt_command(config_dir, recipients);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().context("execute age encrypt")?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("open age stdin"))?
+        .write_all(plaintext)
+        .context("send plaintext to age")?;
+    let output = child.wait_with_output().context("wait for age encrypt")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "age encryption failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let target = crate::evolve::file_ops::resolve_path_in_dir_allow_create(
+        Path::new(config_dir),
+        relative_path,
+    )?;
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(target, output.stdout).context("write encrypted age file")
+}
+
+/// Build a command to encrypt a secret with age, using the configured recipients.
+fn age_encrypt_command(config_dir: &str, recipients: &[String]) -> std::process::Command {
+    let mut command = nix_command(config_dir);
+    command.args(["shell", "nixpkgs#age", "-c", "age", "--encrypt"]);
+    for recipient in recipients {
+        command.args(["--recipient", recipient]);
+    }
+    command
+}
+
+/// Add a new agenix rule to the rules file, pointing to the specified encrypted file and listing the recipients.
+/// The rule is added as a top-level attribute with the path to the encrypted file as its value, and a `publicKeys` attribute listing the recipients.
+fn declare_agenix_rule(
+    base: &Path,
+    rules_file: &Path,
+    encrypted_relative: &str,
+    recipients: &[String],
+) -> anyhow::Result<()> {
+    let rules_rel = repo_relative_path_string(base, rules_file)?;
+    let rules_dir = repo_relative_path(base, rules_file.parent().unwrap_or(base))?;
+    let rule_path = relative_path_between(&rules_dir, Path::new(encrypted_relative))?
+        .to_string_lossy()
+        .replace('\\', "/");
+    let mut attrs = serde_json::Map::new();
+    attrs.insert("publicKeys".to_string(), serde_json::json!(recipients));
+    crate::evolve::nix_file_editor::apply_semantic_edit(
+        base,
+        &SemanticFileEdit {
+            path: rules_rel,
+            action: FileEditAction::SetAttrs {
+                path: serde_json::to_string(&rule_path).expect("serialize agenix rule key"),
+                attrs,
+            },
+        },
+        true,
+        None,
+    )
+}
+
+/// Add a new agenix secret declaration to the declaration module, pointing to the specified encrypted file.
+/// The declaration is added as a top-level attribute under `age.secrets` with the secret ID as its key and a `file` attribute pointing to the encrypted file.
+fn declare_agenix_secret(
+    base: &Path,
+    declaration_file: &Path,
+    secret_id: &str,
+    encrypted_relative: &str,
+) -> anyhow::Result<()> {
+    let declaration_rel = repo_relative_path_string(base, declaration_file)?;
+    let from = repo_relative_path(base, declaration_file.parent().unwrap_or(base))?;
+    let secret_path = relative_path_between(&from, Path::new(encrypted_relative))?;
+    let rendered_path = secret_path.to_string_lossy().replace('\\', "/");
+    let rendered_path = if rendered_path.starts_with('.') {
+        rendered_path
+    } else {
+        format!("./{rendered_path}")
+    };
+    let mut attrs = serde_json::Map::new();
+    attrs.insert(
+        "file".to_string(),
+        crate::evolve::nix_file_editor::nix_builtins_path_meta_value(&rendered_path),
+    );
+    crate::evolve::nix_file_editor::apply_semantic_edit(
+        base,
+        &SemanticFileEdit {
+            path: declaration_rel,
+            action: FileEditAction::SetAttrs {
+                path: format!("age.secrets.\"{secret_id}\""),
+                attrs,
+            },
+        },
+        true,
+        None,
+    )
 }
 
 /// Add one value to its own SOPS YAML file, declare it in the
@@ -175,12 +718,7 @@ fn add_sops_secret(
     value: &str,
 ) -> anyhow::Result<AddSecretResult> {
     validate_new_secret(secret_id, value)?;
-    let status = crate::git::status(config_dir).context("inspect repository status")?;
-    if !status.clean_head {
-        anyhow::bail!(
-            "The repository has uncommitted changes. Commit or stash them before adding a secret so nixmac can roll back safely if verification fails."
-        );
-    }
+    ensure_clean_repo(config_dir)?;
 
     let base = Path::new(config_dir);
     if !base.join(".sops.yaml").is_file() && !base.join("sops.yaml").is_file() {
@@ -207,16 +745,7 @@ fn add_sops_secret(
         encrypt_sops_yaml(config_dir, &encrypted_file, plaintext.as_bytes())?;
         declare_sops_secret(base, &declaration_file, secret_id, &encrypted_file)?;
 
-        let (passed, stdout, stderr) =
-            crate::rebuild::dry_run_build_check(config_dir, host_attr, false)
-                .context("run darwin build check")?;
-        if !passed {
-            anyhow::bail!(
-                "darwin build check failed after adding the secret:\n{}{}",
-                stdout,
-                stderr
-            );
-        }
+        verify_dry_build_for_secret_edit(config_dir, host_attr, "adding the secret")?;
 
         // Reload the secrets vault to verify that the new secret is present and has the expected SOPS key.
         let declared = load_sops_secrets(host_attr, config_dir)
@@ -247,12 +776,17 @@ fn add_sops_secret(
     })();
 
     if operation.is_err() {
-        // The repository was clean at entry, so restoring these exact paths is
-        // sufficient and cannot discard unrelated user work.
-        let _ = crate::git::restore_file(config_dir, &encrypted_file);
-        if let Ok(declaration_rel) = repo_relative_path_string(base, &declaration_file) {
-            let _ = crate::git::restore_file(config_dir, &declaration_rel);
-        }
+        // The repo was clean at entry, and this helper restores only the files
+        // this operation owns. That keeps the rollback bounded to the secret edit
+        // and prevents accidentally discarding unrelated user work.
+        let declaration_rel = repo_relative_path_string(base, &declaration_file)
+            .ok()
+            .map(|path| path as String)
+            .unwrap_or_default();
+        restore_repo_files_on_failure(
+            config_dir,
+            &[encrypted_file.as_str(), declaration_rel.as_str()],
+        );
     }
     operation
 }
@@ -860,9 +1394,10 @@ fn secret(
 #[cfg(test)]
 mod tests {
     use super::{
-        AGENIX_DECRYPTION_FAILED, SOPS_DECRYPTION_FAILED, age_decrypt_command,
-        find_sops_declaration_file, managed_sops_file, readable_agenix_identity_paths,
-        relative_path_between, resolve_secret_file_path, sanitized_subprocess_error,
+        AGENIX_DECRYPTION_FAILED, SOPS_DECRYPTION_FAILED, age_decrypt_command, age_encrypt_command,
+        find_agenix_declaration_file, find_agenix_rules_file, find_sops_declaration_file,
+        managed_sops_file, matching_agenix_rule_key, readable_agenix_identity_paths,
+        relative_path_between, resolve_secret_file_path, sanitized_subprocess_error, secret,
         sops_decrypt_command, sops_extract_path, sops_plaintext, ssh_to_age_decrypt_command,
         validate_new_secret,
     };
@@ -1012,6 +1547,75 @@ mod tests {
     }
 
     #[test]
+    fn encrypt_invokes_age_with_every_registered_recipient() {
+        let command = age_encrypt_command(
+            "/tmp/config",
+            &[
+                "age1example".to_string(),
+                "ssh-ed25519 AAAAexample".to_string(),
+            ],
+        );
+        let args: Vec<&OsStr> = command.get_args().collect();
+
+        assert_eq!(
+            args,
+            [
+                OsStr::new("shell"),
+                OsStr::new("nixpkgs#age"),
+                OsStr::new("-c"),
+                OsStr::new("age"),
+                OsStr::new("--encrypt"),
+                OsStr::new("--recipient"),
+                OsStr::new("age1example"),
+                OsStr::new("--recipient"),
+                OsStr::new("ssh-ed25519 AAAAexample"),
+            ]
+        );
+    }
+
+    #[test]
+    fn agenix_rule_matching_handles_nix_store_file_names() {
+        let entry = secret(
+            "api-token",
+            "api-token",
+            crate::shared_types::SecretBackend::Agenix,
+            "/nix/store/abc123-api-token.age",
+            None,
+        );
+
+        assert_eq!(
+            matching_agenix_rule_key(
+                &["api-token.age".to_string(), "other.age".to_string()],
+                &entry,
+            )
+            .expect("match store-backed secret"),
+            "api-token.age"
+        );
+    }
+
+    #[test]
+    fn agenix_rule_matching_refuses_ambiguous_basenames() {
+        let entry = secret(
+            "api-token",
+            "api-token",
+            crate::shared_types::SecretBackend::Agenix,
+            "/nix/store/abc123-api-token.age",
+            None,
+        );
+
+        assert!(
+            matching_agenix_rule_key(
+                &[
+                    "hosts/a/api-token.age".to_string(),
+                    "hosts/b/api-token.age".to_string(),
+                ],
+                &entry,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn ssh_to_age_conversion_is_separate_from_native_age_attempt() {
         let identities = TempDir::new().expect("create identities dir");
         let ssh_identity = identities.path().join("ssh host key");
@@ -1124,6 +1728,26 @@ mod tests {
         assert_eq!(
             find_sops_declaration_file(config_dir.path()).expect("find module"),
             standard
+        );
+    }
+
+    #[test]
+    fn agenix_discovery_finds_conventional_rules_and_standard_module() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let rules = config_dir.path().join("secrets/secrets.nix");
+        fs::create_dir_all(rules.parent().unwrap()).expect("create secrets dir");
+        fs::write(&rules, "{ }").expect("write agenix rules");
+        let module = config_dir.path().join("modules/darwin/agenix-secrets.nix");
+        fs::create_dir_all(module.parent().unwrap()).expect("create module dir");
+        fs::write(&module, "{ age.secrets = {}; }").expect("write agenix module");
+
+        assert_eq!(
+            find_agenix_rules_file(config_dir.path()).expect("find agenix rules"),
+            rules
+        );
+        assert_eq!(
+            find_agenix_declaration_file(config_dir.path()).expect("find agenix module"),
+            module
         );
     }
 

--- a/apps/native/src-tauri/src/secrets/secrets_management.rs
+++ b/apps/native/src-tauri/src/secrets/secrets_management.rs
@@ -10,8 +10,8 @@ use crate::{
         identities::load_secret_identities,
         is_readable_file,
         recipients::{
-            apply_recipients_to_secrets_with_identities, load_recipients,
-            recipient_has_local_identity,
+            agenix_filename_matches, apply_recipients_to_secrets_with_identities,
+            discover_agenix_rules_path, load_recipients, recipient_has_local_identity,
         },
         resolve_secret_file_path, sanitized_subprocess_error,
     },
@@ -31,6 +31,7 @@ use std::{
 
 /// The path to the standard nix-darwin module that declares SOPS secrets.
 const STANDARD_SOPS_MODULE: &str = "modules/darwin/sops-secrets.nix";
+const STANDARD_AGENIX_MODULE: &str = "modules/darwin/agenix-secrets.nix";
 
 /// Returns the repository-relative path used for a SOPS secret.
 fn managed_sops_file(secret_id: &str) -> String {
@@ -263,7 +264,7 @@ fn matching_agenix_rule_key(rule_keys: &[String], secret: &SecretEntry) -> anyho
                 Path::new(key)
                     .file_name()
                     .and_then(|name| name.to_str())
-                    .is_some_and(|basename| secret.file.ends_with(basename))
+                    .is_some_and(|basename| agenix_filename_matches(&secret.file, basename))
             })
             .cloned()
             .collect::<Vec<_>>()
@@ -292,7 +293,7 @@ fn remove_agenix_rule(base: &Path, relative_file: &str, rule_key: &str) -> anyho
         .with_context(|| format!("remove agenix rule '{attrpath}'"))
 }
 
-/// Remove an agenix declaration for a specific secret from the rules file, returning an error if the declaration was not found.
+/// Remove an agenix declaration for a specific secret from the declaration module, returning an error if the declaration was not found.
 fn remove_agenix_declaration(
     base: &Path,
     relative_file: &str,
@@ -492,22 +493,8 @@ fn add_age_secret(
 
 /// Locate the classic agenix rules file that nixmac can safely edit and commit.
 fn find_agenix_rules_file(base: &Path) -> anyhow::Result<PathBuf> {
-    let configured = std::env::var_os("RULES").filter(|value| !value.is_empty());
-    let candidate = configured
-        .map(PathBuf::from)
-        .map(|path| {
-            if path.is_absolute() {
-                path
-            } else {
-                base.join(path)
-            }
-        })
-        .or_else(|| {
-            ["secrets.nix", "secrets/secrets.nix"]
-                .into_iter()
-                .map(|path| base.join(path))
-                .find(|path| path.is_file())
-        })
+    let candidate = discover_agenix_rules_path(base)
+        .map_err(|error| anyhow!(error))?
         .ok_or_else(|| {
             anyhow!("Could not find classic agenix rules at secrets.nix or secrets/secrets.nix")
         })?;
@@ -534,8 +521,12 @@ fn find_agenix_rules_file(base: &Path) -> anyhow::Result<PathBuf> {
 
 /// Find the Nix module that owns `age.secrets` declarations.
 fn find_agenix_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
-    const STANDARD_AGENIX_MODULE: &str = "modules/darwin/agenix-secrets.nix";
     find_secret_declaration_file(base, STANDARD_AGENIX_MODULE, "age.secrets", "agenix")
+}
+
+/// Find the Nix module that owns `sops.secrets` declarations.
+fn find_sops_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
+    find_secret_declaration_file(base, STANDARD_SOPS_MODULE, "sops.secrets", "SOPS")
 }
 
 /// Find a Nix module that contains a specific secret declaration, preferring the standard module path if it exists and is visible.
@@ -548,15 +539,29 @@ fn find_secret_declaration_file(
     let visible = GitignoreChecker::new(base)?
         .map(|checker| checker.visible_files())
         .transpose()?;
+    let nixmac_ignore = NixmacIgnoreChecker::new(base)?;
+    let standard_relative = Path::new(standard_relative);
     let standard = base.join(standard_relative);
     if standard.is_file()
         && visible
             .as_ref()
-            .is_none_or(|files| files.contains_file(Path::new(standard_relative)))
+            .is_none_or(|files| files.contains_file(standard_relative))
+        && !nixmac_ignore.is_ignored(standard_relative, false)
     {
-        resolve_existing_path_in_dir(base, standard_relative)
-            .with_context(|| format!("resolve {standard_relative}"))?;
-        return Ok(standard);
+        let resolved = resolve_existing_path_in_dir(
+            base,
+            standard_relative
+                .to_str()
+                .ok_or_else(|| anyhow!("standard declaration path is not valid UTF-8"))?,
+        )
+        .with_context(|| format!("resolve {}", standard_relative.display()))?;
+        if std::fs::read_to_string(&resolved).is_ok_and(|text| text.contains(declaration_marker)) {
+            let base_resolved = base
+                .canonicalize()
+                .with_context(|| format!("resolve repository {}", base.display()))?;
+            let relative = repo_relative_path(&base_resolved, &resolved)?;
+            return Ok(base.join(relative));
+        }
     }
     let candidates = walkdir::WalkDir::new(base)
         .into_iter()
@@ -567,13 +572,15 @@ fn find_secret_declaration_file(
             let Ok(relative) = entry.path().strip_prefix(base) else {
                 return false;
             };
-            visible.as_ref().is_none_or(|files| {
-                if entry.file_type().is_dir() {
-                    files.contains_dir(relative)
-                } else {
-                    files.contains_file(relative)
-                }
-            })
+            let is_dir = entry.file_type().is_dir();
+            !nixmac_ignore.is_ignored(relative, is_dir)
+                && visible.as_ref().is_none_or(|files| {
+                    if is_dir {
+                        files.contains_dir(relative)
+                    } else {
+                        files.contains_file(relative)
+                    }
+                })
         })
         .filter_map(Result::ok)
         .filter(|entry| {
@@ -590,7 +597,8 @@ fn find_secret_declaration_file(
         [path] => Ok(path.clone()),
         [] => anyhow::bail!("Could not find a Nix module containing {declaration_marker}"),
         _ => anyhow::bail!(
-            "Found multiple Nix modules containing {declaration_marker}; expected one {backend_name} declaration module"
+            "Found multiple Nix modules containing {declaration_marker}; expected {} for {backend_name}",
+            standard_relative.display()
         ),
     }
 }
@@ -886,65 +894,6 @@ fn apply_sops_identity(command: &mut std::process::Command, identity: Option<&De
                 command.env("SOPS_AGE_SSH_PRIVATE_KEY_FILE", &identity.path);
             }
         }
-    }
-}
-
-/// Finds the nix-darwin module that declares SOPS secrets.
-/// If the standard module exists, it is returned.
-/// Otherwise, the repository is searched for a module that contains `sops.secrets`.
-/// If multiple modules are found, an error is returned.
-fn find_sops_declaration_file(base: &Path) -> anyhow::Result<PathBuf> {
-    let visible = GitignoreChecker::new(base)?
-        .map(|checker| checker.visible_files())
-        .transpose()?;
-    let nixmac_ignore = NixmacIgnoreChecker::new(base)?;
-    let standard = base.join(STANDARD_SOPS_MODULE);
-    if standard.is_file()
-        && visible
-            .as_ref()
-            .is_none_or(|files| files.contains_file(Path::new(STANDARD_SOPS_MODULE)))
-        && !nixmac_ignore.is_ignored(Path::new(STANDARD_SOPS_MODULE), false)
-    {
-        resolve_existing_path_in_dir(base, STANDARD_SOPS_MODULE)
-            .with_context(|| format!("resolve {STANDARD_SOPS_MODULE}"))?;
-        return Ok(standard);
-    }
-    let candidates = walkdir::WalkDir::new(base)
-        .into_iter()
-        .filter_entry(|entry| {
-            if entry.depth() == 0 {
-                return true;
-            }
-            let Ok(relative) = entry.path().strip_prefix(base) else {
-                return false;
-            };
-            let is_dir = entry.file_type().is_dir();
-            !nixmac_ignore.is_ignored(relative, is_dir)
-                && visible.as_ref().is_none_or(|files| {
-                    if is_dir {
-                        files.contains_dir(relative)
-                    } else {
-                        files.contains_file(relative)
-                    }
-                })
-        })
-        .filter_map(Result::ok)
-        .filter(|entry| {
-            entry.file_type().is_file() && entry.path().extension().is_some_and(|ext| ext == "nix")
-        })
-        .filter_map(|entry| {
-            std::fs::read_to_string(entry.path())
-                .ok()
-                .filter(|text| text.contains("sops.secrets"))
-                .map(|_| entry.into_path())
-        })
-        .collect::<Vec<_>>();
-    match candidates.as_slice() {
-        [path] => Ok(path.clone()),
-        [] => anyhow::bail!("Could not find a Nix module containing sops.secrets"),
-        _ => anyhow::bail!(
-            "Found multiple Nix modules containing sops.secrets; expected {STANDARD_SOPS_MODULE}"
-        ),
     }
 }
 
@@ -1580,7 +1529,7 @@ mod tests {
             "api-token",
             "api-token",
             crate::shared_types::SecretBackend::Agenix,
-            "/nix/store/abc123-api-token.age",
+            "/nix/store/0123456789abcdfghijklmnpqrsvwxyz-api-token.age",
             None,
         );
 
@@ -1600,7 +1549,7 @@ mod tests {
             "api-token",
             "api-token",
             crate::shared_types::SecretBackend::Agenix,
-            "/nix/store/abc123-api-token.age",
+            "/nix/store/0123456789abcdfghijklmnpqrsvwxyz-api-token.age",
             None,
         );
 
@@ -1614,6 +1563,24 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn agenix_rule_matching_ignores_partial_filename_suffixes() {
+        let entry = secret(
+            "api-token",
+            "api-token",
+            crate::shared_types::SecretBackend::Agenix,
+            "/nix/store/0123456789abcdfghijklmnpqrsvwxyz-api-token.age",
+            None,
+        );
+
+        assert_eq!(
+            matching_agenix_rule_key(&["n.age".to_string(), "api-token.age".to_string()], &entry,)
+                .expect("ignore partial filename suffix"),
+            "api-token.age"
+        );
+        assert!(matching_agenix_rule_key(&["n.age".to_string()], &entry).is_err());
     }
 
     #[test]
@@ -1733,6 +1700,40 @@ mod tests {
     }
 
     #[test]
+    fn declaration_discovery_skips_a_standard_module_without_the_marker() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let standard = config_dir.path().join("modules/darwin/agenix-secrets.nix");
+        fs::create_dir_all(standard.parent().unwrap()).expect("create module dir");
+        fs::write(&standard, "{ services.example.enable = true; }")
+            .expect("write unrelated standard module");
+        let declaration = config_dir.path().join("hosts/agenix.nix");
+        fs::create_dir_all(declaration.parent().unwrap()).expect("create declaration dir");
+        fs::write(&declaration, "{ age.secrets = {}; }").expect("write declaration module");
+
+        assert_eq!(
+            find_agenix_declaration_file(config_dir.path()).expect("find declaration module"),
+            declaration
+        );
+    }
+
+    #[test]
+    fn declaration_discovery_returns_the_resolved_standard_module_target() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let target = config_dir.path().join("modules/shared/sops-secrets.nix");
+        fs::create_dir_all(target.parent().unwrap()).expect("create target dir");
+        fs::write(&target, "{ sops.secrets = {}; }").expect("write target module");
+        let standard = config_dir.path().join("modules/darwin/sops-secrets.nix");
+        fs::create_dir_all(standard.parent().unwrap()).expect("create standard dir");
+        std::os::unix::fs::symlink("../shared/sops-secrets.nix", &standard)
+            .expect("link standard module");
+
+        assert_eq!(
+            find_sops_declaration_file(config_dir.path()).expect("find standard module"),
+            target
+        );
+    }
+
+    #[test]
     fn agenix_discovery_finds_conventional_rules_and_standard_module() {
         let config_dir = TempDir::new().expect("create config dir");
         let rules = config_dir.path().join("secrets/secrets.nix");
@@ -1774,6 +1775,23 @@ mod tests {
             relative_nix_path_between(Path::new("hosts/workstation/modules"), Path::new("secrets"))
                 .expect("render encrypted directory from declaration"),
             "../../../secrets"
+        );
+    }
+
+    #[test]
+    fn agenix_declaration_discovery_excludes_nixmac_ignored_modules() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let ignored = config_dir.path().join("private/agenix.nix");
+        fs::create_dir_all(ignored.parent().unwrap()).expect("create ignored dir");
+        fs::write(&ignored, "{ age.secrets = {}; }").expect("write ignored module");
+        fs::write(config_dir.path().join(".nixmacignore"), "private/\n")
+            .expect("write nixmacignore");
+        let visible = config_dir.path().join("visible.nix");
+        fs::write(&visible, "{ age.secrets = {}; }").expect("write visible module");
+
+        assert_eq!(
+            find_agenix_declaration_file(config_dir.path()).expect("find visible module"),
+            visible
         );
     }
 

--- a/apps/native/src-tauri/src/shared_types/secrets_management.rs
+++ b/apps/native/src-tauri/src/shared_types/secrets_management.rs
@@ -138,6 +138,9 @@ pub struct SecretRecipient {
 #[serde(rename_all = "camelCase")]
 pub struct SecretsVault {
     pub primary_decryption_identity_id: Option<String>,
+    pub agenix_rules_file: Option<String>,
+    pub agenix_declaration_file: Option<String>,
+    pub agenix_encrypted_directory_from_declaration: Option<String>,
     pub entries: Vec<SecretEntry>,
     pub recipients: Vec<SecretRecipient>,
     pub decryption_identities: Vec<DecryptionIdentity>,

--- a/apps/native/src/components/widget/secrets/add-secret-view.test.ts
+++ b/apps/native/src/components/widget/secrets/add-secret-view.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { SecretsVault } from "@/ipc/orpc-bindings";
+import { buildAddRequest } from "./add-secret-view";
+
+const vault = (declarationFile: string, encryptedDirectory: string): SecretsVault =>
+  ({
+    agenixRulesFile: "secrets/secrets.nix",
+    agenixDeclarationFile: declarationFile,
+    agenixEncryptedDirectoryFromDeclaration: encryptedDirectory,
+  }) as SecretsVault;
+
+describe("agenix add preview", () => {
+  it("matches the standard declaration module path", () => {
+    const request = buildAddRequest(
+      "api-token",
+      "agenix",
+      vault("modules/darwin/agenix-secrets.nix", "../../secrets"),
+    );
+
+    expect(request.diffFile).toBe("modules/darwin/agenix-secrets.nix");
+    expect(request.diff).toContainEqual({
+      kind: "added",
+      text: '+ age.secrets."api-token".file = builtins.path { path = ../../secrets/api-token.age; };',
+    });
+  });
+
+  it("derives the path from a non-standard declaration module", () => {
+    const request = buildAddRequest(
+      "api-token",
+      "agenix",
+      vault("hosts/workstation/modules/security.nix", "../../../secrets"),
+    );
+
+    expect(request.diffFile).toBe("hosts/workstation/modules/security.nix");
+    expect(request.diff).toContainEqual({
+      kind: "added",
+      text: '+ age.secrets."api-token".file = builtins.path { path = ../../../secrets/api-token.age; };',
+    });
+  });
+
+  it("uses an explicit backend-provided path for a declaration at the repository root", () => {
+    const request = buildAddRequest("api-token", "agenix", vault("agenix.nix", "./secrets"));
+    expect(request.diff).toContainEqual({
+      kind: "added",
+      text: '+ age.secrets."api-token".file = builtins.path { path = ./secrets/api-token.age; };',
+    });
+  });
+});

--- a/apps/native/src/components/widget/secrets/add-secret-view.tsx
+++ b/apps/native/src/components/widget/secrets/add-secret-view.tsx
@@ -9,9 +9,32 @@ import { cn } from "@/lib/utils";
 import { recipientKindLabel, RecipientKindIcon, ViewHeader } from "./shared";
 import { type ApplyRequest, slugifySecretName } from "./types";
 
-function buildAddRequest(slug: string): ApplyRequest {
+function buildAddRequest(slug: string, backend: SecretBackend): ApplyRequest {
+  if (backend === "agenix") {
+    return {
+      origin: "add",
+      backend,
+      title: "Encrypt & commit",
+      subtitle: `New secret · ${slug}`,
+      files: [
+        { path: `secrets/${slug}.age`, note: "· encrypted", mark: "+" },
+        { path: "agenix rules", note: "· recipients added", mark: "~" },
+        { path: "agenix secrets module", note: "· declaration added", mark: "~" },
+      ],
+      diffFile: "agenix secrets module",
+      diff: [
+        { kind: "meta", text: "@@ agenix @@" },
+        { kind: "added", text: `+ age.secrets."${slug}".file = ../../secrets/${slug}.age;` },
+      ],
+      commit: "",
+      commitMsg: `secrets: add ${slug} (agenix)`,
+    };
+  }
+
+  // SOPS backend
   return {
     origin: "add",
+    backend,
     title: "Encrypt & commit",
     subtitle: `New secret · ${slug}`,
     files: [
@@ -30,7 +53,7 @@ function buildAddRequest(slug: string): ApplyRequest {
 }
 
 /**
- * The SOPS add-secret form: name, value, runtime path preview, and the
+ * The add-secret form: backend, name, value, runtime path preview, and the
  * recipients derived from repository configuration. Submitting hands a
  * ready-to-review {@link ApplyRequest} and plaintext payload to the caller.
  */
@@ -40,23 +63,25 @@ export function AddSecretView({
   onBack,
 }: {
   vault: SecretsVault;
-  onSubmit: (request: ApplyRequest, secret: { secretId: string; value: string, backend: SecretBackend }) => void;
+  onSubmit: (request: ApplyRequest, secret: { secretId: string; value: string; backend: SecretBackend }) => void;
   onBack: () => void;
 }) {
-  const committedRecipients = vault.recipients.filter((r) => r.inUse);
-
   const [name, setName] = useState("");
   const [value, setValue] = useState("");
   const [hidden, setHidden] = useState(true);
+  const [backend, setBackend] = useState<SecretBackend>("sops");
 
   const slug = slugifySecretName(name);
-  const encryptTarget = `secrets/secrets.yaml  ›  ${slug}`;
-  const runtimePath = `/run/secrets/${slug}`;
+  const encryptTarget = backend === "agenix" ? `secrets/${slug}.age` : `secrets/secrets.yaml  ›  ${slug}`;
+  const runtimePath = backend === "agenix" ? `/run/agenix/${slug}` : `/run/secrets/${slug}`;
   const invalid = !name.trim() || !value.trim();
+  const committedRecipients = vault.recipients.filter((recipient) =>
+    recipient.registrations.some((registration) => registration.backend === backend),
+  );
 
   const submit = () => {
     if (invalid) return;
-    onSubmit(buildAddRequest(slug), { secretId: slug, value, backend: "sops" });
+    onSubmit(buildAddRequest(slug, backend), { secretId: slug, value, backend });
   };
 
   return (
@@ -78,12 +103,27 @@ export function AddSecretView({
       <div>
         <div className="mb-1.5 flex items-center justify-between">
           <span className="font-medium text-xs">Backend</span>
-          <div className="inline-flex rounded-md border border-border bg-muted px-2.5 py-1 font-medium font-mono text-[11px]">
-            sops-nix
+          <div className="inline-flex rounded-md border border-border bg-muted p-0.5">
+            {(["sops", "agenix"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={backend === option}
+                onClick={() => setBackend(option)}
+                className={cn(
+                  "cursor-pointer rounded px-2.5 py-1 font-medium font-mono text-[11px] transition-colors",
+                  backend === option ? "bg-background text-foreground shadow-sm" : "text-muted-foreground",
+                )}
+              >
+                {option === "sops" ? "sops-nix" : "agenix"}
+              </button>
+            ))}
           </div>
         </div>
         <p className="text-[11px] text-muted-foreground">
-          YAML encrypted with the repository&apos;s SOPS creation rules. Agenix support will be added later.
+          {backend === "agenix"
+            ? "One age-encrypted file, using the recipients in the repository's agenix rules."
+            : "YAML encrypted with the repository's SOPS creation rules."}
         </p>
       </div>
 
@@ -127,9 +167,14 @@ export function AddSecretView({
       <div>
         <span className="mb-1 block font-medium text-xs">Recipients — who can decrypt</span>
         <p className="mb-2 text-[11px] text-muted-foreground">
-          Encryption uses the recipients in the matching <code className="font-mono">.sops.yaml</code> creation rule.
+          Encryption uses the recipients registered in the repository&apos;s {backend === "agenix" ? "agenix rules" : <code className="font-mono">.sops.yaml</code>}.
         </p>
         <div className="flex flex-col gap-1.5">
+          {committedRecipients.length === 0 && (
+            <p className="rounded-[9px] border border-border px-3 py-2 text-[11px] text-muted-foreground">
+              No recipients are registered for this backend. Adding the secret will fail until one is configured.
+            </p>
+          )}
           {committedRecipients.map((recipient) => {
             return (
               <div

--- a/apps/native/src/components/widget/secrets/add-secret-view.tsx
+++ b/apps/native/src/components/widget/secrets/add-secret-view.tsx
@@ -9,22 +9,40 @@ import { cn } from "@/lib/utils";
 import { recipientKindLabel, RecipientKindIcon, ViewHeader } from "./shared";
 import { type ApplyRequest, slugifySecretName } from "./types";
 
-function buildAddRequest(slug: string, backend: SecretBackend): ApplyRequest {
+export function buildAddRequest(
+  slug: string,
+  backend: SecretBackend,
+  vault: SecretsVault,
+): ApplyRequest {
   if (backend === "agenix") {
+    if (
+      !vault.agenixRulesFile ||
+      !vault.agenixDeclarationFile ||
+      !vault.agenixEncryptedDirectoryFromDeclaration
+    ) {
+      throw new Error(
+        "The repository's agenix rules and declaration module must be discoverable before reviewing this change.",
+      );
+    }
+    const encryptedFile = `secrets/${slug}.age`;
+    const declarationPath = `${vault.agenixEncryptedDirectoryFromDeclaration}/${slug}.age`;
     return {
       origin: "add",
       backend,
       title: "Encrypt & commit",
       subtitle: `New secret · ${slug}`,
       files: [
-        { path: `secrets/${slug}.age`, note: "· encrypted", mark: "+" },
-        { path: "agenix rules", note: "· recipients added", mark: "~" },
-        { path: "agenix secrets module", note: "· declaration added", mark: "~" },
+        { path: encryptedFile, note: "· encrypted", mark: "+" },
+        { path: vault.agenixRulesFile, note: "· recipients added", mark: "~" },
+        { path: vault.agenixDeclarationFile, note: "· declaration added", mark: "~" },
       ],
-      diffFile: "agenix secrets module",
+      diffFile: vault.agenixDeclarationFile,
       diff: [
         { kind: "meta", text: "@@ agenix @@" },
-        { kind: "added", text: `+ age.secrets."${slug}".file = ../../secrets/${slug}.age;` },
+        {
+          kind: "added",
+          text: `+ age.secrets."${slug}".file = builtins.path { path = ${declarationPath}; };`,
+        },
       ],
       commit: "",
       commitMsg: `secrets: add ${slug} (agenix)`,
@@ -63,7 +81,10 @@ export function AddSecretView({
   onBack,
 }: {
   vault: SecretsVault;
-  onSubmit: (request: ApplyRequest, secret: { secretId: string; value: string; backend: SecretBackend }) => void;
+  onSubmit: (
+    request: ApplyRequest,
+    secret: { secretId: string; value: string; backend: SecretBackend },
+  ) => void;
   onBack: () => void;
 }) {
   const [name, setName] = useState("");
@@ -72,16 +93,23 @@ export function AddSecretView({
   const [backend, setBackend] = useState<SecretBackend>("sops");
 
   const slug = slugifySecretName(name);
-  const encryptTarget = backend === "agenix" ? `secrets/${slug}.age` : `secrets/secrets.yaml  ›  ${slug}`;
+  const encryptTarget =
+    backend === "agenix" ? `secrets/${slug}.age` : `secrets/secrets.yaml  ›  ${slug}`;
   const runtimePath = backend === "agenix" ? `/run/agenix/${slug}` : `/run/secrets/${slug}`;
-  const invalid = !name.trim() || !value.trim();
+  const agenixTargetsAvailable = Boolean(
+    vault.agenixRulesFile &&
+    vault.agenixDeclarationFile &&
+    vault.agenixEncryptedDirectoryFromDeclaration,
+  );
+  const invalid =
+    !name.trim() || !value.trim() || (backend === "agenix" && !agenixTargetsAvailable);
   const committedRecipients = vault.recipients.filter((recipient) =>
     recipient.registrations.some((registration) => registration.backend === backend),
   );
 
   const submit = () => {
     if (invalid) return;
-    onSubmit(buildAddRequest(slug, backend), { secretId: slug, value, backend });
+    onSubmit(buildAddRequest(slug, backend, vault), { secretId: slug, value, backend });
   };
 
   return (
@@ -112,7 +140,9 @@ export function AddSecretView({
                 onClick={() => setBackend(option)}
                 className={cn(
                   "cursor-pointer rounded px-2.5 py-1 font-medium font-mono text-[11px] transition-colors",
-                  backend === option ? "bg-background text-foreground shadow-sm" : "text-muted-foreground",
+                  backend === option
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground",
                 )}
               >
                 {option === "sops" ? "sops-nix" : "agenix"}
@@ -125,10 +155,18 @@ export function AddSecretView({
             ? "One age-encrypted file, using the recipients in the repository's agenix rules."
             : "YAML encrypted with the repository's SOPS creation rules."}
         </p>
+        {backend === "agenix" && !agenixTargetsAvailable && (
+          <p role="alert" className="mt-1 text-destructive text-[11px]">
+            Could not find both the agenix rules file and the module containing age.secrets.
+          </p>
+        )}
       </div>
 
       <div>
-        <label htmlFor="secret-value" className="mb-1.5 flex items-center justify-between font-medium text-xs">
+        <label
+          htmlFor="secret-value"
+          className="mb-1.5 flex items-center justify-between font-medium text-xs"
+        >
           Value
           <button
             type="button"
@@ -167,12 +205,14 @@ export function AddSecretView({
       <div>
         <span className="mb-1 block font-medium text-xs">Recipients — who can decrypt</span>
         <p className="mb-2 text-[11px] text-muted-foreground">
-          Encryption uses the recipients registered in the repository&apos;s {backend === "agenix" ? "agenix rules" : <code className="font-mono">.sops.yaml</code>}.
+          Encryption uses the recipients registered in the repository&apos;s{" "}
+          {backend === "agenix" ? "agenix rules" : <code className="font-mono">.sops.yaml</code>}.
         </p>
         <div className="flex flex-col gap-1.5">
           {committedRecipients.length === 0 && (
             <p className="rounded-[9px] border border-border px-3 py-2 text-[11px] text-muted-foreground">
-              No recipients are registered for this backend. Adding the secret will fail until one is configured.
+              No recipients are registered for this backend. Adding the secret will fail until one
+              is configured.
             </p>
           )}
           {committedRecipients.map((recipient) => {

--- a/apps/native/src/components/widget/secrets/apply-sheet.tsx
+++ b/apps/native/src/components/widget/secrets/apply-sheet.tsx
@@ -45,6 +45,13 @@ export function ApplySheet({
   onDone: () => void;
   error?: string | null;
 }) {
+  const encryptionBackend =
+    request.backend === "agenix"
+      ? "age"
+      : request.backend === "sops"
+        ? "SOPS"
+        : "the configured backend";
+
   return (
     /* backdrop click-to-dismiss mirrors the app's overlay pattern */
     <div
@@ -117,7 +124,8 @@ export function ApplySheet({
             <div className="flex items-center justify-between gap-3 pt-0.5">
               <span className="inline-flex items-center gap-1.5 text-muted-foreground text-xs">
                 <Shield className="size-3.5" aria-hidden="true" />
-                Encrypted with SOPS, then verified with darwin-rebuild before anything is committed.
+                Encrypted with {encryptionBackend}, then verified with darwin-rebuild before anything
+                is committed.
               </span>
               <div className="flex items-center gap-2">
                 <Button variant="ghost" size="sm" onClick={onCancel}>
@@ -143,7 +151,7 @@ export function ApplySheet({
             <div className="text-center">
               <div className="font-semibold text-[15px]">Applying changes</div>
               <div className="mt-1 text-[13px] text-muted-foreground">
-                Encrypting with SOPS · running{" "}
+                Encrypting with {encryptionBackend} · running{" "}
                 <code className="font-mono text-foreground">darwin-rebuild check</code>
               </div>
             </div>

--- a/apps/native/src/components/widget/secrets/mock-data.ts
+++ b/apps/native/src/components/widget/secrets/mock-data.ts
@@ -6,6 +6,9 @@ import type { SecretsVault } from "@/ipc/orpc-bindings";
  */
 export const MOCK_VAULT: SecretsVault = {
   primaryDecryptionIdentityId: "demo-mbp",
+  agenixRulesFile: "secrets/secrets.nix",
+  agenixDeclarationFile: "modules/darwin/agenix-secrets.nix",
+  agenixEncryptedDirectoryFromDeclaration: "../../secrets",
   decryptionIdentities: [
     {
       kind: "sshKeyPath",

--- a/apps/native/src/components/widget/secrets/secret-detail-view.tsx
+++ b/apps/native/src/components/widget/secrets/secret-detail-view.tsx
@@ -67,6 +67,9 @@ export function SecretDetailView({
   // deliberate, per-secret opt-in.
   const [toolEnabled, setToolEnabled] = useState(false);
   const toolSupported = secret.backend === "sops";
+  // SOPS deletion must decrypt and rewrite its shared YAML document. Agenix
+  // deletion removes an opaque per-secret file and does not need a local key.
+  const canDelete = secret.backend === "agenix" || capability !== "unavailable";
 
   const onToggleReveal = async () => {
     if (isRevealed) {
@@ -98,7 +101,7 @@ export function SecretDetailView({
   };
 
   const onDelete = async () => {
-    if (capability === "unavailable" || isDeleting) return;
+    if (!canDelete || isDeleting) return;
     setIsDeleting(true);
     setDeleteError(null);
     try {
@@ -282,7 +285,7 @@ export function SecretDetailView({
           variant="ghost"
           size="sm"
           className="text-destructive"
-          disabled={capability === "unavailable" || isDeleting}
+          disabled={!canDelete || isDeleting}
           onClick={() => {
             setDeleteError(null);
             setDeleteOpen(true);
@@ -303,8 +306,10 @@ export function SecretDetailView({
           <AlertDialogHeader>
             <AlertDialogTitle>Delete {secret.name}?</AlertDialogTitle>
             <AlertDialogDescription>
-              This removes the encrypted value and Nix declaration, verifies the configuration,
-              and commits the change. You can restore it later from Git history.
+              {secret.backend === "agenix"
+                ? "This removes the encrypted .age file, recipient rule, and Nix declaration, verifies the configuration, and commits the change."
+                : "This removes the encrypted value and Nix declaration, verifies the configuration, and commits the change."}{" "}
+              You can restore it later from Git history.
             </AlertDialogDescription>
           </AlertDialogHeader>
           {deleteError && (
@@ -315,7 +320,7 @@ export function SecretDetailView({
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              disabled={capability === "unavailable" || isDeleting}
+              disabled={!canDelete || isDeleting}
               onClick={(event) => {
                 event.preventDefault();
                 void onDelete();

--- a/apps/native/src/components/widget/secrets/secrets-management.tsx
+++ b/apps/native/src/components/widget/secrets/secrets-management.tsx
@@ -221,7 +221,7 @@ export function SecretsManagement({
         setPendingSecret(null);
         setApplyPhase("done");
       } catch (error) {
-        setApplyError(error instanceof Error ? error.message : "Failed to add SOPS secret");
+        setApplyError(error instanceof Error ? error.message : "Failed to add secret");
         setApplyPhase("review");
       } finally {
         applyInFlight.current = false;

--- a/apps/native/src/components/widget/secrets/types.ts
+++ b/apps/native/src/components/widget/secrets/types.ts
@@ -27,6 +27,8 @@ export interface ApplyFileChip {
 /** Payload for the review → build → commit sheet. */
 export interface ApplyRequest {
   origin: "add" | "rotate" | "prompt" | "register";
+  /** Encryption backend for requests that operate on one backend. */
+  backend?: SecretBackend;
   title: string;
   subtitle: string;
   plan?: string[];

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -1800,7 +1800,7 @@ export type SecretEntry = { id: string; name: string; backend: SecretBackend; fi
 
 export type SecretRecipient = { id: string; label: string; kind: RecipientKind; device: string; fingerprint: string; publicKey: string; keyType: RecipientKeyType; source: RecipientSource; inUse: boolean; registrations: RecipientRegistration[] }
 
-export type SecretsVault = { primaryDecryptionIdentityId: string | null; entries: SecretEntry[]; recipients: SecretRecipient[]; decryptionIdentities: DecryptionIdentity[] }
+export type SecretsVault = { primaryDecryptionIdentityId: string | null; agenixRulesFile: string | null; agenixDeclarationFile: string | null; agenixEncryptedDirectoryFromDeclaration: string | null; entries: SecretEntry[]; recipients: SecretRecipient[]; decryptionIdentities: DecryptionIdentity[] }
 
 /**
  * Backend-owned lifecycle for the derived secrets vault.

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -2118,7 +2118,7 @@ export type SecretEntry = { id: string; name: string; backend: SecretBackend; fi
 
 export type SecretRecipient = { id: string; label: string; kind: RecipientKind; device: string; fingerprint: string; publicKey: string; keyType: RecipientKeyType; source: RecipientSource; inUse: boolean; registrations: RecipientRegistration[] }
 
-export type SecretsVault = { primaryDecryptionIdentityId: string | null; entries: SecretEntry[]; recipients: SecretRecipient[]; decryptionIdentities: DecryptionIdentity[] }
+export type SecretsVault = { primaryDecryptionIdentityId: string | null; agenixRulesFile: string | null; agenixDeclarationFile: string | null; agenixEncryptedDirectoryFromDeclaration: string | null; entries: SecretEntry[]; recipients: SecretRecipient[]; decryptionIdentities: DecryptionIdentity[] }
 
 /**
  * Backend-owned lifecycle for the derived secrets vault.


### PR DESCRIPTION
## Summary

Implement the agenix secret add/delete analogous to what we did for SOPS. (Not including screenshots since there's no practical difference in the UI.)

Also includes some related DRY refactoring in secrets_management.rs and recipients.rs.

<!-- What does this PR do? Why? -->

## Test Plan

Some new unit tests where possible/appropriate, plus manual e2e testing with my test config repo.

- [ ] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\___)
- [x] No docs update needed