### PR TITLE
chore(nixmac-ds): reformat skill docs

### DIFF
--- a/.agent/skills/nixmac-ds/SKILL.md
+++ b/.agent/skills/nixmac-ds/SKILL.md
@@ -1,9 +1,6 @@
----
-name: nixmac-ds
-description: "The nixmac design system — a dark-first, monochrome-neutral UI language with a lime brand accent and a signature teal build glow, built for nixmac (an AI-powered nix-darwin config manager). Copy-in React components styled with inline styles over CSS-variable tokens (no Tailwind, no runtime deps beyond React). Use this whenever building any nixmac app or UI such as landing pages, dashboards, agent/diff review screens, settings, forms, onboarding, or any screen that should look and feel like nixmac. This is the canonical source for nixmac components, tokens, theming (dark + light), fonts, and layout — prefer it over generic shadcn/ui."
-metadata:
-  v0.kind: design-system
----
+______________________________________________________________________
+
+## name: nixmac-ds description: "The nixmac design system — a dark-first, monochrome-neutral UI language with a lime brand accent and a signature teal build glow, built for nixmac (an AI-powered nix-darwin config manager). Copy-in React components styled with inline styles over CSS-variable tokens (no Tailwind, no runtime deps beyond React). Use this whenever building any nixmac app or UI such as landing pages, dashboards, agent/diff review screens, settings, forms, onboarding, or any screen that should look and feel like nixmac. This is the canonical source for nixmac components, tokens, theming (dark + light), fonts, and layout — prefer it over generic shadcn/ui." metadata: v0.kind: design-system
 
 # nixmac design system
 
@@ -76,8 +73,8 @@ import {
 Before finishing any nixmac screen:
 
 1. Renders correctly in **dark** (the default); if a light toggle exists, verify light too.
-2. All colors/spacing/radii/type come from **tokens**, not literals.
-3. Components imported from `@/components/nixmac` (the barrel), and the rendering page/subtree is a **client component**.
-4. Machine text is **Geist Mono**; UI text is **Inter**.
-5. The teal glow appears only on the primary build/run action; the lime brand is used sparingly.
-6. Layout uses the system's spacing scale and stays responsive (see `foundations/spacing-layout.md`).
+1. All colors/spacing/radii/type come from **tokens**, not literals.
+1. Components imported from `@/components/nixmac` (the barrel), and the rendering page/subtree is a **client component**.
+1. Machine text is **Geist Mono**; UI text is **Inter**.
+1. The teal glow appears only on the primary build/run action; the lime brand is used sparingly.
+1. Layout uses the system's spacing scale and stays responsive (see `foundations/spacing-layout.md`).

--- a/.agent/skills/nixmac-ds/references/components/index.md
+++ b/.agent/skills/nixmac-ds/references/components/index.md
@@ -12,6 +12,7 @@
 | Brand | `NixmacMark` | `brand.md` |
 
 Conventions shared by all:
+
 - Styling is inline `style={{}}` over CSS-variable tokens; there are no `className` variants. To restyle, pass `style` (it wins) — but stick to tokens.
 - Controlled/uncontrolled: `Switch`, `Checkbox`, and `Tabs` support both (`checked`/`defaultChecked` + `onCheckedChange`; `value`/`defaultValue` + `onValueChange`).
 - Icons: pass lucide-react nodes to `icon` props (`BadgeButton`, `Alert`, `FileBadge`). Size them to the slot (12–16px).

--- a/.agent/skills/nixmac-ds/references/examples/agent-diff-review.md
+++ b/.agent/skills/nixmac-ds/references/examples/agent-diff-review.md
@@ -134,6 +134,7 @@ export function DiffReview() {
 ```
 
 Notes:
+
 - The container uses `repeat(auto-fit, minmax(320px, 1fr))` so the two cards sit side-by-side on desktop and stack on narrow screens — the token-driven responsiveness pattern from `foundations/spacing-layout.md`.
 - Diff line backgrounds are a 10% mix of the diff token over transparent; the glyph/text is the full-strength token. Never use plain green/red here.
 - `ButtonGlow` is the only glow on the screen — the build action.


### PR DESCRIPTION
Markdown auto-format run to fix failing CI checks.

## Summary

CI is red on main because of auto-formatting
Ran the auto-format

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
