### PR TITLE
test: prove frontend is always dev

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -256,6 +256,32 @@ jobs:
           VITE_SERVER_URL: ${{ secrets.VITE_SERVER_URL }}
           SUBMITTED_FEEDBACK_DSN: ${{ secrets.SUBMITTED_FEEDBACK_DSN }}
 
+      # TEMPORARY diagnostic — delete before merging. Reads the exact frontend
+      # bundle the step above embeds into the app and reports how the
+      # `__NIXMAC_PROFILE_JSON__` Vite define was substituted:
+      #   string literal  -> JSON.parse succeeds, the release profile is used
+      #   object literal  -> JSON.parse throws, src/lib/env.ts silently falls
+      #                      back to env.development.json (VITE_NIXMAC_SKIP_PERMISSIONS)
+      # Never fails the job; the verdict is in the log.
+      - name: TEMP prove profile define shape
+        working-directory: apps/native
+        shell: bash
+        run: |
+          set -uo pipefail
+          ls -la dist/assets/main-*.js
+          bundle=$(cat dist/assets/main-*.js)
+          # unquoted key => object literal (bug); quoted key => string literal (fixed)
+          object_literal=$(printf '%s' "$bundle" | grep -c -F ',NIXMAC_ENV:"' || true)
+          string_literal=$(printf '%s' "$bundle" | grep -c -F '"NIXMAC_ENV":"' || true)
+          echo "object-literal define occurrences: $object_literal"
+          echo "string-literal define occurrences: $string_literal"
+          printf '%s' "$bundle" | grep -o -E '.{0,40},NIXMAC_ENV:"[a-z]*".{0,40}' | head -2 || true
+          if [ "$object_literal" -gt 0 ]; then
+            echo "VERDICT: bug PRESENT — this production bundle runs on env.development.json"
+          else
+            echo "VERDICT: bug ABSENT — define is a string literal"
+          fi
+
       - name: Unit Test frontend
         working-directory: apps/native
         run: bun run test:unit

--- a/apps/native/src/lib/env.test.ts
+++ b/apps/native/src/lib/env.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { settings } from "./env";
+
+// A Vite `define` is raw text substitution. If its value is not itself a JSON
+// *string* literal, it lands in the bundle as a bare object literal and the
+// `JSON.parse(__NIXMAC_PROFILE_JSON__)` in ./env.ts throws on it. These tests
+// pin the encoding: vitest.config.ts applies the same defines as the app build
+// (`define: nixmacBuildDefines(import.meta.dirname)`).
+declare const __NIXMAC_PROFILE_JSON__: string;
+
+describe("__NIXMAC_PROFILE_JSON__ define", () => {
+  it("substitutes as a string literal, not an object literal", () => {
+    const raw: unknown = __NIXMAC_PROFILE_JSON__;
+    expect(typeof raw).toBe("string");
+  });
+
+  it("round-trips into settings, so no fallback profile was used", () => {
+    const parsed = JSON.parse(__NIXMAC_PROFILE_JSON__) as { NIXMAC_ENV: string };
+    expect(settings.nixmacEnv).toBe(parsed.NIXMAC_ENV);
+  });
+});


### PR DESCRIPTION
## Summary

Frontend always uses `apps/native/env.development.json` even in release builds

## Test Plan

- [ ] Fix in a separate PR
- [ ] Use this PR to verify it's fixed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
