### PR TITLE
feat(helper)!: detach activations, freeze wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "activation-runner"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,10 +3694,12 @@ dependencies = [
 name = "nixmac"
 version = "0.22.0"
 dependencies = [
+ "activation-runner",
  "anyhow",
  "async-openai",
  "async-trait",
  "backtrace",
+ "block2",
  "chrono",
  "clap",
  "cocoa",
@@ -3699,6 +3708,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dirs 5.0.1",
+ "dispatch2",
  "fancy-regex 0.17.0",
  "futures-util",
  "fuzzy-matcher",
@@ -3711,6 +3721,10 @@ dependencies = [
  "log",
  "nix",
  "objc",
+ "objc2",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-service-management",
  "once_cell",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -4064,6 +4078,30 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "apps/native/src-tauri",
   "apps/native/src-tauri/configurable",
   "apps/native/src-tauri/configurable-derive",
+  "apps/native/src-tauri/activation-runner",
   # Vendored Oh My Pi extracts — see crates/vendor/oh-my-pi/VENDOR.md
   "crates/vendor/oh-my-pi/pi-walker",
   "crates/vendor/oh-my-pi/pi-uutils-ctx",

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -22,6 +22,9 @@ required-features = ["codegen"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 serde_json = "1"
+# Writes the build-ID-stamped Info.plist the bundler merges; the crate reads the
+# same key back out of an installed bundle (`build_id.rs`).
+plist = "1.9.0"
 
 [dependencies]
 tauri = { version = "2", features = [
@@ -102,6 +105,7 @@ opentelemetry-otlp = { version = "0.29", features = [
 opentelemetry-appender-tracing = "0.29"
 tracing-opentelemetry = "0.30"
 configurable = { path = "configurable" }
+activation-runner = { path = "activation-runner" }
 hmac = "0.12"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 walkdir = "2.5.0"
@@ -139,6 +143,48 @@ window-vibrancy = "0.6"
 core-foundation = "0.10"
 security-framework = "3"
 nix = { version = "0.31", features = ["socket", "user"] }
+# Named `errSecCS*` / `errSecCertificate*` / `CSSMERR_TP_*` status values,
+# generated from the Security.framework headers, for the privileged-helper peer
+# auth status table. A name that does not exist fails the build, where a
+# hand-transcribed number was silently wrong — and a wrong number there can
+# classify a peer nobody could judge as invalid, which authorizes removal.
+#
+# macOS-gated because it cannot build off Apple: 0.3.2 declares `mod generated`
+# with no cfg and an unconditional `#[link(name = "Security", kind =
+# "framework")]`, which rustc rejects with E0455 on other targets. The status
+# table it feeds is therefore macOS-only too, and so are that table's tests —
+# they run on the macOS runner, which executes `cargo test` alongside clippy.
+objc2-security = { version = "0.3.2", default-features = false, features = [
+  "CSCommon",
+  "SecBase",
+  "cssmerr",
+] }
+# SMAppService bindings for the privileged-helper registration
+# (`privileged_helper/service.rs`). Generated from the SDK headers, so the
+# asynchronous `unregisterWithCompletionHandler:` and the typed status enum are
+# both reachable — the two things the published wrapper crates
+# (`smappservice-rs`, `servicemanagement-rs`) do not offer.
+objc2-service-management = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "SMAppService",
+  "SMErrors",
+  "block2",
+  "objc2",
+  "objc2-foundation",
+] }
+# Already in the tree through the objc2 framework crates; declared directly
+# because the SMAppService adapter constructs NSString/NSError values, retains
+# the unregister completion block, and hops onto the main queue itself.
+objc2 = "0.6"
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+  "std",
+  "NSDictionary",
+  "NSError",
+  "NSString",
+  "NSThread",
+] }
+block2 = "0.6"
+dispatch2 = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["user"] }

--- a/apps/native/src-tauri/activation-runner/Cargo.toml
+++ b/apps/native/src-tauri/activation-runner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "activation-runner"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+# no_std on purpose: this crate is the post-fork child path of the privileged
+# helper, where allocation is forbidden (see lib.rs). Depending on libc alone,
+# with std unavailable, turns "no allocation after fork" from a review rule
+# into a compile error.
+libc = { version = "0.2", default-features = false }

--- a/apps/native/src-tauri/activation-runner/src/lib.rs
+++ b/apps/native/src-tauri/activation-runner/src/lib.rs
@@ -1,0 +1,198 @@
+//! The privileged helper's post-fork runner: the code that runs between
+//! `fork()` and `_exit()` in the child that becomes the detached activation
+//! runner.
+//!
+//! # Why this crate is `no_std`
+//!
+//! The helper daemon is multithreaded. `fork()` in a multithreaded process
+//! copies the whole address space but only the calling thread, so every lock
+//! another thread held at that instant — the allocator's included — is frozen
+//! locked in the child forever. The child may therefore only make
+//! async-signal-safe calls until it exits or execs (the same contract
+//! `std::os::unix::process::CommandExt::pre_exec` documents). A single stray
+//! allocation here would deadlock intermittently — and a deadlocked
+//! runner holds the activation lock forever, wedging every future
+//! activation until reboot.
+//!
+//! `#![no_std]` makes the allocation half of that contract a compile error:
+//! this crate cannot reference `std` or `alloc`, only `core` and raw `libc`.
+//! Panic-freedom stays manual — nothing below indexes, unwraps, or does
+//! arithmetic that can trap.
+//!
+//! Everything the child needs — validated argv/envp pointer tables, opened
+//! file descriptors — is prepared by the parent BEFORE the fork, in ordinary
+//! safe Rust, and handed in as [`RunnerPlan`]. The child makes decisions
+//! about nothing; it is plumbing from the first syscall to `_exit`.
+
+#![no_std]
+
+use core::ffi::c_char;
+use core::ffi::c_int;
+
+/// Everything the post-fork child touches. Built entirely before `fork()`;
+/// every pointer must stay valid until the child has exec'd or exited, which
+/// the parent guarantees by keeping the owning allocations alive across the
+/// fork call.
+///
+/// All fds must be numerically greater than 3, or the `dup2` chain below
+/// could close a source before copying it; the parent enforces that when it
+/// opens them.
+pub struct RunnerPlan {
+    /// Null-terminated argv for the activation command; `argv[0]` is the
+    /// absolute program path.
+    pub activate_argv: *const *const c_char,
+    /// Null-terminated envp for the activation command.
+    pub activate_envp: *const *const c_char,
+    /// Null-terminated argv for the post-activation profile update
+    /// (`nix-env --set`), or null when the parent found no usable `nix-env`
+    /// (the failure warning is written instead).
+    pub profile_argv: *const *const c_char,
+    /// Null-terminated envp for the profile update.
+    pub profile_envp: *const *const c_char,
+    /// Pre-formatted warning line (newline included) written to the log when
+    /// the profile update fails or is unavailable. Pre-formatted because the
+    /// child must not format anything.
+    pub profile_warning: *const u8,
+    pub profile_warning_len: usize,
+    /// Read end for stdin: /dev/null.
+    pub devnull_fd: c_int,
+    /// The activation log; becomes the child's stdout and stderr.
+    pub log_fd: c_int,
+    /// The exclusive activation lock. Held by this process for exactly its
+    /// lifetime; never inherited by the activation command (CLOEXEC is set
+    /// after the dup2 chain).
+    pub lock_fd: c_int,
+    /// One past the highest fd to close; the parent captures
+    /// `getdtablesize()` before forking.
+    pub fd_limit: c_int,
+}
+
+/// The fixed fd the lock is parked on inside the runner, chosen so the
+/// close-everything loop below has a stable set to preserve.
+const LOCK_FD: c_int = 3;
+
+/// Runs the activation as the detached runner. Must be called in a freshly
+/// forked child
+/// and nowhere else; the caller passes the returned code straight to
+/// `libc::_exit`.
+///
+/// Exit code: the activation's own exit code; `128 + signal` when it was
+/// killed by a signal; 127 when it could not be spawned at all.
+///
+/// # Safety
+///
+/// - Must run in a forked child of the process that built `plan`, before
+///   anything else touched the child.
+/// - Every pointer in `plan` must be valid and null-terminated as documented.
+/// - All three fds must be open and greater than 3.
+pub unsafe fn run(plan: &RunnerPlan) -> c_int {
+    unsafe {
+        // Own session: outside the daemon's process group, so launchd's
+        // group sweep at unregister (already disabled via
+        // AbandonProcessGroup) cannot touch this process either way.
+        libc::setsid();
+
+        // Inherited signal mask reset, so a mask a helper thread happened to
+        // hold cannot silently block the child's SIGCHLD handling.
+        let mut empty: libc::sigset_t = core::mem::zeroed();
+        libc::sigemptyset(&mut empty);
+        libc::sigprocmask(libc::SIG_SETMASK, &empty, core::ptr::null_mut());
+
+        // The Rust runtime sets SIGPIPE to SIG_IGN at process start, and an
+        // ignored disposition survives both fork and execve. Left in place,
+        // every pipeline inside the activation script would see EPIPE write
+        // errors instead of ordinary pipe termination — a divergence from
+        // both the shell's expectations and the password path's executor
+        // (std::process::Command resets it; the raw execve below does not).
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        // SIGCHLD likewise: an inherited SIG_IGN would auto-reap the
+        // children and make `waitpid` below fail with ECHILD, losing the
+        // activation's real exit code — 127 reported, the profile update
+        // skipped after a success. No daemon code sets it today; this
+        // makes that future regression impossible rather than documented.
+        libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+
+        libc::dup2(plan.devnull_fd, 0);
+        libc::dup2(plan.log_fd, 1);
+        libc::dup2(plan.log_fd, 2);
+        libc::dup2(plan.lock_fd, LOCK_FD);
+
+        // The forked image holds copies of every fd the helper had open —
+        // the listening socket and accepted connections included. An orphan
+        // keeping the listener open would make client connects succeed with
+        // nobody answering for the whole activation; close everything that
+        // is not the four just placed.
+        let mut fd = LOCK_FD + 1;
+        while fd < plan.fd_limit {
+            libc::close(fd);
+            fd += 1;
+        }
+
+        // The lock must die at the activation command's exec: a straggler
+        // the activate script leaves behind must not hold the slot forever.
+        // This process itself keeps it for exactly its lifetime.
+        libc::fcntl(LOCK_FD, libc::F_SETFD, libc::FD_CLOEXEC);
+
+        let code = run_and_wait(plan.activate_argv, plan.activate_envp);
+        if code == 0 {
+            let profile_ok = !plan.profile_argv.is_null()
+                && run_and_wait(plan.profile_argv, plan.profile_envp) == 0;
+            if !profile_ok {
+                // Best-effort marker; the profile command's own output went
+                // to the log through fds 1/2. The system switch already
+                // happened, so this is a warning, never a failure.
+                libc::write(1, plan.profile_warning.cast(), plan.profile_warning_len);
+            }
+        }
+        code
+    }
+}
+
+/// The raw errno read, named per platform: Darwin exposes `__error`, Linux
+/// (where CI compiles this crate) `__errno_location`. Both are a pure
+/// thread-local pointer read — async-signal-safe.
+#[cfg(target_os = "macos")]
+unsafe fn errno() -> c_int {
+    unsafe { *libc::__error() }
+}
+
+#[cfg(not(target_os = "macos"))]
+unsafe fn errno() -> c_int {
+    unsafe { *libc::__errno_location() }
+}
+
+/// Forks and execs one prepared command, waits for it, and folds its status
+/// into an exit code. Async-signal-safe calls only — not literally bare
+/// syscalls: macOS's `fork` runs the process's `pthread_atfork` handlers.
+unsafe fn run_and_wait(argv: *const *const c_char, envp: *const *const c_char) -> c_int {
+    unsafe {
+        match libc::fork() {
+            -1 => 127,
+            0 => {
+                libc::execve(argv.read(), argv, envp);
+                // Exec failed; nothing to clean up and nothing safe to
+                // report beyond the code.
+                libc::_exit(127);
+            }
+            pid => {
+                let mut status: c_int = 0;
+                loop {
+                    let waited = libc::waitpid(pid, &mut status, 0);
+                    if waited == pid {
+                        break;
+                    }
+                    if waited == -1 && errno() != libc::EINTR {
+                        return 127;
+                    }
+                }
+                if libc::WIFEXITED(status) {
+                    libc::WEXITSTATUS(status)
+                } else if libc::WIFSIGNALED(status) {
+                    128 + libc::WTERMSIG(status)
+                } else {
+                    127
+                }
+            }
+        }
+    }
+}

--- a/apps/native/src-tauri/resources/launchd/com.darkmatter.nixmac.helper.plist
+++ b/apps/native/src-tauri/resources/launchd/com.darkmatter.nixmac.helper.plist
@@ -10,6 +10,8 @@
   <true/>
   <key>KeepAlive</key>
   <true/>
+  <key>AbandonProcessGroup</key>
+  <true/>
   <key>AssociatedBundleIdentifiers</key>
   <array>
     <string>com.darkmatter.nixmac</string>

--- a/apps/native/src-tauri/src/privileged_helper/client.rs
+++ b/apps/native/src-tauri/src/privileged_helper/client.rs
@@ -1,56 +1,325 @@
 use crate::privileged_helper::peer_auth;
 use crate::privileged_helper::protocol::{
-    ActivationRequest, HELPER_SOCKET_PATH, HelperOp, HelperRequest, HelperResponse,
+    ActivationRequest, BUILD_ID, HELPER_SOCKET_PATH, HelperReply, HelperRequest,
 };
-use anyhow::{Context, Result, bail};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
+/// The one generous bound in this client, and deliberately not one of the short
+/// leashes above: an activation legitimately runs for many minutes, so nothing
+/// shorter can be put here without turning ordinary long applies into lost
+/// results. Half an hour is the accepted ceiling. An activation still running
+/// when it expires is reported as an unknown outcome by an apply and as a
+/// deferral by the sync agent — neither compensates for it, and the activation
+/// itself keeps running. Do not reuse this on `Status`, and do not shorten it
+/// to match the probe.
 const ACTIVATION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 /// Status probes back the permissions UI; a wedged helper must not stall a
 /// permissions refresh, so they get a short leash instead of CLIENT_TIMEOUT.
 const STATUS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// How an absence is established: this many failed connection attempts, this
+/// far apart. A single failed connect is not "no helper" — a crashed helper
+/// sits dark for launchd's ~10 s relaunch throttle, and a freshly registered
+/// one takes a moment to bind — so the retry exists to keep a transient from
+/// being read as a dead registration and churning an unregister/register
+/// cycle (with its possible re-approval prompt). That is all it protects:
+/// with activations running in the detached runner, a wrong "absent" can no
+/// longer interrupt anything.
+const ABSENCE_ATTEMPTS: u32 = 3;
+const ABSENCE_ATTEMPT_INTERVAL: Duration = Duration::from_millis(2_500);
+
+/// Why one exchange with the helper produced no usable reply. Typed so every
+/// caller decides from structure, never from display text. The
+/// close-before-reply case is its own variant because it means something
+/// specific: the helper (or whatever holds the socket) declined this client
+/// before speaking — every caller treats it as "stop and re-observe".
+#[derive(Debug, thiserror::Error)]
+pub enum HelperClientError {
+    /// The connection could not be established at all.
+    #[error("failed to connect to {HELPER_SOCKET_PATH}: {0}")]
+    Unreachable(std::io::Error),
+    /// Whatever answers the socket failed the helper signature validation
+    /// (or was not root); no request bytes were sent to it.
+    #[error("helper peer failed authentication: {0:#}")]
+    AuthenticationFailed(anyhow::Error),
+    /// The peer closed the connection before any reply. A conforming helper
+    /// uses this for pre-authentication refusal or a connection dropped at
+    /// capacity, but after a `TryActivate` write the client cannot exclude a
+    /// helper crash after dispatch; callers must treat that outcome as
+    /// unknown rather than automatically compensating.
+    #[error("the helper closed the connection before replying")]
+    ClosedBeforeReply,
+    /// The reply did not arrive or could not be read (timeout included);
+    /// ambiguous — the request may or may not have been acted on.
+    #[error("helper connection failed mid-exchange: {0}")]
+    Io(std::io::Error),
+    /// A reply arrived but does not parse as any known reply shape. Treated
+    /// as a refusal everywhere: do not activate, do not mutate.
+    #[error("the helper sent a reply this build cannot parse: {0}")]
+    UnparseableReply(String),
+}
+
+/// What answered the helper socket, judged before any protocol bytes crossed
+/// it.
+///
+/// Reconciliation needs the three-way split: a **root** peer whose validation
+/// completed with a "no" is the pre-contract or tampered helper, which may be
+/// removed without being asked anything, while a validation that could not
+/// reach a judgment — or a peer that is not root — authorizes nothing at all.
+#[derive(Debug)]
+pub enum AssessedExchange {
+    /// Root, and the pinned helper requirement is satisfied. The reply came
+    /// from the signed helper.
+    Answered(HelperReply),
+    /// Root, and validation completed with a "no": unsigned, ad-hoc-signed, or
+    /// the wrong identity. Not one byte was written to it, and none ever is.
+    RootUnverifiable(String),
+    /// Nothing may be concluded — a peer that is not root, or a validation that
+    /// reached no judgment. No bytes were written.
+    Unidentified(String),
+}
+
+/// Whether anything is listening on the helper socket, over the absence
+/// window above. Pure observation: no protocol bytes are written, which is
+/// what makes it safe to point at a helper of any build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListenerObservation {
+    /// Every attempt over the window failed with "nothing there": the socket
+    /// is missing or refuses connections.
+    PositivelyAbsent,
+    /// A connection was accepted; something is listening.
+    Listening,
+    /// An attempt failed in a way that is not evidence of absence (a
+    /// timeout, permissions, an unclassifiable error). Nothing established.
+    Ambiguous(String),
+}
+
+/// Establishes whether the helper socket has a listener, retrying over the
+/// absence window. `wait` is injected so tests pay nothing for the spacing.
+pub fn observe_listener() -> ListenerObservation {
+    observe_listener_with(std::path::Path::new(HELPER_SOCKET_PATH), |interval| {
+        std::thread::sleep(interval)
+    })
+}
+
+fn observe_listener_with(
+    socket: &std::path::Path,
+    mut wait: impl FnMut(Duration),
+) -> ListenerObservation {
+    for attempt in 0..ABSENCE_ATTEMPTS {
+        if attempt > 0 {
+            wait(ABSENCE_ATTEMPT_INTERVAL);
+        }
+        match UnixStream::connect(socket) {
+            // Dropped immediately: connecting writes no protocol bytes, and
+            // the helper closes unauthenticated or over-cap connections on
+            // its own.
+            Ok(_stream) => return ListenerObservation::Listening,
+            Err(error) => match error.kind() {
+                // The two errors that mean "nothing is listening":
+                // no socket file, or nothing accepting on it.
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => {}
+                _ => return ListenerObservation::Ambiguous(error.to_string()),
+            },
+        }
+    }
+    ListenerObservation::PositivelyAbsent
+}
+
+/// Whether the socket path exists. Diagnostic only — it proves nothing about a
+/// helper, which is why nothing in the app reads it: the sync agent's no-config
+/// mode prints it, and every decision comes from an authenticated exchange or
+/// from [`observe_listener`].
+#[allow(dead_code)] // Used by the sync agent binary this module is shared into.
 pub fn socket_available() -> bool {
     std::path::Path::new(HELPER_SOCKET_PATH).exists()
 }
 
-fn request_with_timeout(request: &HelperRequest, timeout: Duration) -> Result<HelperResponse> {
-    let mut stream = UnixStream::connect(HELPER_SOCKET_PATH)
-        .with_context(|| format!("failed to connect to {HELPER_SOCKET_PATH}"))?;
-    stream.set_read_timeout(Some(timeout))?;
-    stream.set_write_timeout(Some(CLIENT_TIMEOUT))?;
+fn connect(read_timeout: Duration) -> Result<UnixStream, HelperClientError> {
+    let stream = UnixStream::connect(HELPER_SOCKET_PATH).map_err(HelperClientError::Unreachable)?;
+    stream
+        .set_read_timeout(Some(read_timeout))
+        .map_err(HelperClientError::Io)?;
+    stream
+        .set_write_timeout(Some(CLIENT_TIMEOUT))
+        .map_err(HelperClientError::Io)?;
+    Ok(stream)
+}
+
+fn exchange(
+    request: &HelperRequest,
+    read_timeout: Duration,
+) -> Result<HelperReply, HelperClientError> {
+    let stream = connect(read_timeout)?;
 
     // Reciprocal check: whatever answers on the socket must be the signed
     // root helper before this process sends it anything.
-    peer_auth::validate_helper_peer(&stream)?;
+    peer_auth::validate_helper_peer(&stream).map_err(HelperClientError::AuthenticationFailed)?;
 
-    let body = serde_json::to_vec(request)?;
-    stream.write_all(&body)?;
-    stream.write_all(b"\n")?;
-    stream.flush()?;
+    exchange_on(stream, request)
+}
 
-    let mut line = String::new();
-    BufReader::new(stream).read_line(&mut line)?;
-    if line.trim().is_empty() {
-        bail!("helper returned an empty response");
+/// [`exchange`] keeping the peer assessment instead of flattening it, and
+/// writing a request only to an authenticated peer.
+///
+/// The three-way judgment is the whole difference: what may be done about a
+/// helper that cannot be talked to depends on whether validation said "no" or
+/// said nothing.
+fn assessed_exchange(
+    request: &HelperRequest,
+    read_timeout: Duration,
+) -> Result<AssessedExchange, HelperClientError> {
+    let stream = connect(read_timeout)?;
+    let (euid, validation) =
+        peer_auth::assess_helper_peer(&stream).map_err(HelperClientError::AuthenticationFailed)?;
+
+    match peer_verdict(euid, validation) {
+        PeerVerdict::Authenticated => exchange_on(stream, request).map(AssessedExchange::Answered),
+        PeerVerdict::NotAuthenticated(assessment) => Ok(assessment),
+    }
+}
+
+/// Whether a request may be written to this peer, or what the peer is instead.
+enum PeerVerdict {
+    Authenticated,
+    NotAuthenticated(AssessedExchange),
+}
+
+/// The three-way judgment, as an allowlist: one combination authenticates a
+/// peer and every other one ends the exchange before a byte is written.
+fn peer_verdict(euid: u32, validation: peer_auth::SignatureValidation) -> PeerVerdict {
+    // A peer that is not root is unidentified whatever its signature says. The
+    // helper binds its socket inside a root-owned directory, so anything else
+    // holding that path is broken permissions or an impostor, and no decision
+    // about terminating a helper may be taken from it.
+    if euid != 0 {
+        return PeerVerdict::NotAuthenticated(AssessedExchange::Unidentified(format!(
+            "the process answering {HELPER_SOCKET_PATH} runs as uid {euid}, not root"
+        )));
+    }
+    match validation {
+        peer_auth::SignatureValidation::Valid => PeerVerdict::Authenticated,
+        // A completed "no" — and the only thing that is one.
+        peer_auth::SignatureValidation::Invalid(detail) => {
+            PeerVerdict::NotAuthenticated(AssessedExchange::RootUnverifiable(detail))
+        }
+        // No judgment was reached, which is never the same as a "no".
+        peer_auth::SignatureValidation::Error(detail) => {
+            PeerVerdict::NotAuthenticated(AssessedExchange::Unidentified(detail))
+        }
+    }
+}
+
+/// The post-authentication half of one exchange: send exactly one request,
+/// read exactly one reply. The helper closes the connection after its reply;
+/// dropping the stream here does the same from this end.
+fn exchange_on(
+    stream: UnixStream,
+    request: &HelperRequest,
+) -> Result<HelperReply, HelperClientError> {
+    let mut line = request.encode();
+    line.push('\n');
+    // A write failure on a freshly closed connection is the helper declining
+    // this client before any bytes — the same signal as an empty read.
+    (&stream)
+        .write_all(line.as_bytes())
+        .and_then(|()| (&stream).flush())
+        .map_err(|error| match error.kind() {
+            std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset => {
+                HelperClientError::ClosedBeforeReply
+            }
+            _ => HelperClientError::Io(error),
+        })?;
+
+    let mut reply_line = String::new();
+    let bytes_read =
+        BufReader::new(&stream)
+            .read_line(&mut reply_line)
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::ConnectionReset => HelperClientError::ClosedBeforeReply,
+                _ => HelperClientError::Io(error),
+            })?;
+    // Nothing at all came back: the peer closed before replying. Every caller
+    // treats this as stop-and-re-observe — it is the same signal a helper at
+    // its connection cap sends, deliberately indistinguishable from an
+    // authentication refusal.
+    if bytes_read == 0 {
+        return Err(HelperClientError::ClosedBeforeReply);
     }
 
-    // The response's protocol version is checked before any of its fields
-    // are used; a missing or different version fails as a classified
-    // protocol skew for callers to act on.
-    HelperResponse::parse(&line)
+    HelperReply::parse(&reply_line)
+        .map_err(|error| HelperClientError::UnparseableReply(format!("{error:#}")))
 }
 
-pub fn status() -> Result<HelperResponse> {
-    request_with_timeout(&HelperRequest::new(HelperOp::Status), STATUS_PROBE_TIMEOUT)
+/// Sends `Status`, keeping the peer assessment. Reconciliation's discovery
+/// exchange: it works against a helper of any build, and what it may do about
+/// one it cannot talk to depends on which way the assessment went.
+pub fn assessed_status() -> Result<AssessedExchange, HelperClientError> {
+    assessed_exchange(&HelperRequest::Status, STATUS_PROBE_TIMEOUT)
 }
 
-/// Sends an activation envelope. `ActivationRequest` is only constructible
-/// through `protocol::activation_request`, so this entry point cannot be
-/// handed a status operation or a hand-assembled version.
-pub fn activate_store_path(request: &ActivationRequest) -> Result<HelperResponse> {
-    request_with_timeout(&request.0, ACTIVATION_TIMEOUT)
+/// Dispatches `TryActivate`, stamped with this build's ID — the helper admits
+/// it only if that ID is exactly its own. `ActivationRequest` is only
+/// constructible through `protocol::activation_request`, so this entry point
+/// cannot be handed a hand-assembled body with a non-canonicalized target. The
+/// reply arrives on the same connection when the activation completes.
+pub fn activate_store_path(request: &ActivationRequest) -> Result<HelperReply, HelperClientError> {
+    exchange(
+        &HelperRequest::TryActivate {
+            build_id: BUILD_ID.to_string(),
+            body: request.0.clone(),
+        },
+        ACTIVATION_TIMEOUT,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+
+    #[test]
+    fn a_missing_socket_is_positively_absent_after_the_full_window() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut waits = Vec::new();
+        let observation = observe_listener_with(&dir.path().join("no-such.sock"), |interval| {
+            waits.push(interval)
+        });
+
+        assert_eq!(observation, ListenerObservation::PositivelyAbsent);
+        // Every attempt after the first is spaced by the interval; a single
+        // failed connect must never conclude absence.
+        assert_eq!(waits.len(), (ABSENCE_ATTEMPTS - 1) as usize);
+        assert!(waits.iter().all(|wait| *wait == ABSENCE_ATTEMPT_INTERVAL));
+    }
+
+    #[test]
+    fn a_listening_socket_is_seen_on_the_first_attempt() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("helper.sock");
+        let _listener = UnixListener::bind(&socket).expect("bind");
+
+        let observation = observe_listener_with(&socket, |_| panic!("no wait needed"));
+
+        assert_eq!(observation, ListenerObservation::Listening);
+    }
+
+    #[test]
+    fn a_listener_appearing_mid_window_ends_the_probe_as_listening() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("helper.sock");
+        let socket_for_wait = socket.clone();
+        let mut listener = None;
+
+        let observation = observe_listener_with(&socket, |_| {
+            // The helper binds between attempts — a fresh registration
+            // starting up, exactly the transient the window exists for.
+            listener = Some(UnixListener::bind(&socket_for_wait).expect("bind"));
+        });
+
+        assert_eq!(observation, ListenerObservation::Listening);
+    }
 }

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -1,19 +1,30 @@
-use crate::privileged_helper::peer_auth::{self, PeerIdentity};
+use crate::privileged_helper::peer_auth::{self, ClientKind, ClientValidation, PeerIdentity};
 use crate::privileged_helper::protocol::{
-    ActivateStorePathRequest, HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HELPER_WARNING_PREFIX,
-    HelperOp, HelperRequest, HelperResponse, UNAUTHORIZED_CLIENT_ERROR,
-    validate_canonical_activate_path,
+    ACTIVATION_LOCK_PATH, ACTIVATION_LOG_PATH, ActivationInfo, ActivationResult, BUILD_ID,
+    HELPER_SOCKET_DIR, HELPER_SOCKET_PATH, HELPER_WARNING_PREFIX, HelperReply, HelperRequest,
+    HelperStateName, TryActivateBody, validate_canonical_activate_path,
 };
 use anyhow::{Context, Result, anyhow, bail};
+use std::ffi::CString;
 use std::fs;
-use std::io::{BufRead, BufReader, Read, Write};
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 /// Post-auth cap on the request line; real requests are well under 4 KiB.
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
+
+/// Hard cap on concurrently served connections. At capacity, the (cap+1)th
+/// connection is accepted and closed before authentication and before any
+/// protocol bytes — deliberately indistinguishable from the unauthenticated
+/// close, which every client already treats as "stop and re-observe". No
+/// frozen "at capacity" reply shape exists or may be added.
+pub(crate) const MAX_CONCURRENT_CONNECTIONS: usize = 4;
 
 /// Fixed PATH for the privileged activation: root-owned system and Nix
 /// profile directories only. The protocol has no field for a requester to
@@ -33,6 +44,424 @@ const STICKY_BIT: u32 = 0o1000;
 /// termination). No longer written; removed on startup if present.
 const LEGACY_SUDOERS_PATH: &str = "/etc/sudoers.d/nixmac-activate-helper";
 
+/// Cap on how much of the activation log is read back into the result reply.
+/// Bounds the helper's memory and the reply frame; the log file itself keeps
+/// everything. (The requests cap above cannot serve here: activation output
+/// is legitimately large.)
+const REPLY_LOG_TAIL_BYTES: u64 = 512 * 1024;
+const LOG_TRUNCATION_MARKER: &str =
+    "nixmac-helper: earlier activation output truncated; the full log is in";
+
+// ---------------------------------------------------------------------------
+// The single activation slot.
+//
+// The slot is an exclusive `flock` on a root-owned lock file, held by the
+// detached runner for exactly its lifetime — across helper generations, and
+// shared with the password path's executor, so "an activation is running" has
+// one source of truth however the activation was started. This process keeps
+// only a display-level memory of the activation it spawned itself (X), and
+// one mutex that serializes its own lock-file operations so a `Status` probe
+// can never turn a racing admission into a spurious `Busy`. External holders
+// are always real activations.
+// ---------------------------------------------------------------------------
+
+pub(crate) struct ActivationSlot {
+    /// In-process serialization of every lock-file operation, plus X for the
+    /// activation this process spawned (display only; cleared when it ends).
+    current: Mutex<Option<ActivationInfo>>,
+    lock_path: PathBuf,
+}
+
+impl ActivationSlot {
+    pub(crate) fn new() -> Self {
+        Self::at(PathBuf::from(ACTIVATION_LOCK_PATH))
+    }
+
+    /// Test seam: a slot over a lock file somewhere writable.
+    pub(crate) fn at(lock_path: PathBuf) -> Self {
+        Self {
+            current: Mutex::new(None),
+            lock_path,
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Option<ActivationInfo>> {
+        self.current.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// The `Status` answer, from live observation: this process's own memory
+    /// when it spawned the running activation, else a momentary shared-lock
+    /// probe (an exclusive holder elsewhere — an orphaned runner or the
+    /// password path — is an activation running). Serialized with admission
+    /// by the mutex, so the probe's `LOCK_SH` cannot make a concurrent
+    /// admission in this process report a phantom `Busy`.
+    fn status_reply(&self, helper_build_id: &str) -> HelperReply {
+        let current = self.lock();
+        let (state, activation) = match &*current {
+            Some(info) => (HelperStateName::Activating, Some(info.clone())),
+            None => match self.foreign_holder() {
+                true => (HelperStateName::Activating, None),
+                false => (HelperStateName::Idle, None),
+            },
+        };
+        HelperReply::Status {
+            state,
+            helper_build_id: helper_build_id.to_string(),
+            activation,
+        }
+    }
+
+    /// Whether something outside this process holds the lock. Errors opening
+    /// or probing the lock file are logged and read as "no holder": a helper
+    /// that cannot observe its own lock cannot admit either, so nothing is
+    /// decided from the optimistic answer.
+    fn foreign_holder(&self) -> bool {
+        match open_lock_file(&self.lock_path) {
+            Ok(fd) => match try_flock(&fd, libc::LOCK_SH) {
+                // The shared lock was granted, so no exclusive holder exists;
+                // dropping the fd releases it immediately.
+                Ok(true) => false,
+                Ok(false) => true,
+                Err(error) => {
+                    eprintln!("nixmac-helper: failed to probe the activation lock: {error}");
+                    false
+                }
+            },
+            Err(error) => {
+                eprintln!("nixmac-helper: failed to open the activation lock: {error}");
+                false
+            }
+        }
+    }
+
+    /// `TryActivate` admission: takes the exclusive lock non-blocking, or
+    /// answers `Busy` immediately. The lock attempt IS the admission decision
+    /// — atomic across processes by `flock` itself, and serialized against
+    /// this process's own status probes by the mutex. X's client kind is
+    /// stamped from the helper's own validation of the submitting client,
+    /// never from the request body.
+    fn admit(
+        &self,
+        body: &TryActivateBody,
+        client_kind: ClientKind,
+    ) -> std::result::Result<AdmittedActivation<'_>, HelperReply> {
+        let mut current = self.lock();
+        if let Some(info) = &*current {
+            return Err(HelperReply::Busy {
+                activation: Some(info.clone()),
+            });
+        }
+        let lock = open_lock_file(&self.lock_path).map_err(admission_failure)?;
+        match try_flock(&lock, libc::LOCK_EX) {
+            Ok(true) => {}
+            // Held elsewhere: an orphaned runner from a previous helper
+            // generation, or the password path. A real activation either way,
+            // whose X this process never knew.
+            Ok(false) => return Err(HelperReply::Busy { activation: None }),
+            Err(error) => return Err(admission_failure(error)),
+        }
+        *current = Some(ActivationInfo {
+            request_id: body.request_id.clone(),
+            script_path: body.script_path.clone(),
+            client_kind,
+        });
+        Ok(AdmittedActivation { slot: self, lock })
+    }
+
+    /// Only [`AdmittedActivation`]'s drop calls this.
+    fn finish_activation(&self) {
+        *self.lock() = None;
+    }
+}
+
+/// An admission failure that is not `Busy`: the lock file itself could not be
+/// used. Reported as a failed activation result — same-build reply, nothing
+/// frozen — so the caller learns why instead of a bare refusal.
+fn admission_failure(error: anyhow::Error) -> HelperReply {
+    HelperReply::ActivationResult(ActivationResult {
+        ok: false,
+        code: -1,
+        stdout: String::new(),
+        error: Some(format!("could not take the activation lock: {error:#}")),
+    })
+}
+
+/// Opens the lock file, creating it if missing. NEVER unlink or truncate it,
+/// here or anywhere: `flock` binds to the inode, so recreating the file while
+/// an orphaned runner holds the old inode's lock would silently double the
+/// slot. (The socket's remove-before-bind pattern in `run_daemon` must not be
+/// copied here.) `O_EXCL` is deliberately absent — the file legitimately
+/// exists from the first activation of a boot on.
+fn open_lock_file(path: &Path) -> Result<OwnedFd> {
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    Ok(file.into())
+}
+
+/// One non-blocking `flock`. `Ok(true)` acquired, `Ok(false)` held elsewhere.
+fn try_flock(fd: &OwnedFd, operation: libc::c_int) -> Result<bool> {
+    // SAFETY: flock on an owned, open descriptor; no memory is involved.
+    let outcome = unsafe { libc::flock(fd.as_raw_fd(), operation | libc::LOCK_NB) };
+    if outcome == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::EWOULDBLOCK) {
+        return Ok(false);
+    }
+    Err(anyhow!("flock failed: {error}"))
+}
+
+/// Proof that this request owns the single activation slot: the exclusive
+/// lock, held here until the runner inherits it, plus this process's memory
+/// of X. Constructed only by successful admission; drop clears the memory on
+/// every exit path, unwind included. The lock itself outlives this value in
+/// the runner's inherited descriptor — dropping the parent's copy releases
+/// nothing while the runner lives.
+pub(crate) struct AdmittedActivation<'slot> {
+    slot: &'slot ActivationSlot,
+    lock: OwnedFd,
+}
+
+impl std::fmt::Debug for AdmittedActivation<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("AdmittedActivation")
+    }
+}
+
+impl AdmittedActivation<'_> {
+    /// The lock, for the runner spawn to inherit.
+    pub(crate) fn lock_fd(&self) -> BorrowedFd<'_> {
+        self.lock.as_fd()
+    }
+
+    /// Consumes the admission — clearing the memory and closing the parent's
+    /// lock copy — and only then builds the reply reporting the activation's
+    /// end, so a client holding a result may immediately re-dispatch. The
+    /// explicit `drop` is load-bearing: left implicit, `self` would fall out
+    /// of scope *after* the tail expression built the reply.
+    fn into_result_reply(self, result: ActivationResult) -> HelperReply {
+        drop(self);
+        HelperReply::ActivationResult(result)
+    }
+}
+
+impl Drop for AdmittedActivation<'_> {
+    fn drop(&mut self) {
+        self.slot.finish_activation();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request handling.
+// ---------------------------------------------------------------------------
+
+enum RequestAction<'slot> {
+    /// Reply immediately.
+    Reply(HelperReply),
+    /// Admitted: the slot is taken; the caller runs the activation, lets the
+    /// admission drop, and only then sends the result reply.
+    RunActivation {
+        body: TryActivateBody,
+        admitted: AdmittedActivation<'slot>,
+    },
+}
+
+/// Which requests each authenticated caller may make. The GUI owns the
+/// helper's lifecycle; the sync agent has none — it may only ask for an
+/// activation, and gets the frozen `CallerNotPermitted` refusal for anything
+/// else.
+fn caller_may_send(client_kind: ClientKind, request: &HelperRequest) -> bool {
+    match client_kind {
+        ClientKind::Gui => true,
+        ClientKind::SyncAgent => matches!(request, HelperRequest::TryActivate { .. }),
+    }
+}
+
+/// Decides one authenticated request, in this order: the request either parses
+/// completely or is not understood → the caller may or may not send it → a
+/// `TryActivate` build ID either equals this helper's or is a build mismatch →
+/// the slot-derived reply. `Status` carries no build ID and is answered
+/// whatever the caller's build.
+fn decide_request<'slot>(
+    slot: &'slot ActivationSlot,
+    client_kind: ClientKind,
+    helper_build_id: &str,
+    line: &str,
+) -> RequestAction<'slot> {
+    let Some(request) = HelperRequest::parse(line) else {
+        return RequestAction::Reply(HelperReply::RequestNotUnderstood);
+    };
+    if !caller_may_send(client_kind, &request) {
+        return RequestAction::Reply(HelperReply::CallerNotPermitted);
+    }
+    match request {
+        HelperRequest::Status => RequestAction::Reply(slot.status_reply(helper_build_id)),
+        HelperRequest::TryActivate { build_id, body } => {
+            if build_id != helper_build_id {
+                return RequestAction::Reply(HelperReply::BuildMismatch {
+                    helper_build_id: helper_build_id.to_string(),
+                });
+            }
+            match slot.admit(&body, client_kind) {
+                Ok(admitted) => RequestAction::RunActivation { body, admitted },
+                Err(refusal) => RequestAction::Reply(refusal),
+            }
+        }
+    }
+}
+
+/// An authenticated connection's client: kernel-derived identity plus the
+/// pinned requirement that matched.
+pub(crate) struct AuthedClient {
+    pub(crate) identity: PeerIdentity,
+    pub(crate) kind: ClientKind,
+}
+
+type Authenticator = dyn Fn(&UnixStream) -> Option<AuthedClient> + Send + Sync;
+type ActivationRunner = dyn for<'a> Fn(&AuthedClient, &TryActivateBody, &AdmittedActivation<'a>) -> ActivationResult
+    + Send
+    + Sync;
+
+/// Everything one daemon instance serves connections with. The slot is the
+/// only state; the closures are injection seams so the connection semantics
+/// are testable without a signed peer or a real activation.
+pub(crate) struct ServeConfig {
+    pub(crate) slot: ActivationSlot,
+    pub(crate) helper_build_id: String,
+    pub(crate) authenticate: Box<Authenticator>,
+    pub(crate) run_activation: Box<ActivationRunner>,
+}
+
+/// Serves one connection: authenticate (an unauthenticated peer receives no
+/// protocol bytes — dropping the stream closes it), read exactly one
+/// request, reply, close. The close carries no meaning a client may act on:
+/// a close *before* the reply is the declined/over-cap signal, a close after
+/// it is just the exchange being over.
+fn serve_connection(mut stream: UnixStream, config: &ServeConfig) -> Result<()> {
+    let Some(client) = (config.authenticate)(&stream) else {
+        return Ok(());
+    };
+
+    let frame = read_request_line(stream.try_clone()?)?;
+    let action = match frame {
+        RequestFrame::PeerClosed => {
+            // The peer closed without sending a request; nothing to answer.
+            return Ok(());
+        }
+        RequestFrame::Complete(line) => match std::str::from_utf8(&line) {
+            Ok(line) => decide_request(&config.slot, client.kind, &config.helper_build_id, line),
+            // Invalid UTF-8 is an unreadable request, not a connection error.
+            Err(_) => RequestAction::Reply(HelperReply::RequestNotUnderstood),
+        },
+        // A missing terminator or a line beyond the existing cap is an
+        // unreadable request. Never dispatch from a valid-looking prefix.
+        RequestFrame::Malformed => RequestAction::Reply(HelperReply::RequestNotUnderstood),
+    };
+    let reply = match action {
+        RequestAction::Reply(reply) => reply,
+        RequestAction::RunActivation { body, admitted } => {
+            let result = (config.run_activation)(&client, &body, &admitted);
+            // The admission is consumed — memory cleared, parent lock copy
+            // closed — before one byte of the result reply is written.
+            admitted.into_result_reply(result)
+        }
+    };
+    stream.write_all(reply.encode().as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+    // Dropping the stream closes the connection: one request, one reply,
+    // done. Nothing holds helper connections open — there is no liveness
+    // signal to preserve — and a freed descriptor is a freed connection slot.
+    Ok(())
+}
+
+enum RequestFrame {
+    PeerClosed,
+    Complete(Vec<u8>),
+    Malformed,
+}
+
+/// Reads one newline-terminated request as raw bytes. UTF-8 decoding belongs
+/// to request classification, and a missing terminator or a line beyond the
+/// existing cap is malformed rather than an admissible JSON prefix.
+fn read_request_line(stream: impl Read) -> std::io::Result<RequestFrame> {
+    let mut line = Vec::new();
+    BufReader::new(stream)
+        .take(MAX_REQUEST_BYTES + 1)
+        .read_until(b'\n', &mut line)?;
+    if line.is_empty() {
+        Ok(RequestFrame::PeerClosed)
+    } else if line.len() as u64 <= MAX_REQUEST_BYTES && line.last() == Some(&b'\n') {
+        Ok(RequestFrame::Complete(line))
+    } else {
+        Ok(RequestFrame::Malformed)
+    }
+}
+
+/// Holds one of the bounded connection slots and releases it on drop —
+/// including while unwinding. A slot leaked by a panicking connection thread
+/// would never come back for the rest of the process lifetime, and four of
+/// them would wedge the helper into refusing every connection.
+struct ConnectionSlot(Arc<AtomicUsize>);
+
+impl ConnectionSlot {
+    /// Takes a slot, or `None` at capacity.
+    fn acquire(active: &Arc<AtomicUsize>) -> Option<Self> {
+        active
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                (count < MAX_CONCURRENT_CONNECTIONS).then_some(count + 1)
+            })
+            .ok()
+            .map(|_| Self(Arc::clone(active)))
+    }
+}
+
+impl Drop for ConnectionSlot {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// Accept loop with bounded concurrent connection handling.
+pub(crate) fn serve(listener: UnixListener, config: Arc<ServeConfig>) -> Result<()> {
+    let active = Arc::new(AtomicUsize::new(0));
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let Some(slot) = ConnectionSlot::acquire(&active) else {
+                    // At capacity: accepted and closed before authentication
+                    // and before any protocol bytes.
+                    drop(stream);
+                    continue;
+                };
+                let config = Arc::clone(&config);
+                let spawned = std::thread::Builder::new().spawn(move || {
+                    // Dropped when this thread ends by any route, panic
+                    // included, so the slot always returns.
+                    let _slot = slot;
+                    if let Err(error) = serve_connection(stream, &config) {
+                        eprintln!("nixmac-helper: request failed: {error:#}");
+                    }
+                });
+                if spawned.is_err() {
+                    eprintln!("nixmac-helper: failed to spawn connection thread");
+                }
+            }
+            Err(error) => eprintln!("nixmac-helper: connection failed: {error}"),
+        }
+    }
+
+    Ok(())
+}
+
 pub fn run_daemon() -> Result<()> {
     if let Err(error) = fs::remove_file(LEGACY_SUDOERS_PATH)
         && error.kind() != std::io::ErrorKind::NotFound
@@ -45,6 +474,9 @@ pub fn run_daemon() -> Result<()> {
     }
     fs::create_dir_all(HELPER_SOCKET_DIR)?;
     let socket_path = Path::new(HELPER_SOCKET_PATH);
+    // The SOCKET is removed before rebinding — a socket file cannot be bound
+    // over. This pattern must never spread to the activation lock file, whose
+    // inode identity is what the single slot rests on (see `open_lock_file`).
     if socket_path.exists() {
         fs::remove_file(socket_path)?;
     }
@@ -52,27 +484,34 @@ pub fn run_daemon() -> Result<()> {
     let listener = UnixListener::bind(socket_path)?;
     harden_socket_permissions(socket_path)?;
 
-    for stream in listener.incoming() {
-        match stream {
-            Ok(stream) => {
-                if let Err(error) = handle_stream(stream) {
-                    eprintln!("nixmac-helper: request failed: {error:#}");
-                }
-            }
-            Err(error) => eprintln!("nixmac-helper: connection failed: {error}"),
-        }
-    }
-
-    Ok(())
+    serve(
+        listener,
+        Arc::new(ServeConfig {
+            slot: ActivationSlot::new(),
+            helper_build_id: BUILD_ID.to_string(),
+            authenticate: Box::new(authenticate_peer),
+            run_activation: Box::new(|client, body, admitted| {
+                run_detached_activation(&client.identity, body, admitted)
+            }),
+        }),
+    )
 }
 
 fn harden_socket_permissions(socket_path: &Path) -> Result<()> {
     let admin_gid = admin_group_id();
+    // A failed chown is not fatal (the daemon can still serve whoever the
+    // default ownership admits) but must not pass silently: with the 0600
+    // mode below it would leave a socket the GUI cannot connect to and no
+    // trace of why.
     if let Some(console_uid) = peer_auth::console_user_uid() {
-        let _ = std::os::unix::fs::chown(socket_path, Some(console_uid), admin_gid);
+        if let Err(error) = std::os::unix::fs::chown(socket_path, Some(console_uid), admin_gid) {
+            eprintln!("nixmac-helper: failed to chown the socket to the console user: {error}");
+        }
         fs::set_permissions(socket_path, fs::Permissions::from_mode(0o600))?;
     } else {
-        let _ = std::os::unix::fs::chown(socket_path, Some(0), admin_gid);
+        if let Err(error) = std::os::unix::fs::chown(socket_path, Some(0), admin_gid) {
+            eprintln!("nixmac-helper: failed to chown the socket to root: {error}");
+        }
         fs::set_permissions(socket_path, fs::Permissions::from_mode(0o660))?;
     }
     Ok(())
@@ -86,40 +525,43 @@ fn admin_group_id() -> Option<u32> {
         .map(|group| group.gid.as_raw())
 }
 
-fn handle_stream(mut stream: UnixStream) -> Result<()> {
-    // The peer is authorized from its socket credentials before the request
-    // body is touched: an unauthorized peer must never reach the reader or
-    // the JSON parser.
-    let response = match authorize_peer(&stream) {
-        Ok(peer) => respond_authorized(&peer, &stream)?,
-        Err(error) => HelperResponse::error(-1, format!("{UNAUTHORIZED_CLIENT_ERROR}: {error:#}")),
+/// Pre-authentication admission: the socket-credential policy first, then
+/// per-binary signature classification. A peer failing either is closed
+/// before any protocol bytes — never a typed refusal.
+fn authenticate_peer(stream: &UnixStream) -> Option<AuthedClient> {
+    let identity = match peer_auth::peer_identity(stream) {
+        Ok(identity) => identity,
+        Err(error) => {
+            eprintln!("nixmac-helper: failed to read peer identity: {error:#}");
+            return None;
+        }
     };
-    serde_json::to_writer(&mut stream, &response)?;
-    stream.write_all(b"\n")?;
-    stream.flush()?;
-    Ok(())
-}
-
-/// Post-authorization request handling: only a request that clears the
-/// version gate reaches an operation handler; anything else — version skew,
-/// a v1 shape, unknown fields, framing violations — becomes a versioned
-/// protocol-error response without an operation being derived.
-fn respond_authorized(peer: &PeerIdentity, stream: &UnixStream) -> Result<HelperResponse> {
-    Ok(match read_request(stream.try_clone()?) {
-        Ok(op) => handle_request(peer, op),
-        Err(error) => HelperResponse::error(-1, error.to_string()),
-    })
-}
-
-fn authorize_peer(stream: &UnixStream) -> Result<PeerIdentity> {
-    let peer = peer_auth::peer_identity(stream)?;
-    check_peer_policy(peer.euid, peer_auth::console_user_uid())?;
-    peer_auth::validate_client_code(&peer)?;
-    Ok(peer)
+    if let Err(error) = check_peer_policy(identity.euid, peer_auth::console_user_uid()) {
+        eprintln!("nixmac-helper: rejected peer: {error:#}");
+        return None;
+    }
+    match peer_auth::classify_client(&identity) {
+        ClientValidation::Valid(kind) => Some(AuthedClient { identity, kind }),
+        ClientValidation::Invalid(detail) | ClientValidation::Error(detail) => {
+            eprintln!("nixmac-helper: rejected peer: {detail}");
+            None
+        }
+    }
 }
 
 /// The peer must be the active console user; root is rejected outright (the
 /// GUI and sync agent always run in the user session).
+///
+/// Note the breadth deliberately: this gate covers `Status` too, not just
+/// activation, and it runs *before* signature validation — a peer failing it
+/// is closed without protocol bytes rather than answered with a typed
+/// refusal. Narrower is the conservative direction, and it is what the
+/// socket's own permissions already imply (the socket is mode 0600 owned by
+/// the console user, so a second login session cannot reach it at all).
+/// Consequence worth knowing before widening or narrowing this: a
+/// second-session GUI reports and defers instead of converging. Changing the
+/// socket's ownership or mode is a separate piece of work; do not scope this
+/// gate down without it.
 fn check_peer_policy(peer_euid: u32, console_uid: Option<u32>) -> Result<()> {
     if peer_euid == 0 {
         bail!("root peers may not drive activation");
@@ -133,53 +575,267 @@ fn check_peer_policy(peer_euid: u32, console_uid: Option<u32>) -> Result<()> {
     Ok(())
 }
 
-/// Reads one framed request and returns the operation only if the sender
-/// speaks this daemon's protocol version. A version mismatch and an
-/// unrecognized field are both hard errors here, so no operation is derived
-/// from a request the daemon does not fully understand.
-fn read_request(stream: impl Read) -> Result<HelperOp> {
-    let mut line = String::new();
-    BufReader::new(stream)
-        .take(MAX_REQUEST_BYTES)
-        .read_line(&mut line)?;
-    if !line.ends_with('\n') && line.len() as u64 >= MAX_REQUEST_BYTES {
-        bail!("request exceeds {MAX_REQUEST_BYTES} bytes");
-    }
-    HelperRequest::parse(&line)
-}
+// ---------------------------------------------------------------------------
+// Activation execution: the detached runner.
+//
+// The helper never runs an activation in-process. It validates, prepares
+// everything in ordinary safe Rust, then forks the runner — its own session,
+// surviving `SMAppService` unregister together with the plist's
+// AbandonProcessGroup — whose post-fork code lives in the `activation-runner`
+// no_std crate (see its crate docs for why syscalls-only is enforced there).
+// The runner holds the activation lock, execs the activate script with
+// stdio on the log file, runs the profile update, and exits — releasing the
+// lock. The parent waits for it and reads a capped log tail back into the
+// result reply.
+// ---------------------------------------------------------------------------
 
-fn handle_request(peer: &PeerIdentity, op: HelperOp) -> HelperResponse {
-    match op {
-        HelperOp::Status => HelperResponse::ok("nixmac helper ready"),
-        HelperOp::ActivateStorePath(request) => match activate_store_path(peer, &request) {
-            Ok(response) => response,
-            Err(error) => HelperResponse::error(-1, error.to_string()),
+/// Runs one admitted activation to completion in a detached runner and folds
+/// every failure into the result reply, so an activation that could not run
+/// still reports an outcome rather than unwinding.
+fn run_detached_activation(
+    peer: &PeerIdentity,
+    body: &TryActivateBody,
+    admitted: &AdmittedActivation<'_>,
+) -> ActivationResult {
+    match detached_activation(peer, &body.script_path, admitted.lock_fd()) {
+        Ok(result) => result,
+        Err(error) => ActivationResult {
+            ok: false,
+            code: -1,
+            stdout: String::new(),
+            error: Some(format!("{error:#}")),
         },
     }
 }
 
-fn activate_store_path(
+fn detached_activation(
     peer: &PeerIdentity,
-    request: &ActivateStorePathRequest,
-) -> Result<HelperResponse> {
-    let activate_path = canonical_activation_target(&request.activate_path)?;
+    script_path: &str,
+    lock: BorrowedFd<'_>,
+) -> Result<ActivationResult> {
+    let activate_path = canonical_activation_target(script_path)?;
     let argv = activation_argv_for_peer(peer, &activate_path)?;
-    let (status, mut stdout) = run_activation_command(&argv)?;
+    let (code, stdout) = spawn_runner(
+        &argv,
+        profile_update_argv(&activate_path)?.as_deref(),
+        Path::new(ACTIVATION_LOG_PATH),
+        lock,
+    )?;
+    Ok(ActivationResult {
+        ok: code == 0,
+        code,
+        stdout,
+        error: None,
+    })
+}
 
-    // Profile maintenance runs only after a successful activation and is
-    // best-effort: the system switch already happened, so its failures
-    // surface as warnings instead of failing the apply.
-    if status.success() {
-        for warning in post_activation_maintenance(&activate_path) {
-            stdout.push_str(&format!("\n{HELPER_WARNING_PREFIX} {warning}"));
-        }
+/// The post-activation profile update as a ready argv, or `None` when no
+/// root-owned `nix-env` exists (the runner then writes the warning). Runs
+/// inside the runner, after a successful activate — one unit, so a helper
+/// replacement can no longer land between the two. The password path's
+/// in-process twin is [`set_system_profile`]; keep the two commands
+/// identical when touching either.
+fn profile_update_argv(activate_path: &str) -> Result<Option<Vec<String>>> {
+    let system_path = Path::new(activate_path)
+        .parent()
+        .context("activation path has no parent")?;
+    let Some(nix_env) = NIX_ENV_CANDIDATES
+        .iter()
+        .find(|candidate| Path::new(candidate).exists())
+    else {
+        return Ok(None);
+    };
+    Ok(Some(vec![
+        (*nix_env).to_string(),
+        "-p".to_string(),
+        SYSTEM_PROFILE.to_string(),
+        "--set".to_string(),
+        system_path.to_string_lossy().into_owned(),
+    ]))
+}
+
+/// A null-terminated C argv/envp built pre-fork, so the post-fork child only
+/// reads pointers. The pointer table borrows the owned strings; both live in
+/// this value, which the parent keeps alive across the fork.
+struct CArgv {
+    _strings: Vec<CString>,
+    pointers: Vec<*const libc::c_char>,
+}
+
+impl CArgv {
+    fn new(values: &[String]) -> Result<Self> {
+        let strings = values
+            .iter()
+            .map(|value| CString::new(value.as_str()).context("argument contains a NUL byte"))
+            .collect::<Result<Vec<_>>>()?;
+        let mut pointers: Vec<*const libc::c_char> =
+            strings.iter().map(|value| value.as_ptr()).collect();
+        pointers.push(std::ptr::null());
+        Ok(Self {
+            _strings: strings,
+            pointers,
+        })
     }
 
-    Ok(HelperResponse::from_exit(
-        status.success(),
-        status.code().unwrap_or(-1),
-        stdout,
-    ))
+    fn as_ptr(&self) -> *const *const libc::c_char {
+        self.pointers.as_ptr()
+    }
+}
+
+/// Duplicates `fd` above the stdio range if needed, so the runner's dup2
+/// chain cannot close a source before copying it.
+fn above_stdio(fd: OwnedFd) -> Result<OwnedFd> {
+    if fd.as_raw_fd() > 3 {
+        return Ok(fd);
+    }
+    // SAFETY: F_DUPFD on an owned, open descriptor.
+    let raised = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_DUPFD, 10) };
+    if raised < 0 {
+        bail!(
+            "failed to raise descriptor: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    // SAFETY: freshly returned by F_DUPFD, owned by nothing else.
+    Ok(unsafe { OwnedFd::from_raw_fd(raised) })
+}
+
+/// Forks the detached runner, waits it out, and reads the capped log tail
+/// back. The child executes only `activation_runner::run` — no
+/// allocation, no unwinding — and `_exit`s with the activation's code.
+fn spawn_runner(
+    activate_argv: &[String],
+    profile_argv: Option<&[String]>,
+    log_path: &Path,
+    lock: BorrowedFd<'_>,
+) -> Result<(i32, String)> {
+    // Everything the child touches, built before the fork.
+    let activate = CArgv::new(activate_argv)?;
+    let empty_env = CArgv::new(&[])?;
+    let profile = profile_argv.map(CArgv::new).transpose()?;
+    let profile_env = CArgv::new(&[format!("PATH={ACTIVATION_PATH_ENV}")])?;
+    let warning = format!("{HELPER_WARNING_PREFIX} failed to update system profile\n");
+
+    let devnull: OwnedFd = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/null")
+        .context("failed to open /dev/null")?
+        .into();
+    let log: OwnedFd = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(log_path)
+        .with_context(|| format!("failed to open activation log {}", log_path.display()))?
+        .into();
+    let devnull = above_stdio(devnull)?;
+    let log = above_stdio(log)?;
+    // The lock is borrowed from the admission; a duplicate keeps ownership
+    // simple and is closed with the other parent copies after the fork.
+    // SAFETY: F_DUPFD on an owned, open descriptor.
+    let lock_dup = unsafe { libc::fcntl(lock.as_raw_fd(), libc::F_DUPFD, 10) };
+    if lock_dup < 0 {
+        bail!(
+            "failed to duplicate the activation lock: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    // SAFETY: freshly returned by F_DUPFD, owned by nothing else.
+    let lock_dup = unsafe { OwnedFd::from_raw_fd(lock_dup) };
+
+    let plan = activation_runner::RunnerPlan {
+        activate_argv: activate.as_ptr(),
+        activate_envp: empty_env.as_ptr(),
+        profile_argv: profile
+            .as_ref()
+            .map_or(std::ptr::null(), |profile| profile.as_ptr()),
+        profile_envp: profile_env.as_ptr(),
+        profile_warning: warning.as_ptr(),
+        profile_warning_len: warning.len(),
+        devnull_fd: devnull.as_raw_fd(),
+        log_fd: log.as_raw_fd(),
+        lock_fd: lock_dup.as_raw_fd(),
+        // SAFETY: getdtablesize has no preconditions.
+        fd_limit: unsafe { libc::getdtablesize() },
+    };
+
+    // SAFETY: fork in a multithreaded process; the child calls only
+    // `activation_runner::run` (async-signal-safe by that crate's contract)
+    // and `_exit`.
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        bail!(
+            "failed to fork the activation runner: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    if pid == 0 {
+        // CHILD. Nothing but the runner's code may run here.
+        // SAFETY: freshly forked child; the plan's pointers and fds are the
+        // copied parent allocations, valid until _exit.
+        let code = unsafe { activation_runner::run(&plan) };
+        // SAFETY: terminating the child without running any parent-owned
+        // destructors, which is the point.
+        unsafe { libc::_exit(code) };
+    }
+
+    // Parent: the runner owns its copies now; close this function's. One
+    // parent fd on the lock's open file description deliberately remains —
+    // the admission fd inside `AdmittedActivation` — so the lock is held
+    // until the runner exits AND the admission drops at reply-build time
+    // (`into_result_reply`). A helper killed mid-wait loses that fd with the
+    // process, leaving the runner's own descriptor as the lock's exact
+    // lifetime.
+    drop(devnull);
+    drop(lock_dup);
+
+    let mut status: libc::c_int = 0;
+    loop {
+        // SAFETY: waitpid on our own direct child.
+        let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
+        if waited == pid {
+            break;
+        }
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EINTR) {
+            bail!("failed to wait for the activation runner: {error}");
+        }
+    }
+    let code = if libc::WIFEXITED(status) {
+        libc::WEXITSTATUS(status)
+    } else if libc::WIFSIGNALED(status) {
+        128 + libc::WTERMSIG(status)
+    } else {
+        -1
+    };
+
+    drop(log);
+    Ok((code, read_log_tail(log_path)?))
+}
+
+/// The last [`REPLY_LOG_TAIL_BYTES`] of the activation log, with a marker
+/// line when older output was left behind in the file.
+fn read_log_tail(log_path: &Path) -> Result<String> {
+    let mut file = fs::File::open(log_path)
+        .with_context(|| format!("failed to read activation log {}", log_path.display()))?;
+    let len = file
+        .metadata()
+        .context("failed to stat activation log")?
+        .len();
+    let mut tail = String::new();
+    if len > REPLY_LOG_TAIL_BYTES {
+        file.seek(SeekFrom::End(-(REPLY_LOG_TAIL_BYTES as i64)))
+            .context("failed to seek activation log")?;
+        tail.push_str(&format!("{LOG_TRUNCATION_MARKER} {}\n", log_path.display()));
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .context("failed to read activation log")?;
+    tail.push_str(&String::from_utf8_lossy(&bytes));
+    Ok(tail)
 }
 
 /// Resolves and authorizes the activation target at the privileged boundary,
@@ -267,11 +923,12 @@ fn check_component_policy(path: &Path, owner_uid: u32, mode: u32, is_dir: bool) 
     Ok(())
 }
 
-/// Runs a prepared activation argv with stderr merged into stdout (the old
-/// script's `2>&1`): consumers stream, log, and summarize a single output
-/// stream, and the activate script writes most of its output to stderr.
-/// Shared by the helper daemon and the interactive fallback's root re-entry
-/// (`privileged_helper::root_activation`).
+/// Runs a prepared activation argv IN-PROCESS with stderr merged into stdout,
+/// for the admin-password path's root re-entry only
+/// (`privileged_helper::root_activation`): that executor is its own fresh
+/// root process, already independent of any daemon's fate, so it needs no
+/// detached runner — but it takes the same activation lock. The helper
+/// daemon never calls this; its activations run in the detached runner.
 pub(crate) fn run_activation_command(
     argv: &[String],
 ) -> Result<(std::process::ExitStatus, String)> {
@@ -294,6 +951,20 @@ pub(crate) fn run_activation_command(
         .context("failed to read activation output")?;
     let status = child.wait().context("failed to wait for activation")?;
     Ok((status, String::from_utf8_lossy(&output).to_string()))
+}
+
+/// Takes the shared activation slot for the admin-password path's executor.
+/// `Ok(fd)` holds the exclusive lock until the fd drops — the caller keeps it
+/// alive across the whole activation. `Ok(None)`-shaped refusal is an error
+/// here: an activation is already running, and the caller reports rather
+/// than waits.
+pub(crate) fn acquire_activation_lock() -> Result<OwnedFd> {
+    fs::create_dir_all(HELPER_SOCKET_DIR).context("failed to create the helper directory")?;
+    let lock = open_lock_file(Path::new(ACTIVATION_LOCK_PATH))?;
+    if !try_flock(&lock, libc::LOCK_EX)? {
+        bail!("an activation is already running; try again once it finishes");
+    }
+    Ok(lock)
 }
 
 /// Direct-exec activation command: no shell, absolute programs only, a fixed
@@ -326,14 +997,15 @@ fn activation_argv_for_peer(peer: &PeerIdentity, activate_path: &str) -> Result<
     Ok(activation_argv(peer.euid, &account, activate_path))
 }
 
-pub(crate) fn post_activation_maintenance(activate_path: &str) -> Vec<String> {
-    let mut warnings = Vec::new();
-    if let Err(error) = set_system_profile(activate_path) {
-        warnings.push(format!("failed to update system profile: {error:#}"));
-    }
-    warnings
+pub(crate) fn post_activation_maintenance(activate_path: &str) -> Option<String> {
+    set_system_profile(activate_path)
+        .err()
+        .map(|error| format!("failed to update system profile: {error:#}"))
 }
 
+/// In-process profile update, for the password path's executor. The helper
+/// daemon's runner performs the same step via `profile_update_argv` inside
+/// the runner.
 fn set_system_profile(activate_path: &str) -> Result<()> {
     let system_path = Path::new(activate_path)
         .parent()
@@ -387,8 +1059,832 @@ pub(crate) fn user_account(_uid: u32) -> Result<UserAccount> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const HELPER_BUILD: &str = "build-a";
+    const OTHER_BUILD: &str = "build-b";
+    const SCRIPT: &str = "/nix/store/abc-darwin-system/activate";
+
+    fn body(request_id: &str) -> TryActivateBody {
+        TryActivateBody {
+            request_id: request_id.to_string(),
+            script_path: SCRIPT.to_string(),
+        }
+    }
+
+    fn status_line() -> String {
+        HelperRequest::Status.encode()
+    }
+
+    fn try_activate_line(build_id: &str, request_id: &str) -> String {
+        HelperRequest::TryActivate {
+            build_id: build_id.to_string(),
+            body: body(request_id),
+        }
+        .encode()
+    }
+
+    /// A slot over a tempdir lock file, plus the dir keeping it alive.
+    fn test_slot() -> (ActivationSlot, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        (ActivationSlot::at(dir.path().join("activation.lock")), dir)
+    }
+
+    /// Serializes the tests that fork against the tests that assert flock
+    /// release. A freshly forked runner briefly holds copies of every fd
+    /// in this test process — other tests' lock fds included, and a `flock`
+    /// lives until every fd of its open file description closes — so a
+    /// concurrent "dropping the admission released the lock" assertion can
+    /// observe a lock the child is still microseconds from closing. A test
+    /// artifact only: the real helper has one admitted lock at a time by
+    /// construction, and a lingering probe copy can at worst answer one
+    /// transient `Busy`.
+    fn exclusive_fds() -> MutexGuard<'static, ()> {
+        static FDS: Mutex<()> = Mutex::new(());
+        FDS.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn state_of(slot: &ActivationSlot) -> (HelperStateName, Option<ActivationInfo>) {
+        match slot.status_reply(HELPER_BUILD) {
+            HelperReply::Status {
+                state, activation, ..
+            } => (state, activation),
+            other => panic!("status_reply answered {other:?}"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // The slot: flock-backed admission and observation.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn an_idle_slot_admits_and_reports_the_activation_it_admitted() {
+        let _fds = exclusive_fds();
+        let (slot, _dir) = test_slot();
+        assert_eq!(state_of(&slot).0, HelperStateName::Idle);
+
+        let admitted = slot
+            .admit(&body("req-1"), ClientKind::Gui)
+            .expect("admitted");
+
+        let (state, activation) = state_of(&slot);
+        assert_eq!(state, HelperStateName::Activating);
+        let info = activation.expect("this process knows X");
+        assert_eq!(info.request_id, "req-1");
+        assert_eq!(info.client_kind, ClientKind::Gui);
+
+        // A second admission is refused with X, from memory.
+        match slot.admit(&body("req-2"), ClientKind::SyncAgent) {
+            Err(HelperReply::Busy {
+                activation: Some(info),
+            }) => assert_eq!(info.request_id, "req-1"),
+            other => panic!("unexpected admission outcome: {other:?}"),
+        }
+
+        // The end transition precedes the reply the caller then sends.
+        let reply = admitted.into_result_reply(ActivationResult {
+            ok: true,
+            code: 0,
+            stdout: String::new(),
+            error: None,
+        });
+        assert!(matches!(reply, HelperReply::ActivationResult(_)));
+        assert_eq!(state_of(&slot).0, HelperStateName::Idle);
+        assert!(slot.admit(&body("req-3"), ClientKind::Gui).is_ok());
+    }
+
+    #[test]
+    fn a_foreign_lock_holder_is_an_activation_without_details() {
+        let _fds = exclusive_fds();
+        // Another process — an orphaned runner or the password executor —
+        // holds the exclusive lock: modeled by a second slot over the same
+        // file, which is a distinct open file description exactly like a
+        // foreign process's.
+        let (slot, dir) = test_slot();
+        let foreign = ActivationSlot::at(dir.path().join("activation.lock"));
+        let held = foreign
+            .admit(&body("foreign"), ClientKind::Gui)
+            .expect("foreign admission");
+
+        let (state, activation) = state_of(&slot);
+        assert_eq!(state, HelperStateName::Activating);
+        assert!(activation.is_none(), "X was never known to this process");
+
+        match slot.admit(&body("req-1"), ClientKind::Gui) {
+            Err(HelperReply::Busy { activation: None }) => {}
+            other => panic!("unexpected admission outcome: {other:?}"),
+        }
+
+        drop(held);
+        assert_eq!(state_of(&slot).0, HelperStateName::Idle);
+        assert!(slot.admit(&body("req-2"), ClientKind::Gui).is_ok());
+    }
+
+    #[test]
+    fn the_slot_is_released_even_when_the_activation_unwinds() {
+        let _fds = exclusive_fds();
+        // A slot stranded in Activating would refuse every later TryActivate
+        // with Busy for the rest of this process's lifetime.
+        let (slot, _dir) = test_slot();
+        let admitted = slot
+            .admit(&body("req-1"), ClientKind::Gui)
+            .expect("activation admitted");
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _admitted = admitted;
+            panic!("activation exploded");
+        }));
+
+        assert!(unwound.is_err(), "the activation was supposed to panic");
+        assert_eq!(state_of(&slot).0, HelperStateName::Idle);
+        assert!(slot.admit(&body("req-2"), ClientKind::Gui).is_ok());
+    }
+
+    #[test]
+    fn status_probes_never_hold_the_lock() {
+        let _fds = exclusive_fds();
+        // A status probe takes LOCK_SH momentarily and releases it with the
+        // fd; an admission immediately afterwards must succeed.
+        let (slot, _dir) = test_slot();
+        for _ in 0..3 {
+            assert_eq!(state_of(&slot).0, HelperStateName::Idle);
+        }
+        assert!(slot.admit(&body("req-1"), ClientKind::Gui).is_ok());
+    }
+
+    // ------------------------------------------------------------------
+    // The decision table.
+    // ------------------------------------------------------------------
+
+    fn decide<'slot>(
+        slot: &'slot ActivationSlot,
+        kind: ClientKind,
+        line: &str,
+    ) -> RequestAction<'slot> {
+        decide_request(slot, kind, HELPER_BUILD, line)
+    }
+
+    fn reply_of(action: RequestAction<'_>) -> HelperReply {
+        match action {
+            RequestAction::Reply(reply) => reply,
+            RequestAction::RunActivation { .. } => panic!("expected a reply, got an admission"),
+        }
+    }
+
+    #[test]
+    fn table_idle() {
+        let (slot, _dir) = test_slot();
+
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &status_line())),
+            HelperReply::Status {
+                state: HelperStateName::Idle,
+                activation: None,
+                ..
+            }
+        ));
+
+        assert!(matches!(
+            decide(
+                &slot,
+                ClientKind::Gui,
+                &try_activate_line(HELPER_BUILD, "req-1")
+            ),
+            RequestAction::RunActivation { .. }
+        ));
+    }
+
+    #[test]
+    fn table_activating() {
+        let (slot, _dir) = test_slot();
+        let _admitted = slot
+            .admit(&body("req-1"), ClientKind::Gui)
+            .expect("admitted");
+
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::Gui, &status_line())),
+            HelperReply::Status {
+                state: HelperStateName::Activating,
+                activation: Some(_),
+                ..
+            }
+        ));
+        assert!(matches!(
+            reply_of(decide(
+                &slot,
+                ClientKind::SyncAgent,
+                &try_activate_line(HELPER_BUILD, "req-2")
+            )),
+            HelperReply::Busy {
+                activation: Some(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn a_request_that_does_not_parse_gets_request_not_understood() {
+        let (slot, _dir) = test_slot();
+        for line in [
+            "not json",
+            r#"{"kind":"selfDestruct"}"#,
+            r#"{"op":"status"}"#,
+            r#"{"kind":"tryActivate","buildId":"build-a","body":{"bogus":1}}"#,
+        ] {
+            assert!(
+                matches!(
+                    reply_of(decide(&slot, ClientKind::Gui, line)),
+                    HelperReply::RequestNotUnderstood
+                ),
+                "line: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_sync_agent_may_only_ask_for_an_activation() {
+        let (slot, _dir) = test_slot();
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::SyncAgent, &status_line())),
+            HelperReply::CallerNotPermitted
+        ));
+        assert!(matches!(
+            decide(
+                &slot,
+                ClientKind::SyncAgent,
+                &try_activate_line(HELPER_BUILD, "req-1")
+            ),
+            RequestAction::RunActivation { .. }
+        ));
+    }
+
+    #[test]
+    fn an_unpermitted_caller_and_another_build_get_their_own_refusals() {
+        let (slot, _dir) = test_slot();
+        // Caller policy is decided before the build comparison.
+        assert!(matches!(
+            reply_of(decide(&slot, ClientKind::SyncAgent, &status_line())),
+            HelperReply::CallerNotPermitted
+        ));
+        match reply_of(decide(
+            &slot,
+            ClientKind::Gui,
+            &try_activate_line(OTHER_BUILD, "req-1"),
+        )) {
+            HelperReply::BuildMismatch { helper_build_id } => {
+                assert_eq!(helper_build_id, HELPER_BUILD);
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+        // A mismatch never touches the slot.
+        assert_eq!(state_of(&slot).0, HelperStateName::Idle);
+    }
+
+    #[test]
+    fn an_empty_peer_build_id_is_a_build_mismatch_not_a_parse_failure() {
+        let (slot, _dir) = test_slot();
+        assert!(matches!(
+            reply_of(decide(
+                &slot,
+                ClientKind::Gui,
+                &try_activate_line("", "req-1")
+            )),
+            HelperReply::BuildMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn control_requests_are_answered_whatever_the_peers_build() {
+        let (slot, _dir) = test_slot();
+        // Status carries no build ID; a peer from any build gets an answer.
+        assert!(matches!(
+            reply_of(decide(
+                &slot,
+                ClientKind::Gui,
+                r#"{"kind":"status","fieldFromAnotherBuild":true}"#
+            )),
+            HelperReply::Status { .. }
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // Connection semantics.
+    // ------------------------------------------------------------------
+
     #[cfg(target_os = "macos")]
-    use crate::privileged_helper::protocol::HELPER_PROTOCOL_VERSION;
+    fn test_config(kind: ClientKind) -> (Arc<ServeConfig>, tempfile::TempDir) {
+        let (slot, dir) = test_slot();
+        (
+            Arc::new(ServeConfig {
+                slot,
+                helper_build_id: HELPER_BUILD.to_string(),
+                authenticate: Box::new(move |stream| {
+                    let identity = peer_auth::peer_identity(stream).ok()?;
+                    Some(AuthedClient { identity, kind })
+                }),
+                run_activation: Box::new(|_, _, _| ActivationResult {
+                    ok: true,
+                    code: 0,
+                    stdout: "activated".to_string(),
+                    error: None,
+                }),
+            }),
+            dir,
+        )
+    }
+
+    #[cfg(target_os = "macos")]
+    fn refusing_config() -> (Arc<ServeConfig>, tempfile::TempDir) {
+        let (slot, dir) = test_slot();
+        (
+            Arc::new(ServeConfig {
+                slot,
+                helper_build_id: HELPER_BUILD.to_string(),
+                authenticate: Box::new(|_| None),
+                run_activation: Box::new(|_, _, _| {
+                    unreachable!("no activation from a refused peer")
+                }),
+            }),
+            dir,
+        )
+    }
+
+    /// Sends one request line on a fresh connection and returns the reply.
+    #[cfg(target_os = "macos")]
+    fn request_on_new_connection(socket_path: &Path, line: &str) -> HelperReply {
+        let client = UnixStream::connect(socket_path).expect("connect");
+        client
+            .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+            .expect("set timeout");
+        (&client)
+            .write_all(format!("{line}\n").as_bytes())
+            .expect("write request");
+        let mut reply = String::new();
+        BufReader::new(&client)
+            .read_line(&mut reply)
+            .expect("read reply");
+        HelperReply::parse(&reply).expect("reply parses")
+    }
+
+    /// Sends a raw request through the authenticated connection handler, then
+    /// parses the newline-framed bytes exactly as a client does.
+    #[cfg(target_os = "macos")]
+    fn raw_request_through_wire(line: &str) -> HelperReply {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let (config, _dir) = test_config(ClientKind::Gui);
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        (&client)
+            .write_all(format!("{line}\n").as_bytes())
+            .expect("write request");
+        let mut reply = String::new();
+        BufReader::new(&client)
+            .read_line(&mut reply)
+            .expect("read reply");
+        handler.join().expect("handler").expect("serves");
+        HelperReply::parse(&reply).expect("client parses reply")
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn cross_build_control_requests_are_answered_through_the_real_wire_path() {
+        // A GUI from another build asks with fields this build never heard of;
+        // the answer must still come back on the wire.
+        assert!(matches!(
+            raw_request_through_wire(r#"{"kind":"status","fieldFromAnotherBuild":9999}"#),
+            HelperReply::Status {
+                state: HelperStateName::Idle,
+                ..
+            }
+        ));
+        assert!(matches!(
+            raw_request_through_wire(r#"{"kind":"selfDestruct"}"#),
+            HelperReply::RequestNotUnderstood
+        ));
+
+        // A TryActivate body from another build: syntactically valid JSON that
+        // exceeds serde_json's materialization depth. It is a request this
+        // build cannot parse, so it is not understood — the build ID it
+        // carries is never reached, and nothing dispatches from the readable
+        // prefix.
+        let nested = format!("{}null{}", "[".repeat(150), "]".repeat(150));
+        let future_body = format!(
+            r#"{{"kind":"tryActivate","buildId":"{OTHER_BUILD}","body":{{"requestId":"req-future","scriptPath":"{SCRIPT}","future":{nested}}}}}"#
+        );
+        assert!(matches!(
+            raw_request_through_wire(&future_body),
+            HelperReply::RequestNotUnderstood
+        ));
+
+        // A well-formed request from another build does reach the comparison.
+        assert!(matches!(
+            raw_request_through_wire(&try_activate_line(OTHER_BUILD, "req-future")),
+            HelperReply::BuildMismatch { .. }
+        ));
+    }
+
+    /// A daemon over a real listener whose activation blocks until the
+    /// returned gate is released — the fake long activation the concurrency
+    /// obligations are stated against.
+    #[cfg(target_os = "macos")]
+    #[allow(clippy::type_complexity)]
+    fn blocking_activation_daemon() -> (
+        std::path::PathBuf,
+        Arc<ServeConfig>,
+        Arc<(Mutex<bool>, std::sync::Condvar)>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("helper-test.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+        let gate = Arc::new((Mutex::new(false), std::sync::Condvar::new()));
+        let runner_gate = Arc::clone(&gate);
+        let config = Arc::new(ServeConfig {
+            slot: ActivationSlot::at(dir.path().join("activation.lock")),
+            helper_build_id: HELPER_BUILD.to_string(),
+            authenticate: Box::new(|stream| {
+                let identity = peer_auth::peer_identity(stream).ok()?;
+                Some(AuthedClient {
+                    identity,
+                    kind: ClientKind::Gui,
+                })
+            }),
+            run_activation: Box::new(move |_, _, _| {
+                let (released, signal) = &*runner_gate;
+                let mut released = released.lock().expect("gate");
+                while !*released {
+                    released = signal.wait(released).expect("gate wait");
+                }
+                ActivationResult {
+                    ok: true,
+                    code: 0,
+                    stdout: "activated".to_string(),
+                    error: None,
+                }
+            }),
+        });
+        let serving = Arc::clone(&config);
+        std::thread::spawn(move || serve(listener, serving));
+        (socket_path, config, gate, dir)
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn status_is_answered_while_an_activation_actually_runs() {
+        let _fds = exclusive_fds();
+        let (socket_path, config, gate, _dir) = blocking_activation_daemon();
+
+        // Dispatch an activation that will not finish until released, on its
+        // own connection, and wait until the slot really is occupied.
+        let activation = std::thread::spawn({
+            let socket_path = socket_path.clone();
+            move || {
+                request_on_new_connection(&socket_path, &try_activate_line(HELPER_BUILD, "req-1"))
+            }
+        });
+        while state_of(&config.slot).0 != HelperStateName::Activating {
+            std::thread::yield_now();
+        }
+
+        // Status is answered promptly and carries X.
+        match request_on_new_connection(&socket_path, &status_line()) {
+            HelperReply::Status {
+                state: HelperStateName::Activating,
+                activation: Some(info),
+                ..
+            } => assert_eq!(info.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // A second TryActivate is refused Busy with X, promptly.
+        match request_on_new_connection(&socket_path, &try_activate_line(HELPER_BUILD, "req-2")) {
+            HelperReply::Busy {
+                activation: Some(info),
+            } => assert_eq!(info.request_id, "req-1"),
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // Releasing the activation delivers its result, and the slot is free
+        // by the time the result is readable (transition-before-reply).
+        {
+            let (released, signal) = &*gate;
+            *released.lock().expect("gate") = true;
+            signal.notify_all();
+        }
+        let result = activation.join().expect("activation");
+        assert!(matches!(
+            result,
+            HelperReply::ActivationResult(ActivationResult { ok: true, .. })
+        ));
+        assert_eq!(state_of(&config.slot).0, HelperStateName::Idle);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn the_connection_is_closed_after_the_reply() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let (config, _dir) = test_config(ClientKind::Gui);
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        (&client)
+            .write_all(format!("{}\n", status_line()).as_bytes())
+            .expect("write request");
+        let mut reply = String::new();
+        let mut reader = BufReader::new(&client);
+        reader.read_line(&mut reply).expect("read reply");
+        assert!(matches!(
+            HelperReply::parse(&reply).expect("reply parses"),
+            HelperReply::Status { .. }
+        ));
+
+        // One reply, then the helper closes: the next read is end-of-file.
+        let mut probe = String::new();
+        assert_eq!(reader.read_line(&mut probe).expect("read eof"), 0);
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn invalid_utf8_gets_request_not_understood() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let (config, _dir) = test_config(ClientKind::Gui);
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        (&client).write_all(b"\xff\n").expect("write invalid UTF-8");
+        let mut reply = String::new();
+        BufReader::new(&client)
+            .read_line(&mut reply)
+            .expect("read refusal");
+        assert_eq!(
+            reply,
+            format!("{}\n", HelperReply::RequestNotUnderstood.encode())
+        );
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[test]
+    fn a_connection_slot_is_released_even_when_its_thread_unwinds() {
+        // A leaked slot never comes back for the process lifetime, and four
+        // leaks would wedge the helper into refusing every connection — so
+        // the slot must survive a panicking connection thread.
+        let active = Arc::new(AtomicUsize::new(0));
+        for _ in 0..MAX_CONCURRENT_CONNECTIONS * 3 {
+            let slot = ConnectionSlot::acquire(&active).expect("a slot is free");
+            let panicked = std::thread::spawn(move || {
+                let _slot = slot;
+                panic!("connection handling exploded");
+            })
+            .join();
+
+            assert!(panicked.is_err(), "the thread was supposed to panic");
+            assert_eq!(active.load(Ordering::Acquire), 0, "slot was not released");
+        }
+    }
+
+    #[test]
+    fn slots_are_handed_out_up_to_the_cap_and_no_further() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let held: Vec<ConnectionSlot> = (0..MAX_CONCURRENT_CONNECTIONS)
+            .map(|_| ConnectionSlot::acquire(&active).expect("a slot is free"))
+            .collect();
+
+        assert!(ConnectionSlot::acquire(&active).is_none());
+
+        drop(held);
+        assert!(ConnectionSlot::acquire(&active).is_some());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn unauthenticated_peer_is_closed_before_any_protocol_bytes() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let (config, _dir) = refusing_config();
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        // The peer never even sends a request; the close must come first.
+        let mut probe = [0u8; 8];
+        assert_eq!((&client).read(&mut probe).expect("read"), 0);
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn oversized_valid_prefix_is_refused_as_request_not_understood() {
+        let (client, server) = UnixStream::pair().expect("socketpair");
+        let (config, _dir) = test_config(ClientKind::Gui);
+        let handler = std::thread::spawn(move || serve_connection(server, &config));
+
+        // The first MAX_REQUEST_BYTES bytes are a valid Status envelope plus
+        // JSON whitespace. Accepting that prefix before reading the suffix
+        // would dispatch an oversized, incomplete frame.
+        let mut oversized = status_line().into_bytes();
+        oversized.resize(MAX_REQUEST_BYTES as usize, b' ');
+        oversized.extend_from_slice(b"x\n");
+        (&client).write_all(&oversized).expect("write");
+
+        let mut reply = String::new();
+        BufReader::new(&client)
+            .read_line(&mut reply)
+            .expect("read reply");
+        assert!(matches!(
+            HelperReply::parse(&reply).expect("reply parses"),
+            HelperReply::RequestNotUnderstood
+        ));
+        handler.join().expect("handler").expect("serves");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn connections_past_the_cap_are_closed_without_protocol_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("helper-test.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+        let (config, _slot_dir) = test_config(ClientKind::Gui);
+        std::thread::spawn(move || serve(listener, config));
+
+        // Fill every slot with connections that have not sent a request yet:
+        // each occupies its slot until it closes (the helper now closes
+        // answered connections itself, so only unanswered ones can hold a
+        // slot open from outside).
+        let held: Vec<UnixStream> = (0..MAX_CONCURRENT_CONNECTIONS)
+            .map(|_| UnixStream::connect(&socket_path).expect("connect"))
+            .collect();
+        // Give the accept loop a moment to hand every held connection to a
+        // handler thread.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // The (cap+1)th connection is accepted and closed before any bytes.
+        let extra = UnixStream::connect(&socket_path).expect("connect");
+        extra
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .expect("set timeout");
+        let mut probe = [0u8; 8];
+        assert_eq!((&extra).read(&mut probe).expect("read"), 0);
+        drop(held);
+    }
+
+    // ------------------------------------------------------------------
+    // The detached runner (real forks, fake activations).
+    // ------------------------------------------------------------------
+
+    fn shell_argv(script: &str) -> Vec<String> {
+        vec!["/bin/sh".to_string(), "-c".to_string(), script.to_string()]
+    }
+
+    #[test]
+    fn the_runner_executes_the_command_and_reports_its_exit_and_output() {
+        let _fds = exclusive_fds();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("activation.log");
+        let lock = open_lock_file(&dir.path().join("activation.lock")).expect("lock");
+        assert!(try_flock(&lock, libc::LOCK_EX).expect("flock"));
+
+        let (code, output) = spawn_runner(
+            &shell_argv("echo to-stdout; echo to-stderr 1>&2; exit 3"),
+            None,
+            &log_path,
+            lock.as_fd(),
+        )
+        .expect("runner completes");
+
+        assert_eq!(code, 3);
+        assert!(output.contains("to-stdout"));
+        assert!(output.contains("to-stderr"), "stderr merged into the log");
+    }
+
+    #[test]
+    fn a_straggler_left_by_the_activation_does_not_hold_the_lock() {
+        let _fds = exclusive_fds();
+        // The CLOEXEC discipline: the lock fd dies at the activation
+        // command's exec, so a background process the script leaves behind
+        // cannot hold the slot after the runner exits.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_path = dir.path().join("activation.lock");
+        let log_path = dir.path().join("activation.log");
+        let lock = open_lock_file(&lock_path).expect("lock");
+        assert!(try_flock(&lock, libc::LOCK_EX).expect("flock"));
+
+        let (code, _output) = spawn_runner(
+            &shell_argv("sleep 30 & echo spawned"),
+            None,
+            &log_path,
+            lock.as_fd(),
+        )
+        .expect("runner completes");
+        assert_eq!(code, 0);
+
+        // This process still holds its own fd; release it, then prove the
+        // lock is free even though the straggler sleep is still alive.
+        drop(lock);
+        let probe = open_lock_file(&lock_path).expect("probe open");
+        assert!(
+            try_flock(&probe, libc::LOCK_EX).expect("probe flock"),
+            "a straggler inherited the activation lock"
+        );
+    }
+
+    #[test]
+    fn a_failed_profile_update_writes_the_warning_and_keeps_the_success() {
+        let _fds = exclusive_fds();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("activation.log");
+        let lock = open_lock_file(&dir.path().join("activation.lock")).expect("lock");
+        assert!(try_flock(&lock, libc::LOCK_EX).expect("flock"));
+
+        let (code, output) = spawn_runner(
+            &shell_argv("echo activated"),
+            Some(&["/usr/bin/false".to_string()]),
+            &log_path,
+            lock.as_fd(),
+        )
+        .expect("runner completes");
+
+        assert_eq!(code, 0, "profile maintenance never fails the activation");
+        assert!(output.contains("activated"));
+        assert!(output.contains(HELPER_WARNING_PREFIX));
+    }
+
+    #[test]
+    fn a_missing_profile_updater_writes_the_warning_too() {
+        let _fds = exclusive_fds();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("activation.log");
+        let lock = open_lock_file(&dir.path().join("activation.lock")).expect("lock");
+        assert!(try_flock(&lock, libc::LOCK_EX).expect("flock"));
+
+        let (code, output) =
+            spawn_runner(&shell_argv("echo activated"), None, &log_path, lock.as_fd())
+                .expect("runner completes");
+
+        assert_eq!(code, 0);
+        assert!(output.contains(HELPER_WARNING_PREFIX));
+    }
+
+    #[test]
+    fn a_signal_killed_activation_reports_128_plus_signal() {
+        let _fds = exclusive_fds();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("activation.log");
+        let lock = open_lock_file(&dir.path().join("activation.lock")).expect("lock");
+        assert!(try_flock(&lock, libc::LOCK_EX).expect("flock"));
+
+        let (code, _output) =
+            spawn_runner(&shell_argv("kill -TERM $$"), None, &log_path, lock.as_fd())
+                .expect("runner completes");
+
+        assert_eq!(code, 128 + libc::SIGTERM);
+    }
+
+    #[test]
+    fn the_reply_carries_a_capped_log_tail() {
+        let _fds = exclusive_fds();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("activation.log");
+        let lock = open_lock_file(&dir.path().join("activation.lock")).expect("lock");
+        assert!(try_flock(&lock, libc::LOCK_EX).expect("flock"));
+
+        // Write well past the cap, ending in a recognizable line.
+        let script =
+            "i=0; while [ $i -lt 700 ]; do printf '%01024d\\n' $i; i=$((i+1)); done; echo THE-END";
+        let (code, output) = spawn_runner(&shell_argv(script), None, &log_path, lock.as_fd())
+            .expect("runner completes");
+
+        assert_eq!(code, 0);
+        assert!(output.len() as u64 <= REPLY_LOG_TAIL_BYTES + 1024);
+        assert!(output.starts_with(LOG_TRUNCATION_MARKER));
+        // The script's last line survives the cap; the missing-profile
+        // warning lands after it (no nix-env in the test environment).
+        assert!(output.contains("THE-END\n"));
+        assert!(
+            output
+                .trim_end()
+                .ends_with("failed to update system profile")
+        );
+        // The file itself keeps everything.
+        let full = fs::metadata(&log_path).expect("log metadata").len();
+        assert!(full > REPLY_LOG_TAIL_BYTES);
+    }
+
+    // ------------------------------------------------------------------
+    // Peer policy (unchanged) and activation hardening (unchanged).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn peer_policy_rejects_root_peer() {
+        assert!(check_peer_policy(0, Some(501)).is_err());
+    }
+
+    #[test]
+    fn peer_policy_rejects_uid_not_matching_console_user() {
+        assert!(check_peer_policy(502, Some(501)).is_err());
+    }
+
+    #[test]
+    fn peer_policy_rejects_when_no_console_user() {
+        assert!(check_peer_policy(501, None).is_err());
+    }
+
+    #[test]
+    fn peer_policy_accepts_console_user_peer() {
+        assert!(check_peer_policy(501, Some(501)).is_ok());
+    }
 
     fn account() -> UserAccount {
         UserAccount {
@@ -409,8 +1905,8 @@ mod tests {
         assert_eq!(&argv[1..3], ["asuser", "501"]);
         assert_eq!(&argv[3..5], ["/usr/bin/env", "-i"]);
         assert!(argv.contains(&format!("PATH={ACTIVATION_PATH_ENV}")));
-        // Account values come from the peer lookup. The protocol no longer
-        // has fields for a client to claim these with.
+        // Account values come from the peer lookup. The protocol has no
+        // fields for a client to claim these with.
         assert!(argv.contains(&"HOME=/Users/peer-alice".to_string()));
         assert!(argv.contains(&"USER=peer-alice".to_string()));
         assert_eq!(
@@ -437,36 +1933,23 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn helper_status_request_returns_ready_response() {
-        // A status request never inspects the peer; any real identity works.
+    fn activation_argv_derives_from_the_authenticated_peer_account() {
+        // The peer identity of a socketpair end is this test process, so the
+        // argv must carry this process's uid and its user-database account —
+        // the lookup keys on the authenticated uid and nothing else.
         let (stream, _other_end) = UnixStream::pair().expect("socketpair");
         let peer = peer_auth::peer_identity(&stream).expect("peer identity");
-        let response = handle_request(&peer, HelperOp::Status);
+        let me = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(peer.euid))
+            .expect("user lookup")
+            .expect("account exists");
 
-        assert!(response.ok);
-        assert_eq!(response.code, 0);
-        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-        assert!(!response.helper_build_version.is_empty());
-    }
+        let argv = activation_argv_for_peer(&peer, "/nix/store/abc-darwin-system/activate")
+            .expect("argv for peer");
 
-    #[test]
-    fn peer_policy_rejects_root_peer() {
-        assert!(check_peer_policy(0, Some(501)).is_err());
-    }
-
-    #[test]
-    fn peer_policy_rejects_uid_not_matching_console_user() {
-        assert!(check_peer_policy(502, Some(501)).is_err());
-    }
-
-    #[test]
-    fn peer_policy_rejects_when_no_console_user() {
-        assert!(check_peer_policy(501, None).is_err());
-    }
-
-    #[test]
-    fn peer_policy_accepts_console_user_peer() {
-        assert!(check_peer_policy(501, Some(501)).is_ok());
+        assert_eq!(argv[1], "asuser");
+        assert_eq!(argv[2], peer.euid.to_string());
+        assert!(argv.contains(&format!("USER={}", me.name)));
+        assert!(argv.contains(&format!("HOME={}", me.dir.display())));
     }
 
     #[test]
@@ -577,121 +2060,5 @@ mod tests {
     fn canonical_target_rejects_non_store_and_missing_paths() {
         assert!(canonical_activation_target("/tmp/activate").is_err());
         assert!(canonical_activation_target("/nix/store/no-such-item-c1-test/activate").is_err());
-    }
-
-    fn framed(request: &HelperRequest) -> Vec<u8> {
-        let mut body = serde_json::to_vec(request).expect("serialize request");
-        body.push(b'\n');
-        body
-    }
-
-    #[cfg(target_os = "macos")]
-    fn authorized_response_to(body: &[u8]) -> HelperResponse {
-        let (client, server) = UnixStream::pair().expect("socketpair");
-        let peer = peer_auth::peer_identity(&server).expect("peer identity");
-        (&client).write_all(body).expect("write request");
-
-        respond_authorized(&peer, &server).expect("responds")
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn authorized_current_version_request_crosses_the_gate_to_the_handler() {
-        let response = authorized_response_to(&framed(&HelperRequest::new(HelperOp::Status)));
-
-        assert!(response.ok);
-        assert_eq!(response.stdout, "nixmac helper ready");
-        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn version_rejection_becomes_a_versioned_protocol_error_without_a_handler() {
-        // Missing, lower, and higher versions, each on a body the version
-        // gate must stop. `ok: false` on the status shape proves the status
-        // handler never ran (it would answer ok "ready"); the skew
-        // classification on the others — whose operations are invalid or
-        // carry the v1 claimed fields — proves the gate rejected them before
-        // any operation shape was interpreted, let alone executed.
-        for body in [
-            // Missing: v1 status, no version field at all.
-            "{\"op\":\"status\"}\n".to_string(),
-            // Missing: v1 activation carrying the claimed identity/PATH fields.
-            r#"{"op":"activateStorePath","request":{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/tmp/attacker-bin"}}
-"#
-            .to_string(),
-            // Lower and higher versions on deliberately invalid operations.
-            "{\"protocolVersion\":1,\"op\":\"selfDestruct\"}\n".to_string(),
-            format!(
-                "{{\"protocolVersion\":{},\"op\":\"selfDestruct\"}}\n",
-                HELPER_PROTOCOL_VERSION + 1
-            ),
-        ] {
-            let response = authorized_response_to(body.as_bytes());
-
-            assert!(!response.ok);
-            assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-            assert!(!response.helper_build_version.is_empty());
-            assert!(response.reports_protocol_skew());
-        }
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn activation_argv_derives_from_the_authenticated_peer_account() {
-        // The peer identity of a socketpair end is this test process, so the
-        // argv must carry this process's uid and its user-database account —
-        // the lookup keys on the authenticated uid and nothing else.
-        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
-        let peer = peer_auth::peer_identity(&stream).expect("peer identity");
-        let me = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(peer.euid))
-            .expect("user lookup")
-            .expect("account exists");
-
-        let argv = activation_argv_for_peer(&peer, "/nix/store/abc-darwin-system/activate")
-            .expect("argv for peer");
-
-        assert_eq!(argv[1], "asuser");
-        assert_eq!(argv[2], peer.euid.to_string());
-        assert!(argv.contains(&format!("USER={}", me.name)));
-        assert!(argv.contains(&format!("HOME={}", me.dir.display())));
-    }
-
-    #[test]
-    fn read_request_rejects_oversized_line() {
-        let mut body = vec![b' '; MAX_REQUEST_BYTES as usize + 1];
-        body.push(b'\n');
-
-        let error = read_request(&body[..]).expect_err("oversized request must fail");
-
-        assert!(error.to_string().contains("exceeds"));
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn unauthorized_peer_gets_error_response_without_its_body_being_read() {
-        // The unsigned test binary can never pass code validation, so
-        // handle_stream must answer with an authorization error even though
-        // this end never sends a request line — proof the body is not read
-        // (or parsed) before authorization.
-        let (client, server) = UnixStream::pair().expect("socketpair");
-        let handler = std::thread::spawn(move || handle_stream(server));
-
-        let mut reply = String::new();
-        BufReader::new(client)
-            .read_line(&mut reply)
-            .expect("read response");
-        handler
-            .join()
-            .expect("handler thread")
-            .expect("stream handled");
-
-        // Authorization errors are versioned responses like every other:
-        // the strict client-side parse must accept the reply.
-        let response = HelperResponse::parse(&reply).expect("versioned response");
-        assert!(!response.ok);
-        assert_eq!(response.protocol_version, HELPER_PROTOCOL_VERSION);
-        assert!(!response.helper_build_version.is_empty());
-        assert!(response.reports_unauthorized_client());
     }
 }

--- a/apps/native/src-tauri/src/privileged_helper/mod.rs
+++ b/apps/native/src-tauri/src/privileged_helper/mod.rs
@@ -9,6 +9,7 @@ pub mod client;
 pub mod helper_runtime;
 pub mod peer_auth;
 pub mod protocol;
+pub mod reconcile;
 pub mod root_activation;
 pub mod service;
 pub mod sync_agent;

--- a/apps/native/src-tauri/src/privileged_helper/peer_auth.rs
+++ b/apps/native/src-tauri/src/privileged_helper/peer_auth.rs
@@ -7,17 +7,26 @@
 // live process → `SecCodeCheckValidity` against a pinned signing requirement.
 // Path strings never participate in the decision.
 //
+// Validation has exactly three results, as distinct types: valid (the pinned
+// requirement is satisfied), invalid (the code demonstrably does not satisfy
+// it — a completed judgment, even where the platform expresses it as an
+// error code), and error (no judgment could be reached). An error is never
+// treated as invalid: removal decisions elsewhere hang on that distinction.
+//
 // Compiled into the app, the sync agent, and the helper binaries via
 // `include!` (like `protocol.rs`), so no inner doc comments here.
 
 #[cfg(target_os = "macos")]
 use anyhow::Context;
 use anyhow::{Result, bail};
+// SDK-generated Security.framework status constants; see
+// `INVALID_SIGNATURE_STATUSES`. Aliased because the generated names keep their
+// C spelling. macOS-only: the crate links Security.framework unconditionally
+// and cannot build off Apple.
+#[cfg(target_os = "macos")]
+use objc2_security as sec;
+use serde::{Deserialize, Serialize};
 use std::os::unix::net::UnixStream;
-
-// Marker embedded in client-side daemon-validation failures so callers can
-// distinguish "impostor/stale helper at the socket" from "helper not running".
-pub const HELPER_VALIDATION_FAILED: &str = "helper at socket failed signature validation";
 
 // Everything below up to `AuditToken` builds macOS signing requirements; on
 // other targets only the `bail!` stubs are reachable, so mute dead-code there
@@ -29,6 +38,63 @@ pub const APP_CODE_IDENTIFIER: &str = "com.darkmatter.nixmac";
 pub const SYNC_AGENT_CODE_IDENTIFIER: &str = "com.darkmatter.nixmac.sync-agent";
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub const HELPER_CODE_IDENTIFIER: &str = "com.darkmatter.nixmac.helper";
+
+// Which pinned per-binary requirement a validated client satisfied. Derived
+// from the validated code object only — nothing a peer sends can influence
+// it. Serialized inside the protocol's activation info (X), hence the wire
+// names.
+//
+// These values ride inside X, which is part of the frozen `Status` and
+// `Busy(X)` replies, so the wire name of an existing kind may NEVER change or
+// be removed: the load-bearing upgrade direction is a new GUI reading the
+// installed old helper's replies, and a renamed value breaks exactly that.
+//
+// Adding a kind is weaker but not free. It only affects the reverse direction
+// — an older client reading a newer helper — where every reader is a
+// non-actor: an old client's `TryActivate` is refused as a build mismatch
+// before any `Busy(X)` could be sent, the sync agent may send nothing else at
+// all, and an old GUI is displaced and forbidden from mutating anyway. Each
+// would report an unparseable reply and defer. So a third kind degrades old
+// observers rather than deadlocking an upgrade; add one only as a deliberate
+// decision, knowing no test will fail when you do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ClientKind {
+    Gui,
+    SyncAgent,
+}
+
+impl std::fmt::Display for ClientKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ClientKind::Gui => "app",
+            ClientKind::SyncAgent => "sync agent",
+        })
+    }
+}
+
+// One signature validation's outcome. `Invalid` is a completed judgment
+// (unsigned, ad-hoc, wrong team or identifier — the answer is no); `Error`
+// means no judgment could be reached (dead peer, resource exhaustion,
+// evaluation failure) and is never treated as invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub enum SignatureValidation {
+    Valid,
+    Invalid(String),
+    Error(String),
+}
+
+// The helper's classification of a connecting client against the per-binary
+// pinned requirements, evaluated separately; the requirement that matched is
+// the client's kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub enum ClientValidation {
+    Valid(ClientKind),
+    Invalid(String),
+    Error(String),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
@@ -50,17 +116,21 @@ pub fn requirement_mode() -> RequirementMode {
     }
 }
 
-// The signing team is injected at build time; without it every peer fails
-// validation (fail closed) and unsigned dev builds fall through to the
+// The signing team is injected at build time; without it no judgment can be
+// reached (an error, fail closed) and unsigned dev builds fall through to the
 // interactive osascript path.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn configured_team_id() -> Option<&'static str> {
     option_env!("NIXMAC_TEAM_ID").filter(|team_id| !team_id.trim().is_empty())
 }
 
-// Requirement the daemon checks against a connecting client (app or sync
-// agent). Pure so requirement construction is unit-testable without Security
-// framework calls.
+// Per-binary pinned requirements. Each pins IDENTITY only — anchor, signing
+// team, and that binary's designated identifier — never a hash, version, or
+// anything release-specific: every requirement must be satisfied by every
+// past and future release of its binary, because cross-release validation is
+// what every upgrade depends on. The GUI and sync-agent requirements are
+// mutually exclusive by construction (each pins its own identifier), so the
+// one that matches is the client's kind.
 //
 // Deliberately no `entitlement[…] exists` clause: a custom entitlement is a
 // restricted entitlement, and AMFI refuses to spawn a binary carrying one
@@ -68,26 +138,29 @@ pub fn configured_team_id() -> Option<&'static str> {
 // Developer ID included, and Developer ID distribution cannot obtain such a
 // profile. Adding one here would require shipping an app that cannot launch,
 // and it would prove nothing extra: the anchor, team OU, and identifier pins
-// below already mean only our own signed app or sync agent can match.
+// below already mean only our own signed binaries can match.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-pub fn client_requirement_string(mode: RequirementMode, team_id: &str) -> String {
-    format!(
-        "{anchor} and certificate leaf[subject.OU] = \"{team_id}\" \
-         and (identifier \"{app}\" or identifier \"{agent}\")",
-        anchor = anchor_clause(mode),
-        app = APP_CODE_IDENTIFIER,
-        agent = SYNC_AGENT_CODE_IDENTIFIER,
-    )
+pub fn gui_client_requirement_string(mode: RequirementMode, team_id: &str) -> String {
+    identity_requirement(mode, team_id, APP_CODE_IDENTIFIER)
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn sync_agent_client_requirement_string(mode: RequirementMode, team_id: &str) -> String {
+    identity_requirement(mode, team_id, SYNC_AGENT_CODE_IDENTIFIER)
 }
 
 // Requirement the client checks against the daemon before sending a request.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn helper_requirement_string(mode: RequirementMode, team_id: &str) -> String {
+    identity_requirement(mode, team_id, HELPER_CODE_IDENTIFIER)
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn identity_requirement(mode: RequirementMode, team_id: &str, identifier: &str) -> String {
     format!(
         "{anchor} and certificate leaf[subject.OU] = \"{team_id}\" \
-         and identifier \"{helper}\"",
+         and identifier \"{identifier}\"",
         anchor = anchor_clause(mode),
-        helper = HELPER_CODE_IDENTIFIER,
     )
 }
 
@@ -102,6 +175,89 @@ fn anchor_clause(mode: RequirementMode) -> &'static str {
         }
         RequirementMode::Development => "anchor apple generic",
     }
+}
+
+// Security-framework validation statuses that are completed negative
+// judgments rather than failures to reach a judgment. Every value is the
+// `objc2-security` constant generated from the SDK's Security.framework
+// headers (`CSCommon.h`, `SecBase.h`, `cssmerr.h`), so a name that does not
+// exist is a build failure rather than a silently mis-transcribed number.
+//
+// Membership is still ours to maintain, and stays explicit: treating a new or
+// ambiguous status as invalid could authorize removal of a helper whose
+// identity was never actually judged.
+//
+// macOS-only, following the SDK crate that supplies the constants. Nothing off
+// Apple can produce these statuses — only `validate_signature`'s macOS arm
+// consults the table — so the tests over it are macOS-only too and run on the
+// macOS CI runner.
+#[cfg(target_os = "macos")]
+const INVALID_SIGNATURE_STATUSES: &[i32] = &[
+    // The code has no acceptable signature or does not satisfy the pinned
+    // requirement (unsigned, ad-hoc, wrong team, or wrong identifier).
+    sec::errSecCSGuestInvalid,
+    sec::errSecCSUnsigned,
+    sec::errSecCSSignatureFailed,
+    sec::errSecCSBadDictionaryFormat,
+    sec::errSecCSReqInvalid,
+    sec::errSecCSReqFailed,
+    sec::errSecCSBadObjectFormat,
+    sec::errSecCSHostReject,
+    sec::errSecCSSignatureInvalid,
+    sec::errSecCSStaticCodeChanged,
+    sec::errSecCSInfoPlistFailed,
+    sec::errSecCSNoMainExecutable,
+    sec::errSecCSBadBundleFormat,
+    sec::errSecCSBadMainExecutable,
+    sec::errSecCSInvalidPlatform,
+    sec::errSecCSInvalidTeamIdentifier,
+    sec::errSecCSBadTeamIdentifier,
+    sec::errSecCSSignatureUntrusted,
+    sec::errSecMultipleExecSegments,
+    sec::errSecCSInvalidEntitlements,
+    sec::errSecCSInvalidRuntimeVersion,
+    sec::errSecCSRevokedNotarization,
+    // A seal or nested component was checked and demonstrably failed. Dynamic
+    // validation currently checks only identity-bearing sealed components,
+    // but these remain negative judgments if Security returns them.
+    sec::errSecCSResourcesNotSealed,
+    sec::errSecCSResourcesNotFound,
+    sec::errSecCSResourcesInvalid,
+    sec::errSecCSBadResource,
+    sec::errSecCSResourceRulesInvalid,
+    sec::errSecCSResourceDirectoryFailed,
+    sec::errSecCSUnsignedNestedCode,
+    sec::errSecCSBadNestedCode,
+    sec::errSecCSResourceNotSupported,
+    sec::errSecCSRegularFile,
+    sec::errSecCSUnsealedAppRoot,
+    sec::errSecCSWeakResourceRules,
+    sec::errSecCSDSStoreSymlink,
+    sec::errSecCSAmbiguousBundleFormat,
+    sec::errSecCSBadFrameworkVersion,
+    sec::errSecCSUnsealedFrameworkRoot,
+    sec::errSecCSWeakResourceEnvelope,
+    sec::errSecCSInvalidSymlink,
+    sec::errSecCSInvalidAssociatedFileData,
+    // Certificate trust reached a negative conclusion. These may surface as
+    // either legacy CSSM or modern Security.framework statuses.
+    sec::CSSMERR_TP_CERT_EXPIRED,
+    sec::CSSMERR_TP_CERT_REVOKED,
+    sec::CSSMERR_TP_NOT_TRUSTED,
+    sec::errSecCertificateExpired,
+    sec::errSecCertificateRevoked,
+    sec::errSecNotTrusted,
+];
+
+// The explicit platform mapping behind the valid/invalid/error trichotomy.
+// A status in the table means validation completed and the peer did not
+// satisfy the pinned identity requirement. Everything else remains an error:
+// the peer may have died, resources may be exhausted, the verifier may be
+// unable to read the code, or the platform may have produced a status whose
+// semantics this build does not know well enough to authorize removal.
+#[cfg(target_os = "macos")]
+pub fn signature_judgment_completed(status: i32) -> bool {
+    INVALID_SIGNATURE_STATUSES.contains(&status)
 }
 
 // Raw kernel audit token (opaque; only Security framework and libbsm may
@@ -137,72 +293,150 @@ pub fn peer_identity(_stream: &UnixStream) -> Result<PeerIdentity> {
     bail!("peer credential validation is only implemented on macOS")
 }
 
-// Daemon-side check: the live peer code object must satisfy the client
-// requirement for this build's mode and configured team.
+// Daemon-side classification: the live peer code object is evaluated against
+// each per-binary pinned client requirement separately; the one that matches
+// is the client's kind. Invalid only when every evaluation completed its
+// judgment; any judgment-preventing failure makes the whole classification
+// an error.
 #[cfg(target_os = "macos")]
-pub fn validate_client_code(peer: &PeerIdentity) -> Result<()> {
-    let team_id = configured_team_id()
-        .ok_or_else(|| anyhow::anyhow!("no signing team configured (NIXMAC_TEAM_ID)"))?;
-    check_code_validity(
-        &peer.audit_token,
-        &client_requirement_string(requirement_mode(), team_id),
-    )
+pub fn classify_client(peer: &PeerIdentity) -> ClientValidation {
+    let Some(team_id) = configured_team_id() else {
+        return ClientValidation::Error("no signing team configured (NIXMAC_TEAM_ID)".to_string());
+    };
+    let mode = requirement_mode();
+    let mut failures = Vec::new();
+    for (kind, requirement) in [
+        (
+            ClientKind::Gui,
+            gui_client_requirement_string(mode, team_id),
+        ),
+        (
+            ClientKind::SyncAgent,
+            sync_agent_client_requirement_string(mode, team_id),
+        ),
+    ] {
+        match validate_signature(&peer.audit_token, &requirement) {
+            SignatureValidation::Valid => return ClientValidation::Valid(kind),
+            SignatureValidation::Invalid(detail) => failures.push((kind, detail, true)),
+            SignatureValidation::Error(detail) => failures.push((kind, detail, false)),
+        }
+    }
+    let judgment_completed = failures.iter().all(|(_, _, completed)| *completed);
+    let detail = failures
+        .iter()
+        .map(|(kind, detail, _)| format!("{kind}: {detail}"))
+        .collect::<Vec<_>>()
+        .join("; ");
+    if judgment_completed {
+        ClientValidation::Invalid(detail)
+    } else {
+        ClientValidation::Error(detail)
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn validate_client_code(_peer: &PeerIdentity) -> Result<()> {
+pub fn classify_client(_peer: &PeerIdentity) -> ClientValidation {
+    ClientValidation::Error("peer code validation is only implemented on macOS".to_string())
+}
+
+// Client-side assessment of whatever answers on the helper socket: the
+// peer's euid plus the trichotomous validation against the pinned helper
+// requirement. `Err` means the peer's identity could not even be read — a
+// judgment-preventing failure, so callers treat it as the error class.
+#[cfg(target_os = "macos")]
+pub fn assess_helper_peer(stream: &UnixStream) -> Result<(u32, SignatureValidation)> {
+    let peer = peer_identity(stream)?;
+    let Some(team_id) = configured_team_id() else {
+        return Ok((
+            peer.euid,
+            SignatureValidation::Error("no signing team configured (NIXMAC_TEAM_ID)".to_string()),
+        ));
+    };
+    let requirement = helper_requirement_string(requirement_mode(), team_id);
+    Ok((
+        peer.euid,
+        validate_signature(&peer.audit_token, &requirement),
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn assess_helper_peer(_stream: &UnixStream) -> Result<(u32, SignatureValidation)> {
     bail!("peer code validation is only implemented on macOS")
 }
 
-// Client-side reciprocal check, run after connect and before writing the
-// request: the process on the other end must be root and must be the signed
-// helper — not an impostor squatting on the socket path.
-#[cfg(target_os = "macos")]
+// Client-side authenticated gate, run after connect and before writing any
+// request: the process on the other end must be root and must validate as
+// the signed helper — not an impostor squatting on the socket path.
 pub fn validate_helper_peer(stream: &UnixStream) -> Result<()> {
-    validate_helper_peer_inner(stream).context(HELPER_VALIDATION_FAILED)
-}
-
-#[cfg(target_os = "macos")]
-fn validate_helper_peer_inner(stream: &UnixStream) -> Result<()> {
-    let peer = peer_identity(stream)?;
-    if peer.euid != 0 {
-        bail!("helper peer euid {} is not root", peer.euid);
+    let (euid, validation) = assess_helper_peer(stream)?;
+    if euid != 0 {
+        bail!("helper peer euid {euid} is not root");
     }
-    let team_id = configured_team_id()
-        .ok_or_else(|| anyhow::anyhow!("no signing team configured (NIXMAC_TEAM_ID)"))?;
-    check_code_validity(
-        &peer.audit_token,
-        &helper_requirement_string(requirement_mode(), team_id),
-    )
+    match validation {
+        SignatureValidation::Valid => Ok(()),
+        SignatureValidation::Invalid(detail) => {
+            bail!("helper at socket failed signature validation: {detail}")
+        }
+        SignatureValidation::Error(detail) => {
+            bail!("helper signature validation could not complete: {detail}")
+        }
+    }
 }
 
-#[cfg(not(target_os = "macos"))]
-pub fn validate_helper_peer(_stream: &UnixStream) -> Result<()> {
-    bail!("{HELPER_VALIDATION_FAILED}: only implemented on macOS")
-}
-
+// One signature validation with the explicit trichotomy mapping applied.
 #[cfg(target_os = "macos")]
-fn check_code_validity(token: &AuditToken, requirement_text: &str) -> Result<()> {
+pub fn validate_signature(token: &AuditToken, requirement_text: &str) -> SignatureValidation {
     use core_foundation::base::TCFType;
     use core_foundation::data::CFData;
     use security_framework::os::macos::code_signing::{
         Flags, GuestAttributes, SecCode, SecRequirement,
     };
 
-    let requirement: SecRequirement = requirement_text
-        .parse()
-        .with_context(|| format!("invalid signing requirement: {requirement_text}"))?;
+    let requirement: SecRequirement = match requirement_text.parse() {
+        Ok(requirement) => requirement,
+        Err(error) => {
+            return SignatureValidation::Error(format!(
+                "invalid signing requirement {requirement_text}: {error}"
+            ));
+        }
+    };
 
     let token_bytes: Vec<u8> = token.val.iter().flat_map(|v| v.to_ne_bytes()).collect();
     let token_data = CFData::from_buffer(&token_bytes);
     let mut attributes = GuestAttributes::new();
     attributes.set_audit_token(token_data.as_concrete_TypeRef());
 
-    let code = SecCode::copy_guest_with_attribues(None, &attributes, Flags::NONE)
-        .context("failed to resolve peer code object from audit token")?;
-    code.check_validity(Flags::NONE, &requirement)
-        .context("peer code failed signing-requirement validation")?;
-    Ok(())
+    // A peer whose code object cannot be resolved (it died, or the system is
+    // out of resources) prevented the judgment — an error, never invalid.
+    let code = match SecCode::copy_guest_with_attribues(None, &attributes, Flags::NONE) {
+        Ok(code) => code,
+        Err(error) => {
+            return SignatureValidation::Error(format!(
+                "failed to resolve peer code object from audit token: {error}"
+            ));
+        }
+    };
+    match code.check_validity(Flags::NONE, &requirement) {
+        Ok(()) => SignatureValidation::Valid,
+        Err(error) => {
+            let status = error.code();
+            if signature_judgment_completed(status) {
+                SignatureValidation::Invalid(format!(
+                    "peer code failed signing-requirement validation ({status})"
+                ))
+            } else {
+                SignatureValidation::Error(format!(
+                    "signing-requirement evaluation failed ({status}): {error}"
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
+pub fn validate_signature(_token: &AuditToken, _requirement_text: &str) -> SignatureValidation {
+    SignatureValidation::Error("peer code validation is only implemented on macOS".to_string())
 }
 
 // Uid of the active console user via SCDynamicStoreCopyConsoleUser.
@@ -259,34 +493,218 @@ mod tests {
     const TEAM: &str = "TESTTEAMID";
 
     #[test]
-    fn production_client_requirement_pins_developer_id_chain() {
-        let requirement = client_requirement_string(RequirementMode::Production, TEAM);
+    fn production_requirements_pin_developer_id_chain() {
+        // Pinned by equality, not by fragments: this is the other half of
+        // `requirements_pin_identity_only_never_a_hash_or_version`, which
+        // builds its expected string from this same clause and so cannot
+        // catch anything added inside it.
+        assert_eq!(
+            anchor_clause(RequirementMode::Production),
+            "anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13]"
+        );
 
-        assert!(requirement.starts_with("anchor apple generic"));
-        assert!(requirement.contains("certificate 1[field.1.2.840.113635.100.6.2.6]"));
-        assert!(requirement.contains("certificate leaf[field.1.2.840.113635.100.6.1.13]"));
-        assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac.sync-agent\""));
+        for requirement in [
+            gui_client_requirement_string(RequirementMode::Production, TEAM),
+            sync_agent_client_requirement_string(RequirementMode::Production, TEAM),
+            helper_requirement_string(RequirementMode::Production, TEAM),
+        ] {
+            assert!(requirement.starts_with("anchor apple generic"));
+            assert!(requirement.contains("certificate 1[field.1.2.840.113635.100.6.2.6]"));
+            assert!(requirement.contains("certificate leaf[field.1.2.840.113635.100.6.1.13]"));
+            assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
+        }
     }
 
     #[test]
-    fn development_client_requirement_pins_team_without_developer_id_markers() {
-        let requirement = client_requirement_string(RequirementMode::Development, TEAM);
+    fn development_requirements_pin_team_without_developer_id_markers() {
+        assert_eq!(
+            anchor_clause(RequirementMode::Development),
+            "anchor apple generic"
+        );
+
+        let requirement = gui_client_requirement_string(RequirementMode::Development, TEAM);
 
         assert!(requirement.starts_with("anchor apple generic"));
         assert!(!requirement.contains("field.1.2.840.113635.100.6.2.6"));
         assert!(!requirement.contains("field.1.2.840.113635.100.6.1.13"));
         assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac\""));
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac.sync-agent\""));
     }
 
     #[test]
-    fn helper_requirement_pins_helper_identifier() {
-        let requirement = helper_requirement_string(RequirementMode::Production, TEAM);
+    fn each_client_requirement_pins_exactly_its_own_identifier() {
+        // Mutually exclusive by construction: the requirement that matches
+        // IS the client's kind, so neither may accept the other binary.
+        let gui = gui_client_requirement_string(RequirementMode::Production, TEAM);
+        assert!(gui.contains("identifier \"com.darkmatter.nixmac\""));
+        assert!(!gui.contains(SYNC_AGENT_CODE_IDENTIFIER));
 
-        assert!(requirement.contains("identifier \"com.darkmatter.nixmac.helper\""));
-        assert!(requirement.contains("certificate leaf[subject.OU] = \"TESTTEAMID\""));
+        let agent = sync_agent_client_requirement_string(RequirementMode::Production, TEAM);
+        assert!(agent.contains("identifier \"com.darkmatter.nixmac.sync-agent\""));
+
+        let helper = helper_requirement_string(RequirementMode::Production, TEAM);
+        assert!(helper.contains("identifier \"com.darkmatter.nixmac.helper\""));
+        assert!(!helper.contains(SYNC_AGENT_CODE_IDENTIFIER));
+    }
+
+    // macOS-only for its second half, which reads the SDK status constants.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_nixmac_binary_of_the_wrong_kind_is_invalid_not_an_error() {
+        // The two halves that compose this judgment, stated together because
+        // the conclusion is what the legacy classification depends on:
+        //
+        // 1. Each requirement pins only its own binary's identifier, so a
+        //    genuine nixmac binary evaluated against another kind's
+        //    requirement does not satisfy it...
+        let gui = gui_client_requirement_string(RequirementMode::Production, TEAM);
+        let agent = sync_agent_client_requirement_string(RequirementMode::Production, TEAM);
+        let helper = helper_requirement_string(RequirementMode::Production, TEAM);
+        assert!(!gui.contains(SYNC_AGENT_CODE_IDENTIFIER));
+        assert!(!gui.contains(HELPER_CODE_IDENTIFIER));
+        assert!(!agent.contains(&format!("identifier \"{APP_CODE_IDENTIFIER}\"")));
+        assert!(!agent.contains(HELPER_CODE_IDENTIFIER));
+        assert!(!helper.contains(SYNC_AGENT_CODE_IDENTIFIER));
+
+        // 2. ...and the platform reports that non-satisfaction as
+        //    errSecCSReqFailed, which is a completed judgment. So the answer
+        //    is "no", never "could not tell" — an error would wrongly select
+        //    nothing where invalid selects the legacy removal path.
+        assert!(signature_judgment_completed(sec::errSecCSReqFailed));
+    }
+
+    #[test]
+    fn requirements_pin_identity_only_never_a_hash_or_version() {
+        // A hash/version/release/build-ID constraint would make a genuine
+        // older or newer nixmac binary fail validation — new GUIs would
+        // classify old helpers as legacy and direct-kill them. Identity only,
+        // forever.
+        //
+        // Asserted as exact equality rather than a forbidden-substring list:
+        // any clause added here fails, including one nobody thought to name.
+        // The expected string reuses `anchor_clause`, so this test says only
+        // that nothing but anchor, team, and identifier is present — the two
+        // tests above pin the anchor's own content by equality, which is what
+        // closes the gap.
+        for mode in [RequirementMode::Production, RequirementMode::Development] {
+            let anchor = anchor_clause(mode);
+            for (requirement, identifier) in [
+                (
+                    gui_client_requirement_string(mode, TEAM),
+                    APP_CODE_IDENTIFIER,
+                ),
+                (
+                    sync_agent_client_requirement_string(mode, TEAM),
+                    SYNC_AGENT_CODE_IDENTIFIER,
+                ),
+                (
+                    helper_requirement_string(mode, TEAM),
+                    HELPER_CODE_IDENTIFIER,
+                ),
+            ] {
+                assert_eq!(
+                    requirement,
+                    format!(
+                        "{anchor} and certificate leaf[subject.OU] = \"{TEAM}\" and identifier \"{identifier}\""
+                    )
+                );
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn invalid_classified_platform_codes_are_completed_judgments() {
+        // The explicit mapping covers the contract's named identity failures
+        // and each broader completed-negative category Security can report.
+        // Named via `stringify!` so a failure reports which status, without
+        // restating the name as a string literal beside the constant.
+        macro_rules! assert_completed_judgment {
+            ($($status:path),+ $(,)?) => {
+                $(assert!(
+                    signature_judgment_completed($status),
+                    concat!(stringify!($status), " must be invalid"),
+                );)+
+            };
+        }
+        assert_completed_judgment!(
+            sec::errSecCSUnsigned,
+            sec::errSecCSSignatureFailed,
+            sec::errSecCSReqFailed,
+            sec::errSecCSGuestInvalid,
+            sec::errSecCSResourcesInvalid,
+            sec::errSecCSInfoPlistFailed,
+            sec::errSecCSBadNestedCode,
+            sec::errSecCSSignatureUntrusted,
+            sec::errSecCSRevokedNotarization,
+            sec::CSSMERR_TP_CERT_REVOKED,
+            sec::errSecCertificateRevoked,
+        );
+
+        // Every entry in the maintained table is intentionally classified as
+        // a completed judgment. This catches a future predicate rewrite that
+        // accidentally drops one of the SDK-backed cases.
+        for status in INVALID_SIGNATURE_STATUSES {
+            assert!(signature_judgment_completed(*status), "status {status}");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn other_statuses_are_judgment_preventing_errors() {
+        // Anything not in the explicit invalid set prevented the judgment:
+        // an error, never invalid (an error must never select removal).
+        for status in [
+            0,
+            -1,
+            // memFullErr (resource exhaustion) lives in MacTypes.h, outside the
+            // Security headers, so it has no generated constant.
+            -108,
+            sec::errSecCSNoSuchCode,             // the peer is gone
+            sec::errSecCSSignatureNotVerifiable, // verifier could not read code
+            sec::errSecCSInternalError,
+            sec::errSecCSDBAccess,
+            sec::errSecCSCancelled,
+            i32::MIN,
+        ] {
+            assert!(!signature_judgment_completed(status), "status {status}");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn this_test_binary_classifies_as_invalid_not_error() {
+        // The test binary is unsigned (or ad-hoc signed on Apple silicon):
+        // either way the judgment completes with "no". Landing in Error here
+        // would break the trichotomy — a merely-unsigned peer must be a
+        // completed judgment.
+        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
+        let peer = peer_identity(&stream).expect("peer identity");
+
+        match classify_client(&peer) {
+            ClientValidation::Invalid(_) => {}
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn assess_helper_peer_reports_euid_and_a_completed_judgment() {
+        // A socketpair peer is this (non-root, unsigned/ad-hoc) process: the
+        // assessment must carry the real euid and an Invalid judgment — the
+        // shape the legacy-vs-error distinction is built from.
+        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
+
+        let (euid, validation) = assess_helper_peer(&stream).expect("assessment");
+
+        assert_eq!(euid, nix::unistd::geteuid().as_raw());
+        assert!(matches!(validation, SignatureValidation::Invalid(_)));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn validate_helper_peer_rejects_this_non_root_test_process() {
+        let (stream, _other_end) = UnixStream::pair().expect("socketpair");
+
+        assert!(validate_helper_peer(&stream).is_err());
     }
 }

--- a/apps/native/src-tauri/src/privileged_helper/protocol.rs
+++ b/apps/native/src-tauri/src/privileged_helper/protocol.rs
@@ -1,8 +1,14 @@
+use crate::privileged_helper::peer_auth::ClientKind;
 use anyhow::{Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::path::{Component, Path, PathBuf};
 
+// The protocol's name for the frozen launchd label. The value takes effect
+// through the shipped resource plist (see the plist note below); the test
+// that reads that plist is what ties the two together, and is also this
+// constant's consumer in targets that ship no plist.
+#[cfg_attr(not(test), allow(dead_code))]
 pub const HELPER_LABEL: &str = "com.darkmatter.nixmac.helper";
 pub const SYNC_AGENT_LABEL: &str = "com.darkmatter.nixmac.sync-agent";
 #[cfg(target_os = "macos")]
@@ -12,189 +18,139 @@ pub const SYNC_AGENT_PLIST_NAME: &str = "com.darkmatter.nixmac.sync-agent.plist"
 pub const HELPER_SOCKET_PATH: &str = "/var/run/nixmac/helper.sock";
 #[allow(dead_code)]
 pub const HELPER_SOCKET_DIR: &str = "/var/run/nixmac";
-/// Prefix of the daemon's response when the connecting peer fails
-/// authorization. The app matches on it — only through
-/// `HelperResponse::reports_unauthorized_client`, which requires it as a
-/// prefix — to fall back to the interactive osascript path instead of
-/// surfacing a hard error (unsigned dev builds land here by design).
-pub const UNAUTHORIZED_CLIENT_ERROR: &str = "unauthorized helper client";
-/// Wire marker for protocol-version skew: the prefix of `ProtocolSkew`'s
-/// display form, and therefore of the daemon's response `error` string when
-/// a request's version is missing or wrong. Classification cannot cross the
-/// JSON boundary, so a *daemon-reported* skew is detected from this marker —
-/// only through `HelperResponse::reports_protocol_skew`, which requires it
-/// as a prefix. For client-side failures use `is_protocol_skew`, never
-/// display text. Kept distinct from `UNAUTHORIZED_CLIENT_ERROR` so a
-/// version-skewed helper/app pairing is distinguishable from a rejected
-/// client.
-pub const UNSUPPORTED_PROTOCOL_ERROR: &str = "unsupported helper protocol version";
-/// Wire protocol the daemon and its clients speak. Version 2 dropped every
-/// claimed-identity field: the daemon derives the account from the socket
-/// peer's credentials, so there is nothing left for a client to assert about
-/// itself.
-pub const HELPER_PROTOCOL_VERSION: u32 = 2;
+/// The exclusive activation lock. FROZEN — this path may never change in any
+/// future build: it is the rendezvous between an orphaned activation runner
+/// from one helper generation and the helper (or password-path executor) of
+/// any other. A build that moved it would admit a second activation beside a
+/// runner it can no longer see. Root-owned, mode 0600, and NEVER unlinked:
+/// `flock` binds to the inode, so unlink-and-recreate while an orphan holds
+/// the old inode's lock would silently double the single slot.
+pub const ACTIVATION_LOCK_PATH: &str = "/var/run/nixmac/activation.lock";
+/// The activation runner's merged output. Not frozen: only the helper that
+/// spawned a runner reads it back (same build by construction). Root-owned,
+/// mode 0600, truncated per activation, never unlinked.
+pub const ACTIVATION_LOG_PATH: &str = "/var/run/nixmac/activation.log";
+/// Build identity compiled into this binary (`build.rs` embeds it for the GUI,
+/// helper, and sync-agent targets alike). It identifies a build and nothing
+/// else: the only operation performed on it is exact string equality, so no
+/// syntax is required or checked — not here, and not on any peer's value.
+pub const BUILD_ID: &str = env!("NIXMAC_BUILD_ID");
 const DEFAULT_SYNC_AGENT_INTERVAL_SECONDS: u32 = 900;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct HelperServiceStatus {
-    pub label: String,
-    pub available: bool,
-    pub registered: bool,
-    pub authorized: bool,
-    pub socket_available: bool,
-    /// The daemon answered an authenticated status round-trip: the client
-    /// validated the daemon's signature, the daemon accepted this client,
-    /// and both sides proved they speak the same protocol version. A
-    /// protocol-error response never sets this.
-    pub responding: bool,
-    pub detail: Option<String>,
-}
+// ---------------------------------------------------------------------------
+// Requests.
+//
+// Two request shapes, tagged by `kind`, and the set is closed forever. A
+// request either parses completely or is not understood: there is no envelope
+// to read separately from a body, and no version field — a receiver that
+// cannot parse a request cannot serve it either way.
+//
+// `Status` is the cross-build control language and is frozen forever: a new
+// GUI must be able to ask an older installed helper what it is. That is the
+// entire negotiation — replacing a helper needs no cooperation from it,
+// because activations run in a detached runner that survives the helper's
+// termination. `TryActivate` only ever succeeds between binaries of the same
+// build (it carries a build ID that must equal the helper's), so its shape
+// may evolve freely.
+// ---------------------------------------------------------------------------
 
-impl HelperServiceStatus {
-    pub fn unavailable(detail: impl Into<String>) -> Self {
-        Self {
-            label: HELPER_LABEL.to_string(),
-            available: false,
-            registered: false,
-            authorized: false,
-            socket_available: false,
-            responding: false,
-            detail: Some(detail.into()),
-        }
-    }
-}
-
-/// The activation target, and nothing else. Account name, uid, and home come
-/// from the socket peer's credentials, and the privileged `PATH` is fixed, so
-/// a client has nothing left to claim. Unknown fields are rejected rather
-/// than ignored: a v1 client's `userName`/`userId`/`home`/`nixPath` must fail
-/// loudly, never look like it was honored.
-#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct ActivateStorePathRequest {
-    pub activate_path: String,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Type, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct SyncAgentLaunchConfig {
-    pub config_dir: Option<String>,
-    pub host_attr: Option<String>,
-    pub sync_pull: bool,
-    pub unattended_apply: bool,
-    pub start_interval_seconds: Option<u32>,
-}
-
-/// Everything a client puts on the socket. The version is outside the
-/// operation so it can be checked before the operation is acted on.
+/// The `TryActivate` activation body: the client-generated request ID and the
+/// activation script path. NOT frozen. Unknown fields are rejected so a field
+/// this build does not honor can never look like it was.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct HelperRequest {
-    pub protocol_version: u32,
-    pub op: HelperOp,
+pub struct TryActivateBody {
+    pub request_id: String,
+    pub script_path: String,
+}
+
+/// Everything a client may put on the socket. `Status` is kind-only: it
+/// carries no build ID because it is exactly the request that must work
+/// across builds. FROZEN — the `kind` tags and the kind-only shape may never
+/// change, and no kind may ever be added.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum HelperRequest {
+    Status,
+    /// The sender's build ID plus its activation body. The helper compares the
+    /// ID after parsing the whole request, as a race guard on an exchange that
+    /// is only ever same-build.
+    #[serde(rename_all = "camelCase")]
+    TryActivate {
+        build_id: String,
+        body: TryActivateBody,
+    },
 }
 
 impl HelperRequest {
-    pub fn new(op: HelperOp) -> Self {
-        Self {
-            protocol_version: HELPER_PROTOCOL_VERSION,
-            op,
-        }
+    /// Serializes one request line, without the trailing newline the caller
+    /// appends.
+    pub fn encode(&self) -> String {
+        serde_json::to_string(self).expect("helper request serializes")
     }
 
-    /// Daemon-side gate: no operation is derived until the sender is known
-    /// to speak this daemon's protocol. The version is probed before the
-    /// strict parse so an alien shape is reported as version skew rather
-    /// than as whichever unfamiliar field serde trips over first.
-    pub fn parse(line: &str) -> Result<HelperOp> {
-        check_wire_version(line)?;
-        let request: Self = serde_json::from_str(line)?;
-        Ok(request.op)
+    /// Reads one wire line. `None` means the request is not understood — not
+    /// JSON, an unknown kind, or a malformed activation body — which the
+    /// helper answers with the frozen request-not-understood refusal. Unknown
+    /// fields on a known kind are ignored, so a future build's `Status` still
+    /// reads as `Status`.
+    pub fn parse(line: &str) -> Option<Self> {
+        serde_json::from_str(line).ok()
     }
 }
 
-/// Classified protocol-version skew. This is the error type behind every
-/// version-gate rejection, so consumers detect skew structurally with
-/// `is_protocol_skew` instead of parsing display text.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ProtocolSkew {
-    /// Version the other side sent; `None` when the shape carried no
-    /// version at all (the v1 wire).
-    pub peer_version: Option<u32>,
+// ---------------------------------------------------------------------------
+// Replies.
+// ---------------------------------------------------------------------------
+
+/// The two helper states, named verbatim in `Status` replies so every caller
+/// can distinguish them. Part of the frozen surface. There is no third state:
+/// activations run in a detached runner, and the single slot is an OS lock
+/// the helper observes rather than a phase it moves through.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum HelperStateName {
+    Idle,
+    Activating,
 }
 
-impl std::fmt::Display for ProtocolSkew {
+impl std::fmt::Display for HelperStateName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.peer_version {
-            Some(version) => write!(
-                f,
-                "{UNSUPPORTED_PROTOCOL_ERROR} {version} (this build speaks {HELPER_PROTOCOL_VERSION})"
-            ),
-            None => write!(
-                f,
-                "{UNSUPPORTED_PROTOCOL_ERROR}: no protocolVersion field (this build speaks {HELPER_PROTOCOL_VERSION})"
-            ),
-        }
+        f.write_str(match self {
+            HelperStateName::Idle => "idle",
+            HelperStateName::Activating => "activating",
+        })
     }
 }
 
-impl std::error::Error for ProtocolSkew {}
-
-/// True when `error` is (or wraps) a version-gate `ProtocolSkew`. This is
-/// the client-side classification callers act on — the display text is not
-/// part of the contract.
-pub fn is_protocol_skew(error: &anyhow::Error) -> bool {
-    error
-        .chain()
-        .any(|cause| cause.downcast_ref::<ProtocolSkew>().is_some())
-}
-
-/// Reads only `protocolVersion` out of one wire line and requires it to be
-/// exactly this build's version. The probe deliberately ignores every other
-/// field: its job is to decide whether the rest of the shape may be
-/// interpreted at all, so it must parse shapes this build otherwise rejects
-/// (v1 carried no version field at all).
-fn check_wire_version(line: &str) -> Result<()> {
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct VersionProbe {
-        protocol_version: Option<u32>,
-    }
-
-    match serde_json::from_str::<VersionProbe>(line)?.protocol_version {
-        Some(HELPER_PROTOCOL_VERSION) => Ok(()),
-        peer_version => Err(ProtocolSkew { peer_version }.into()),
-    }
-}
-
-/// Externally tagged: serde honors `deny_unknown_fields` on a plain payload
-/// struct, but ignores it on the variants of an internally tagged enum, and
-/// rejecting unknown fields is the point of this shape.
+/// X: the in-flight activation's identity — the client-generated request ID
+/// and script path from the `TryActivate` body, plus the submitting client's
+/// kind, which the helper stamps from its own validation of that client,
+/// never from the body. Informational only; no decision branches on these
+/// fields, which is also why a helper relaunched over a running activation
+/// may report the state without them. Its representation inside `Status`
+/// replies is part of the frozen surface.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub enum HelperOp {
-    Status,
-    ActivateStorePath(ActivateStorePathRequest),
+pub struct ActivationInfo {
+    pub request_id: String,
+    pub script_path: String,
+    pub client_kind: ClientKind,
 }
 
-/// Everything the daemon puts back on the socket. Every response — status,
-/// activation success or failure, and protocol errors alike — carries the
-/// version, because the constructors below stamp it and the daemon builds
-/// responses only through them. `helper_build_version` is diagnostic (for
-/// support and telemetry): release versions are not unique across rebuilds,
-/// so the update and trust decisions belong to the signature checks and the
-/// version gate, never to this string. There is no stderr field: the
-/// activation runs with stderr merged into stdout (`2>&1`), so `stdout` is
-/// the whole interleaved log, and helper-level failures use `error`.
+/// A finished activation's result, sent on the same connection when the
+/// activation completes; within this protocol it is the only way to learn an
+/// activation's outcome. NOT frozen — it never crosses builds. There is no
+/// stderr field: the activation runs with stderr merged into stdout, so
+/// `stdout` is the whole interleaved log and helper-level failures use
+/// `error`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct HelperResponse {
-    pub protocol_version: u32,
-    pub helper_build_version: String,
+#[serde(rename_all = "camelCase")]
+pub struct ActivationResult {
     pub ok: bool,
     pub code: i32,
     pub stdout: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
@@ -202,12 +158,12 @@ pub struct HelperResponse {
 /// the (merged) stdout, so consumers can surface them.
 pub const HELPER_WARNING_PREFIX: &str = "nixmac-helper: warning:";
 
-impl HelperResponse {
+impl ActivationResult {
     /// Human-readable failure detail: the explicit error when present, else
     /// the tail of stdout — the helper merges the activation's stderr into
-    /// stdout (`2>&1`), so on a plain nonzero exit the detail lives there.
-    /// Used by the sync-agent binary (this file is `include!`d there), hence
-    /// dead code in targets that report through other paths.
+    /// stdout, so on a plain nonzero exit the detail lives there. Used by the
+    /// sync-agent binary (this file is `include!`d there), hence dead code in
+    /// targets that report through other paths.
     #[allow(dead_code)]
     pub fn failure_detail(&self) -> String {
         if let Some(error) = self.error.as_deref().filter(|error| !error.is_empty()) {
@@ -229,62 +185,126 @@ impl HelperResponse {
             .filter(|line| line.starts_with(HELPER_WARNING_PREFIX))
             .collect()
     }
+}
 
-    pub fn ok(stdout: impl Into<String>) -> Self {
-        Self::from_exit(true, 0, stdout.into())
+/// Everything the helper puts back on the socket, tagged by `reply`.
+///
+/// Frozen forever: the `Status` reply (including X's representation) and the
+/// three typed refusals (`BuildMismatch`, `CallerNotPermitted`,
+/// `RequestNotUnderstood`). The `Busy` and `ActivationResult` replies are NOT
+/// frozen — they only ever answer `TryActivate`, which never crosses builds.
+///
+/// Refusals are typed wire shapes; nothing classifies a reply from display
+/// strings.
+///
+/// The `reply` tag of every frozen variant below may NEVER be renamed or
+/// removed: a new GUI must be able to parse the replies of the older installed
+/// helper it is replacing, and that is the direction every upgrade depends on.
+///
+/// Adding a variant is a separate question, and the reply table answers it:
+/// each request already has a fixed set of permitted replies, so a new variant
+/// may not be sent in answer to `Status` regardless of whether older clients
+/// could parse it. A genuinely new reply belongs on an unfrozen exchange
+/// (today, only `TryActivate`'s).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "reply", rename_all = "camelCase")]
+pub enum HelperReply {
+    /// State named verbatim, the helper's build ID, and X while an activation
+    /// runs — when this helper process knows it. A helper relaunched over a
+    /// running activation observes `activating` from the lock but never knew
+    /// X, so `activation` may be absent in that state. This is the
+    /// cross-build discovery exchange: the build ID is read whatever it
+    /// contains, empty included — an empty ID is simply unequal to this
+    /// build's, never a reason to reject the reply.
+    #[serde(rename_all = "camelCase")]
+    Status {
+        state: HelperStateName,
+        helper_build_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        activation: Option<ActivationInfo>,
+    },
+    /// To `TryActivate`: an activation is running; transient. `activation`
+    /// carries X when this helper process spawned the running activation; a
+    /// relaunched helper, or one refusing over the password path's lock,
+    /// never knew it.
+    Busy {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        activation: Option<ActivationInfo>,
+    },
+    /// The completion-time result of an admitted `TryActivate`.
+    ActivationResult(ActivationResult),
+    /// Typed refusal: the `TryActivate` sender's build ID is not exactly the
+    /// helper's. The helper must be upgraded or disabled — this is a refusal,
+    /// never permission to activate some other way.
+    #[serde(rename_all = "camelCase")]
+    BuildMismatch { helper_build_id: String },
+    /// Typed refusal: the authenticated caller may not make this request (the
+    /// sync agent may only send `TryActivate`).
+    CallerNotPermitted,
+    /// Typed refusal: the request did not parse — not JSON, an unknown kind,
+    /// or a malformed activation body.
+    RequestNotUnderstood,
+}
+
+impl HelperReply {
+    pub fn encode(&self) -> String {
+        serde_json::to_string(self).expect("helper reply serializes")
     }
 
-    pub fn error(code: i32, error: impl Into<String>) -> Self {
-        Self {
-            error: Some(error.into()),
-            ..Self::from_exit(false, code, String::new())
-        }
-    }
-
-    /// Base constructor the other constructors delegate to; also used
-    /// directly for a finished activation command, where `ok` mirrors the
-    /// exit status and `stdout` is the merged activation log.
-    pub fn from_exit(ok: bool, code: i32, stdout: String) -> Self {
-        Self {
-            protocol_version: HELPER_PROTOCOL_VERSION,
-            helper_build_version: env!("NIXMAC_VERSION").to_string(),
-            ok,
-            code,
-            stdout,
-            error: None,
-        }
-    }
-
-    /// Client-side gate, mirroring `HelperRequest::parse`: the version is
-    /// checked before `ok`, output, or error fields exist to be read, and a
-    /// missing or different version fails as a classified `ProtocolSkew`.
-    /// How to recover — reconciling the installed helper, or an interactive
-    /// fallback — is the caller's policy, not this layer's contract.
+    /// Client-side parse. A reply that does not parse is treated as a
+    /// refusal by every caller: do not activate, do not mutate, report and
+    /// defer.
     pub fn parse(line: &str) -> Result<Self> {
-        check_wire_version(line)?;
-        Ok(serde_json::from_str(line)?)
+        let reply: Self = serde_json::from_str(line)?;
+        if let HelperReply::Status {
+            state: HelperStateName::Idle,
+            activation: Some(_),
+            ..
+        } = &reply
+        {
+            // The reverse — `activating` with no X — is a legitimate reply
+            // from a helper relaunched over a running activation.
+            bail!("Status state idle carries an activation payload");
+        }
+        Ok(reply)
     }
 
-    /// True when this daemon-reported response is the version gate's own
-    /// rejection. The marker is required as a prefix — the daemon puts the
-    /// classification first in `error` — so an unrelated failure that merely
-    /// mentions the marker text deeper in its message never classifies as
-    /// skew.
-    pub fn reports_protocol_skew(&self) -> bool {
-        self.reports_marker(UNSUPPORTED_PROTOCOL_ERROR)
-    }
-
-    /// True when this daemon-reported response is the daemon refusing the
-    /// connecting peer. Prefix-matched for the same reason as
-    /// `reports_protocol_skew`.
-    pub fn reports_unauthorized_client(&self) -> bool {
-        self.reports_marker(UNAUTHORIZED_CLIENT_ERROR)
-    }
-
-    fn reports_marker(&self, marker: &str) -> bool {
-        self.error
-            .as_deref()
-            .is_some_and(|error| error.starts_with(marker))
+    /// One-line human description for reports and logs. Display only —
+    /// classification always goes through the typed variants, never through
+    /// this text.
+    #[allow(dead_code)]
+    pub fn summary(&self) -> String {
+        match self {
+            HelperReply::Status {
+                state,
+                helper_build_id,
+                ..
+            } => format!("helper is {state} at build {helper_build_id}"),
+            HelperReply::Busy {
+                activation: Some(activation),
+            } => format!(
+                "the helper is running an activation ({} submitted by the {})",
+                activation.script_path, activation.client_kind
+            ),
+            HelperReply::Busy { activation: None } => {
+                "the helper is running an activation".to_string()
+            }
+            HelperReply::ActivationResult(result) if result.ok => {
+                "activation completed".to_string()
+            }
+            HelperReply::ActivationResult(result) => {
+                format!("activation failed (exit code {})", result.code)
+            }
+            HelperReply::BuildMismatch { helper_build_id } => format!(
+                "the installed helper is from a different nixmac build (build {helper_build_id})"
+            ),
+            HelperReply::CallerNotPermitted => {
+                "the helper does not permit this caller to make that request".to_string()
+            }
+            HelperReply::RequestNotUnderstood => {
+                "the helper did not understand the request".to_string()
+            }
+        }
     }
 }
 
@@ -324,56 +344,40 @@ pub fn canonicalize_activate_path(path: impl AsRef<Path>) -> Result<PathBuf> {
     validate_canonical_activate_path(&canonical)
 }
 
-/// A ready-to-send activation envelope. Opaque on purpose: `activation_request`
+/// A ready-to-send activation body. Opaque on purpose: `activation_request`
 /// is the only constructor, so the client's activation entry point cannot be
-/// handed a status operation or a hand-assembled envelope with a different
-/// version or a non-canonicalized target.
+/// handed a hand-assembled body with a non-canonicalized target.
 #[derive(Debug, Clone)]
-pub struct ActivationRequest(pub(crate) HelperRequest);
+pub struct ActivationRequest(pub(crate) TryActivateBody);
 
-/// Builds the versioned activation envelope for the current process.
-/// Resolving the path here is a convenience so an obviously wrong target
-/// fails before a round trip; the daemon canonicalizes and revalidates
-/// independently, and treats nothing in this request as trusted beyond the
-/// path it re-derives.
+/// Builds the `TryActivate` body for the current process, with a fresh
+/// client-generated request ID. Resolving the path here is a convenience so
+/// an obviously wrong target fails before a round trip; the helper
+/// canonicalizes and revalidates independently, and treats nothing in this
+/// request as trusted beyond the path it re-derives.
 pub fn activation_request(activate_path: &Path) -> Result<ActivationRequest> {
     let canonical = canonicalize_activate_path(activate_path)?;
 
-    Ok(ActivationRequest(HelperRequest::new(
-        HelperOp::ActivateStorePath(ActivateStorePathRequest {
-            activate_path: canonical.to_string_lossy().into_owned(),
-        }),
-    )))
+    Ok(ActivationRequest(TryActivateBody {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        script_path: canonical.to_string_lossy().into_owned(),
+    }))
 }
 
-#[allow(dead_code)]
-pub fn helper_launch_daemon_plist() -> String {
-    format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>{HELPER_LABEL}</string>
-  <key>BundleProgram</key>
-  <string>Contents/MacOS/nixmac-helper</string>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>AssociatedBundleIdentifiers</key>
-  <array>
-    <string>com.darkmatter.nixmac</string>
-    <string>com.darkmatter.nixmac.dev</string>
-  </array>
-  <key>StandardOutPath</key>
-  <string>/Library/Logs/nixmac-helper.log</string>
-  <key>StandardErrorPath</key>
-  <string>/Library/Logs/nixmac-helper.err.log</string>
-</dict>
-</plist>
-"#
-    )
+// The helper's LaunchDaemon plist is NOT generated here: the bundle ships
+// `resources/launchd/com.darkmatter.nixmac.helper.plist` — one source of truth,
+// asserted by `the_shipped_helper_plist_carries_the_load_bearing_keys` below
+// so this module notices if the shipped artifact drifts from what the
+// protocol relies on.
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncAgentLaunchConfig {
+    pub config_dir: Option<String>,
+    pub host_attr: Option<String>,
+    pub sync_pull: bool,
+    pub unattended_apply: bool,
+    pub start_interval_seconds: Option<u32>,
 }
 
 pub fn sync_agent_plist(program_path: &str, config: Option<&SyncAgentLaunchConfig>) -> String {
@@ -458,6 +462,323 @@ fn escape_xml(value: &str) -> String {
 mod tests {
     use super::*;
 
+    const BUILD_A: &str = "build-a";
+    const BUILD_B: &str = "build-b";
+    const SCRIPT: &str = "/nix/store/abc-darwin-system/activate";
+
+    fn activation_info(kind: ClientKind) -> ActivationInfo {
+        ActivationInfo {
+            request_id: "req-1".to_string(),
+            script_path: SCRIPT.to_string(),
+            client_kind: kind,
+        }
+    }
+
+    fn try_activate(build_id: &str) -> HelperRequest {
+        HelperRequest::TryActivate {
+            build_id: build_id.to_string(),
+            body: TryActivateBody {
+                request_id: "req-1".to_string(),
+                script_path: SCRIPT.to_string(),
+            },
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Frozen-surface golden fixtures.
+    //
+    // The frozen surface is the cross-build control language and nothing
+    // else: `Status`, its replies, and the typed refusals. Each fixture
+    // below says exactly which bytes may never change. `TryActivate`, its
+    // `Busy` refusal, and its result are explicitly unfrozen and covered by
+    // ordinary round-trip tests further down.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn frozen_control_request() {
+        // FROZEN SURFACE — this fixture may never change. It carries no
+        // build ID and no version: it is exactly the request that must work
+        // when the peer is from another build.
+        let fixture = r#"{"kind":"status"}"#;
+        assert_eq!(HelperRequest::Status.encode(), fixture);
+        assert_eq!(
+            HelperRequest::parse(fixture).expect("parses"),
+            HelperRequest::Status
+        );
+    }
+
+    #[test]
+    fn frozen_framing_is_one_newline_terminated_json_line() {
+        // FROZEN SURFACE — the framing may never change. Every exchange on
+        // this socket is one newline-terminated JSON line in each direction,
+        // and both sides read exactly one newline-delimited frame. Switching
+        // to length-prefixed or multi-line framing would break every
+        // cross-build exchange while leaving the shape fixtures above
+        // passing, so it is pinned here rather than only in the behavioral
+        // socket tests.
+        let request = HelperRequest::Status.encode();
+        let reply = HelperReply::RequestNotUnderstood.encode();
+
+        // Encoders emit exactly one line and never the terminator itself —
+        // the caller appends it, so a terminator here would frame two lines.
+        for encoded in [&request, &reply] {
+            assert!(!encoded.contains('\n'), "encoded {encoded:?} spans lines");
+        }
+
+        // What actually goes on the wire, byte for byte.
+        assert_eq!(format!("{request}\n"), "{\"kind\":\"status\"}\n");
+        assert_eq!(
+            format!("{reply}\n"),
+            "{\"reply\":\"requestNotUnderstood\"}\n"
+        );
+    }
+
+    #[test]
+    fn frozen_status_reply_per_state() {
+        // FROZEN SURFACE — one fixture per state, plus the bare `activating`
+        // a relaunched helper reports; none may ever change.
+        let cases = [
+            (
+                HelperReply::Status {
+                    state: HelperStateName::Idle,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: None,
+                },
+                format!(r#"{{"reply":"status","state":"idle","helperBuildId":"{BUILD_A}"}}"#),
+            ),
+            (
+                HelperReply::Status {
+                    state: HelperStateName::Activating,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: Some(activation_info(ClientKind::Gui)),
+                },
+                format!(
+                    r#"{{"reply":"status","state":"activating","helperBuildId":"{BUILD_A}","activation":{{"requestId":"req-1","scriptPath":"{SCRIPT}","clientKind":"gui"}}}}"#
+                ),
+            ),
+            (
+                HelperReply::Status {
+                    state: HelperStateName::Activating,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: Some(activation_info(ClientKind::SyncAgent)),
+                },
+                format!(
+                    r#"{{"reply":"status","state":"activating","helperBuildId":"{BUILD_A}","activation":{{"requestId":"req-1","scriptPath":"{SCRIPT}","clientKind":"syncAgent"}}}}"#
+                ),
+            ),
+            (
+                // A helper relaunched over a running activation: it observes
+                // the state from the lock but never knew X.
+                HelperReply::Status {
+                    state: HelperStateName::Activating,
+                    helper_build_id: BUILD_A.to_string(),
+                    activation: None,
+                },
+                format!(r#"{{"reply":"status","state":"activating","helperBuildId":"{BUILD_A}"}}"#),
+            ),
+        ];
+
+        for (reply, fixture) in cases {
+            assert_eq!(reply.encode(), fixture);
+            assert_eq!(HelperReply::parse(&fixture).expect("parses"), reply);
+        }
+    }
+
+    #[test]
+    fn frozen_typed_refusals() {
+        // FROZEN SURFACE — the three typed refusals; may never change.
+        let build_mismatch = HelperReply::BuildMismatch {
+            helper_build_id: BUILD_B.to_string(),
+        };
+        let build_mismatch_fixture =
+            format!(r#"{{"reply":"buildMismatch","helperBuildId":"{BUILD_B}"}}"#);
+        assert_eq!(build_mismatch.encode(), build_mismatch_fixture);
+        assert_eq!(
+            HelperReply::parse(&build_mismatch_fixture).expect("parses"),
+            build_mismatch
+        );
+
+        assert_eq!(
+            HelperReply::CallerNotPermitted.encode(),
+            r#"{"reply":"callerNotPermitted"}"#
+        );
+        assert_eq!(
+            HelperReply::parse(r#"{"reply":"callerNotPermitted"}"#).expect("parses"),
+            HelperReply::CallerNotPermitted
+        );
+
+        assert_eq!(
+            HelperReply::RequestNotUnderstood.encode(),
+            r#"{"reply":"requestNotUnderstood"}"#
+        );
+        assert_eq!(
+            HelperReply::parse(r#"{"reply":"requestNotUnderstood"}"#).expect("parses"),
+            HelperReply::RequestNotUnderstood
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Request and reply semantics beyond the golden bytes.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn try_activate_round_trips_with_its_build_id_and_body() {
+        // Unfrozen: an ordinary round trip, not a byte fixture.
+        let request = try_activate(BUILD_A);
+        let encoded = request.encode();
+
+        assert_eq!(HelperRequest::parse(&encoded).expect("parses"), request);
+        match HelperRequest::parse(&encoded).expect("parses") {
+            HelperRequest::TryActivate { build_id, body } => {
+                assert_eq!(build_id, BUILD_A);
+                assert_eq!(body.script_path, SCRIPT);
+            }
+            other => panic!("unexpected request: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn busy_round_trips_with_and_without_activation_details() {
+        // Unfrozen (answers only same-build TryActivate), but both shapes
+        // must round-trip: a relaunched helper refuses without X.
+        for busy in [
+            HelperReply::Busy {
+                activation: Some(activation_info(ClientKind::SyncAgent)),
+            },
+            HelperReply::Busy { activation: None },
+        ] {
+            assert_eq!(HelperReply::parse(&busy.encode()).expect("parses"), busy);
+        }
+    }
+
+    #[test]
+    fn an_unknown_kind_is_not_understood() {
+        // The kind set is closed forever; anything else is a request no
+        // receiver may serve.
+        assert!(HelperRequest::parse(r#"{"kind":"selfDestruct"}"#).is_none());
+    }
+
+    #[test]
+    fn a_control_request_from_another_build_still_reads_as_itself() {
+        // Cross-build tolerance in the direction that matters: an older or
+        // newer build's Status — including fields this build knows nothing
+        // about — must still be recognized, because it is the request that
+        // discovers a helper that is not this build.
+        assert_eq!(
+            HelperRequest::parse(r#"{"kind":"status","somethingNew":true}"#).expect("parses"),
+            HelperRequest::Status
+        );
+    }
+
+    #[test]
+    fn shipped_pre_build_id_wire_shapes_are_not_understood() {
+        // The shapes previous releases put on this socket carry no kind
+        // field; they must never be misread as a request.
+        for line in [
+            r#"{"op":"status"}"#,
+            r#"{"protocolVersion":2,"op":"status"}"#,
+            r#"{"protocolVersion":2,"op":{"activateStorePath":{"activatePath":"/nix/store/abc-darwin-system/activate"}}}"#,
+            "not json at all",
+            "",
+        ] {
+            assert!(HelperRequest::parse(line).is_none(), "line: {line:?}");
+        }
+    }
+
+    #[test]
+    fn a_malformed_try_activate_is_not_understood() {
+        // A missing body, a body field this build does not honor, and a
+        // missing build ID all fail the one parse — there is no partially
+        // readable request to act on.
+        for line in [
+            r#"{"kind":"tryActivate","buildId":"build-a"}"#,
+            r#"{"kind":"tryActivate","body":{"requestId":"req-1","scriptPath":"/nix/store/abc-darwin-system/activate"}}"#,
+            r#"{"kind":"tryActivate","buildId":"build-a","body":{"requestId":"req-1","scriptPath":"/nix/store/abc-darwin-system/activate","nixPath":"/tmp/attacker-bin"}}"#,
+            r#"{"kind":"tryActivate","buildId":"build-a","body":{"somethingElse":1}}"#,
+        ] {
+            assert!(HelperRequest::parse(line).is_none(), "line: {line:?}");
+        }
+    }
+
+    #[test]
+    fn a_peer_build_id_is_read_whatever_it_contains() {
+        // Build IDs are compared, never validated: every string is a readable
+        // ID, the empty string included. An empty peer ID is simply unequal to
+        // this build's non-empty one — rejecting the request or reply that
+        // carries it would instead make the mismatch unreportable.
+        for build_id in ["", " ", "0123456", "not-a-commit", "\u{1f600}"] {
+            let request = try_activate(build_id);
+            assert_eq!(
+                HelperRequest::parse(&request.encode()).expect("parses"),
+                request
+            );
+
+            let status = HelperReply::Status {
+                state: HelperStateName::Idle,
+                helper_build_id: build_id.to_string(),
+                activation: None,
+            };
+            assert_eq!(
+                HelperReply::parse(&status.encode()).expect("parses"),
+                status
+            );
+
+            let mismatch = HelperReply::BuildMismatch {
+                helper_build_id: build_id.to_string(),
+            };
+            assert_eq!(
+                HelperReply::parse(&mismatch.encode()).expect("parses"),
+                mismatch
+            );
+        }
+    }
+
+    #[test]
+    fn reply_parse_tolerates_unknown_fields_and_rejects_unknown_tags() {
+        // Frozen replies from other builds must keep parsing even if a
+        // diagnostic field is ever (wrongly) added; an unknown reply tag is
+        // an unparseable reply, which every client treats as a refusal.
+        let with_extra = format!(
+            r#"{{"reply":"status","state":"idle","helperBuildId":"{BUILD_A}","note":"diagnostic"}}"#
+        );
+        assert!(matches!(
+            HelperReply::parse(&with_extra).expect("parses"),
+            HelperReply::Status {
+                state: HelperStateName::Idle,
+                ..
+            }
+        ));
+
+        assert!(HelperReply::parse(r#"{"reply":"shutdown"}"#).is_err());
+        assert!(
+            HelperReply::parse(r#"{"reply":"status","state":"unheardOf","helperBuildId":"b"}"#)
+                .is_err()
+        );
+        assert!(HelperReply::parse(r#"{"ok":true,"code":0,"stdout":"ready"}"#).is_err());
+        assert!(HelperReply::parse("").is_err());
+    }
+
+    #[test]
+    fn status_reply_rejects_an_idle_state_with_an_activation() {
+        let impossible = HelperReply::Status {
+            state: HelperStateName::Idle,
+            helper_build_id: BUILD_A.to_string(),
+            activation: Some(activation_info(ClientKind::Gui)),
+        };
+
+        assert!(HelperReply::parse(&impossible.encode()).is_err());
+    }
+
+    #[test]
+    fn activation_request_canonicalizes_and_generates_request_ids() {
+        // Non-store paths fail before any round trip.
+        assert!(activation_request(Path::new("/tmp/result/activate")).is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // Path validation (unchanged behavior).
+    // ------------------------------------------------------------------
+
     #[test]
     fn validate_accepts_direct_nix_store_activate_path() {
         let path = validate_canonical_activate_path(
@@ -497,249 +818,24 @@ mod tests {
     }
 
     #[test]
-    fn request_round_trips_at_the_current_version() {
-        for op in [
-            HelperOp::Status,
-            HelperOp::ActivateStorePath(ActivateStorePathRequest {
-                activate_path: "/nix/store/abc-darwin-system/activate".to_string(),
-            }),
-        ] {
-            let wire = serde_json::to_string(&HelperRequest::new(op.clone())).expect("serializes");
-
-            assert!(wire.contains(&format!("\"protocolVersion\":{HELPER_PROTOCOL_VERSION}")));
-            assert_eq!(HelperRequest::parse(&wire).expect("parses"), op);
-        }
-    }
-
-    #[test]
-    fn request_rejects_other_protocol_versions_before_reading_the_shape() {
-        // The operation is deliberately invalid: getting the skew
-        // classification rather than an unknown-variant parse error proves
-        // the version gate wins before the rest of the shape is interpreted.
-        for version in [1, 3, 99] {
-            let json = format!("{{\"protocolVersion\":{version},\"op\":\"selfDestruct\"}}");
-            let error = HelperRequest::parse(&json).expect_err("version must be rejected");
-
-            assert!(is_protocol_skew(&error));
-            assert_eq!(
-                error.downcast_ref::<ProtocolSkew>(),
-                Some(&ProtocolSkew {
-                    peer_version: Some(version)
-                })
-            );
-        }
-    }
-
-    #[test]
-    fn activation_request_rejects_claimed_identity_fields() {
-        // A v1 body at the current version: the claimed account values and
-        // requester PATH are a hard parse error now, so they can never look
-        // like they were honored.
-        let json = format!(
-            r#"{{"protocolVersion":{HELPER_PROTOCOL_VERSION},"op":{{"activateStorePath":{{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/tmp/attacker-bin"}}}}}}"#
-        );
-
-        assert!(HelperRequest::parse(&json).is_err());
-    }
-
-    #[test]
-    fn request_rejects_unknown_envelope_fields() {
-        let json = format!(
-            r#"{{"protocolVersion":{HELPER_PROTOCOL_VERSION},"op":"status","userId":501}}"#
-        );
-
-        assert!(HelperRequest::parse(&json).is_err());
-    }
-
-    #[test]
-    fn request_rejects_the_v1_wire_shape_as_protocol_skew() {
-        // v1 tagged the operation inline and carried no version at all. Both
-        // v1 shapes must be rejected, and classified as version skew rather
-        // than a shape error, before any operation is derived.
-        for v1 in [
-            r#"{"op":"status"}"#,
-            r#"{"op":"activateStorePath","request":{"activatePath":"/nix/store/abc-darwin-system/activate","userName":"alice","userId":501,"home":"/Users/alice","nixPath":"/bin"}}"#,
-        ] {
-            let error = HelperRequest::parse(v1).expect_err("v1 shape must be rejected");
-
-            assert_eq!(
-                error.downcast_ref::<ProtocolSkew>(),
-                Some(&ProtocolSkew { peer_version: None })
-            );
-        }
-    }
-
-    /// The exact request parser the deployed v1 daemon uses, vendored as a
-    /// minimal fixture for the opposite temporal direction of the break.
-    #[derive(Deserialize)]
-    #[serde(tag = "op", rename_all = "camelCase")]
-    enum V1HelperRequest {
-        Status,
-        ActivateStorePath {
-            // Deserialized into but never read, like the payload fields.
-            #[allow(dead_code)]
-            request: V1ActivateStorePathRequest,
-        },
-    }
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    #[allow(dead_code)]
-    struct V1ActivateStorePathRequest {
-        activate_path: String,
-        user_name: String,
-        user_id: u32,
-        home: String,
-        nix_path: String,
-    }
-
-    #[test]
-    fn v1_daemon_parser_cannot_derive_an_activation_from_a_v2_request() {
-        // No-double-apply defense: if a still-resident v1 root daemon could
-        // parse a v2 activation request, it would execute the activation and
-        // answer with a versionless v1 response — which the v2 app rejects
-        // as skew, so any recovery it then attempts would re-run an
-        // already-finished activation. The v2 activation envelope must
-        // therefore be unparseable by the exact v1 request enum.
-        let activation = serde_json::to_string(&HelperRequest::new(HelperOp::ActivateStorePath(
-            ActivateStorePathRequest {
-                activate_path: "/nix/store/abc-darwin-system/activate".to_string(),
-            },
-        )))
-        .expect("serializes");
-
-        assert!(serde_json::from_str::<V1HelperRequest>(&activation).is_err());
-
-        // The v1 daemon does parse a v2 *status* request (its internally
-        // tagged enum ignores the unfamiliar protocolVersion field). That is
-        // the accepted read-only asymmetry — pinned here so an envelope
-        // change that alters it is revisited deliberately.
-        let status =
-            serde_json::to_string(&HelperRequest::new(HelperOp::Status)).expect("serializes");
-
-        assert!(matches!(
-            serde_json::from_str::<V1HelperRequest>(&status),
-            Ok(V1HelperRequest::Status)
-        ));
-    }
-
-    #[test]
-    fn every_response_shape_serializes_the_current_version() {
-        // Status, activation success, activation failure, and protocol-error
-        // responses: all carry the version and the diagnostic build version.
-        for response in [
-            HelperResponse::ok("nixmac helper ready"),
-            HelperResponse::from_exit(true, 0, "activated".to_string()),
-            HelperResponse::from_exit(false, 2, "activation exploded".to_string()),
-            HelperResponse::error(-1, format!("{UNSUPPORTED_PROTOCOL_ERROR} 1")),
-        ] {
-            assert!(!response.helper_build_version.is_empty());
-            let wire = serde_json::to_string(&response).expect("serializes");
-
-            assert!(wire.contains(&format!("\"protocolVersion\":{HELPER_PROTOCOL_VERSION}")));
-            assert!(wire.contains("\"helperBuildVersion\""));
-            assert_eq!(HelperResponse::parse(&wire).expect("parses"), response);
-        }
-    }
-
-    #[test]
-    fn response_parse_rejects_the_exact_v1_status_response() {
-        // What an installed v1 helper answers a status probe with. It must
-        // fail before ok/stdout/error are readable, classified as protocol
-        // skew for the caller's recovery policy to act on.
-        let v1 = r#"{"ok":true,"code":0,"stdout":"nixmac helper ready","stderr":"","error":null}"#;
-
-        let error = HelperResponse::parse(v1).expect_err("v1 response must be rejected");
-
-        assert!(is_protocol_skew(&error));
-        assert_eq!(
-            error.downcast_ref::<ProtocolSkew>(),
-            Some(&ProtocolSkew { peer_version: None })
-        );
-    }
-
-    #[test]
-    fn response_parse_rejects_other_protocol_versions_before_reading_the_shape() {
-        // The rest of the shape is deliberately invalid (missing required
-        // fields, an unknown one instead): getting the skew classification
-        // rather than a field-level parse error proves the version gate wins
-        // before any response field is interpreted.
-        for version in [1, 3, 99] {
-            let json = format!(r#"{{"protocolVersion":{version},"bogus":true}}"#);
-
-            let error = HelperResponse::parse(&json).expect_err("version must be rejected");
-
-            assert!(is_protocol_skew(&error));
-            assert_eq!(
-                error.downcast_ref::<ProtocolSkew>(),
-                Some(&ProtocolSkew {
-                    peer_version: Some(version)
-                })
-            );
-        }
-    }
-
-    #[test]
-    fn daemon_markers_classify_only_as_prefixes() {
-        let skew = HelperResponse::error(
-            -1,
-            ProtocolSkew {
-                peer_version: Some(1),
-            }
-            .to_string(),
-        );
-        assert!(skew.reports_protocol_skew());
-        assert!(!skew.reports_unauthorized_client());
-
-        let refused =
-            HelperResponse::error(-1, format!("{UNAUTHORIZED_CLIENT_ERROR}: bad signature"));
-        assert!(refused.reports_unauthorized_client());
-        assert!(!refused.reports_protocol_skew());
-
-        // An unrelated failure that merely mentions a marker deeper in its
-        // message must not classify.
-        let unrelated = HelperResponse::error(
-            1,
-            format!(
-                "activation failed: log mentioned '{UNSUPPORTED_PROTOCOL_ERROR}' and '{UNAUTHORIZED_CLIENT_ERROR}'"
-            ),
-        );
-        assert!(!unrelated.reports_protocol_skew());
-        assert!(!unrelated.reports_unauthorized_client());
-        assert!(!HelperResponse::ok("nixmac helper ready").reports_protocol_skew());
-    }
-
-    #[test]
-    fn response_parse_rejects_unknown_fields() {
-        let wire = serde_json::to_string(&HelperResponse::ok("ready")).expect("serializes");
-        let with_extra = wire.replacen('{', r#"{"sshAuthSock":"/tmp/ssh.sock","#, 1);
-
-        assert!(HelperResponse::parse(&with_extra).is_err());
-    }
-
-    fn response(stdout: &str, error: Option<&str>) -> HelperResponse {
-        HelperResponse {
-            error: error.map(String::from),
-            ..HelperResponse::from_exit(false, 1, stdout.to_string())
-        }
-    }
-
-    #[test]
     fn failure_detail_prefers_error_then_stdout_tail() {
-        assert_eq!(response("out", Some("boom")).failure_detail(), "boom");
+        let failed = |stdout: &str, error: Option<&str>| ActivationResult {
+            ok: false,
+            code: 1,
+            stdout: stdout.to_string(),
+            error: error.map(String::from),
+        };
+
+        assert_eq!(failed("out", Some("boom")).failure_detail(), "boom");
         // The helper merges activation stderr into stdout, so a plain nonzero
         // exit must still produce a detail.
         assert_eq!(
-            response("activation exploded\n", None).failure_detail(),
+            failed("activation exploded\n", None).failure_detail(),
             "activation exploded"
         );
-    }
 
-    #[test]
-    fn failure_detail_returns_stdout_tail_only() {
         let lines: Vec<String> = (1..=30).map(|n| format!("line {n}")).collect();
-        let detail = response(&lines.join("\n"), None).failure_detail();
-
+        let detail = failed(&lines.join("\n"), None).failure_detail();
         assert!(detail.starts_with("line 11"));
         assert!(detail.ends_with("line 30"));
     }
@@ -749,7 +845,12 @@ mod tests {
         let stdout = format!(
             "activated\n{HELPER_WARNING_PREFIX} failed to update system profile\nplain line"
         );
-        let with_warning = response(&stdout, None);
+        let with_warning = ActivationResult {
+            ok: true,
+            code: 0,
+            stdout,
+            error: None,
+        };
 
         assert_eq!(
             with_warning.warnings(),
@@ -757,16 +858,41 @@ mod tests {
                 "{HELPER_WARNING_PREFIX} failed to update system profile"
             )]
         );
-        assert!(response("no warnings here\n", None).warnings().is_empty());
     }
 
     #[test]
-    fn helper_plist_uses_bundle_program_for_smappservice() {
-        let plist = helper_launch_daemon_plist();
+    fn the_shipped_helper_plist_carries_the_load_bearing_keys() {
+        // The SHIPPED artifact, not a generator: this is the plist the bundle
+        // installs and `SMAppService` registers, and it is the only place
+        // these keys take effect.
+        let plist = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/resources/launchd/com.darkmatter.nixmac.helper.plist"
+        ))
+        .expect("the bundled helper plist exists");
 
         assert!(plist.contains("<key>BundleProgram</key>"));
         assert!(plist.contains("Contents/MacOS/nixmac-helper"));
         assert!(plist.contains(HELPER_LABEL));
+        // launchd's documented teardown at unregister kills remaining
+        // processes in the job's process group; this key disables that
+        // sweep. The detached activation runner is additionally in its own
+        // session (`setsid`), so the key is belt and braces — but the runner
+        // surviving unregister is what makes replacing the helper unable to
+        // interrupt an activation, so the key must stay in every shipped
+        // plist.
+        assert!(plist.contains("<key>AbandonProcessGroup</key>"));
+        // A crashed helper relaunches without a client connection; the
+        // relaunched instance derives its state from the activation lock.
+        assert!(plist.contains("<key>KeepAlive</key>"));
+    }
+
+    #[test]
+    fn the_lock_and_log_live_beside_the_socket() {
+        // The lock path is frozen (see its constant); both files sit in the
+        // same root-owned directory the socket already claims.
+        assert!(ACTIVATION_LOCK_PATH.starts_with(HELPER_SOCKET_DIR));
+        assert!(ACTIVATION_LOG_PATH.starts_with(HELPER_SOCKET_DIR));
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/root_activation.rs
+++ b/apps/native/src-tauri/src/privileged_helper/root_activation.rs
@@ -119,6 +119,12 @@ fn run_root_activation(args: impl IntoIterator<Item = String>) -> Result<i32> {
             "root-activation mode must run as root (it is only ever invoked via the admin prompt)"
         );
     }
+    // The same single slot the helper's runner uses: one exclusive lock for
+    // "an activation is running", across both paths and across helper
+    // generations. Held (by this process's fd) until this process exits;
+    // a holder elsewhere — a helper-spawned runner, an orphan, another
+    // password activation — refuses this one before it mutates anything.
+    let _activation_slot = helper_runtime::acquire_activation_lock()?;
     let legacy_sudoers_warning = remove_legacy_sudoers();
     // stderr is what `do shell script` surfaces on any failure — a nonzero
     // activation or any early `?` return below — so emit the warning there
@@ -154,7 +160,7 @@ fn run_root_activation(args: impl IntoIterator<Item = String>) -> Result<i32> {
         }
         // Best-effort, same as the helper: the system switch already
         // happened, so maintenance failures are warnings, not errors.
-        for warning in helper_runtime::post_activation_maintenance(&activate_path) {
+        if let Some(warning) = helper_runtime::post_activation_maintenance(&activate_path) {
             println!("{WARNING_PREFIX} {warning}");
         }
     } else {


### PR DESCRIPTION
## Summary

**Problem:** `SMAppService` unregister kills the helper process, and the helper was the process running the root activation — so replacing the helper on upgrade risked interrupting a root mutation in flight. And whatever wire surface ships is a forever commitment: every future GUI must be able to talk to a helper of any older build.

**Solution:** the helper only authenticates and admits. The activation runs in a forked `no_std` supervisor in its own session that survives unregister (the shipped plist gains `AbandonProcessGroup`, asserted by a test against the real resource), so terminating a helper interrupts nothing. The single activation slot is an exclusive `flock` on a never-unlinked lock file, shared with the password path's root executor, so "an activation is running" has one source of truth across helper generations and both paths. The cross-build wire is kept minimal — a frozen `Status` exchange plus three typed refusals, byte-pinned by golden tests — while `TryActivate` stays same-build-only and free to change. Connections close after the reply.

Stacked on #667.

## Test Plan

- [x] `cargo test` green: golden wire fixtures, flock admission/release (incl. unwind paths), real fork+supervise integration tests (exit codes, signal deaths, straggler cannot inherit the lock, capped log tail, profile-update warning)
- [x] Platform behavior verified by hand on macOS 26.6.2: a detached child of an SMAppService daemon survives `unregister`, `launchctl asuser` keeps working from the orphan, and a full real nix-darwin activation started before unregister ran to completion (exit 0) after it

## Docs

- [x] No docs update needed

## Prior review

`peer_auth.rs` (710 lines) is byte-identical to the version Scott approved in #619. Everything else here is the redesign that replaced #619's single-slot state machine — the detached runner, the flock slot, and the shrunken frozen wire — and is the part that needs a real review.