### PR TITLE
feat(helper): reconcile installs, route applies

### DIFF
--- a/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
+++ b/apps/native/src-tauri/src/bin/nixmac-sync-agent.rs
@@ -40,17 +40,77 @@ mod out_link {
     ));
 }
 
+use privileged_helper::client::HelperClientError;
+use privileged_helper::protocol::{ActivationResult, HelperReply};
+
+/// Every line this agent writes, stamped with the local time and sent to
+/// stderr, so a run's verdict sits next to the detail behind it — and next to
+/// the `nix build` output, which the child also writes to stderr — in the
+/// order it happened. The stamp is what tells one scheduled run from the next
+/// in a log that accumulates across runs.
+macro_rules! note {
+    ($($arg:tt)*) => {
+        eprintln!(
+            "[{}] nixmac-sync-agent: {}",
+            chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            format_args!($($arg)*)
+        )
+    };
+}
+
 fn main() {
     if let Err(error) = run_once() {
-        eprintln!("nixmac-sync-agent failed: {error:#}");
+        note!("run failed: {error:#}");
         std::process::exit(1);
+    }
+}
+
+/// What one `TryActivate` dispatch means for this run. The agent is an
+/// ordinary exact-build protocol client with no lifecycle role: a delivered
+/// result ends the run normally, and every obstacle defers activation to the
+/// next scheduled run — never a retry, never the password
+/// path, and never a nonzero exit (the agent plist sets
+/// `KeepAlive.SuccessfulExit = false`, so a nonzero exit would trip the
+/// launchd restart loop instead of waiting for the next interval).
+enum DispatchOutcome {
+    /// Delivered success: activation set the durable system-profile GC
+    /// root, so the out-link can be cleaned up.
+    Activated(ActivationResult),
+    /// Delivered failure: reported, out-link kept (it GC-roots the built
+    /// closure for the next attempt), clean exit.
+    ActivationFailed(ActivationResult),
+    /// Any obstacle — `Busy`, a typed refusal, a helper that fails
+    /// authentication, an unreachable helper, an unparseable reply, a
+    /// lost connection: out-link kept, run reported as activation-deferred,
+    /// clean exit. The next scheduled run is a fresh request.
+    Deferred(String),
+}
+
+impl DispatchOutcome {
+    /// Whether this run may release the out-link. Only a delivered success
+    /// may: activation has set the durable system-profile GC root by then.
+    /// Every other outcome keeps it, because it GC-roots the built closure
+    /// for the next scheduled run's attempt.
+    fn releases_out_link(&self) -> bool {
+        matches!(self, DispatchOutcome::Activated(_))
+    }
+}
+
+fn classify_dispatch(outcome: Result<HelperReply, HelperClientError>) -> DispatchOutcome {
+    match outcome {
+        Ok(HelperReply::ActivationResult(result)) if result.ok => {
+            DispatchOutcome::Activated(result)
+        }
+        Ok(HelperReply::ActivationResult(result)) => DispatchOutcome::ActivationFailed(result),
+        Ok(reply) => DispatchOutcome::Deferred(reply.summary()),
+        Err(error) => DispatchOutcome::Deferred(error.to_string()),
     }
 }
 
 fn run_once() -> anyhow::Result<()> {
     let Some(config_dir) = non_empty_env("NIXMAC_SYNC_CONFIG_DIR") else {
-        verify_helper_ready();
-        println!("nixmac-sync-agent: no NIXMAC_SYNC_CONFIG_DIR configured; readiness probe only");
+        report_helper_socket();
+        note!("no NIXMAC_SYNC_CONFIG_DIR configured; nothing to do");
         return Ok(());
     };
     let host_attr = std::env::var("NIXMAC_SYNC_HOST_ATTR")
@@ -85,52 +145,60 @@ fn run_once() -> anyhow::Result<()> {
         // Build-only mode keeps nothing pinned: the goal is warming the store,
         // not rooting a closure that may never be activated.
         out_link::cleanup_out_link(&link);
-        println!("nixmac-sync-agent: build completed; unattended activation disabled");
+        note!("build completed; unattended activation disabled");
         return Ok(());
     }
 
     let activate_path = store_path.join("activate");
     let request = privileged_helper::protocol::activation_request(&activate_path)?;
-    let response = privileged_helper::client::activate_store_path(&request)?;
-    if !response.ok {
-        // Leave the out-link in place: it keeps the built closure GC-rooted
-        // for the next attempt, and that attempt's --out-link replaces it.
-        return Err(anyhow::anyhow!(
-            "activation failed ({}): {}",
-            response.code,
-            response.failure_detail()
-        ));
-    }
-    for warning in response.warnings() {
-        eprintln!("nixmac-sync-agent: {warning}");
+    let outcome = classify_dispatch(privileged_helper::client::activate_store_path(&request));
+
+    // One place decides the out-link's fate, so no reporting branch can
+    // release it by accident.
+    if outcome.releases_out_link() {
+        // Activation set the durable system-profile GC root, so the out-link
+        // is no longer needed. Also clear the `result` link older nixmac
+        // versions left in the config dir.
+        out_link::cleanup_out_link(&link);
+        out_link::remove_legacy_result_link(&config_dir);
     }
 
-    // Activation set the durable system-profile GC root, so the out-link is
-    // no longer needed. Also clear the `result` link older nixmac versions
-    // left in the config dir.
-    out_link::cleanup_out_link(&link);
-    out_link::remove_legacy_result_link(&config_dir);
-
-    println!("nixmac-sync-agent: build and activation completed");
+    match outcome {
+        DispatchOutcome::Activated(result) => {
+            for warning in result.warnings() {
+                note!("{warning}");
+            }
+            note!("build and activation completed");
+        }
+        DispatchOutcome::ActivationFailed(result) => {
+            note!(
+                "activation failed ({}): {}",
+                result.code,
+                result.failure_detail()
+            );
+            note!("build completed; activation failed");
+        }
+        DispatchOutcome::Deferred(reason) => {
+            note!("activation deferred until the next scheduled run: {reason}");
+            note!("build completed; activation deferred");
+        }
+    }
+    // Every dispatch outcome ends the run normally: the agent plist sets
+    // `KeepAlive.SuccessfulExit = false`, so a nonzero exit here would trip
+    // the launchd restart loop instead of waiting for the next interval.
     Ok(())
 }
 
-fn verify_helper_ready() {
-    match privileged_helper::client::status() {
-        Ok(response) if response.ok => {
-            println!("nixmac-sync-agent: helper ready");
-        }
-        Ok(response) => {
-            eprintln!(
-                "nixmac-sync-agent: helper unhealthy: {}",
-                response.failure_detail()
-            );
-            std::process::exit(2);
-        }
-        Err(error) => {
-            eprintln!("nixmac-sync-agent: helper unavailable: {error:#}");
-            std::process::exit(1);
-        }
+/// Diagnostic-only note for the mode with no sync config set. The agent may
+/// only send `TryActivate` — asking the helper what it is belongs to the GUI —
+/// so this reports the socket's presence and nothing more. It gates nothing,
+/// and it never fails the run: a nonzero exit here would trip the launchd
+/// restart loop.
+fn report_helper_socket() {
+    if privileged_helper::client::socket_available() {
+        note!("privileged helper socket present");
+    } else {
+        note!("privileged helper socket absent");
     }
 }
 
@@ -165,4 +233,102 @@ fn run_command_in_dir(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use privileged_helper::protocol::{ActivationInfo, HelperStateName};
+
+    fn exchange(reply: HelperReply) -> Result<HelperReply, HelperClientError> {
+        Ok(reply)
+    }
+
+    fn activation_info() -> ActivationInfo {
+        ActivationInfo {
+            request_id: "req-1".to_string(),
+            script_path: "/nix/store/abc-darwin-system/activate".to_string(),
+            client_kind: privileged_helper::peer_auth::ClientKind::Gui,
+        }
+    }
+
+    #[test]
+    fn delivered_success_is_the_only_outcome_that_releases_the_out_link() {
+        let outcome =
+            classify_dispatch(exchange(HelperReply::ActivationResult(ActivationResult {
+                ok: true,
+                code: 0,
+                stdout: "activated".to_string(),
+                error: None,
+            })));
+
+        assert!(matches!(outcome, DispatchOutcome::Activated(_)));
+        assert!(outcome.releases_out_link());
+    }
+
+    #[test]
+    fn delivered_failure_is_reported_with_the_out_link_kept() {
+        // A delivered failure ends the run normally — reported, out-link
+        // kept, no restart-loop exit (run_once returns Ok on this path).
+        let outcome =
+            classify_dispatch(exchange(HelperReply::ActivationResult(ActivationResult {
+                ok: false,
+                code: 2,
+                stdout: "activation exploded".to_string(),
+                error: None,
+            })));
+
+        assert!(matches!(outcome, DispatchOutcome::ActivationFailed(_)));
+        assert!(!outcome.releases_out_link());
+    }
+
+    #[test]
+    fn every_obstacle_defers_and_keeps_the_out_link() {
+        // Busy, each typed refusal, an unreachable helper, a failed
+        // helper authentication, a closed connection, an ambiguous I/O
+        // failure, and an unparseable reply: all defer to the next scheduled
+        // run. run_once returns Ok on the deferred path, so each of these is
+        // also a clean (zero) exit — never a launchd restart loop.
+        let obstacles: Vec<Result<HelperReply, HelperClientError>> = vec![
+            exchange(HelperReply::Busy {
+                activation: Some(activation_info()),
+            }),
+            exchange(HelperReply::Busy { activation: None }),
+            exchange(HelperReply::BuildMismatch {
+                helper_build_id: "build-b".to_string(),
+            }),
+            exchange(HelperReply::CallerNotPermitted),
+            exchange(HelperReply::RequestNotUnderstood),
+            // A Status reply to TryActivate would be nonsense — still defer.
+            exchange(HelperReply::Status {
+                state: HelperStateName::Idle,
+                helper_build_id: "build-b".to_string(),
+                activation: None,
+            }),
+            Err(HelperClientError::Unreachable(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no socket",
+            ))),
+            Err(HelperClientError::AuthenticationFailed(anyhow::anyhow!(
+                "not the signed helper"
+            ))),
+            Err(HelperClientError::ClosedBeforeReply),
+            Err(HelperClientError::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "read timed out",
+            ))),
+            Err(HelperClientError::UnparseableReply(
+                "unknown reply tag".to_string(),
+            )),
+        ];
+
+        for obstacle in obstacles {
+            let outcome = classify_dispatch(obstacle);
+            assert!(
+                matches!(outcome, DispatchOutcome::Deferred(_)),
+                "expected a deferral"
+            );
+            assert!(!outcome.releases_out_link());
+        }
+    }
 }

--- a/apps/native/src-tauri/src/commands/settings_io.rs
+++ b/apps/native/src-tauri/src/commands/settings_io.rs
@@ -14,7 +14,7 @@ use super::helpers::capture_err;
 use crate::evolve::config::UserPreferences;
 use crate::observable::Observable;
 use crate::shared_types::{ExportResult, ImportResult};
-use crate::state::preferences::GlobalPreferences;
+use crate::state::preferences::{GlobalPreferences, is_device_local_key};
 use serde_json::{Map, Value};
 use std::borrow::Borrow;
 use tauri::{AppHandle, Manager};
@@ -25,6 +25,25 @@ const SENSITIVE_KEYS: &[&str] = &["openrouterApiKey", "openaiApiKey", "openaiCom
 
 fn is_sensitive_key(key: &str) -> bool {
     SENSITIVE_KEYS.contains(&key) || key.ends_with("ApiKey")
+}
+
+/// The imported slice, with every device-local value
+/// ([`crate::state::preferences::DEVICE_LOCAL_KEYS`], which the legacy-store
+/// migration skips for the same reason) taken from `current` instead.
+///
+/// The helper decision is the case this exists for. A settings file from another
+/// Mac must not decide whether this one runs a privileged helper, and — because
+/// import replaces a slice wholesale — a file that simply lacks the key must not
+/// reset the decision to "never decided", which is exactly what makes an explicit
+/// disable stick.
+fn imported_over_device_local(
+    current: &GlobalPreferences,
+    imported: GlobalPreferences,
+) -> GlobalPreferences {
+    GlobalPreferences {
+        helper_preference: current.helper_preference,
+        ..imported
+    }
 }
 
 fn collect_export_entries<K, V>(
@@ -39,6 +58,12 @@ where
     let mut skipped: Vec<String> = Vec::new();
     for (key, value) in entries {
         let key = key.as_ref();
+        // Not reported as skipped: `keys_skipped` is presented to the user as
+        // withheld secrets, and this is neither withheld nor a secret — it
+        // simply is not a portable setting.
+        if is_device_local_key(key) {
+            continue;
+        }
         if !include_secrets && is_sensitive_key(key) {
             skipped.push(key.to_string());
             continue;
@@ -165,8 +190,11 @@ pub async fn settings_import(app: AppHandle) -> Result<Option<ImportResult>, Str
         // Exports from pre-map versions carry the deprecated single-model
         // fields; fold them into the per-provider maps like the load path does.
         crate::state::preferences::migrate_model_scalars_to_maps(&mut prefs);
-        crate::state::preferences::write(&app, move |current| *current = prefs)
-            .map_err(|e| capture_err("settings_import", e))?;
+        crate::state::preferences::write(&app, move |current| {
+            let merged = imported_over_device_local(current, prefs);
+            *current = merged;
+        })
+        .map_err(|e| capture_err("settings_import", e))?;
     }
 
     if let Some(limits) = app.try_state::<Observable<UserPreferences>>() {
@@ -207,6 +235,61 @@ mod tests {
             skipped,
             vec!["customApiKey".to_string(), "openrouterApiKey".to_string()]
         );
+    }
+
+    #[test]
+    fn export_never_carries_a_device_local_key_even_with_secrets() {
+        // The helper decision describes this Mac's own installation; a settings
+        // file handed to another machine must not carry it, with or without
+        // secrets, and it is not reported as a withheld secret either.
+        let entries = BTreeMap::from([
+            ("helperPreference".to_string(), json!("disabled")),
+            ("developerMode".to_string(), json!(true)),
+        ]);
+
+        for include_secrets in [false, true] {
+            let (output, skipped) = collect_export_entries(entries.iter(), include_secrets);
+
+            assert!(!output.contains_key("helperPreference"));
+            assert_eq!(output.get("developerMode"), Some(&json!(true)));
+            assert!(skipped.is_empty());
+        }
+    }
+
+    #[test]
+    fn an_import_never_changes_the_stored_helper_decision() {
+        // Both directions of the risk: a file that carries somebody else's
+        // decision, and a file (any older export) that carries none at all and
+        // would otherwise reset this Mac's to "never decided".
+        use crate::shared_types::HelperPreference;
+
+        for stored in [
+            HelperPreference::Unset,
+            HelperPreference::Granted,
+            HelperPreference::Disabled,
+        ] {
+            let current = GlobalPreferences {
+                helper_preference: stored,
+                ..GlobalPreferences::default()
+            };
+            for carried in [
+                HelperPreference::Unset,
+                HelperPreference::Granted,
+                HelperPreference::Disabled,
+            ] {
+                let imported = GlobalPreferences {
+                    helper_preference: carried,
+                    host_attr: Some("from-the-file".to_string()),
+                    ..GlobalPreferences::default()
+                };
+
+                let merged = imported_over_device_local(&current, imported);
+
+                assert_eq!(merged.helper_preference, stored);
+                // Everything else is still wholesale-replaced.
+                assert_eq!(merged.host_attr.as_deref(), Some("from-the-file"));
+            }
+        }
     }
 
     #[test]

--- a/apps/native/src-tauri/src/main.rs
+++ b/apps/native/src-tauri/src/main.rs
@@ -11,6 +11,10 @@
 // are declared by their parent `mod.rs` files so rust-analyzer resolves them via Cargo.
 mod ai;
 mod bootstrap;
+// Consumed by `build.rs` via include!; declared here so its resolution table
+// stays under `cargo test`.
+#[allow(dead_code)]
+mod build_id;
 mod cli;
 mod commands;
 mod db;
@@ -716,6 +720,18 @@ fn run_gui_mode(
                     _ => {}
                 }
             });
+
+            // Reconcile the installed privileged helper with this build. This is
+            // the only actor in an upgrade: a Finder replacement and the
+            // updater's relaunch both converge here, on the new GUI's ordinary
+            // startup, and the old one prepares nothing.
+            //
+            // Off the main thread, and off the startup path: the run makes
+            // ServiceManagement calls *on* the main queue and awaits them, and it
+            // waits — legitimately, for as long as it takes — on an activation a
+            // previous build's helper is still running. It reports through the
+            // permission row; nothing here waits for it.
+            system::helper_permission::start_converging(handle);
 
             // Background initialize the nix-darwin docs index once at startup for fast option-shape lookup.
             let docs_handle = handle.clone();

--- a/apps/native/src-tauri/src/privileged_helper/client.rs
+++ b/apps/native/src-tauri/src/privileged_helper/client.rs
@@ -62,21 +62,29 @@ pub enum HelperClientError {
     UnparseableReply(String),
 }
 
-/// What answered the helper socket, judged before any protocol bytes crossed
-/// it.
+/// What answered the helper socket.
 ///
-/// Reconciliation needs the three-way split: a **root** peer whose validation
-/// completed with a "no" is the pre-contract or tampered helper, which may be
-/// removed without being asked anything, while a validation that could not
-/// reach a judgment — or a peer that is not root — authorizes nothing at all.
+/// Reconciliation needs the split: a **root** peer whose validation completed
+/// with a "no" is the pre-contract or tampered helper. It may be removed, and
+/// its own `Status` answer can buy exactly one thing — postponing that removal
+/// while it reports a running activation — and can authorize nothing. A
+/// validation that could not reach a judgment, or a peer that is not root,
+/// authorizes nothing at all and is never written to.
 #[derive(Debug)]
 pub enum AssessedExchange {
     /// Root, and the pinned helper requirement is satisfied. The reply came
     /// from the signed helper.
     Answered(HelperReply),
     /// Root, and validation completed with a "no": unsigned, ad-hoc-signed, or
-    /// the wrong identity. Not one byte was written to it, and none ever is.
+    /// the wrong identity — and the `Status` probe got no usable answer out of
+    /// it. `Status` is the only request ever written to such a peer
+    /// ([`assessed_status`] hardcodes it); a mutating request never is.
     RootUnverifiable(String),
+    /// Root, validation completed with a "no", and it answered the `Status`
+    /// probe anyway. The reply came from unverified code: display-only, good
+    /// for exactly one decision — postponing this peer's own replacement while
+    /// it reports a running activation — and never an authorization.
+    UnverifiableAnswered { detail: String, reply: HelperReply },
     /// Nothing may be concluded — a peer that is not root, or a validation that
     /// reached no judgment. No bytes were written.
     Unidentified(String),
@@ -162,54 +170,35 @@ fn exchange(
     exchange_on(stream, request)
 }
 
-/// [`exchange`] keeping the peer assessment instead of flattening it, and
-/// writing a request only to an authenticated peer.
-///
-/// The three-way judgment is the whole difference: what may be done about a
-/// helper that cannot be talked to depends on whether validation said "no" or
-/// said nothing.
-fn assessed_exchange(
-    request: &HelperRequest,
-    read_timeout: Duration,
-) -> Result<AssessedExchange, HelperClientError> {
-    let stream = connect(read_timeout)?;
-    let (euid, validation) =
-        peer_auth::assess_helper_peer(&stream).map_err(HelperClientError::AuthenticationFailed)?;
-
-    match peer_verdict(euid, validation) {
-        PeerVerdict::Authenticated => exchange_on(stream, request).map(AssessedExchange::Answered),
-        PeerVerdict::NotAuthenticated(assessment) => Ok(assessment),
-    }
-}
-
-/// Whether a request may be written to this peer, or what the peer is instead.
+/// Whether a request may be written to this peer, and with what trust.
 enum PeerVerdict {
     Authenticated,
-    NotAuthenticated(AssessedExchange),
+    /// Root with a completed validation "no": only `Status` may be written,
+    /// and only by [`assessed_status`].
+    RootUnverifiable(String),
+    /// Nothing established; nothing is written.
+    Unidentified(String),
 }
 
 /// The three-way judgment, as an allowlist: one combination authenticates a
-/// peer and every other one ends the exchange before a byte is written.
+/// peer, one permits the read-only `Status` probe, and every other one ends
+/// the exchange before a byte is written.
 fn peer_verdict(euid: u32, validation: peer_auth::SignatureValidation) -> PeerVerdict {
     // A peer that is not root is unidentified whatever its signature says. The
     // helper binds its socket inside a root-owned directory, so anything else
     // holding that path is broken permissions or an impostor, and no decision
     // about terminating a helper may be taken from it.
     if euid != 0 {
-        return PeerVerdict::NotAuthenticated(AssessedExchange::Unidentified(format!(
+        return PeerVerdict::Unidentified(format!(
             "the process answering {HELPER_SOCKET_PATH} runs as uid {euid}, not root"
-        )));
+        ));
     }
     match validation {
         peer_auth::SignatureValidation::Valid => PeerVerdict::Authenticated,
         // A completed "no" — and the only thing that is one.
-        peer_auth::SignatureValidation::Invalid(detail) => {
-            PeerVerdict::NotAuthenticated(AssessedExchange::RootUnverifiable(detail))
-        }
+        peer_auth::SignatureValidation::Invalid(detail) => PeerVerdict::RootUnverifiable(detail),
         // No judgment was reached, which is never the same as a "no".
-        peer_auth::SignatureValidation::Error(detail) => {
-            PeerVerdict::NotAuthenticated(AssessedExchange::Unidentified(detail))
-        }
+        peer_auth::SignatureValidation::Error(detail) => PeerVerdict::Unidentified(detail),
     }
 }
 
@@ -257,8 +246,33 @@ fn exchange_on(
 /// Sends `Status`, keeping the peer assessment. Reconciliation's discovery
 /// exchange: it works against a helper of any build, and what it may do about
 /// one it cannot talk to depends on which way the assessment went.
+///
+/// This is the one relaxed entry point: an unverifiable **root** peer is still
+/// sent the request, because its answer may carry the one fact worth
+/// postponing a replacement for — a running activation. The request is
+/// hardcoded here so no mutating request can ever take the relaxed path;
+/// [`exchange`] stays strict for everything else.
 pub fn assessed_status() -> Result<AssessedExchange, HelperClientError> {
-    assessed_exchange(&HelperRequest::Status, STATUS_PROBE_TIMEOUT)
+    let stream = connect(STATUS_PROBE_TIMEOUT)?;
+    let (euid, validation) =
+        peer_auth::assess_helper_peer(&stream).map_err(HelperClientError::AuthenticationFailed)?;
+
+    match peer_verdict(euid, validation) {
+        PeerVerdict::Authenticated => {
+            exchange_on(stream, &HelperRequest::Status).map(AssessedExchange::Answered)
+        }
+        // The relaxed read. Any failure of it — closed, timed out,
+        // unparseable — collapses to the bare verdict, exactly as if the
+        // probe were never sent: the read can only ever add a postponement,
+        // never block a removal.
+        PeerVerdict::RootUnverifiable(detail) => {
+            Ok(match exchange_on(stream, &HelperRequest::Status) {
+                Ok(reply) => AssessedExchange::UnverifiableAnswered { detail, reply },
+                Err(_) => AssessedExchange::RootUnverifiable(detail),
+            })
+        }
+        PeerVerdict::Unidentified(detail) => Ok(AssessedExchange::Unidentified(detail)),
+    }
 }
 
 /// Dispatches `TryActivate`, stamped with this build's ID — the helper admits

--- a/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
+++ b/apps/native/src-tauri/src/privileged_helper/helper_runtime.rs
@@ -953,6 +953,13 @@ pub(crate) fn run_activation_command(
     Ok((status, String::from_utf8_lossy(&output).to_string()))
 }
 
+/// What [`acquire_activation_lock`] bails with when the slot is held. On the
+/// admin-password path this reaches the app only as process text (osascript
+/// wraps the exit), so `rebuild::darwin::classify_activate_error` matches this
+/// sentence to report a refusal instead of a generic failure.
+pub(crate) const ACTIVATION_ALREADY_RUNNING_MESSAGE: &str =
+    "an activation is already running; try again once it finishes";
+
 /// Takes the shared activation slot for the admin-password path's executor.
 /// `Ok(fd)` holds the exclusive lock until the fd drops — the caller keeps it
 /// alive across the whole activation. `Ok(None)`-shaped refusal is an error
@@ -962,7 +969,7 @@ pub(crate) fn acquire_activation_lock() -> Result<OwnedFd> {
     fs::create_dir_all(HELPER_SOCKET_DIR).context("failed to create the helper directory")?;
     let lock = open_lock_file(Path::new(ACTIVATION_LOCK_PATH))?;
     if !try_flock(&lock, libc::LOCK_EX)? {
-        bail!("an activation is already running; try again once it finishes");
+        bail!("{ACTIVATION_ALREADY_RUNNING_MESSAGE}");
     }
     Ok(lock)
 }

--- a/apps/native/src-tauri/src/privileged_helper/reconcile.rs
+++ b/apps/native/src-tauri/src/privileged_helper/reconcile.rs
@@ -1,0 +1,1570 @@
+// Reconciling the installed privileged helper with the running build.
+//
+// One idempotent function. Every run observes the world, drives it one step
+// closer to the stored decision, and forgets everything: no phase, no
+// progress, no recovery mode. A run that dies anywhere is repaired by the
+// next one, which starts over from fresh observation. That is the whole
+// design — there is deliberately nothing here that coordinates, queues, or
+// remembers.
+//
+// The shape of a run:
+//
+//   gate → resolve the stored decision → the status × decision table →
+//   classify the peer → unregister → register → verify
+//
+// No cooperation is needed from the old helper beyond one `Status`
+// answer: activations run in a detached runner that survives
+// `SMAppService` unregister (see `helper_runtime`), so terminating a helper
+// interrupts nothing. When the old helper reports a running activation, the
+// pass simply ends with [`Reconciled::WaitingOnActivation`] — the convergence
+// loop re-observes on its waiting cadence, and the next pass that finds the
+// helper idle replaces it. A truly hung activation therefore keeps the
+// report on screen for as long as the app runs; nothing here force-kills
+// anything.
+//
+// One type rather than discipline carries the safety of the register step:
+// `Committed` is demanded by every register and minted in exactly one place —
+// the register step's immediately-before checks. Nothing outside this module
+// can construct one, so a register reached from anywhere else has nothing to
+// pass.
+//
+// Nothing here can open System Settings: that capability is absent from the
+// seam, which is how startup and refresh are kept from doing it.
+
+use crate::build_id;
+use crate::privileged_helper::client::{
+    self, AssessedExchange, HelperClientError, ListenerObservation,
+};
+use crate::privileged_helper::protocol::{self, ActivationInfo, HelperReply, HelperStateName};
+use crate::privileged_helper::service::{
+    self, RegisterFailure, RegistrationStatus, ReplaceFailure,
+};
+use crate::shared_types::{HelperDecision, HelperPreference};
+use crate::state::preferences;
+use crate::system::install_location::{self, InstallLocation};
+use std::fmt::Display;
+use std::sync::{Mutex, PoisonError, TryLockError};
+use std::time::Duration;
+use tauri::{AppHandle, Runtime};
+
+/// Bound on one ServiceManagement call reporting back. The unregister's
+/// completion is the signal that the old process was killed, and re-register
+/// is safe after it — but exactly-once delivery is a promise of the API, not
+/// of the universe, so a run is never held open on silence. Expiry ends the
+/// run, which loses nothing: a later pass converges from what it observes.
+const SERVICE_CALL_WINDOW: Duration = Duration::from_secs(30);
+
+/// The window a fresh registration gets to start answering before it is
+/// judged missing: launchd still has to spawn the helper and let it bind its
+/// socket. Deliberately longer than the absence window the client uses to
+/// prove a socket dead (~2 × its ~7.5 s) — reuse the absence numbers here and
+/// every fresh install reports a verification failure it recovered from a
+/// moment later.
+const VERIFY_ATTEMPT_INTERVAL: Duration = Duration::from_millis(2_500);
+const VERIFY_LISTEN_ATTEMPTS: u32 = 7;
+
+// ---------------------------------------------------------------------------
+// What a run reports.
+// ---------------------------------------------------------------------------
+
+/// What one run of the function found and did.
+///
+/// Total: every path out of a run is one of these, so the UI decides by
+/// matching. Nothing here is progress or state — a report describes the world
+/// at the moment the run ended, and the next run derives its own.
+///
+/// The two text-carrying variants hold the finished sentence the permissions
+/// UI shows, written at the site that read the failure. This app already puts
+/// helper detail text this way (`system::permissions` composes the same kind of
+/// string and the panel renders it verbatim); `system::helper_permission` is
+/// what turns a report into the row's detail. No decision anywhere reads that
+/// text — what a caller acts on is the variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reconciled {
+    /// A registration exists and an authenticated `Status` reported this
+    /// build's ID. The goal is met; the normal outcome of almost every
+    /// startup.
+    AtThisBuild,
+    /// Registered, and macOS is waiting on the user in Login Items — never
+    /// approved, or approval revoked. A state, not a failure, and it may
+    /// persist for weeks.
+    ///
+    /// Two passes produce it — the status × goal table's `requiresApproval`
+    /// row, which registers nothing, and `verify`, which is reachable only from
+    /// a register. The report does not distinguish them, and the UI has one
+    /// sentence for both.
+    PendingApproval,
+    /// No helper is registered and none is wanted: the user disabled it, or
+    /// has never decided and there is nothing to adopt. A first-time
+    /// registration needs the explicit Grant action.
+    NoHelper,
+    /// The registration was removed, as the stored decision asks.
+    Removed,
+    /// A run was already in flight, so this observation did nothing at all.
+    /// Only observations report it: a Grant or Disable waits the in-flight
+    /// pass out instead ([`decide`]), so a decision is never dropped against
+    /// a busy slot.
+    Busy,
+    /// The installed helper (of whatever build) reported a running
+    /// activation, so this pass mutated nothing and ended. Not a failure:
+    /// the convergence loop re-observes on its waiting cadence — activations
+    /// take minutes and are never interrupted — and the pass that finds the
+    /// helper idle carries on. `activation` is display-only and absent when
+    /// the reporting helper never knew X (it was relaunched over the
+    /// running activation).
+    WaitingOnActivation(Option<ActivationInfo>),
+    /// Final: this copy of nixmac may not mutate a helper — it does not run
+    /// from `/Applications`, or its bundle was replaced underneath it. Nothing
+    /// was unregistered, registered, or written, and no later run changes the
+    /// answer: the user has to move the app or restart it.
+    Displaced(String),
+    /// Final: `notFound` — the bundle's own service definition is broken, so
+    /// there is nothing to register and nothing to remove. A property of the
+    /// bundle, read identically every time.
+    ServiceDefinitionBroken,
+    /// Retryable: the run stopped short. Nothing further was mutated; a later
+    /// run converges from what it observes then.
+    Stopped(String),
+}
+
+// The sentences a stopped run shows, written once each and next to nothing
+// else. Every one of them is a clause without a full stop — `helper_permission`
+// terminates it.
+
+fn preference_unreadable(detail: impl Display) -> Reconciled {
+    Reconciled::Stopped(format!(
+        "the stored helper decision could not be read: {detail}"
+    ))
+}
+
+fn preference_unwritable(detail: impl Display) -> Reconciled {
+    Reconciled::Stopped(format!("the helper decision could not be stored: {detail}"))
+}
+
+fn peer_unidentified(detail: impl Display) -> Reconciled {
+    Reconciled::Stopped(format!(
+        "the helper socket is held by something unidentified: {detail}"
+    ))
+}
+
+fn socket_unusable(detail: impl Display) -> Reconciled {
+    Reconciled::Stopped(format!("the helper socket is unusable: {detail}"))
+}
+
+fn unregister_failed(detail: impl Display) -> Reconciled {
+    Reconciled::Stopped(format!("the helper could not be unregistered: {detail}"))
+}
+
+fn register_failed(detail: impl Display) -> Reconciled {
+    Reconciled::Stopped(format!("the helper could not be registered: {detail}"))
+}
+
+/// A step's outcome. `Ok` is a pass that reached a resting state, `Err` one
+/// that ended before the step it was heading for — a stop, a displacement, or
+/// (in the one case of an undecided user with nothing to adopt) a resting state
+/// reached early. Both channels are terminal and both are reported the same
+/// way; the split is what lets `?` end a pass from anywhere without a
+/// control-flow enum.
+type Step = Result<Reconciled, Reconciled>;
+
+// ---------------------------------------------------------------------------
+// The single-flight slot.
+// ---------------------------------------------------------------------------
+
+/// One run at a time, process-wide. An observation that finds it taken is
+/// told [`Reconciled::Busy`] rather than made to wait; a decision *waits* and
+/// then makes its own pass.
+///
+/// The split is what keeps a decision from being dropped: the convergence
+/// loop only re-runs while it has something left to do, so a Disable stored
+/// while the loop's final pass was mid-flight would otherwise never be read —
+/// the loop ends on the stale resting state and nothing re-runs until the
+/// next refresh. Blocking the decision instead is affordable now that every
+/// pass is bounded (the longest waits are the verify listen window and the
+/// two service-call windows); there is no unbounded step left for a click to
+/// hang on.
+///
+/// The guard's `Drop` releases the slot on every path out of a run, a panic
+/// included.
+static RUNNING: Mutex<()> = Mutex::new(());
+
+// ---------------------------------------------------------------------------
+// Evidence: what the register step is handed rather than asserting.
+// ---------------------------------------------------------------------------
+
+/// The register step's immediately-before checks passed. Demanded by every
+/// register, and minted in exactly one place — [`commit_to_register`] — so a
+/// registration that skipped the gates and the fresh preference read cannot be
+/// expressed.
+mod evidence {
+    pub struct Committed(());
+
+    impl Committed {
+        pub(super) fn checked() -> Self {
+            Self(())
+        }
+    }
+}
+
+// `Committed` is nameable outside this module because the environment methods
+// that demand one are; minting one is not — `Committed::checked` stays visible
+// only in here, so the register step remains the only place one comes from.
+pub use evidence::Committed;
+
+// ---------------------------------------------------------------------------
+// The seam.
+// ---------------------------------------------------------------------------
+
+/// One exchange with whatever answers the helper socket.
+///
+/// The peer assessment is kept apart rather than flattened: what may be done
+/// about a helper that cannot be talked to depends entirely on whether
+/// validation said "no" or said nothing.
+pub enum PeerReply {
+    /// Root, validated, and it answered.
+    Answered(HelperReply),
+    /// Root, and validation completed with a "no".
+    RootUnverifiable(String),
+    /// A peer that is not root, or a validation that reached no judgment.
+    Unidentified(String),
+    /// The exchange did not happen.
+    Failed(HelperClientError),
+}
+
+/// Everything a run observes or does, injected so the decisions above can be
+/// driven through every case without a helper, a bundle, or a settings store.
+///
+/// Only observations and effects live here, and no method decides anything
+/// about the goal or the helper. Nothing this function does asks for System
+/// Settings either — the capability is simply not in the seam, so a run that no
+/// click is waiting on (startup, a status refresh) opens nothing, whatever it
+/// observes.
+pub trait Environment {
+    /// The build ID compiled into this process.
+    fn compiled_build_id(&self) -> &str;
+
+    /// Whether this copy of nixmac may mutate a helper at all: it runs from
+    /// `/Applications`, and its bundle on disk is still the build it was
+    /// compiled as. An `Err` is the report the run ends with.
+    fn gate(&self) -> Result<(), Reconciled>;
+
+    /// What `SMAppService` reports about nixmac's helper registration.
+    fn registration_status(&self) -> Result<RegistrationStatus, String>;
+
+    /// The stored decision about the helper.
+    fn preference(&self) -> Result<HelperPreference, String>;
+
+    /// Stores a decision. There is deliberately no way to store "undecided".
+    fn store_decision(&self, decision: HelperDecision) -> Result<(), String>;
+
+    /// Whether anything is listening on the helper socket, over the absence
+    /// window. Pure observation: no protocol bytes are written, which is
+    /// what makes it safe to point at a helper of any build.
+    fn observe_listener(&self) -> ListenerObservation;
+
+    /// Sends `Status` on a fresh connection.
+    fn status_exchange(&self) -> PeerReply;
+
+    /// Unregisters, with nothing to be registered afterwards.
+    fn unregister(&self) -> Result<(), String>;
+
+    /// Unregisters, waits for the completion that says the old process was
+    /// killed, asks `commit_to_register`, and registers the replacement.
+    fn replace_helper(
+        &self,
+        commit_to_register: &dyn Fn() -> Result<Committed, Reconciled>,
+    ) -> Result<(), ReplaceFailure<Reconciled>>;
+
+    /// Registers with nothing unregistered first — the path from
+    /// `notRegistered`. The token is the proof the immediately-before checks
+    /// ran.
+    fn register(&self, committed: Committed) -> Result<(), RegisterFailure>;
+
+    /// Waits. Injected so the bounded verify window costs tests nothing.
+    fn wait(&self, interval: Duration);
+}
+
+/// The environment the app runs in.
+pub struct LiveEnvironment<'a, R: Runtime> {
+    app: &'a AppHandle<R>,
+}
+
+impl<'a, R: Runtime> LiveEnvironment<'a, R> {
+    pub fn new(app: &'a AppHandle<R>) -> Self {
+        Self { app }
+    }
+}
+
+impl<R: Runtime> Environment for LiveEnvironment<'_, R> {
+    fn compiled_build_id(&self) -> &str {
+        protocol::BUILD_ID
+    }
+
+    fn gate(&self) -> Result<(), Reconciled> {
+        gates_live()
+    }
+
+    fn registration_status(&self) -> Result<RegistrationStatus, String> {
+        service::registration_status().map_err(|error| format!("{error:#}"))
+    }
+
+    fn preference(&self) -> Result<HelperPreference, String> {
+        preferences::read_helper_preference(self.app).map_err(|error| format!("{error:#}"))
+    }
+
+    fn store_decision(&self, decision: HelperDecision) -> Result<(), String> {
+        preferences::store_helper_decision(self.app, decision).map_err(|error| format!("{error:#}"))
+    }
+
+    fn observe_listener(&self) -> ListenerObservation {
+        client::observe_listener()
+    }
+
+    fn status_exchange(&self) -> PeerReply {
+        match client::assessed_status() {
+            Ok(AssessedExchange::Answered(reply)) => PeerReply::Answered(reply),
+            Ok(AssessedExchange::RootUnverifiable(detail)) => PeerReply::RootUnverifiable(detail),
+            Ok(AssessedExchange::Unidentified(detail)) => PeerReply::Unidentified(detail),
+            Err(error) => PeerReply::Failed(error),
+        }
+    }
+
+    fn unregister(&self) -> Result<(), String> {
+        service::unregister().map_err(|error| format!("{error:#}"))
+    }
+
+    fn replace_helper(
+        &self,
+        commit_to_register: &dyn Fn() -> Result<Committed, Reconciled>,
+    ) -> Result<(), ReplaceFailure<Reconciled>> {
+        service::replace_helper(SERVICE_CALL_WINDOW, || {
+            commit_to_register().map(|_committed| ())
+        })
+    }
+
+    fn register(&self, _committed: Committed) -> Result<(), RegisterFailure> {
+        service::register_on_later_turn(SERVICE_CALL_WINDOW)
+    }
+
+    fn wait(&self, interval: Duration) {
+        std::thread::sleep(interval);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The gates.
+// ---------------------------------------------------------------------------
+
+/// The two gates in front of every mutation and every write, over the live
+/// facts.
+///
+/// Public for one reason: Apply asks the same question before deciding whether
+/// it may touch a helper, and a second implementation of it could disagree with
+/// this one.
+pub fn gates_live() -> Result<(), Reconciled> {
+    let location = install_location::locate_app_bundle();
+    let on_disk = match &location {
+        InstallLocation::Canonical(bundle) => build_id::read_bundle_build_id(bundle),
+        // The install gate ends any run that reaches this, and a bundle that
+        // moved mid-run has no stamp worth comparing.
+        InstallLocation::Elsewhere(_) => {
+            Err("nixmac is not installed in /Applications".to_string())
+        }
+    };
+    judge_gates(&location, protocol::BUILD_ID, on_disk)
+}
+
+/// The gate judgment itself, over the three facts it is about.
+///
+/// Re-evaluated before each mutation and each write rather than once per pass:
+/// two of these facts can change while a pass runs — an app can be moved, and a
+/// bundle can be replaced by an update — and what they guard is destructive.
+fn judge_gates(
+    location: &InstallLocation,
+    compiled: &str,
+    on_disk: Result<String, String>,
+) -> Result<(), Reconciled> {
+    // Canonical install. A copy running from anywhere else observes and
+    // reports only.
+    if let InstallLocation::Elsewhere(observed) = location {
+        return Err(Reconciled::Displaced(match observed {
+            Some(path) => format!(
+                "nixmac runs from {} — move it to /Applications",
+                path.display()
+            ),
+            None => "nixmac is not running from an app bundle in /Applications".to_string(),
+        }));
+    }
+    // Stale GUI. A bundle replaced underneath this process means the helper it
+    // would register is not the one it is compiled to talk to, so it would be
+    // replacing helpers its own verification could never accept.
+    let on_disk = on_disk.map_err(|detail| {
+        Reconciled::Stopped(format!(
+            "this app's installed build could not be read: {detail}"
+        ))
+    })?;
+    if on_disk != compiled {
+        return Err(Reconciled::Displaced(format!(
+            "this app was replaced while running (build {compiled} is running, {on_disk} is installed) — restart nixmac"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Entry points.
+// ---------------------------------------------------------------------------
+
+/// Reconciles the installed helper with this build. Idempotent, and its normal
+/// path is a single `Status` exchange, so running it at startup and on every
+/// status refresh is cheap.
+pub fn reconcile<E: Environment>(env: &E) -> Reconciled {
+    run(&RUNNING, env)
+}
+
+/// The explicit Grant action: record the decision, then reconcile under it.
+/// First-time registration and repairing a half-finished one are the same
+/// step, and the write is idempotent.
+///
+/// Opening Login Items is the caller's action, never this function's.
+pub fn grant<E: Environment>(env: &E) -> Reconciled {
+    decide(&RUNNING, env, HelperDecision::Granted)
+}
+
+/// The explicit Disable action: record the decision, then reconcile under it.
+/// The decision is written first, so a crash halfway resumes the removal
+/// rather than repairing the helper.
+pub fn disable<E: Environment>(env: &E) -> Reconciled {
+    decide(&RUNNING, env, HelperDecision::Disabled)
+}
+
+/// Stores a decision and reconciles under it. The slot is a parameter so tests
+/// get one of their own rather than the process-wide static.
+///
+/// Unlike an observation, a decision never takes `Busy` for an answer: it
+/// waits out an in-flight pass (bounded — see [`RUNNING`]) and then makes its
+/// own, so the pass that carries the decision out always exists and its
+/// report is what the click's caller renders.
+fn decide<E: Environment>(running: &Mutex<()>, env: &E, decision: HelperDecision) -> Reconciled {
+    // A copy that may not mutate a helper may not record a decision about one
+    // either — the gates cover the write, not just the effects.
+    if let Err(report) = env.gate() {
+        return reported(report);
+    }
+    if let Err(detail) = env.store_decision(decision) {
+        return reported(preference_unwritable(detail));
+    }
+    // Nothing this slot guards is half-applied by a panic — it guards no
+    // data — so a poisoned lock is taken rather than propagated.
+    let _slot = running.lock().unwrap_or_else(PoisonError::into_inner);
+    reported(converge(env).unwrap_or_else(|report| report))
+}
+
+fn run<E: Environment>(running: &Mutex<()>, env: &E) -> Reconciled {
+    let _slot = match running.try_lock() {
+        Ok(slot) => slot,
+        // Poison handled as in [`decide`].
+        Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+        // Immediate, never a wait: observations are cheap to repeat and the
+        // convergence loop repeats them on its own cadence.
+        Err(TryLockError::WouldBlock) => return reported(Reconciled::Busy),
+    };
+    reported(converge(env).unwrap_or_else(|report| report))
+}
+
+/// Logs one run's outcome and hands it back.
+fn reported(outcome: Reconciled) -> Reconciled {
+    log::info!("helper reconciliation: {outcome:?}");
+    outcome
+}
+
+/// What the stored decision asks for. The third stored value, "undecided", is
+/// not a goal — it is resolved into one of these, or the pass ends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Goal {
+    Install,
+    Remove,
+}
+
+fn converge<E: Environment>(env: &E) -> Step {
+    env.gate()?;
+    let status = status(env)?;
+    let goal = goal(env, status)?;
+    match (status, goal) {
+        (RegistrationStatus::NotRegistered, Goal::Install) => register_fresh(env),
+        (RegistrationStatus::NotRegistered, Goal::Remove) => Ok(Reconciled::NoHelper),
+        // Approval is a state, not an error: reported, never re-registered,
+        // and never a reason to open System Settings. This arm registers
+        // nothing, however often it is reached.
+        (RegistrationStatus::RequiresApproval, Goal::Install) => Ok(Reconciled::PendingApproval),
+        // An approval-pending service has no process, so there is nothing
+        // to observe before removing it.
+        (RegistrationStatus::RequiresApproval, Goal::Remove) => remove(env),
+        (RegistrationStatus::Enabled, goal) => classify(env, goal),
+        // Nothing to register and nothing to remove: the definition this
+        // would act on is not there.
+        (RegistrationStatus::NotFound, _) => Err(Reconciled::ServiceDefinitionBroken),
+    }
+}
+
+fn status<E: Environment>(env: &E) -> Result<RegistrationStatus, Reconciled> {
+    env.registration_status().map_err(|detail| {
+        Reconciled::Stopped(format!(
+            "the helper registration could not be read: {detail}"
+        ))
+    })
+}
+
+/// Resolves the stored decision into a goal, adopting an existing registration
+/// as the user's earlier opt-in.
+///
+/// The resolution is a write, so the stale-GUI gate applies to it: a GUI whose
+/// bundle was replaced underneath it records nothing.
+fn goal<E: Environment>(env: &E, status: RegistrationStatus) -> Result<Goal, Reconciled> {
+    let preference = env.preference().map_err(preference_unreadable)?;
+    match preference {
+        HelperPreference::Granted => Ok(Goal::Install),
+        HelperPreference::Disabled => Ok(Goal::Remove),
+        HelperPreference::Unset => match status {
+            // A registration that already exists is the user's earlier
+            // opt-in — including the pre-contract one, which is what makes
+            // the migration automatic. Recorded before anything is
+            // mutated, so a crash cannot lose it.
+            RegistrationStatus::RequiresApproval | RegistrationStatus::Enabled => {
+                env.gate()?;
+                env.store_decision(HelperDecision::Granted)
+                    .map_err(preference_unwritable)?;
+                Ok(Goal::Install)
+            }
+            // Nothing to adopt. A first registration needs the explicit
+            // Grant action, never an automatic path.
+            RegistrationStatus::NotRegistered => Err(Reconciled::NoHelper),
+            // Never resolves the decision; reported as the failure it is.
+            RegistrationStatus::NotFound => Err(Reconciled::ServiceDefinitionBroken),
+        },
+    }
+}
+
+/// What is answering the socket of an `enabled` registration. Exactly one of
+/// four things, and only an authenticated peer is ever spoken to.
+fn classify<E: Environment>(env: &E, goal: Goal) -> Step {
+    match env.status_exchange() {
+        PeerReply::Answered(reply) => decide_from_status(env, goal, reply),
+        // The pre-contract helper, or a tampered one: removed without
+        // being asked anything, because no reply from it could be
+        // trusted. Only a *completed* "no" reaches this arm — a
+        // validation that got no answer is `Unidentified` below and
+        // authorizes nothing. This is also the one removal that can
+        // interrupt an in-process activation (the legacy helper is its
+        // own executor), the accepted one-time migration risk.
+        PeerReply::RootUnverifiable(detail) => {
+            // The only record of the judgment: no report this arm can end
+            // in carries the detail, and an incident log that cannot say
+            // why the peer was rejected cannot be reconstructed.
+            log::info!("helper peer unverifiable: {detail}");
+            remove_or_replace(env, goal)
+        }
+        PeerReply::Unidentified(detail) => Err(peer_unidentified(detail)),
+        // Nothing answered. Whether that is a real absence — as opposed
+        // to a helper mid-crash-relaunch or mid-startup — takes the
+        // absence window to establish; the cost of a wrong "absent" is
+        // registration churn, never an interrupted activation.
+        PeerReply::Failed(HelperClientError::Unreachable(error)) => {
+            decide_from_absence(env, goal, error.to_string())
+        }
+        PeerReply::Failed(error) => Err(exchange_failed(error)),
+    }
+}
+
+fn decide_from_status<E: Environment>(env: &E, goal: Goal, reply: HelperReply) -> Step {
+    let HelperReply::Status {
+        state,
+        helper_build_id,
+        activation,
+    } = &reply
+    else {
+        // A helper of any build answers `Status` with a state. Anything
+        // else is a refusal, and refusals are never acted on.
+        return Err(helper_refused(&reply));
+    };
+    // The one place the discovered state is visible: several reports
+    // (`AtThisBuild` in particular) do not carry it, and an incident log
+    // that cannot say what the helper answered cannot be reconstructed.
+    log::info!(
+        "helper status: {state} at build {helper_build_id}{}",
+        match activation {
+            Some(info) => format!(
+                " ({} submitted by the {})",
+                info.script_path, info.client_kind
+            ),
+            None => String::new(),
+        }
+    );
+    // Byte equality, and nothing else: an empty peer build ID is a
+    // perfectly legitimate reply that simply is not this build's, so it
+    // takes the different-build path rather than being rejected.
+    if helper_build_id == env.compiled_build_id() && goal == Goal::Install {
+        // This build's helper, wanted — running an activation or not,
+        // there is nothing to change.
+        return Ok(Reconciled::AtThisBuild);
+    }
+    // A helper that has to go — the wrong build, or a removal — is never
+    // touched while it reports a running activation: unregister would
+    // orphan the runner harmlessly, but the pass defers anyway so the
+    // running apply keeps its result reply and the report tells the user
+    // what everything is waiting for. The convergence loop re-observes.
+    if matches!(state, HelperStateName::Activating) {
+        return Ok(Reconciled::WaitingOnActivation(activation.clone()));
+    }
+    remove_or_replace(env, goal)
+}
+
+/// Establishes whether an unreachable socket means no listener at all.
+///
+/// Total over the three verdicts: only the proved absence proceeds to a
+/// mutation, and everything else — something answering, or nothing
+/// established — leaves the registration alone for a later pass.
+fn decide_from_absence<E: Environment>(env: &E, goal: Goal, connect_error: String) -> Step {
+    match env.observe_listener() {
+        ListenerObservation::PositivelyAbsent => remove_or_replace(env, goal),
+        ListenerObservation::Listening => Err(socket_unusable(format!(
+            "{connect_error}; something is listening on it but did not answer"
+        ))),
+        ListenerObservation::Ambiguous(detail) => {
+            Err(socket_unusable(format!("{connect_error}; {detail}")))
+        }
+    }
+}
+
+/// Removes the registration, then registers this build's helper if that is the
+/// goal. The gates are re-checked immediately before the mutation: both facts
+/// they observe can change while a pass runs.
+fn remove_or_replace<E: Environment>(env: &E, goal: Goal) -> Step {
+    env.gate()?;
+    match goal {
+        Goal::Install => replace(env),
+        // A recorded Disable is never overridden by an automatic path, the
+        // one-time migration of a pre-contract helper included.
+        Goal::Remove => remove(env),
+    }
+}
+
+fn remove<E: Environment>(env: &E) -> Step {
+    env.gate()?;
+    env.unregister().map_err(unregister_failed)?;
+    Ok(Reconciled::Removed)
+}
+
+fn replace<E: Environment>(env: &E) -> Step {
+    match env.replace_helper(&|| commit_to_register(env)) {
+        Ok(()) => verify(env),
+        Err(failure) => Err(match failure {
+            // The register step's own report, whatever it was: this pass
+            // unregistered the old helper and deliberately registered
+            // nothing in its place.
+            ReplaceFailure::RegisterDeclined(report) => report,
+            ReplaceFailure::UnregisterFailed(error) => unregister_failed(error),
+            ReplaceFailure::UnregisterSilent => unregister_failed("the unregister never reported"),
+            ReplaceFailure::RegisterFailed(error) => register_failed(error),
+            ReplaceFailure::RegisterSilent => register_failed("the register never reported"),
+            // Refused before anything was dispatched, so nothing changed.
+            ReplaceFailure::CalledOnMainThread => {
+                register_failed("a helper replacement cannot run on the main thread")
+            }
+        }),
+    }
+}
+
+fn register_fresh<E: Environment>(env: &E) -> Step {
+    // The gates are inside the commitment, which is where every register's
+    // immediately-before checks live.
+    let committed = commit_to_register(env)?;
+    env.register(committed).map_err(|failure| match failure {
+        RegisterFailure::Failed(error) => register_failed(error),
+        RegisterFailure::Silent => register_failed("the register never reported"),
+        RegisterFailure::CalledOnMainThread => {
+            register_failed("a registration cannot run on the main thread")
+        }
+    })?;
+    verify(env)
+}
+
+/// The register step's immediately-before checks, and the only mint of the
+/// token every register demands.
+///
+/// A Disable clicked while a replacement was under way must not be followed by
+/// a fresh registration and its Login Items prompt, so the stored decision is
+/// re-read here, at the last moment a registration can still be declined. This
+/// is the one place a decision made mid-pass takes effect in that pass, and it
+/// can only ever stop a registration.
+///
+/// The window between this read and the register itself is not zero, and needs
+/// no closing: a decision is written before its own pass ([`decide`]), and that
+/// pass — blocked on [`RUNNING`] until this one ends — carries the decision out
+/// against whatever this pass did. A write that lands after this read costs at
+/// most one registration that the very next pass removes; it is never lost.
+fn commit_to_register<E: Environment>(env: &E) -> Result<Committed, Reconciled> {
+    // A register is a mutation like any other.
+    env.gate()?;
+    match env.preference() {
+        Ok(HelperPreference::Granted) => Ok(evidence::Committed::checked()),
+        Ok(HelperPreference::Disabled | HelperPreference::Unset) => Err(Reconciled::Stopped(
+            "the helper is no longer granted; it was being replaced".to_string(),
+        )),
+        Err(detail) => Err(preference_unreadable(detail)),
+    }
+}
+
+/// Every registration this pass dispatches is verified.
+fn verify<E: Environment>(env: &E) -> Step {
+    match status(env)? {
+        RegistrationStatus::Enabled => verify_listening(env),
+        settled => verify_from_status(settled),
+    }
+}
+
+/// Judges a dispatched registration from a status read alone.
+///
+/// Both status reads a verification can make land here: the one above, whose
+/// `enabled` goes to the listen window rather than to a verdict, and the fresh
+/// one taken when that window expires. So the `enabled` arm belongs to the
+/// second read alone — nothing answered, and the registration still says
+/// something should have.
+fn verify_from_status(status: RegistrationStatus) -> Step {
+    match status {
+        // Registered, and macOS wants the user's approval. Normal.
+        RegistrationStatus::RequiresApproval => Ok(Reconciled::PendingApproval),
+        RegistrationStatus::NotRegistered => Err(Reconciled::Stopped(
+            "the helper registration disappeared while it was being verified".to_string(),
+        )),
+        RegistrationStatus::NotFound => Err(Reconciled::ServiceDefinitionBroken),
+        RegistrationStatus::Enabled => Err(Reconciled::Stopped(
+            "the registered helper never answered on its socket".to_string(),
+        )),
+    }
+}
+
+/// Waits out the listen window for the fresh helper to answer, then judges what
+/// answered. Never a retry loop around a verdict: only a socket that is not
+/// there yet is worth another attempt.
+fn verify_listening<E: Environment>(env: &E) -> Step {
+    for attempt in 0..VERIFY_LISTEN_ATTEMPTS {
+        if attempt > 0 {
+            env.wait(VERIFY_ATTEMPT_INTERVAL);
+        }
+        match env.status_exchange() {
+            PeerReply::Answered(reply) => return judge(env, reply),
+            // launchd still has to spawn the helper and let it bind. The
+            // one outcome this window exists for.
+            PeerReply::Failed(HelperClientError::Unreachable(_)) => continue,
+            PeerReply::RootUnverifiable(detail) | PeerReply::Unidentified(detail) => {
+                return Err(peer_unidentified(detail));
+            }
+            PeerReply::Failed(error) => return Err(exchange_failed(error)),
+        }
+    }
+    // Silence is judged from a fresh read, never from the one that opened
+    // the window: a registration can require approval, or be gone, by the
+    // time the window ends, and either would be reported as a helper that
+    // never answered — a failure — for a state that is not one. The window
+    // is the only thing between the two reads, and it is long enough for
+    // macOS to have changed its answer inside it.
+    verify_from_status(status(env)?)
+}
+
+fn judge<E: Environment>(env: &E, reply: HelperReply) -> Step {
+    match &reply {
+        HelperReply::Status {
+            helper_build_id, ..
+        } => {
+            // The allowlist: this build's ID, byte for byte. Either state
+            // is fine — a fresh helper can already be running a sync
+            // agent's activation.
+            if helper_build_id == env.compiled_build_id() {
+                Ok(Reconciled::AtThisBuild)
+            } else {
+                Err(Reconciled::Stopped(format!(
+                    "the registered helper reports build {helper_build_id}, not this build"
+                )))
+            }
+        }
+        _ => Err(helper_refused(&reply)),
+    }
+}
+
+/// An authenticated helper answered something a step cannot act on.
+fn helper_refused(reply: &HelperReply) -> Reconciled {
+    Reconciled::Stopped(format!("the helper refused: {}", reply.summary()))
+}
+
+/// Reads one failed exchange into a report.
+fn exchange_failed(error: HelperClientError) -> Reconciled {
+    match error {
+        HelperClientError::Unreachable(error) => socket_unusable(error),
+        // A close before a reply is a live helper declining this client or a
+        // connection over the cap — stop and re-observe, never a conclusion.
+        HelperClientError::ClosedBeforeReply => {
+            socket_unusable("the helper closed the connection before replying")
+        }
+        HelperClientError::AuthenticationFailed(error) => peer_unidentified(format!("{error:#}")),
+        HelperClientError::Io(error) => socket_unusable(error),
+        HelperClientError::UnparseableReply(detail) => Reconciled::Stopped(format!(
+            "the helper sent a reply this build cannot parse: {detail}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privileged_helper::peer_auth::ClientKind;
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+
+    const THIS_BUILD: &str = "build-current";
+    const OTHER_BUILD: &str = "build-previous";
+    const SCRIPT: &str = "/nix/store/abc-darwin-system/activate";
+
+    fn activation(kind: ClientKind) -> ActivationInfo {
+        ActivationInfo {
+            request_id: "req-1".to_string(),
+            script_path: SCRIPT.to_string(),
+            client_kind: kind,
+        }
+    }
+
+    fn status_reply(
+        build: &str,
+        state: HelperStateName,
+        activation: Option<ActivationInfo>,
+    ) -> HelperReply {
+        HelperReply::Status {
+            state,
+            helper_build_id: build.to_string(),
+            activation,
+        }
+    }
+
+    /// What one scripted status exchange answers, cloneable for scripting.
+    #[derive(Clone)]
+    enum Peer {
+        Answered(HelperReply),
+        RootUnverifiable,
+        Unidentified,
+        Unreachable,
+        ClosedBeforeReply,
+        Unparseable,
+    }
+
+    impl Peer {
+        fn reply(&self) -> PeerReply {
+            match self {
+                Peer::Answered(reply) => PeerReply::Answered(reply.clone()),
+                Peer::RootUnverifiable => {
+                    PeerReply::RootUnverifiable("ad-hoc signature".to_string())
+                }
+                Peer::Unidentified => PeerReply::Unidentified("no judgment".to_string()),
+                Peer::Unreachable => PeerReply::Failed(HelperClientError::Unreachable(
+                    std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+                )),
+                Peer::ClosedBeforeReply => PeerReply::Failed(HelperClientError::ClosedBeforeReply),
+                Peer::Unparseable => {
+                    PeerReply::Failed(HelperClientError::UnparseableReply("not json".to_string()))
+                }
+            }
+        }
+    }
+
+    /// Everything one pass may do, recorded.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Act {
+        StoredGranted,
+        StoredDisabled,
+        ObservedListener,
+        Unregistered,
+        Replaced,
+        Registered,
+    }
+
+    /// A scripted world. `exchanges` is consumed front to back — one entry per
+    /// status exchange the pass makes (classification first, then each verify
+    /// attempt).
+    struct World {
+        compiled: &'static str,
+        /// One entry per gate the pass reaches, front to back; the last one
+        /// answers every gate after it. Scripting them apart is what pins
+        /// *which* gate a refusal stopped.
+        gates: RefCell<Vec<Result<(), Reconciled>>>,
+        status: RefCell<Vec<Result<RegistrationStatus, String>>>,
+        preference: RefCell<Result<HelperPreference, String>>,
+        exchanges: RefCell<Vec<Peer>>,
+        listener: ListenerObservation,
+        unregister: Result<(), String>,
+        replace: RefCell<Option<ReplaceFailure<Reconciled>>>,
+        register: RefCell<Option<RegisterFailure>>,
+        /// The user disables while the old helper is being killed, which is
+        /// exactly when the commitment re-reads the stored decision.
+        disable_during_replace: bool,
+        acts: RefCell<Vec<Act>>,
+    }
+
+    impl Default for World {
+        fn default() -> Self {
+            Self {
+                compiled: THIS_BUILD,
+                gates: RefCell::new(vec![Ok(())]),
+                status: RefCell::new(vec![Ok(RegistrationStatus::Enabled)]),
+                preference: RefCell::new(Ok(HelperPreference::Granted)),
+                exchanges: RefCell::new(Vec::new()),
+                listener: ListenerObservation::PositivelyAbsent,
+                unregister: Ok(()),
+                replace: RefCell::new(None),
+                register: RefCell::new(None),
+                disable_during_replace: false,
+                acts: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl World {
+        /// Registered, granted, and the helper answers `first` on the first
+        /// exchange.
+        fn answering(first: HelperReply) -> Self {
+            Self {
+                exchanges: RefCell::new(vec![Peer::Answered(first)]),
+                ..Self::default()
+            }
+        }
+
+        fn with_gates(mut self, gates: Vec<Result<(), Reconciled>>) -> Self {
+            self.gates = RefCell::new(gates);
+            self
+        }
+
+        fn with_statuses(mut self, statuses: Vec<Result<RegistrationStatus, String>>) -> Self {
+            self.status = RefCell::new(statuses);
+            self
+        }
+
+        fn with_exchanges(mut self, exchanges: Vec<Peer>) -> Self {
+            self.exchanges = RefCell::new(exchanges);
+            self
+        }
+
+        fn acts(&self) -> Vec<Act> {
+            self.acts.borrow().clone()
+        }
+
+        fn did(&self, act: Act) {
+            self.acts.borrow_mut().push(act);
+        }
+    }
+
+    impl Environment for World {
+        fn compiled_build_id(&self) -> &str {
+            self.compiled
+        }
+
+        fn gate(&self) -> Result<(), Reconciled> {
+            let mut gates = self.gates.borrow_mut();
+            if gates.len() > 1 {
+                gates.remove(0)
+            } else {
+                gates[0].clone()
+            }
+        }
+
+        fn registration_status(&self) -> Result<RegistrationStatus, String> {
+            let mut statuses = self.status.borrow_mut();
+            if statuses.len() > 1 {
+                statuses.remove(0)
+            } else {
+                statuses[0].clone()
+            }
+        }
+
+        fn preference(&self) -> Result<HelperPreference, String> {
+            self.preference.borrow().clone()
+        }
+
+        fn store_decision(&self, decision: HelperDecision) -> Result<(), String> {
+            let (act, preference) = match decision {
+                HelperDecision::Granted => (Act::StoredGranted, HelperPreference::Granted),
+                HelperDecision::Disabled => (Act::StoredDisabled, HelperPreference::Disabled),
+            };
+            self.did(act);
+            *self.preference.borrow_mut() = Ok(preference);
+            Ok(())
+        }
+
+        fn observe_listener(&self) -> ListenerObservation {
+            self.did(Act::ObservedListener);
+            self.listener.clone()
+        }
+
+        fn status_exchange(&self) -> PeerReply {
+            let mut exchanges = self.exchanges.borrow_mut();
+            assert!(
+                !exchanges.is_empty(),
+                "a status exchange the script did not provide"
+            );
+            exchanges.remove(0).reply()
+        }
+
+        fn unregister(&self) -> Result<(), String> {
+            self.did(Act::Unregistered);
+            self.unregister.clone()
+        }
+
+        fn replace_helper(
+            &self,
+            commit_to_register: &dyn Fn() -> Result<Committed, Reconciled>,
+        ) -> Result<(), ReplaceFailure<Reconciled>> {
+            self.did(Act::Replaced);
+            if self.disable_during_replace {
+                *self.preference.borrow_mut() = Ok(HelperPreference::Disabled);
+            }
+            if let Some(failure) = self.replace.borrow_mut().take() {
+                return Err(failure);
+            }
+            // The live adapter asks the commitment between the kill and the
+            // register; a decline is reported verbatim.
+            commit_to_register()
+                .map(|_committed| ())
+                .map_err(ReplaceFailure::RegisterDeclined)
+        }
+
+        fn register(&self, _committed: Committed) -> Result<(), RegisterFailure> {
+            self.did(Act::Registered);
+            match self.register.borrow_mut().take() {
+                Some(failure) => Err(failure),
+                None => Ok(()),
+            }
+        }
+
+        fn wait(&self, _interval: Duration) {}
+    }
+
+    fn fresh_run(world: &World) -> Reconciled {
+        run(&Mutex::new(()), world)
+    }
+
+    fn this_build_idle() -> HelperReply {
+        status_reply(THIS_BUILD, HelperStateName::Idle, None)
+    }
+
+    /// The sentence a stopped report carries, or a failure naming what came
+    /// instead.
+    fn stopped_text(report: &Reconciled) -> String {
+        match report {
+            Reconciled::Stopped(text) => text.clone(),
+            other => panic!("expected a stopped report, got {other:?}"),
+        }
+    }
+
+    fn displaced_text(report: &Reconciled) -> String {
+        match report {
+            Reconciled::Displaced(text) => text.clone(),
+            other => panic!("expected a displaced report, got {other:?}"),
+        }
+    }
+
+    // ── the normal startup ─────────────────────────────────────────────────
+
+    #[test]
+    fn a_helper_at_this_build_is_the_resting_state() {
+        let world = World::answering(this_build_idle());
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert!(world.acts().is_empty(), "nothing to mutate");
+    }
+
+    #[test]
+    fn this_builds_helper_running_an_activation_is_still_at_this_build() {
+        let world = World::answering(status_reply(
+            THIS_BUILD,
+            HelperStateName::Activating,
+            Some(activation(ClientKind::SyncAgent)),
+        ));
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert!(world.acts().is_empty());
+    }
+
+    // ── the upgrade ────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_different_build_idle_is_replaced_and_verified() {
+        let world = World::default().with_exchanges(vec![
+            Peer::Answered(status_reply(OTHER_BUILD, HelperStateName::Idle, None)),
+            // Verify: the fresh helper answers at this build.
+            Peer::Answered(this_build_idle()),
+        ]);
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert_eq!(world.acts(), vec![Act::Replaced]);
+    }
+
+    #[test]
+    fn a_different_build_running_an_activation_is_waited_on_not_touched() {
+        // The one deferral in the design: never unregister a helper that
+        // reports a running activation. The pass ends; the loop re-observes.
+        let info = activation(ClientKind::SyncAgent);
+        let world = World::answering(status_reply(
+            OTHER_BUILD,
+            HelperStateName::Activating,
+            Some(info.clone()),
+        ));
+
+        assert_eq!(
+            fresh_run(&world),
+            Reconciled::WaitingOnActivation(Some(info))
+        );
+        assert!(world.acts().is_empty(), "a deferral mutates nothing");
+    }
+
+    #[test]
+    fn a_relaunched_helpers_bare_activating_is_waited_on_too() {
+        let world = World::answering(status_reply(OTHER_BUILD, HelperStateName::Activating, None));
+
+        assert_eq!(fresh_run(&world), Reconciled::WaitingOnActivation(None));
+        assert!(world.acts().is_empty());
+    }
+
+    #[test]
+    fn a_verified_replacement_accepts_a_fresh_helper_already_activating() {
+        // A sync agent can win the race to the fresh helper; that is a
+        // working replacement, not a failure.
+        let world = World::default().with_exchanges(vec![
+            Peer::Answered(status_reply(OTHER_BUILD, HelperStateName::Idle, None)),
+            Peer::Answered(status_reply(
+                THIS_BUILD,
+                HelperStateName::Activating,
+                Some(activation(ClientKind::SyncAgent)),
+            )),
+        ]);
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+    }
+
+    #[test]
+    fn verify_retries_while_the_fresh_helper_binds_its_socket() {
+        let world = World::default().with_exchanges(vec![
+            Peer::Answered(status_reply(OTHER_BUILD, HelperStateName::Idle, None)),
+            Peer::Unreachable,
+            Peer::Unreachable,
+            Peer::Answered(this_build_idle()),
+        ]);
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+    }
+
+    #[test]
+    fn verify_that_never_hears_an_answer_judges_from_a_fresh_status_read() {
+        let unreachable = vec![Peer::Unreachable; VERIFY_LISTEN_ATTEMPTS as usize];
+        let mut exchanges = vec![Peer::Answered(status_reply(
+            OTHER_BUILD,
+            HelperStateName::Idle,
+            None,
+        ))];
+        exchanges.extend(unreachable);
+
+        // The fresh read finds requiresApproval: the pending state, not a
+        // failure — macOS wanted a new approval for the replacement.
+        let world = World::default()
+            .with_exchanges(exchanges.clone())
+            .with_statuses(vec![
+                Ok(RegistrationStatus::Enabled),          // converge's read
+                Ok(RegistrationStatus::Enabled),          // verify's first read
+                Ok(RegistrationStatus::RequiresApproval), // the fresh read
+            ]);
+        assert_eq!(fresh_run(&world), Reconciled::PendingApproval);
+
+        // Still enabled and still silent: a real verification failure.
+        let world = World::default().with_exchanges(exchanges);
+        assert_eq!(
+            stopped_text(&fresh_run(&world)),
+            "the registered helper never answered on its socket"
+        );
+    }
+
+    #[test]
+    fn a_wrong_build_answering_verification_is_a_failure() {
+        let world = World::default().with_exchanges(vec![
+            Peer::Answered(status_reply(OTHER_BUILD, HelperStateName::Idle, None)),
+            Peer::Answered(status_reply(OTHER_BUILD, HelperStateName::Idle, None)),
+        ]);
+
+        assert_eq!(
+            stopped_text(&fresh_run(&world)),
+            format!("the registered helper reports build {OTHER_BUILD}, not this build")
+        );
+    }
+
+    // ── absence, and what does not prove it ────────────────────────────────
+
+    #[test]
+    fn an_enabled_registration_with_positively_no_listener_is_replaced() {
+        let world = World::default()
+            .with_exchanges(vec![Peer::Unreachable, Peer::Answered(this_build_idle())]);
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert_eq!(world.acts(), vec![Act::ObservedListener, Act::Replaced]);
+    }
+
+    #[test]
+    fn an_absence_that_could_not_be_established_mutates_nothing() {
+        for listener in [
+            ListenerObservation::Listening,
+            ListenerObservation::Ambiguous("timed out".to_string()),
+        ] {
+            let world = World {
+                listener,
+                exchanges: RefCell::new(vec![Peer::Unreachable]),
+                ..World::default()
+            };
+
+            assert!(
+                stopped_text(&fresh_run(&world)).starts_with("the helper socket is unusable: ")
+            );
+            assert_eq!(world.acts(), vec![Act::ObservedListener]);
+        }
+    }
+
+    // ── the legacy / unverifiable helper ───────────────────────────────────
+
+    #[test]
+    fn an_unverifiable_root_peer_is_replaced_without_being_asked() {
+        let world = World::default().with_exchanges(vec![
+            Peer::RootUnverifiable,
+            Peer::Answered(this_build_idle()),
+        ]);
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert_eq!(world.acts(), vec![Act::Replaced]);
+    }
+
+    #[test]
+    fn an_unverifiable_root_peer_is_removed_when_the_user_disabled() {
+        let world = World {
+            preference: RefCell::new(Ok(HelperPreference::Disabled)),
+            exchanges: RefCell::new(vec![Peer::RootUnverifiable]),
+            ..World::default()
+        };
+
+        assert_eq!(fresh_run(&world), Reconciled::Removed);
+        assert_eq!(world.acts(), vec![Act::Unregistered]);
+    }
+
+    #[test]
+    fn an_unidentified_peer_authorizes_nothing() {
+        let world = World::default().with_exchanges(vec![Peer::Unidentified]);
+
+        assert!(
+            stopped_text(&fresh_run(&world))
+                .starts_with("the helper socket is held by something unidentified: ")
+        );
+        assert!(world.acts().is_empty());
+    }
+
+    // ── the rest of the status × goal table ────────────────────────────────
+
+    #[test]
+    fn nothing_registered_and_granted_registers_fresh_and_verifies() {
+        let world = World::default()
+            .with_statuses(vec![
+                Ok(RegistrationStatus::NotRegistered),
+                Ok(RegistrationStatus::Enabled),
+            ])
+            .with_exchanges(vec![Peer::Answered(this_build_idle())]);
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert_eq!(world.acts(), vec![Act::Registered]);
+    }
+
+    #[test]
+    fn nothing_registered_and_nothing_wanted_is_no_helper() {
+        for preference in [HelperPreference::Disabled, HelperPreference::Unset] {
+            let world = World {
+                preference: RefCell::new(Ok(preference)),
+                status: RefCell::new(vec![Ok(RegistrationStatus::NotRegistered)]),
+                ..World::default()
+            };
+
+            assert_eq!(fresh_run(&world), Reconciled::NoHelper);
+            assert!(world.acts().is_empty());
+        }
+    }
+
+    #[test]
+    fn a_pending_approval_is_reported_and_never_reregistered() {
+        let world = World {
+            status: RefCell::new(vec![Ok(RegistrationStatus::RequiresApproval)]),
+            ..World::default()
+        };
+
+        assert_eq!(fresh_run(&world), Reconciled::PendingApproval);
+        assert!(world.acts().is_empty(), "no registration churn");
+    }
+
+    #[test]
+    fn a_pending_approval_is_removed_when_the_user_disabled() {
+        let world = World {
+            preference: RefCell::new(Ok(HelperPreference::Disabled)),
+            status: RefCell::new(vec![Ok(RegistrationStatus::RequiresApproval)]),
+            ..World::default()
+        };
+
+        assert_eq!(fresh_run(&world), Reconciled::Removed);
+        assert_eq!(world.acts(), vec![Act::Unregistered]);
+    }
+
+    #[test]
+    fn an_existing_registration_is_adopted_as_the_users_earlier_opt_in() {
+        let world = World {
+            preference: RefCell::new(Ok(HelperPreference::Unset)),
+            exchanges: RefCell::new(vec![Peer::Answered(this_build_idle())]),
+            ..World::default()
+        };
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert_eq!(world.acts(), vec![Act::StoredGranted]);
+    }
+
+    #[test]
+    fn a_broken_service_definition_stops_the_pass() {
+        let world = World {
+            status: RefCell::new(vec![Ok(RegistrationStatus::NotFound)]),
+            ..World::default()
+        };
+
+        assert_eq!(fresh_run(&world), Reconciled::ServiceDefinitionBroken);
+    }
+
+    // ── refusals and failures that end a pass ──────────────────────────────
+
+    #[test]
+    fn a_reply_that_is_not_a_status_is_a_refusal() {
+        let world = World::answering(HelperReply::RequestNotUnderstood);
+
+        assert!(stopped_text(&fresh_run(&world)).starts_with("the helper refused: "));
+        assert!(world.acts().is_empty());
+    }
+
+    #[test]
+    fn exchange_failures_end_the_pass_without_mutating() {
+        for (peer, expected) in [
+            (Peer::ClosedBeforeReply, "the helper socket is unusable: "),
+            (
+                Peer::Unparseable,
+                "the helper sent a reply this build cannot parse: ",
+            ),
+        ] {
+            let world = World::default().with_exchanges(vec![peer]);
+            assert!(stopped_text(&fresh_run(&world)).starts_with(expected));
+            assert!(world.acts().is_empty());
+        }
+    }
+
+    #[test]
+    fn an_unreadable_registration_stops_before_anything_else() {
+        let world = World::default().with_statuses(vec![Err("no service".to_string())]);
+
+        assert_eq!(
+            stopped_text(&fresh_run(&world)),
+            "the helper registration could not be read: no service"
+        );
+    }
+
+    #[test]
+    fn a_failed_unregister_is_reported() {
+        let world = World {
+            preference: RefCell::new(Ok(HelperPreference::Disabled)),
+            exchanges: RefCell::new(vec![Peer::Answered(status_reply(
+                OTHER_BUILD,
+                HelperStateName::Idle,
+                None,
+            ))]),
+            unregister: Err("not permitted".to_string()),
+            ..World::default()
+        };
+
+        assert_eq!(
+            stopped_text(&fresh_run(&world)),
+            "the helper could not be unregistered: not permitted"
+        );
+    }
+
+    #[test]
+    fn a_disable_recorded_mid_replacement_declines_the_register() {
+        // The commitment re-reads the stored decision between the kill and
+        // the register; this world flips it just before the pass gets there.
+        let world = World {
+            disable_during_replace: true,
+            ..World::default().with_exchanges(vec![Peer::Answered(status_reply(
+                OTHER_BUILD,
+                HelperStateName::Idle,
+                None,
+            ))])
+        };
+
+        assert_eq!(
+            stopped_text(&fresh_run(&world)),
+            "the helper is no longer granted; it was being replaced"
+        );
+    }
+
+    // ── the gates ──────────────────────────────────────────────────────────
+
+    fn refused() -> Result<(), Reconciled> {
+        Err(Reconciled::Displaced("moved".to_string()))
+    }
+
+    #[test]
+    fn a_displaced_copy_reports_and_touches_nothing() {
+        let world = World::default().with_gates(vec![refused()]);
+
+        assert_eq!(displaced_text(&fresh_run(&world)), "moved");
+        assert!(world.acts().is_empty());
+    }
+
+    #[test]
+    fn a_displaced_copy_records_no_decision_either() {
+        let world = World::default().with_gates(vec![refused()]);
+
+        let report = decide(&Mutex::new(()), &world, HelperDecision::Granted);
+
+        assert!(matches!(report, Reconciled::Displaced(_)));
+        assert!(world.acts().is_empty(), "the gates cover the write");
+    }
+
+    #[test]
+    fn the_adoption_write_is_behind_a_gate_of_its_own() {
+        // The pass's own gate is open; the one immediately before the write is
+        // not, and nothing is recorded.
+        let world = World {
+            preference: RefCell::new(Ok(HelperPreference::Unset)),
+            ..World::default().with_gates(vec![Ok(()), refused()])
+        };
+
+        assert_eq!(displaced_text(&fresh_run(&world)), "moved");
+        assert!(world.acts().is_empty(), "nothing adopted behind the gate");
+    }
+
+    #[test]
+    fn the_mutation_is_behind_a_gate_of_its_own() {
+        // Same shape one step later: the pass classifies a helper it would
+        // replace, and the gate in front of the replacement refuses.
+        let world = World::default()
+            .with_gates(vec![Ok(()), refused()])
+            .with_exchanges(vec![Peer::Answered(status_reply(
+                OTHER_BUILD,
+                HelperStateName::Idle,
+                None,
+            ))]);
+
+        assert_eq!(displaced_text(&fresh_run(&world)), "moved");
+        assert!(world.acts().is_empty(), "nothing replaced behind the gate");
+    }
+
+    #[test]
+    fn the_gate_judgment_reads_the_three_facts_it_is_about() {
+        let installed = InstallLocation::Canonical(PathBuf::from("/Applications/nixmac.app"));
+
+        assert_eq!(
+            judge_gates(&installed, THIS_BUILD, Ok(THIS_BUILD.to_string())),
+            Ok(())
+        );
+
+        // Not in /Applications, with and without an observed path — and the
+        // on-disk stamp is never what such a copy is judged on.
+        let elsewhere = InstallLocation::Elsewhere(Some(PathBuf::from("/tmp/nixmac.app")));
+        assert_eq!(
+            judge_gates(&elsewhere, THIS_BUILD, Err("unreadable".to_string())),
+            Err(Reconciled::Displaced(
+                "nixmac runs from /tmp/nixmac.app — move it to /Applications".to_string()
+            ))
+        );
+        assert_eq!(
+            judge_gates(
+                &InstallLocation::Elsewhere(None),
+                THIS_BUILD,
+                Err("unreadable".to_string())
+            ),
+            Err(Reconciled::Displaced(
+                "nixmac is not running from an app bundle in /Applications".to_string()
+            ))
+        );
+
+        // The bundle was replaced underneath this process.
+        assert_eq!(
+            judge_gates(&installed, THIS_BUILD, Ok("build-newer".to_string())),
+            Err(Reconciled::Displaced(format!(
+                "this app was replaced while running (build {THIS_BUILD} is running, build-newer is installed) — restart nixmac"
+            )))
+        );
+
+        // An unanswered gate mutates nothing, and says why.
+        assert_eq!(
+            judge_gates(&installed, THIS_BUILD, Err("no Info.plist".to_string())),
+            Err(Reconciled::Stopped(
+                "this app's installed build could not be read: no Info.plist".to_string()
+            ))
+        );
+    }
+
+    // ── the single-flight slot ─────────────────────────────────────────────
+
+    #[test]
+    fn a_second_caller_is_told_busy() {
+        // The slot is a plain try-lock: a caller that finds it held is turned
+        // away at once and mutates nothing. Releasing it on every path out of
+        // a run, a panic included, is `MutexGuard`'s own `Drop`.
+        let running = Mutex::new(());
+        let world = World::answering(this_build_idle());
+
+        let held = running.lock().expect("a fresh lock");
+        assert_eq!(run(&running, &world), Reconciled::Busy);
+        assert!(world.acts().is_empty(), "a turned-away caller does nothing");
+
+        drop(held);
+        assert_eq!(run(&running, &world), Reconciled::AtThisBuild);
+    }
+
+    #[test]
+    fn a_decision_waits_out_an_in_flight_pass_and_then_runs_its_own() {
+        // The pass that carries a decision out must always exist: the
+        // convergence loop only re-runs while it has something left to do,
+        // so a decision that merely took `Busy` against the loop's final
+        // pass would never be read. A decision therefore blocks on the slot
+        // and then makes its own pass.
+        let running = Mutex::new(());
+        let held = running.lock().expect("a fresh lock");
+        std::thread::scope(|scope| {
+            let decided = scope.spawn(|| {
+                let world = World {
+                    status: RefCell::new(vec![
+                        Ok(RegistrationStatus::NotRegistered),
+                        Ok(RegistrationStatus::Enabled),
+                    ]),
+                    exchanges: RefCell::new(vec![Peer::Answered(this_build_idle())]),
+                    ..World::default()
+                };
+                let report = decide(&running, &world, HelperDecision::Granted);
+                (report, world.acts())
+            });
+            // Give the decision time to reach the slot. It must still be
+            // waiting — not returned with Busy — when the slot frees.
+            std::thread::sleep(Duration::from_millis(100));
+            assert!(
+                !decided.is_finished(),
+                "the decision did not wait for the slot"
+            );
+            drop(held);
+
+            let (report, acts) = decided.join().expect("decide");
+            // NotRegistered + the stored Grant: the decision's own pass ran
+            // the registration it was stored for.
+            assert_eq!(report, Reconciled::AtThisBuild);
+            assert_eq!(acts, vec![Act::StoredGranted, Act::Registered]);
+        });
+    }
+}

--- a/apps/native/src-tauri/src/privileged_helper/reconcile.rs
+++ b/apps/native/src-tauri/src/privileged_helper/reconcile.rs
@@ -223,8 +223,13 @@ pub use evidence::Committed;
 pub enum PeerReply {
     /// Root, validated, and it answered.
     Answered(HelperReply),
-    /// Root, and validation completed with a "no".
+    /// Root, and validation completed with a "no"; the `Status` probe got no
+    /// usable answer out of it.
     RootUnverifiable(String),
+    /// Root, validation completed with a "no", and it answered the `Status`
+    /// probe anyway. The reply is unverified: it may postpone this peer's own
+    /// replacement, and authorizes nothing.
+    UnverifiableAnswered { detail: String, reply: HelperReply },
     /// A peer that is not root, or a validation that reached no judgment.
     Unidentified(String),
     /// The exchange did not happen.
@@ -324,6 +329,9 @@ impl<R: Runtime> Environment for LiveEnvironment<'_, R> {
         match client::assessed_status() {
             Ok(AssessedExchange::Answered(reply)) => PeerReply::Answered(reply),
             Ok(AssessedExchange::RootUnverifiable(detail)) => PeerReply::RootUnverifiable(detail),
+            Ok(AssessedExchange::UnverifiableAnswered { detail, reply }) => {
+                PeerReply::UnverifiableAnswered { detail, reply }
+            }
             Ok(AssessedExchange::Unidentified(detail)) => PeerReply::Unidentified(detail),
             Err(error) => PeerReply::Failed(error),
         }
@@ -545,14 +553,15 @@ fn goal<E: Environment>(env: &E, status: RegistrationStatus) -> Result<Goal, Rec
     }
 }
 
-/// What is answering the socket of an `enabled` registration. Exactly one of
-/// four things, and only an authenticated peer is ever spoken to.
+/// What is answering the socket of an `enabled` registration. Only an
+/// authenticated peer's answer is acted on; an unverifiable root peer is asked
+/// `Status` too, and its answer buys at most a postponement.
 fn classify<E: Environment>(env: &E, goal: Goal) -> Step {
     match env.status_exchange() {
         PeerReply::Answered(reply) => decide_from_status(env, goal, reply),
-        // The pre-contract helper, or a tampered one: removed without
-        // being asked anything, because no reply from it could be
-        // trusted. Only a *completed* "no" reaches this arm — a
+        // The pre-contract helper, or a tampered one, whose `Status` probe
+        // got no usable answer: removed, because no reply from it could be
+        // trusted anyway. Only a *completed* "no" reaches this arm — a
         // validation that got no answer is `Unidentified` below and
         // authorizes nothing. This is also the one removal that can
         // interrupt an in-process activation (the legacy helper is its
@@ -563,6 +572,28 @@ fn classify<E: Environment>(env: &E, goal: Goal) -> Step {
             // why the peer was rejected cannot be reconstructed.
             log::info!("helper peer unverifiable: {detail}");
             remove_or_replace(env, goal)
+        }
+        // The same peer, but it answered `Status`. Its words are unverified,
+        // so they may buy exactly one thing — postponing its own replacement
+        // while it reports a running activation, the same deferral the
+        // verified path takes — and may authorize nothing: not a kill, not an
+        // `AtThisBuild` resting state (its build ID claim is ignored). Every
+        // other answer takes the arm above's path unchanged. The activation
+        // details are withheld from the report because they came from
+        // unverified code; the log line carries what is known.
+        PeerReply::UnverifiableAnswered { detail, reply } => {
+            log::info!("helper peer unverifiable: {detail}");
+            if matches!(
+                reply,
+                HelperReply::Status {
+                    state: HelperStateName::Activating,
+                    ..
+                }
+            ) {
+                Ok(Reconciled::WaitingOnActivation(None))
+            } else {
+                remove_or_replace(env, goal)
+            }
         }
         PeerReply::Unidentified(detail) => Err(peer_unidentified(detail)),
         // Nothing answered. Whether that is a real absence — as opposed
@@ -757,7 +788,12 @@ fn verify_listening<E: Environment>(env: &E) -> Step {
             // launchd still has to spawn the helper and let it bind. The
             // one outcome this window exists for.
             PeerReply::Failed(HelperClientError::Unreachable(_)) => continue,
-            PeerReply::RootUnverifiable(detail) | PeerReply::Unidentified(detail) => {
+            // During verification the peer should be the helper this pass
+            // just registered; an unverifiable one is a failure, and its
+            // answer buys nothing here — not even a postponement.
+            PeerReply::RootUnverifiable(detail)
+            | PeerReply::UnverifiableAnswered { detail, .. }
+            | PeerReply::Unidentified(detail) => {
                 return Err(peer_unidentified(detail));
             }
             PeerReply::Failed(error) => return Err(exchange_failed(error)),
@@ -850,6 +886,7 @@ mod tests {
     enum Peer {
         Answered(HelperReply),
         RootUnverifiable,
+        UnverifiableAnswered(HelperReply),
         Unidentified,
         Unreachable,
         ClosedBeforeReply,
@@ -863,6 +900,10 @@ mod tests {
                 Peer::RootUnverifiable => {
                     PeerReply::RootUnverifiable("ad-hoc signature".to_string())
                 }
+                Peer::UnverifiableAnswered(reply) => PeerReply::UnverifiableAnswered {
+                    detail: "ad-hoc signature".to_string(),
+                    reply: reply.clone(),
+                },
                 Peer::Unidentified => PeerReply::Unidentified("no judgment".to_string()),
                 Peer::Unreachable => PeerReply::Failed(HelperClientError::Unreachable(
                     std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
@@ -1252,6 +1293,33 @@ mod tests {
 
         assert_eq!(fresh_run(&world), Reconciled::Removed);
         assert_eq!(world.acts(), vec![Act::Unregistered]);
+    }
+
+    #[test]
+    fn an_unverifiable_peer_reporting_an_activation_postpones_its_replacement() {
+        // Claims this build and attaches activation details; neither is
+        // believed — no `AtThisBuild`, and the report carries `None`. The
+        // answer buys the deferral and nothing else.
+        let world =
+            World::default().with_exchanges(vec![Peer::UnverifiableAnswered(status_reply(
+                THIS_BUILD,
+                HelperStateName::Activating,
+                Some(activation(ClientKind::SyncAgent)),
+            ))]);
+
+        assert_eq!(fresh_run(&world), Reconciled::WaitingOnActivation(None));
+        assert!(world.acts().is_empty(), "a deferral mutates nothing");
+    }
+
+    #[test]
+    fn an_unverifiable_peer_answering_idle_is_replaced_as_without_the_answer() {
+        let world = World::default().with_exchanges(vec![
+            Peer::UnverifiableAnswered(status_reply(OTHER_BUILD, HelperStateName::Idle, None)),
+            Peer::Answered(this_build_idle()),
+        ]);
+
+        assert_eq!(fresh_run(&world), Reconciled::AtThisBuild);
+        assert_eq!(world.acts(), vec![Act::Replaced]);
     }
 
     #[test]

--- a/apps/native/src-tauri/src/privileged_helper/service.rs
+++ b/apps/native/src-tauri/src/privileged_helper/service.rs
@@ -1,47 +1,338 @@
-use crate::privileged_helper::client;
 #[cfg(target_os = "macos")]
-use crate::privileged_helper::protocol::{HELPER_LABEL, HELPER_PLIST_NAME};
-use crate::privileged_helper::protocol::{HelperResponse, HelperServiceStatus};
+use crate::privileged_helper::protocol::HELPER_PLIST_NAME;
 use anyhow::Result;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::{Duration, Instant};
 
-pub fn status() -> HelperServiceStatus {
-    let mut status = platform_status();
-    status.socket_available = client::socket_available();
-    // SMAppService state and a socket path prove nothing about the daemon:
-    // only an authenticated round-trip (mutual code-signature validation at
-    // this build's protocol version) shows the connection actually works.
-    if status.socket_available {
-        fold_status_probe(&mut status, client::status());
-    }
-    status
+/// The four statuses `SMAppService` defines, and no others.
+///
+/// A raw value outside this set is an adapter error, never a fifth status:
+/// every reconciliation decision is a total match over these four, and a
+/// catch-all would let an unreadable registration pass for one of them.
+// Only the macOS adapter reads a raw status, so off Apple nothing constructs
+// one; mute dead-code there while keeping macOS builds strict.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistrationStatus {
+    /// Never registered, or unregistered after having been registered.
+    NotRegistered,
+    /// Registered and eligible to run.
+    Enabled,
+    /// Registered, but waiting on the user in System Settings — including a
+    /// consent the user revoked there. An approval-pending service has no
+    /// process.
+    RequiresApproval,
+    /// The bundle's service definition could not be found.
+    NotFound,
 }
 
-/// Folds one authenticated status round-trip into the service status. Only a
-/// same-version `ok` response marks the daemon responding: a version-skewed
-/// response fails `client::status` before its fields are readable and lands
-/// in the `Err` arm, and a daemon-reported protocol error arrives with
-/// `ok: false` — either way a protocol error can only ever reach `detail`.
-fn fold_status_probe(status: &mut HelperServiceStatus, probe: anyhow::Result<HelperResponse>) {
-    match probe {
-        Ok(response) if response.ok => status.responding = true,
-        Ok(response) => {
-            status.detail =
-                Some(response.error.unwrap_or_else(|| {
-                    "helper answered the status probe with an error".to_string()
-                }));
+impl RegistrationStatus {
+    /// Maps one raw `SMAppServiceStatus`. `Err` carries the unrecognized value
+    /// so the caller can report it verbatim.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    fn from_raw(raw: i64) -> Result<Self, i64> {
+        match raw {
+            0 => Ok(Self::NotRegistered),
+            1 => Ok(Self::Enabled),
+            2 => Ok(Self::RequiresApproval),
+            3 => Ok(Self::NotFound),
+            unknown => Err(unknown),
         }
-        Err(error) => status.detail = Some(format!("{error:#}")),
     }
 }
 
-pub fn register() -> Result<HelperServiceStatus> {
-    platform_register()?;
-    Ok(status())
+impl std::fmt::Display for RegistrationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The Apple names, which the permissions UI already surfaces as detail.
+        f.write_str(match self {
+            RegistrationStatus::NotRegistered => "notRegistered",
+            RegistrationStatus::Enabled => "enabled",
+            RegistrationStatus::RequiresApproval => "requiresApproval",
+            RegistrationStatus::NotFound => "notFound",
+        })
+    }
 }
 
-pub fn unregister() -> Result<HelperServiceStatus> {
-    platform_unregister()?;
-    Ok(status())
+/// A failed ServiceManagement call, preserved structurally.
+///
+/// The `NSError` domain and code are the identity of the failure; the localized
+/// description is diagnostic text for reports and logs and nothing else. No
+/// decision may be derived from it — it is localized, and Apple may reword it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceCallError {
+    pub domain: String,
+    pub code: i64,
+    pub localized: String,
+}
+
+impl std::fmt::Display for ServiceCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}: {}", self.domain, self.code, self.localized)
+    }
+}
+
+/// What one asynchronous ServiceManagement call reported.
+pub type ServiceCallOutcome = Result<(), ServiceCallError>;
+
+/// Why a helper replacement stopped short.
+///
+/// Total, like [`RegistrationStatus`]: every way out of [`replace_helper`] is
+/// one of these, so a caller decides by matching and never by a catch-all. Each
+/// variant also states what is registered afterwards, because that is what the
+/// caller has to report and what its next observation has to agree with.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplaceFailure<E> {
+    /// Refused before anything was dispatched, so nothing changed. The main
+    /// thread is the one that has to issue both calls; awaiting them there
+    /// would starve the queue that makes them.
+    CalledOnMainThread,
+    /// The platform refused the unregister. The old helper is still registered.
+    UnregisterFailed(ServiceCallError),
+    /// The unregister never reported inside the window. The old process may
+    /// still be alive, so no replacement was registered.
+    UnregisterSilent,
+    /// The old process is gone and the caller declined the replacement, so no
+    /// helper is registered now. The reason is the caller's own: this module
+    /// supplies the point where such a decision is possible and takes none.
+    RegisterDeclined(E),
+    /// The old process is gone and the replacement was refused: no helper is
+    /// registered now.
+    RegisterFailed(ServiceCallError),
+    /// The old process is gone and the replacement never reported. Whether it
+    /// took is unknown — only a fresh observation can say.
+    RegisterSilent,
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for ReplaceFailure<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CalledOnMainThread => {
+                f.write_str("a helper replacement cannot be awaited on the main thread")
+            }
+            Self::UnregisterFailed(error) => write!(f, "unregister failed: {error}"),
+            Self::UnregisterSilent => f.write_str("unregister never reported"),
+            Self::RegisterDeclined(reason) => write!(f, "the replacement was declined: {reason}"),
+            Self::RegisterFailed(error) => write!(f, "register failed: {error}"),
+            Self::RegisterSilent => f.write_str("register never reported"),
+        }
+    }
+}
+
+/// Why a standalone register stopped short. [`ReplaceFailure`]'s register
+/// variants say the same things about a register that followed a kill.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegisterFailure {
+    /// Refused before anything was dispatched: the main thread is the one that
+    /// has to make the call, so awaiting it there would starve the queue.
+    CalledOnMainThread,
+    /// The platform refused the registration; nothing is registered.
+    Failed(ServiceCallError),
+    /// The call never reported inside the window. Whether it took is unknown —
+    /// only a fresh observation can say.
+    Silent,
+}
+
+impl std::fmt::Display for RegisterFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CalledOnMainThread => {
+                f.write_str("a registration cannot be awaited on the main thread")
+            }
+            Self::Failed(error) => write!(f, "register failed: {error}"),
+            Self::Silent => f.write_str("register never reported"),
+        }
+    }
+}
+
+/// How work reaches a later main-queue run-loop turn. Injectable so a test can
+/// run the work somewhere other than a main queue it has no run loop to drain.
+type LaterMainQueueTurn<'a> = &'a dyn Fn(Box<dyn FnOnce() + Send + 'static>);
+
+/// The typed registration status of nixmac's helper service — the only thing
+/// this module reports about it.
+///
+/// There is deliberately no folded "is the helper working" readout here: what a
+/// helper is and whether it may be used are the reconciliation function's to
+/// decide, from an authenticated `Status` reply, and a status flag summarising a
+/// socket round-trip is exactly what an activation must never be admitted on.
+pub fn registration_status() -> Result<RegistrationStatus> {
+    platform_registration_status()
+}
+
+/// Removes the registration, synchronously. The running helper is killed, and
+/// this call does not wait for that: only [`replace_helper`] does, because only
+/// a replacement needs to know the old process is gone.
+pub fn unregister() -> Result<()> {
+    platform_unregister()
+}
+
+/// Replaces the registered helper: unregisters, waits for the running process
+/// to be killed, asks `commit_to_register`, then registers the replacement.
+///
+/// The asynchronous unregister exists for one reason: its completion fires
+/// *after* the running helper process has been killed, which is the only signal
+/// that makes re-registering safe. The synchronous [`unregister`] returns before
+/// the process is reaped and cannot answer that question. Registering only after
+/// that completion has arrived is also the Apple DTS workaround for an immediate
+/// re-registration failing (<https://developer.apple.com/forums/thread/783539>):
+/// the second dispatch is unavoidably a later main-queue turn than the first,
+/// because this function does not reach it until the first has reported.
+///
+/// `commit_to_register` runs at the one moment between the two calls where the
+/// old process is confirmed gone and nothing is registered yet — the only place
+/// a caller can re-check a decision that a replacement would otherwise
+/// invalidate. It runs on the *calling* thread, not on the main queue, and an
+/// `Err` leaves no helper registered and is reported verbatim as
+/// [`ReplaceFailure::RegisterDeclined`]. Nothing here inspects that reason:
+/// which conditions may decline a replacement is the caller's policy, and this
+/// module holds none.
+///
+/// Blocks for at most `within` across both calls. Both are issued *on* the main
+/// queue, so a main-thread caller would starve the queue that has to make them
+/// and see a callback that never arrives; that is refused up front rather than
+/// left to a misread timeout. A GUI calls this off the main thread.
+pub fn replace_helper<E>(
+    within: Duration,
+    commit_to_register: impl FnOnce() -> Result<(), E>,
+) -> Result<(), ReplaceFailure<E>> {
+    replace_helper_via(
+        &on_later_main_queue_turn,
+        on_main_thread(),
+        within,
+        commit_to_register,
+    )
+}
+
+fn replace_helper_via<E>(
+    dispatch: LaterMainQueueTurn<'_>,
+    on_main_thread: bool,
+    within: Duration,
+    commit_to_register: impl FnOnce() -> Result<(), E>,
+) -> Result<(), ReplaceFailure<E>> {
+    if on_main_thread {
+        return Err(ReplaceFailure::CalledOnMainThread);
+    }
+    let deadline = Instant::now() + within;
+
+    // Nothing but the sink crosses the queue boundary: the work reads the
+    // compiled plist name and builds the service and its completion block on the
+    // main queue itself. That no retained object can travel is enforced rather
+    // than trusted — `Retained` is not `Send` and the dispatch demands `Send`.
+    let killed = dispatched_call(dispatch, platform_unregister_awaiting_kill);
+    fold_replacement(awaited(killed, deadline), commit_to_register, || {
+        // Reached only once the unregister has reported, which is what makes
+        // this dispatch a later main-queue turn than that one.
+        dispatched_register(dispatch, deadline)
+    })
+}
+
+/// Decides a replacement from what the two calls reported, `None` meaning
+/// nothing reported inside the window.
+///
+/// `commit_to_register` and `register` are reached only when the unregister
+/// confirmed the kill: every other path leaves a process that may still be
+/// running, and registering on top of one is the thing this whole sequence
+/// exists to avoid. A caller that declines stops there too — with the old
+/// process already gone, since the decision is only possible after the kill it
+/// is being asked about.
+fn fold_replacement<E>(
+    killed: Option<ServiceCallOutcome>,
+    commit_to_register: impl FnOnce() -> Result<(), E>,
+    register: impl FnOnce() -> Option<ServiceCallOutcome>,
+) -> Result<(), ReplaceFailure<E>> {
+    match killed {
+        Some(Ok(())) => {}
+        Some(Err(error)) => return Err(ReplaceFailure::UnregisterFailed(error)),
+        None => return Err(ReplaceFailure::UnregisterSilent),
+    }
+    if let Err(reason) = commit_to_register() {
+        return Err(ReplaceFailure::RegisterDeclined(reason));
+    }
+    match register() {
+        Some(Ok(())) => Ok(()),
+        Some(Err(error)) => Err(ReplaceFailure::RegisterFailed(error)),
+        None => Err(ReplaceFailure::RegisterSilent),
+    }
+}
+
+/// Registers the bundled helper on a later main-queue run-loop turn, with
+/// nothing unregistered first.
+///
+/// This is the path from `notRegistered`, where there is no process to kill and
+/// so nothing to wait for. Replacing a *running* helper goes through
+/// [`replace_helper`], which calls the same dispatch as its second half — one
+/// register implementation, so the later-turn dispatch and the window cannot
+/// drift apart between the two paths.
+///
+/// Refused on the main thread for the same reason as [`replace_helper`]: the
+/// call is issued *on* the main queue and awaited here.
+pub fn register_on_later_turn(within: Duration) -> Result<(), RegisterFailure> {
+    register_on_later_turn_via(&on_later_main_queue_turn, on_main_thread(), within)
+}
+
+fn register_on_later_turn_via(
+    dispatch: LaterMainQueueTurn<'_>,
+    on_main_thread: bool,
+    within: Duration,
+) -> Result<(), RegisterFailure> {
+    if on_main_thread {
+        return Err(RegisterFailure::CalledOnMainThread);
+    }
+    match dispatched_register(dispatch, Instant::now() + within) {
+        Some(Ok(())) => Ok(()),
+        Some(Err(error)) => Err(RegisterFailure::Failed(error)),
+        None => Err(RegisterFailure::Silent),
+    }
+}
+
+/// Dispatches the register to a later main-queue turn and waits out `deadline`
+/// for it, like every other call here.
+fn dispatched_register(
+    dispatch: LaterMainQueueTurn<'_>,
+    deadline: Instant,
+) -> Option<ServiceCallOutcome> {
+    let registered = dispatched_call(dispatch, |sink| {
+        let _ = sink.send(platform_register_reporting_error());
+    });
+    awaited(registered, deadline)
+}
+
+/// Dispatches one ServiceManagement call to a later main-queue turn and hands
+/// back the receiver its outcome arrives on.
+///
+/// Apple documents the completion handler as running once. Nothing here relies
+/// on that. [`awaited`] reads one value and then drops the receiver, so if the
+/// handler ran a second time its outcome would either sit unread in the channel
+/// or find no receiver left to take it. The caller sees the first outcome and no
+/// other.
+fn dispatched_call(
+    dispatch: LaterMainQueueTurn<'_>,
+    call: impl FnOnce(Sender<ServiceCallOutcome>) + Send + 'static,
+) -> Receiver<ServiceCallOutcome> {
+    let (sink, outcome) = mpsc::channel();
+    dispatch(Box::new(move || call(sink)));
+    outcome
+}
+
+/// The outcome, or `None` once `deadline` has passed with nothing reported.
+///
+/// A dropped sender counts as nothing reported: work that was never run and a
+/// callback that never fired are the same fact to the caller, and neither may
+/// be waited out past the deadline it set.
+fn awaited(outcome: Receiver<ServiceCallOutcome>, deadline: Instant) -> Option<ServiceCallOutcome> {
+    outcome
+        .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        .ok()
+}
+
+#[cfg(target_os = "macos")]
+fn on_main_thread() -> bool {
+    objc2_foundation::NSThread::isMainThread_class()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn on_main_thread() -> bool {
+    false
 }
 
 pub fn open_login_items_settings() {
@@ -49,34 +340,35 @@ pub fn open_login_items_settings() {
 }
 
 #[cfg(target_os = "macos")]
-fn platform_status() -> HelperServiceStatus {
-    match macos::service_status() {
-        Ok(raw) => HelperServiceStatus {
-            label: HELPER_LABEL.to_string(),
-            available: true,
-            registered: raw != macos::SM_APP_SERVICE_STATUS_NOT_REGISTERED,
-            authorized: raw == macos::SM_APP_SERVICE_STATUS_ENABLED,
-            socket_available: false,
-            responding: false,
-            detail: Some(macos::describe_status(raw).to_string()),
-        },
-        Err(error) => HelperServiceStatus::unavailable(error.to_string()),
-    }
+fn on_later_main_queue_turn(work: Box<dyn FnOnce() + Send + 'static>) {
+    dispatch2::DispatchQueue::main().exec_async(work);
 }
 
+/// No main queue to hop onto off Apple platforms; the work runs inline and its
+/// only possible outcome there is the "macOS only" error.
 #[cfg(not(target_os = "macos"))]
-fn platform_status() -> HelperServiceStatus {
-    HelperServiceStatus::unavailable("SMAppService is only available on macOS")
+fn on_later_main_queue_turn(work: Box<dyn FnOnce() + Send + 'static>) {
+    work();
 }
 
 #[cfg(target_os = "macos")]
-fn platform_register() -> Result<()> {
-    macos::register_service()
+fn platform_registration_status() -> Result<RegistrationStatus> {
+    macos::registration_status()
 }
 
 #[cfg(not(target_os = "macos"))]
-fn platform_register() -> Result<()> {
+fn platform_registration_status() -> Result<RegistrationStatus> {
     anyhow::bail!("SMAppService is only available on macOS")
+}
+
+#[cfg(target_os = "macos")]
+fn platform_register_reporting_error() -> ServiceCallOutcome {
+    macos::register_service_reporting_error()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_register_reporting_error() -> ServiceCallOutcome {
+    Err(adapter_error("SMAppService is only available on macOS"))
 }
 
 #[cfg(target_os = "macos")]
@@ -90,6 +382,30 @@ fn platform_unregister() -> Result<()> {
 }
 
 #[cfg(target_os = "macos")]
+fn platform_unregister_awaiting_kill(sink: Sender<ServiceCallOutcome>) {
+    macos::unregister_service_awaiting_kill(sink);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_unregister_awaiting_kill(sink: Sender<ServiceCallOutcome>) {
+    let _ = sink.send(Err(adapter_error(
+        "SMAppService is only available on macOS",
+    )));
+}
+
+/// Domain reported when the adapter itself refused to make the call, so a
+/// caller can tell "the platform said no" from "we never asked it".
+const ADAPTER_ERROR_DOMAIN: &str = "com.darkmatter.nixmac.serviceAdapter";
+
+fn adapter_error(detail: impl Into<String>) -> ServiceCallError {
+    ServiceCallError {
+        domain: ADAPTER_ERROR_DOMAIN.to_string(),
+        code: 0,
+        localized: detail.into(),
+    }
+}
+
+#[cfg(target_os = "macos")]
 fn platform_open_login_items_settings() {
     macos::open_login_items_settings();
 }
@@ -98,107 +414,144 @@ fn platform_open_login_items_settings() {
 fn platform_open_login_items_settings() {}
 
 #[cfg(target_os = "macos")]
-#[allow(deprecated)]
 mod macos {
-    use super::HELPER_PLIST_NAME;
-    use anyhow::{Result, anyhow};
-    use cocoa::base::{BOOL, NO, nil};
-    use cocoa::foundation::{NSAutoreleasePool, NSString};
-    use objc::runtime::{Class, Object};
-    use objc::{msg_send, sel, sel_impl};
-    use std::ptr;
+    use super::{
+        HELPER_PLIST_NAME, RegistrationStatus, ServiceCallError, ServiceCallOutcome, adapter_error,
+    };
+    use anyhow::{Result, anyhow, bail};
+    use block2::RcBlock;
+    use objc2::rc::{Retained, autoreleasepool};
+    use objc2::runtime::AnyClass;
+    use objc2_foundation::{NSError, NSString};
+    use objc2_service_management::SMAppService;
+    use std::sync::mpsc::Sender;
 
-    #[link(name = "ServiceManagement", kind = "framework")]
-    unsafe extern "C" {}
-
-    pub const SM_APP_SERVICE_STATUS_NOT_REGISTERED: i64 = 0;
-    pub const SM_APP_SERVICE_STATUS_ENABLED: i64 = 1;
-    pub const SM_APP_SERVICE_STATUS_REQUIRES_APPROVAL: i64 = 2;
-    pub const SM_APP_SERVICE_STATUS_NOT_FOUND: i64 = 3;
-
-    pub fn describe_status(status: i64) -> &'static str {
-        match status {
-            SM_APP_SERVICE_STATUS_NOT_REGISTERED => "notRegistered",
-            SM_APP_SERVICE_STATUS_ENABLED => "enabled",
-            SM_APP_SERVICE_STATUS_REQUIRES_APPROVAL => "requiresApproval",
-            SM_APP_SERVICE_STATUS_NOT_FOUND => "notFound",
-            _ => "unknown",
-        }
+    pub fn registration_status() -> Result<RegistrationStatus> {
+        autoreleasepool(|_| {
+            let service = daemon_service()?;
+            let raw = unsafe { service.status() }.0 as i64;
+            RegistrationStatus::from_raw(raw)
+                .map_err(|unknown| anyhow!("SMAppService reported an unknown status: {unknown}"))
+        })
     }
 
-    pub fn service_status() -> Result<i64> {
-        unsafe {
-            let _pool = NSAutoreleasePool::new(nil);
-            let service = daemon_service()?;
-            let status: i64 = msg_send![service, status];
-            Ok(status)
-        }
-    }
-
-    pub fn register_service() -> Result<()> {
-        unsafe {
-            let _pool = NSAutoreleasePool::new(nil);
-            let service = daemon_service()?;
-            let mut error: *mut Object = ptr::null_mut();
-            let ok: BOOL = msg_send![service, registerAndReturnError: &mut error];
-            if ok == NO {
-                return Err(ns_error(error, "SMAppService register failed"));
-            }
-            Ok(())
-        }
+    /// Registers, reporting the platform failure structurally. Runs wherever it
+    /// is dispatched — the caller guarantees a later main-queue turn — and builds
+    /// its own service from the compiled plist name, so no retained object is
+    /// ever moved between threads.
+    pub fn register_service_reporting_error() -> ServiceCallOutcome {
+        autoreleasepool(|_| {
+            let service = daemon_service().map_err(|error| adapter_error(error.to_string()))?;
+            unsafe { service.registerAndReturnError() }.map_err(|error| structured(&error))
+        })
     }
 
     pub fn unregister_service() -> Result<()> {
-        unsafe {
-            let _pool = NSAutoreleasePool::new(nil);
+        autoreleasepool(|_| {
             let service = daemon_service()?;
-            let mut error: *mut Object = ptr::null_mut();
-            let ok: BOOL = msg_send![service, unregisterAndReturnError: &mut error];
-            if ok == NO {
-                return Err(ns_error(error, "SMAppService unregister failed"));
-            }
-            Ok(())
-        }
+            unsafe { service.unregisterAndReturnError() }
+                .map_err(|error| anyhow!(describe(&error, "SMAppService unregister failed")))
+        })
+    }
+
+    /// Asynchronous unregister. Per the SDK header — the public documentation
+    /// page does not state this — the completion handler is invoked after the
+    /// running process has been killed on success, or whenever an error occurs,
+    /// and re-registering is safe once it has been invoked. The header also says
+    /// it is invoked on libdispatch's default target queue, which is why nothing
+    /// Objective-C is dropped inside it.
+    pub fn unregister_service_awaiting_kill(sink: Sender<ServiceCallOutcome>) {
+        autoreleasepool(|_| {
+            let service = match daemon_service() {
+                Ok(service) => service,
+                Err(error) => {
+                    let _ = sink.send(Err(adapter_error(error.to_string())));
+                    return;
+                }
+            };
+
+            // The handler captures nothing but the sink. It reads the error
+            // through a borrow, so the NSError's retain count is untouched, and
+            // the only Objective-C objects it drops are the two strings
+            // `structured` copies out of it — Foundation value objects, safe to
+            // release on whatever queue libdispatch invokes this on. Nothing
+            // this turn created is released there.
+            //
+            // The send is unchecked because both ways it can fail are the
+            // caller's business and not this queue's: the caller's window
+            // expired and it dropped the receiver, or the API called back twice
+            // and only the first value is read.
+            let block = RcBlock::new(move |error: *mut NSError| {
+                let outcome = match unsafe { error.as_ref() } {
+                    None => Ok(()),
+                    Some(error) => Err(structured(error)),
+                };
+                let _ = sink.send(outcome);
+            });
+            unsafe { service.unregisterWithCompletionHandler(&block) };
+
+            // Deliberately kept alive past the callback, which fires long after
+            // this call returns. By convention this is not required — the
+            // handler is taken by borrow, which is exactly the block-ABI
+            // signal that a callee storing it must copy it, and a framework
+            // continuation retains whatever it captures — but the convention is
+            // all there is: nothing in the binding or the SDK header states
+            // either retain, and the callback is the step the whole replacement
+            // hangs on. Dropping them here would be sound thread-wise (this is
+            // the main queue, where they were created); leaking them costs two
+            // small objects per unregister, and a GUI unregisters at most a
+            // handful of times per run.
+            std::mem::forget(block);
+            std::mem::forget(service);
+        });
     }
 
     pub fn open_login_items_settings() {
-        unsafe {
-            let Some(class) = Class::get("SMAppService") else {
-                fallback_open_login_items_settings();
-                return;
-            };
-            let _: () = msg_send![class, openSystemSettingsLoginItems];
+        if !service_management_available() {
+            fallback_open_login_items_settings();
+            return;
+        }
+        autoreleasepool(|_| unsafe { SMAppService::openSystemSettingsLoginItems() });
+    }
+
+    /// `SMAppService` exists from macOS 13 on; the bundle still launches on
+    /// older systems, where every call here has to fail rather than trap on a
+    /// missing class.
+    fn service_management_available() -> bool {
+        AnyClass::get(c"SMAppService").is_some()
+    }
+
+    /// The daemon service for nixmac's helper plist. The missing-class check is
+    /// the only failure this can report: the generated binding declares the
+    /// result non-optional, following Apple's nonnull annotation, so objc2
+    /// panics on a nil rather than returning it — and on the dispatched paths
+    /// that panic crosses libdispatch's `extern "C"` boundary and aborts. Apple
+    /// annotating the return nonnull is the whole reason this is acceptable; the
+    /// hand-rolled predecessor reported nil as an error instead.
+    fn daemon_service() -> Result<Retained<SMAppService>> {
+        if !service_management_available() {
+            bail!("SMAppService is unavailable on this macOS version");
+        }
+        let plist_name = NSString::from_str(HELPER_PLIST_NAME);
+        Ok(unsafe { SMAppService::daemonServiceWithPlistName(&plist_name) })
+    }
+
+    /// Splits an `NSError` into the parts decisions may use (domain, code) and
+    /// the part only reports may use (the localized description).
+    pub fn structured(error: &NSError) -> ServiceCallError {
+        ServiceCallError {
+            domain: error.domain().to_string(),
+            code: error.code() as i64,
+            localized: error.localizedDescription().to_string(),
         }
     }
 
-    unsafe fn daemon_service() -> Result<*mut Object> {
-        let class = Class::get("SMAppService")
-            .ok_or_else(|| anyhow!("SMAppService is unavailable on this macOS version"))?;
-        let plist = unsafe { NSString::alloc(nil).init_str(HELPER_PLIST_NAME) };
-        let service: *mut Object = msg_send![class, daemonServiceWithPlistName: plist];
-        if service.is_null() {
-            return Err(anyhow!("SMAppService did not return a daemon service"));
+    fn describe(error: &NSError, fallback: &str) -> String {
+        let structured = structured(error);
+        if structured.localized.is_empty() {
+            return format!("{fallback} ({} {})", structured.domain, structured.code);
         }
-        Ok(service)
-    }
-
-    unsafe fn ns_error(error: *mut Object, fallback: &str) -> anyhow::Error {
-        if error.is_null() {
-            return anyhow!("{fallback}");
-        }
-        let description: *mut Object = msg_send![error, localizedDescription];
-        if description.is_null() {
-            return anyhow!("{fallback}");
-        }
-        let c_string: *const std::os::raw::c_char = msg_send![description, UTF8String];
-        if c_string.is_null() {
-            return anyhow!("{fallback}");
-        }
-        anyhow!(
-            unsafe { std::ffi::CStr::from_ptr(c_string) }
-                .to_string_lossy()
-                .into_owned()
-        )
+        structured.to_string()
     }
 
     fn fallback_open_login_items_settings() {
@@ -211,78 +564,281 @@ mod macos {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::privileged_helper::protocol::{HELPER_LABEL, UNSUPPORTED_PROTOCOL_ERROR};
-
-    fn probed_status() -> HelperServiceStatus {
-        HelperServiceStatus {
-            label: HELPER_LABEL.to_string(),
-            available: true,
-            registered: true,
-            authorized: true,
-            socket_available: true,
-            responding: false,
-            detail: None,
-        }
-    }
+    use std::cell::Cell;
 
     #[test]
-    fn same_version_ok_probe_sets_responding() {
-        let mut status = probed_status();
-
-        fold_status_probe(&mut status, Ok(HelperResponse::ok("nixmac helper ready")));
-
-        assert!(status.responding);
-        assert_eq!(status.detail, None);
-    }
-
-    #[test]
-    fn skew_rejected_probes_never_set_responding() {
-        // What reaches the fold when the daemon answered with the exact v1
-        // status response or a mismatched version: the client-side parse
-        // already classified it as skew, so the probe arrives as an error.
-        for wire in [
-            r#"{"ok":true,"code":0,"stdout":"nixmac helper ready","stderr":"","error":null}"#
-                .to_string(),
-            format!(
-                r#"{{"protocolVersion":{},"helperBuildVersion":"9.9.9","ok":true,"code":0,"stdout":"","stderr":"","error":null}}"#,
-                crate::privileged_helper::protocol::HELPER_PROTOCOL_VERSION + 1
-            ),
+    fn the_four_smappservice_statuses_map_by_raw_value() {
+        // The raw values are Apple's enum order; a wrong mapping would send the
+        // whole decision table down the wrong column.
+        for (raw, expected, name) in [
+            (0, RegistrationStatus::NotRegistered, "notRegistered"),
+            (1, RegistrationStatus::Enabled, "enabled"),
+            (2, RegistrationStatus::RequiresApproval, "requiresApproval"),
+            (3, RegistrationStatus::NotFound, "notFound"),
         ] {
-            let mut status = probed_status();
-
-            fold_status_probe(&mut status, HelperResponse::parse(&wire));
-
-            assert!(!status.responding);
-            assert!(
-                status
-                    .detail
-                    .expect("skew detail")
-                    .contains(UNSUPPORTED_PROTOCOL_ERROR)
-            );
+            assert_eq!(RegistrationStatus::from_raw(raw), Ok(expected));
+            assert_eq!(expected.to_string(), name);
         }
     }
 
     #[test]
-    fn parsed_protocol_error_response_never_sets_responding() {
-        // A same-version daemon reporting a protocol error (it rejected the
-        // request's version) parses fine — it must still never count as
-        // responding.
-        let mut status = probed_status();
+    fn an_unknown_raw_status_is_an_error_and_never_a_fifth_status() {
+        // No catch-all: an unrecognized value is reported, so it can never be
+        // mistaken for "not registered" (which would authorize a register) or
+        // for "enabled" (which would authorize a removal).
+        for unknown in [-1, 4, 99] {
+            assert_eq!(RegistrationStatus::from_raw(unknown), Err(unknown));
+        }
+    }
 
-        fold_status_probe(
-            &mut status,
-            Ok(HelperResponse::error(
-                -1,
-                format!("{UNSUPPORTED_PROTOCOL_ERROR} 1 (this build speaks 2)"),
-            )),
+    fn refusal(code: i64) -> ServiceCallError {
+        ServiceCallError {
+            domain: "SMAppServiceErrorDomain".to_string(),
+            code,
+            localized: "operation not permitted".to_string(),
+        }
+    }
+
+    /// Counts dispatches and drops the work unrun. Dropping is deliberate on
+    /// both counts: running it would unregister and register the real service,
+    /// and a dropped sink is exactly the callback that never arrives.
+    fn counting_dispatch(dispatched: &Cell<usize>) -> impl Fn(Box<dyn FnOnce() + Send + 'static>) {
+        move |work| {
+            dispatched.set(dispatched.get() + 1);
+            drop(work);
+        }
+    }
+
+    /// The gate every test below that is not about declining passes: it commits,
+    /// and records that it was consulted at all.
+    fn committing(consulted: &Cell<bool>) -> impl FnOnce() -> Result<(), &'static str> {
+        move || {
+            consulted.set(true);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn a_replacement_on_the_main_thread_is_refused_before_anything_is_dispatched() {
+        // The whole reason this is one blocking call. The main thread is what
+        // has to issue both calls, so awaiting them there would starve the
+        // queue and expire as "the callback never arrived" — a wrong diagnosis
+        // of a deadlock. Refusing up front makes it a fact instead, and leaves
+        // the registration exactly as it was.
+        let dispatched = Cell::new(0);
+        let consulted = Cell::new(false);
+
+        let outcome = replace_helper_via(
+            &counting_dispatch(&dispatched),
+            true,
+            Duration::from_secs(30),
+            committing(&consulted),
         );
 
-        assert!(!status.responding);
+        assert_eq!(outcome, Err(ReplaceFailure::CalledOnMainThread));
+        assert_eq!(dispatched.get(), 0);
         assert!(
-            status
-                .detail
-                .expect("protocol error detail")
-                .contains(UNSUPPORTED_PROTOCOL_ERROR)
+            !consulted.get(),
+            "asked to commit to a replacement it refused"
         );
+    }
+
+    #[test]
+    fn a_silent_unregister_expires_and_never_dispatches_a_register() {
+        // A completion that never fires leaves the old process possibly alive,
+        // so the replacement must not be registered on top of it — and the
+        // window is what stops a silent callback from holding the caller. The
+        // gate is not consulted either: there is no point asking whether to
+        // replace a process that may still be running.
+        let dispatched = Cell::new(0);
+        let consulted = Cell::new(false);
+
+        let outcome = replace_helper_via(
+            &counting_dispatch(&dispatched),
+            false,
+            Duration::from_secs(30),
+            committing(&consulted),
+        );
+
+        assert_eq!(outcome, Err(ReplaceFailure::UnregisterSilent));
+        assert_eq!(dispatched.get(), 1, "the register was never dispatched");
+        assert!(!consulted.get());
+    }
+
+    #[test]
+    fn a_register_on_the_main_thread_is_refused_before_anything_is_dispatched() {
+        // Same starvation argument as the replacement: this call is issued on
+        // the main queue and awaited here.
+        let dispatched = Cell::new(0);
+
+        let outcome = register_on_later_turn_via(
+            &counting_dispatch(&dispatched),
+            true,
+            Duration::from_secs(30),
+        );
+
+        assert_eq!(outcome, Err(RegisterFailure::CalledOnMainThread));
+        assert_eq!(dispatched.get(), 0);
+    }
+
+    #[test]
+    fn a_register_that_never_reports_expires_as_silent() {
+        // The dropped sink is the callback that never arrives; the window is
+        // what keeps it from holding the caller.
+        let dispatched = Cell::new(0);
+
+        let outcome = register_on_later_turn_via(
+            &counting_dispatch(&dispatched),
+            false,
+            Duration::from_secs(30),
+        );
+
+        assert_eq!(outcome, Err(RegisterFailure::Silent));
+        assert_eq!(dispatched.get(), 1);
+    }
+
+    #[test]
+    fn a_replacement_registers_only_after_the_kill_was_confirmed() {
+        // The decision table, and the one rule inside it: every outcome but a
+        // confirmed kill leaves a process that may still be running, and
+        // neither the gate nor the register may be reached from any of them.
+        for (killed, expected) in [
+            (
+                Some(Err(refusal(3))),
+                Err(ReplaceFailure::UnregisterFailed(refusal(3))),
+            ),
+            (None, Err(ReplaceFailure::UnregisterSilent)),
+        ] {
+            let consulted = Cell::new(false);
+            let registered = Cell::new(false);
+
+            let outcome = fold_replacement(killed, committing(&consulted), || {
+                registered.set(true);
+                Some(Ok(()))
+            });
+
+            assert_eq!(outcome, expected);
+            assert!(
+                !consulted.get(),
+                "asked to commit after an unconfirmed kill"
+            );
+            assert!(!registered.get(), "registered after an unconfirmed kill");
+        }
+
+        let consulted = Cell::new(false);
+        assert_eq!(
+            fold_replacement(Some(Ok(())), committing(&consulted), || Some(Ok(()))),
+            Ok(())
+        );
+        assert!(consulted.get(), "registered without asking");
+        assert_eq!(
+            fold_replacement(Some(Ok(())), committing(&consulted), || Some(Err(refusal(
+                4
+            )))),
+            Err(ReplaceFailure::RegisterFailed(refusal(4)))
+        );
+        assert_eq!(
+            fold_replacement(Some(Ok(())), committing(&consulted), || None),
+            Err(ReplaceFailure::RegisterSilent)
+        );
+    }
+
+    #[test]
+    fn a_declined_replacement_kills_the_old_helper_and_registers_nothing() {
+        // The point of the gate: after the kill is confirmed, a caller whose
+        // decision changed meanwhile stops the sequence here rather than
+        // discovering afterwards that a helper it no longer wants is
+        // registered. Its reason travels back untouched — this module reads
+        // nothing into it.
+        let registered = Cell::new(false);
+
+        let outcome = fold_replacement(
+            Some(Ok(())),
+            || Err("the user disabled the helper while it was being replaced"),
+            || {
+                registered.set(true);
+                Some(Ok(()))
+            },
+        );
+
+        assert_eq!(
+            outcome,
+            Err(ReplaceFailure::RegisterDeclined(
+                "the user disabled the helper while it was being replaced"
+            ))
+        );
+        assert!(!registered.get(), "registered after being declined");
+    }
+
+    #[test]
+    fn only_the_first_of_a_repeated_callback_is_reported() {
+        // "The completion handler is invoked once" is a promise of the API and
+        // not of the universe; a platform that called back twice cannot
+        // overwrite what was already read.
+        let (sink, outcome) = mpsc::channel::<ServiceCallOutcome>();
+        sink.send(Err(refusal(3))).expect("first");
+        sink.send(Ok(())).expect("second");
+
+        assert_eq!(
+            awaited(outcome, Instant::now() + Duration::from_secs(30)),
+            Some(Err(refusal(3)))
+        );
+    }
+
+    #[test]
+    fn a_call_that_never_reports_expires_rather_than_being_waited_out_twice() {
+        // Both ways a call goes quiet — work that never ran, a callback that
+        // never fired — read as nothing reported, and a deadline already passed
+        // costs the next wait nothing. That is what keeps one window bounding
+        // the pair instead of each call getting a fresh one.
+        let (sink, outcome) = mpsc::channel::<ServiceCallOutcome>();
+        drop(sink);
+        let (_held, silent) = mpsc::channel::<ServiceCallOutcome>();
+        let deadline = Instant::now() + Duration::from_millis(50);
+
+        let started = Instant::now();
+
+        assert_eq!(awaited(outcome, deadline), None);
+        assert_eq!(awaited(silent, deadline), None);
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn an_outcome_cuts_the_window_short_rather_than_waiting_it_out() {
+        // A 30 s bound that is always paid would be 30 s of held reconciliation
+        // on every replacement.
+        let (sink, outcome) = mpsc::channel::<ServiceCallOutcome>();
+        let handle = std::thread::spawn(move || sink.send(Ok(())));
+
+        let started = Instant::now();
+
+        assert_eq!(
+            awaited(outcome, Instant::now() + Duration::from_secs(30)),
+            Some(Ok(()))
+        );
+        assert!(started.elapsed() < Duration::from_secs(5));
+        handle.join().expect("deliverer").expect("sent");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn an_ns_error_keeps_its_domain_and_code_whatever_its_text_says() {
+        // Decisions read domain and code; the localized description is report
+        // text. Both are carried, and the structured pair does not depend on
+        // the wording.
+        use objc2_foundation::NSString;
+
+        let domain = NSString::from_str("SMAppServiceErrorDomain");
+        let error =
+            unsafe { objc2_foundation::NSError::errorWithDomain_code_userInfo(&domain, 3, None) };
+
+        let structured = macos::structured(&error);
+
+        assert_eq!(structured.domain, "SMAppServiceErrorDomain");
+        assert_eq!(structured.code, 3);
+        // Apple supplies the wording for an unknown code; whatever it is, the
+        // decision-bearing fields above are unaffected by it.
+        assert!(!structured.localized.is_empty());
+        assert!(structured.to_string().contains("SMAppServiceErrorDomain 3"));
     }
 }

--- a/apps/native/src-tauri/src/rebuild/activation_path.rs
+++ b/apps/native/src-tauri/src/rebuild/activation_path.rs
@@ -1,0 +1,887 @@
+// Which of the two activation paths one apply may use.
+//
+// There are exactly two ways nixmac activates a built generation: it asks the
+// privileged helper, or it prompts for an administrator password. This module
+// decides which, and its whole purpose is that the decision is made *before*
+// any bytes reach the helper, from reconciled service state — and that nothing
+// a helper exchange returns afterwards can select the password path. A refusal
+// is reported; it is never quietly substituted with a password prompt.
+//
+// [`Route`] carries that: it comes from `route`, a total match over the stored
+// decision and all four registration statuses. A status the platform can
+// report has nowhere to hide, and only one pairing dispatches.
+//
+// Overlap between the two paths is refused structurally, not here: both
+// executors take the same exclusive activation lock (see
+// `privileged_helper::helper_runtime`), so a password activation racing a
+// helper one — whichever way — loses at the lock with a clear report, never
+// by running alongside.
+
+use crate::privileged_helper::client::{HelperClientError, ListenerObservation};
+use crate::privileged_helper::protocol::{ActivationInfo, HelperReply};
+use crate::privileged_helper::service::RegistrationStatus;
+use crate::rebuild::darwin::ActivateResult;
+use crate::shared_types::HelperPreference;
+
+/// Everything one apply observes or does about the two paths, injected so every
+/// row below can be driven without a helper, a bundle, or a settings store.
+///
+/// Observations and effects only — no method here decides which path an apply
+/// takes.
+pub trait ApplyEnvironment {
+    /// The stored decision about the helper, read as-is: only the replacement
+    /// function ever resolves "undecided".
+    fn preference(&self) -> Result<HelperPreference, String>;
+
+    /// The sentence to carry when this copy of nixmac may not touch a helper at
+    /// all — it runs from outside `/Applications`, or its bundle was replaced
+    /// underneath it. `None` when it may.
+    fn displacement(&self) -> Option<String>;
+
+    /// What `SMAppService` reports about nixmac's helper registration.
+    fn registration_status(&self) -> Result<RegistrationStatus, String>;
+
+    /// Sends `TryActivate` and waits for its result. An activation legitimately
+    /// runs for many minutes, so an implementation must not leash this wait to
+    /// the short deadlines the other exchanges use; the live one bounds it only
+    /// at `client::ACTIVATION_TIMEOUT`, past which the outcome is unknown.
+    fn dispatch_activation(&self, activate_path: &str) -> Result<HelperReply, DispatchFailure>;
+
+    /// Whether anything is listening on the helper socket, over the absence
+    /// window. Pure observation, and the only thing that can establish that an
+    /// `enabled` registration has no process behind it.
+    fn observe_listener(&self) -> ListenerObservation;
+
+    /// Runs the administrator-password activation. Its root executor takes the
+    /// shared activation lock before mutating anything, so a concurrent
+    /// activation — helper-run or password-run — refuses it there.
+    fn password_activate(&self, activate_path: &str) -> Result<ActivateResult, anyhow::Error>;
+}
+
+/// Why a dispatch produced no reply.
+pub enum DispatchFailure {
+    /// The exchange with the helper.
+    Exchange(HelperClientError),
+    /// The request could not even be assembled, because the activation path is
+    /// not one the helper accepts. Nothing was dispatched, and no other path is
+    /// tried: that is an error about this apply, not about the helper.
+    Unusable(anyhow::Error),
+}
+
+/// Activates `activate_path` by whichever path is allowed, or reports that
+/// neither is.
+///
+/// A refusal comes back as a failed [`ActivateResult`] carrying the report — the
+/// same shape a failed activation has, which every consumer already renders.
+pub fn activate<E: ApplyEnvironment>(
+    env: &E,
+    activate_path: &str,
+) -> Result<ActivateResult, anyhow::Error> {
+    let helper = helper_use(env.preference(), env.displacement());
+    match route(&helper, env.registration_status()) {
+        Route::Dispatch => dispatch(env, activate_path, &helper),
+        Route::Password => env.password_activate(activate_path),
+        Route::Refuse(reason) => Ok(refused(reason, &helper)),
+    }
+}
+
+/// Whether this apply may use a helper at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HelperUse {
+    /// The stored decision is `granted`, and this copy may touch a helper.
+    Permitted,
+    /// It may not. `note` is the extra sentence its refusals carry: move the
+    /// app, restart the app, or why the stored decision could not be read.
+    Withheld { note: Option<String> },
+}
+
+/// Folds the stored decision and the two displacement gates into the one
+/// question the table asks.
+///
+/// Every failure lands on `Withheld`, and `Withheld` is not the password path:
+/// it still refuses while a registration is enabled. So neither an unreadable
+/// decision nor a displaced copy can talk nixmac into password-activating
+/// underneath a helper.
+fn helper_use(
+    preference: Result<HelperPreference, String>,
+    displacement: Option<String>,
+) -> HelperUse {
+    // A copy running from outside `/Applications`, or one whose bundle was
+    // replaced while it ran, touches no helper whatever the decision says.
+    if let Some(note) = displacement {
+        return HelperUse::Withheld { note: Some(note) };
+    }
+    match preference {
+        Ok(HelperPreference::Granted) => HelperUse::Permitted,
+        // Undecided or disabled: an existing registration is the replacement
+        // function's to adopt or remove, not this apply's to use.
+        Ok(HelperPreference::Unset | HelperPreference::Disabled) => {
+            HelperUse::Withheld { note: None }
+        }
+        Err(detail) => HelperUse::Withheld {
+            note: Some(format!(
+                "The stored helper decision could not be read: {detail}."
+            )),
+        },
+    }
+}
+
+/// Which path this apply takes, decided before any helper exchange.
+#[derive(Debug, PartialEq, Eq)]
+enum Route {
+    /// Send `TryActivate`. The helper decides admission atomically, and no
+    /// probe result gates this dispatch.
+    Dispatch,
+    /// The administrator-password path: nixmac knows no helper activation is
+    /// running or was dispatched.
+    Password,
+    /// Neither path. Reported, never silently substituted.
+    Refuse(Reason),
+}
+
+/// Why an apply refuses — one variant per case, so a missing row would be a
+/// missing variant rather than a silent password prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Reason {
+    /// A registration is enabled that this apply may not use. It could still
+    /// admit a scheduled sync-agent activation, so nixmac does not
+    /// password-activate underneath it; the replacement function adopts or
+    /// removes it first.
+    HelperStillInstalled,
+    /// `SMAppService` could not be read, so nothing proves the helper quiet.
+    RegistrationUnreadable(String),
+    /// Something holds the helper socket that could not be identified: a
+    /// validation that reached no judgment, or a peer that is not root.
+    PeerUnidentified(String),
+    /// The socket could not be used and its absence could not be proven either.
+    SocketUnusable(String),
+    /// The installed helper cannot run this build's activation — a build
+    /// mismatch, or a helper too old to parse this build's request body. Both
+    /// mean the same thing: it must be replaced or disabled first.
+    HelperUpdateRequired(String),
+    /// An activation is already running; the `ActivationInfo` says whose, when
+    /// the refusing helper knew it.
+    ActivationRunning(Option<ActivationInfo>),
+    /// An authenticated helper answered something that is not an activation
+    /// result.
+    HelperRefused(String),
+    /// The request was dispatched and the outcome is not known.
+    UnknownOutcome(String),
+}
+
+/// The [`Reason::ActivationRunning`] sentence when the refusing side knew no
+/// activation details. Shared with `rebuild::darwin::classify_activate_error`,
+/// which reports the admin-password path's lock refusal with the same words.
+pub(crate) const ACTIVATION_RUNNING_REPORT: &str =
+    "An activation is already running, so nixmac did not start another.";
+
+// These sentences land in the ActivateResult's stderr. The reasons marked
+// `refused` (see [`refused`]) are shown verbatim; only the `UnknownOutcome`
+// sentence is still substring-scanned by
+// `rebuild::darwin::classify_activate_error` — check its phrase lists before
+// rewording that one, including the error detail it embeds.
+impl std::fmt::Display for Reason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HelperStillInstalled => f.write_str(
+                "The unattended sync helper is still installed but is not enabled for this app, so nixmac did not activate and did not fall back to the administrator-password prompt. Enable or disable the helper, then apply again.",
+            ),
+            Self::RegistrationUnreadable(detail) => write!(
+                f,
+                "The unattended sync helper's registration could not be read ({detail}), so nixmac did not activate."
+            ),
+            Self::PeerUnidentified(detail) => write!(
+                f,
+                "The process answering the helper socket could not be identified ({detail}), so nixmac did not activate and did not fall back to the administrator-password prompt."
+            ),
+            Self::SocketUnusable(detail) => write!(
+                f,
+                "The helper socket could not be used and its absence could not be established either ({detail}), so nixmac did not activate."
+            ),
+            Self::HelperUpdateRequired(detail) => write!(
+                f,
+                "The installed unattended sync helper cannot run this build's activation: {detail}. nixmac replaces it the next time it reads the helper — opening Settings → Permissions does that now, and so does relaunching nixmac; apply again after that."
+            ),
+            Self::ActivationRunning(Some(activation)) => write!(
+                f,
+                "An activation is already running ({} submitted by the {}), so nixmac did not start another.",
+                activation.script_path, activation.client_kind
+            ),
+            Self::ActivationRunning(None) => f.write_str(ACTIVATION_RUNNING_REPORT),
+            Self::HelperRefused(detail) => write!(
+                f,
+                "The unattended sync helper did not start the activation: {detail}. nixmac did not fall back to the administrator-password prompt."
+            ),
+            Self::UnknownOutcome(detail) => write!(
+                f,
+                "The unattended sync helper did not return a trustworthy result: {detail}. The activation may have completed or may still be running; nixmac did not fall back to the administrator-password prompt."
+            ),
+        }
+    }
+}
+
+/// The table. Total over the stored decision and all four statuses.
+fn route(helper: &HelperUse, status: Result<RegistrationStatus, String>) -> Route {
+    let status = match status {
+        Ok(status) => status,
+        Err(detail) => return Route::Refuse(Reason::RegistrationUnreadable(detail)),
+    };
+    match (helper, status) {
+        // Granted, and a registration is enabled: dispatch and let the helper
+        // decide admission.
+        (HelperUse::Permitted, RegistrationStatus::Enabled) => Route::Dispatch,
+        // Enabled, but not this apply's to use. Refusing is what keeps nixmac
+        // from password-activating while that registration could still admit a
+        // scheduled sync-agent activation.
+        (HelperUse::Withheld { .. }, RegistrationStatus::Enabled) => {
+            Route::Refuse(Reason::HelperStillInstalled)
+        }
+        // Proven quiet: nothing registered, a registration pending approval
+        // (which has no process), or a service definition that is not there.
+        // The shared activation lock backstops what this point-in-time read
+        // cannot see.
+        (
+            _,
+            RegistrationStatus::NotRegistered
+            | RegistrationStatus::RequiresApproval
+            | RegistrationStatus::NotFound,
+        ) => Route::Password,
+    }
+}
+
+/// Dispatches the activation and reads what came back.
+///
+/// Only an activation result is an activation. Every other reply and every
+/// failure is a refusal — with one exception that is not one: a connection that
+/// was never established wrote no request bytes, so nothing was dispatched, and
+/// the absence it may prove is still a pre-dispatch observation.
+fn dispatch<E: ApplyEnvironment>(
+    env: &E,
+    activate_path: &str,
+    helper: &HelperUse,
+) -> Result<ActivateResult, anyhow::Error> {
+    match env.dispatch_activation(activate_path) {
+        // The activation ran in the helper. Its own success or failure is the
+        // apply's, and this is the only way to learn it.
+        Ok(HelperReply::ActivationResult(result)) => Ok(ActivateResult {
+            success: result.ok,
+            code: result.code,
+            stdout: result.stdout,
+            // The result has no stderr: the activation log arrives merged into
+            // stdout, so only a helper-level error belongs in the stderr slot
+            // consumers show for failures.
+            stderr: result.error.unwrap_or_default(),
+            refused: false,
+        }),
+        Ok(reply) => Ok(refused(reply_refusal(reply), helper)),
+        // Not a refusal and not an outcome: the apply itself cannot be
+        // expressed, so it fails rather than looking for another path.
+        Err(DispatchFailure::Unusable(error)) => Err(error),
+        Err(DispatchFailure::Exchange(error)) => match exchange_failure(error) {
+            ExchangeFailure::Refused(reason) => Ok(refused(reason, helper)),
+            // Nothing was dispatched. Whether the socket has no process at all —
+            // the one remaining observation that proves quiet — takes the full
+            // absence window to establish.
+            ExchangeFailure::NeverConnected(connect_error) => match env.observe_listener() {
+                ListenerObservation::PositivelyAbsent => env.password_activate(activate_path),
+                ListenerObservation::Listening => Ok(refused(
+                    Reason::SocketUnusable(format!(
+                        "{connect_error}; something is listening on it but did not answer"
+                    )),
+                    helper,
+                )),
+                ListenerObservation::Ambiguous(detail) => Ok(refused(
+                    Reason::SocketUnusable(format!("{connect_error}; {detail}")),
+                    helper,
+                )),
+            },
+        },
+    }
+}
+
+/// What one failed exchange means for this apply.
+#[derive(Debug, PartialEq, Eq)]
+enum ExchangeFailure {
+    /// No connection was established, so no request bytes were written and
+    /// nothing was dispatched.
+    NeverConnected(String),
+    /// Everything else. Report it — an exchange that was attempted can never
+    /// select the password path, whether or not it proved anything.
+    Refused(Reason),
+}
+
+/// Reads one exchange failure. Total over the client's error set.
+fn exchange_failure(error: HelperClientError) -> ExchangeFailure {
+    match error {
+        HelperClientError::Unreachable(ref connect_error) => {
+            ExchangeFailure::NeverConnected(connect_error.to_string())
+        }
+        // Nothing was written to this peer either, but an unidentified process
+        // holding the helper socket is exactly what makes "no activation is
+        // running" impossible to establish.
+        HelperClientError::AuthenticationFailed(ref failure) => {
+            ExchangeFailure::Refused(Reason::PeerUnidentified(format!("{failure:#}")))
+        }
+        // Past the request write, nothing can prove the helper did not run it —
+        // a close, an I/O failure mid-exchange, and a reply this build cannot
+        // read are all unknown outcomes.
+        HelperClientError::ClosedBeforeReply
+        | HelperClientError::Io(_)
+        | HelperClientError::UnparseableReply(_) => {
+            ExchangeFailure::Refused(Reason::UnknownOutcome(error.to_string()))
+        }
+    }
+}
+
+/// Reads one reply that is not an activation result.
+fn reply_refusal(reply: HelperReply) -> Reason {
+    match reply {
+        HelperReply::Busy { activation } => Reason::ActivationRunning(activation),
+        // One thing to a client: the installed helper cannot run this build's
+        // activation. There is deliberately no promise about which of the two an
+        // older helper answers with.
+        HelperReply::BuildMismatch { .. } | HelperReply::RequestNotUnderstood => {
+            Reason::HelperUpdateRequired(reply.summary())
+        }
+        other => Reason::HelperRefused(other.summary()),
+    }
+}
+
+/// One refusal, as the failed result every consumer already renders.
+fn refused(reason: Reason, helper: &HelperUse) -> ActivateResult {
+    let mut report = reason.to_string();
+    // A displaced copy's refusals carry what the user should do about it.
+    if let HelperUse::Withheld { note: Some(note) } = helper {
+        report.push(' ');
+        report.push_str(note);
+    }
+    ActivateResult {
+        success: false,
+        code: -1,
+        stdout: String::new(),
+        stderr: report,
+        // Every reason but one means nothing was mutated. An unknown outcome
+        // is the exception: the request was dispatched, so the result may not
+        // claim the system untouched, and it presents as a plain failure.
+        refused: !matches!(reason, Reason::UnknownOutcome(_)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privileged_helper::peer_auth::ClientKind;
+    use crate::privileged_helper::protocol::ActivationResult;
+    use std::cell::RefCell;
+
+    const ACTIVATE_PATH: &str = "/nix/store/abc-darwin-system/activate";
+
+    /// What one apply is allowed to do, and what it did.
+    struct World {
+        preference: Result<HelperPreference, String>,
+        displacement: Option<String>,
+        status: Result<RegistrationStatus, String>,
+        /// What `TryActivate` comes back with, when it is sent at all.
+        dispatch: RefCell<Option<Result<HelperReply, HelperClientError>>>,
+        /// The activation body cannot be assembled from the path at all.
+        unusable: bool,
+        listener: ListenerObservation,
+        acts: RefCell<Vec<Act>>,
+    }
+
+    /// The three things that can actually happen, in order. Every "never the
+    /// password path" assertion is about this sequence.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Act {
+        Dispatched,
+        Probed,
+        Prompted,
+    }
+
+    impl Default for World {
+        fn default() -> Self {
+            Self {
+                preference: Ok(HelperPreference::Granted),
+                displacement: None,
+                status: Ok(RegistrationStatus::Enabled),
+                dispatch: RefCell::new(None),
+                unusable: false,
+                listener: ListenerObservation::PositivelyAbsent,
+                acts: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl World {
+        /// Granted, enabled, and the helper answers `reply`.
+        fn answering(reply: HelperReply) -> Self {
+            Self {
+                dispatch: RefCell::new(Some(Ok(reply))),
+                ..Self::default()
+            }
+        }
+
+        /// Granted, enabled, and the exchange fails.
+        fn failing(error: HelperClientError) -> Self {
+            Self {
+                dispatch: RefCell::new(Some(Err(error))),
+                ..Self::default()
+            }
+        }
+
+        fn acts(&self) -> Vec<Act> {
+            self.acts.borrow().clone()
+        }
+
+        fn did(&self, act: Act) {
+            self.acts.borrow_mut().push(act);
+        }
+    }
+
+    impl ApplyEnvironment for World {
+        fn preference(&self) -> Result<HelperPreference, String> {
+            self.preference.clone()
+        }
+
+        fn displacement(&self) -> Option<String> {
+            self.displacement.clone()
+        }
+
+        fn registration_status(&self) -> Result<RegistrationStatus, String> {
+            self.status.clone()
+        }
+
+        fn dispatch_activation(&self, activate_path: &str) -> Result<HelperReply, DispatchFailure> {
+            assert_eq!(activate_path, ACTIVATE_PATH);
+            self.did(Act::Dispatched);
+            if self.unusable {
+                return Err(DispatchFailure::Unusable(anyhow::anyhow!(
+                    "not a store activation path"
+                )));
+            }
+            self.dispatch
+                .borrow_mut()
+                .take()
+                .expect("one dispatch, and only where the table dispatches")
+                .map_err(DispatchFailure::Exchange)
+        }
+
+        fn observe_listener(&self) -> ListenerObservation {
+            self.did(Act::Probed);
+            self.listener.clone()
+        }
+
+        fn password_activate(&self, activate_path: &str) -> Result<ActivateResult, anyhow::Error> {
+            assert_eq!(activate_path, ACTIVATE_PATH);
+            self.did(Act::Prompted);
+            Ok(ActivateResult {
+                success: true,
+                code: 0,
+                stdout: "activated with an administrator password".to_string(),
+                stderr: String::new(),
+                refused: false,
+            })
+        }
+    }
+
+    fn activation() -> ActivationInfo {
+        ActivationInfo {
+            request_id: "request-1".to_string(),
+            script_path: ACTIVATE_PATH.to_string(),
+            client_kind: ClientKind::SyncAgent,
+        }
+    }
+
+    fn apply(world: &World) -> ActivateResult {
+        activate(world, ACTIVATE_PATH).expect("the fake password path cannot fail to run")
+    }
+
+    /// Refused: nothing activated, and — the part that matters — no prompt.
+    fn assert_refused(world: &World, result: &ActivateResult) {
+        assert!(!result.success, "a refusal is not a successful activation");
+        assert_eq!(result.code, -1);
+        assert!(
+            !world.acts().contains(&Act::Prompted),
+            "a refusal must never fall back to the administrator-password prompt: {}",
+            result.stderr
+        );
+    }
+
+    #[test]
+    fn a_refusal_is_marked_and_an_unknown_outcome_is_not() {
+        assert!(refused(Reason::HelperStillInstalled, &HelperUse::Permitted).refused);
+        assert!(
+            !refused(
+                Reason::UnknownOutcome("timed out".to_string()),
+                &HelperUse::Permitted
+            )
+            .refused,
+            "a dispatched request with an unknown outcome may not claim the system untouched"
+        );
+    }
+
+    // ── the table ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn granted_and_enabled_is_the_only_pairing_that_dispatches() {
+        assert_eq!(
+            route(&HelperUse::Permitted, Ok(RegistrationStatus::Enabled)),
+            Route::Dispatch
+        );
+    }
+
+    #[test]
+    fn every_proven_quiet_observation_takes_the_password_path() {
+        // The closed set of eligibility observations: nothing registered, a
+        // registration pending approval (which has no process), and a broken
+        // service definition. Under either column — the password path itself
+        // needs no grant.
+        for helper in [
+            HelperUse::Permitted,
+            HelperUse::Withheld { note: None },
+            HelperUse::Withheld {
+                note: Some("move it".to_string()),
+            },
+        ] {
+            for status in [
+                RegistrationStatus::NotRegistered,
+                RegistrationStatus::RequiresApproval,
+                RegistrationStatus::NotFound,
+            ] {
+                assert_eq!(route(&helper, Ok(status)), Route::Password, "{status}");
+            }
+        }
+    }
+
+    #[test]
+    fn an_enabled_registration_this_apply_may_not_use_refuses_instead() {
+        // Never the password path: that registration could still admit a
+        // scheduled sync-agent activation, and nixmac does not activate
+        // underneath one.
+        for note in [None, Some("restart nixmac".to_string())] {
+            assert_eq!(
+                route(
+                    &HelperUse::Withheld { note },
+                    Ok(RegistrationStatus::Enabled)
+                ),
+                Route::Refuse(Reason::HelperStillInstalled)
+            );
+        }
+    }
+
+    #[test]
+    fn an_unreadable_registration_refuses_rather_than_guessing_quiet() {
+        assert_eq!(
+            route(&HelperUse::Permitted, Err("no service".to_string())),
+            Route::Refuse(Reason::RegistrationUnreadable("no service".to_string()))
+        );
+    }
+
+    #[test]
+    fn nothing_about_managed_app_bundles_can_divert_a_granted_helper_apply() {
+        // The decision's inputs are the stored decision, the displacement gates
+        // and the registration status — a closed set. An apply that touches
+        // managed app bundles (App Management) therefore dispatches through the
+        // helper like any other: skipping the helper for those was a silent
+        // password-path substitution, and the preflight already refuses the
+        // apply outright when the permission is missing.
+        let world = World::answering(HelperReply::ActivationResult(ActivationResult {
+            ok: true,
+            code: 0,
+            stdout: "activated".to_string(),
+            error: None,
+        }));
+
+        let result = apply(&world);
+
+        assert!(result.success);
+        assert_eq!(world.acts(), vec![Act::Dispatched]);
+    }
+
+    // ── what a copy that may not touch a helper does ───────────────────────
+
+    #[test]
+    fn a_displaced_copy_is_withheld_whatever_the_stored_decision_says() {
+        for preference in [
+            Ok(HelperPreference::Granted),
+            Ok(HelperPreference::Unset),
+            Ok(HelperPreference::Disabled),
+            Err("unreadable".to_string()),
+        ] {
+            assert_eq!(
+                helper_use(preference, Some("move it to /Applications".to_string())),
+                HelperUse::Withheld {
+                    note: Some("move it to /Applications".to_string())
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_granted_decision_permits_a_helper() {
+        assert_eq!(
+            helper_use(Ok(HelperPreference::Granted), None),
+            HelperUse::Permitted
+        );
+        for preference in [HelperPreference::Unset, HelperPreference::Disabled] {
+            assert_eq!(
+                helper_use(Ok(preference), None),
+                HelperUse::Withheld { note: None }
+            );
+        }
+    }
+
+    #[test]
+    fn an_unreadable_decision_is_withheld_and_says_so() {
+        let HelperUse::Withheld { note: Some(note) } =
+            helper_use(Err("store missing".to_string()), None)
+        else {
+            panic!("an unreadable decision must not permit a helper");
+        };
+        assert!(note.contains("store missing"));
+    }
+
+    #[test]
+    fn a_displaced_copy_carries_its_guidance_into_the_refusal() {
+        let world = World {
+            displacement: Some("Move nixmac to /Applications.".to_string()),
+            ..World::default()
+        };
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains("Move nixmac to /Applications."));
+        assert!(
+            world.acts().is_empty(),
+            "a displaced copy touches no helper at all"
+        );
+    }
+
+    #[test]
+    fn a_displaced_copy_still_uses_the_password_path_when_nothing_is_registered() {
+        // The password path itself requires no canonical install.
+        let world = World {
+            displacement: Some("Move nixmac to /Applications.".to_string()),
+            status: Ok(RegistrationStatus::NotRegistered),
+            ..World::default()
+        };
+
+        let result = apply(&world);
+
+        assert!(result.success);
+        assert_eq!(world.acts(), vec![Act::Prompted]);
+    }
+
+    // ── what came back from a dispatch ─────────────────────────────────────
+
+    #[test]
+    fn an_activation_result_is_the_applys_own_result() {
+        for (ok, code, error) in [
+            (true, 0, None),
+            (false, 1, Some("activation script failed".to_string())),
+        ] {
+            let world = World::answering(HelperReply::ActivationResult(ActivationResult {
+                ok,
+                code,
+                stdout: "log".to_string(),
+                error: error.clone(),
+            }));
+
+            let result = apply(&world);
+
+            assert_eq!(result.success, ok);
+            assert_eq!(result.code, code);
+            assert_eq!(result.stdout, "log");
+            assert_eq!(result.stderr, error.unwrap_or_default());
+            assert_eq!(world.acts(), vec![Act::Dispatched]);
+        }
+    }
+
+    #[test]
+    fn every_reply_that_is_not_a_result_refuses() {
+        // The complete reply set, minus the activation result above. None of
+        // them is permission to activate some other way.
+        let replies = [
+            (
+                HelperReply::Busy {
+                    activation: Some(activation()),
+                },
+                Reason::ActivationRunning(Some(activation())),
+            ),
+            (
+                // A relaunched helper refusing over a lock it never admitted:
+                // still a running activation, just without the details.
+                HelperReply::Busy { activation: None },
+                Reason::ActivationRunning(None),
+            ),
+            (
+                HelperReply::BuildMismatch {
+                    helper_build_id: "build-previous".to_string(),
+                },
+                Reason::HelperUpdateRequired(
+                    "the installed helper is from a different nixmac build (build build-previous)"
+                        .to_string(),
+                ),
+            ),
+            (
+                HelperReply::RequestNotUnderstood,
+                Reason::HelperUpdateRequired(HelperReply::RequestNotUnderstood.summary()),
+            ),
+            (
+                HelperReply::CallerNotPermitted,
+                Reason::HelperRefused(HelperReply::CallerNotPermitted.summary()),
+            ),
+            (
+                HelperReply::Status {
+                    state: crate::privileged_helper::protocol::HelperStateName::Idle,
+                    helper_build_id: "build-current".to_string(),
+                    activation: None,
+                },
+                Reason::HelperRefused(
+                    HelperReply::Status {
+                        state: crate::privileged_helper::protocol::HelperStateName::Idle,
+                        helper_build_id: "build-current".to_string(),
+                        activation: None,
+                    }
+                    .summary(),
+                ),
+            ),
+        ];
+
+        for (reply, expected) in replies {
+            assert_eq!(reply_refusal(reply.clone()), expected, "{reply:?}");
+
+            let world = World::answering(reply);
+            let result = apply(&world);
+
+            assert_refused(&world, &result);
+            assert_eq!(world.acts(), vec![Act::Dispatched]);
+        }
+    }
+
+    #[test]
+    fn a_build_mismatch_reports_the_helper_build_it_found() {
+        let world = World::answering(HelperReply::BuildMismatch {
+            helper_build_id: "build-previous".to_string(),
+        });
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains("build-previous"));
+    }
+
+    #[test]
+    fn a_running_activation_is_reported_with_the_script_and_the_client_that_submitted_it() {
+        let world = World::answering(HelperReply::Busy {
+            activation: Some(activation()),
+        });
+
+        let result = apply(&world);
+
+        assert_refused(&world, &result);
+        assert!(result.stderr.contains(ACTIVATE_PATH));
+        assert!(result.stderr.contains("sync agent"));
+    }
+
+    // ── what a failed exchange means ───────────────────────────────────────
+
+    #[test]
+    fn only_a_connection_that_was_never_established_dispatched_nothing() {
+        assert_eq!(
+            exchange_failure(HelperClientError::Unreachable(std::io::Error::from(
+                std::io::ErrorKind::ConnectionRefused
+            ))),
+            ExchangeFailure::NeverConnected(
+                std::io::Error::from(std::io::ErrorKind::ConnectionRefused).to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn every_other_exchange_failure_is_reported_and_never_falls_back() {
+        // An authentication failure is the one that most invites a fallback: it
+        // is where an unsigned local build lands. It is a refusal — something
+        // unidentified holds the socket, so nixmac cannot establish that no
+        // activation is running.
+        // Built twice rather than cloned: a client error carries an
+        // `anyhow::Error` and an `io::Error`, neither of which clones.
+        let failures: [fn() -> HelperClientError; 4] = [
+            || HelperClientError::AuthenticationFailed(anyhow::anyhow!("unsigned")),
+            || HelperClientError::ClosedBeforeReply,
+            || HelperClientError::Io(std::io::Error::from(std::io::ErrorKind::TimedOut)),
+            || HelperClientError::UnparseableReply("not json".to_string()),
+        ];
+        for failure in failures {
+            assert!(
+                matches!(exchange_failure(failure()), ExchangeFailure::Refused(_)),
+                "{}",
+                failure()
+            );
+
+            let world = World::failing(failure());
+            let result = apply(&world);
+
+            assert_refused(&world, &result);
+            assert_eq!(
+                world.acts(),
+                vec![Act::Dispatched],
+                "an attempted exchange is never followed by an absence probe"
+            );
+        }
+    }
+
+    #[test]
+    fn a_socket_with_no_listener_at_all_takes_the_password_path() {
+        // Positive absence is the fourth eligibility observation, and nothing
+        // was dispatched: the connection was never established.
+        let world = World::failing(HelperClientError::Unreachable(std::io::Error::from(
+            std::io::ErrorKind::ConnectionRefused,
+        )));
+
+        let result = apply(&world);
+
+        assert!(result.success);
+        assert_eq!(
+            world.acts(),
+            vec![Act::Dispatched, Act::Probed, Act::Prompted]
+        );
+    }
+
+    #[test]
+    fn an_absence_that_could_not_be_established_refuses() {
+        for listener in [
+            ListenerObservation::Listening,
+            ListenerObservation::Ambiguous("timed out".to_string()),
+        ] {
+            let world = World {
+                listener,
+                dispatch: RefCell::new(Some(Err(HelperClientError::Unreachable(
+                    std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+                )))),
+                ..World::default()
+            };
+
+            let result = apply(&world);
+
+            assert_refused(&world, &result);
+            assert_eq!(world.acts(), vec![Act::Dispatched, Act::Probed]);
+        }
+    }
+
+    #[test]
+    fn an_activation_body_that_cannot_be_assembled_fails_the_apply() {
+        // Not a refusal and not an outcome: the apply itself cannot be
+        // expressed, so it fails rather than looking for another path.
+        let world = World {
+            unusable: true,
+            ..World::default()
+        };
+
+        let error = activate(&world, ACTIVATE_PATH).expect_err("an unusable path cannot activate");
+
+        assert!(error.to_string().contains("store activation path"));
+        assert_eq!(world.acts(), vec![Act::Dispatched]);
+    }
+}

--- a/apps/native/src-tauri/src/rebuild/darwin.rs
+++ b/apps/native/src-tauri/src/rebuild/darwin.rs
@@ -4,9 +4,11 @@
 
 use crate::ai::log_summarizer;
 use crate::privileged_helper::{
-    client as helper_client, protocol as helper_protocol, root_activation,
-    service as helper_service,
+    client as helper_client, helper_runtime, protocol as helper_protocol, reconcile,
+    root_activation, service as helper_service,
 };
+use crate::rebuild::activation_path;
+use crate::system::helper_permission;
 use crate::utils::nix_string_literal;
 use chrono::Local;
 use log::{error, info, warn};
@@ -353,7 +355,8 @@ fn app_management_error_payload(
 /// Runs the equivalent of `darwin-rebuild switch` with streaming output in two steps:
 /// 1. `nix build` of the system closure as the user (no sudo), with the
 ///    out-link in app-support so the config dir stays clean
-/// 2. `<store path>/activate` as root via native macOS authentication dialog (supports Touch ID)
+/// 2. `<store path>/activate` as root — through the privileged helper when one is
+///    installed and enabled, otherwise via the native macOS admin password prompt
 ///
 /// This pattern avoids Git ownership issues by keeping all file operations
 /// under the user's permissions during the build phase while still making system
@@ -474,11 +477,22 @@ struct BuildResult {
 }
 
 /// Result of the activation step.
-struct ActivateResult {
-    success: bool,
-    code: i32,
-    stdout: String,
-    stderr: String,
+///
+/// Also how a refused activation is reported: `success: false` with the reason
+/// in `stderr`, which is the shape every consumer already renders (see
+/// [`super::activation_path`]).
+#[derive(Debug)]
+pub(crate) struct ActivateResult {
+    pub(crate) success: bool,
+    pub(crate) code: i32,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    /// The apply refused to start an activation and mutated nothing; `stderr`
+    /// carries the finished sentence saying why. `code` is fabricated on these
+    /// results, so classification keys on this flag, never on the code or the
+    /// text. False for an activation that ran — and for a dispatched one whose
+    /// outcome is unknown, which cannot claim the system is untouched.
+    pub(crate) refused: bool,
 }
 
 /// Run the build step as the current user (no sudo).
@@ -607,46 +621,47 @@ fn run_build_step(
     })
 }
 
-/// Run the activation step as root using native macOS authentication dialog.
-/// Uses `osascript` to show Touch ID / password dialog on compatible hardware.
-///
-/// Root cause of the "updating apps over SSH" error:
-///   `osascript do shell script ... with administrator privileges` spawns the
-///   privileged process in the *system* bootstrap domain (root context), not
-///   the user's Aqua GUI session domain.  The nix-darwin activation script
-///   calls `launchctl managername` and aborts with the "over SSH" error
-///   whenever the result is not "Aqua" — even when called from a GUI app.
-///
-/// Fix: the elevated step uses `launchctl asuser <uid>` to re-enter the
-///   user's Aqua bootstrap domain before exec'ing the activation script.
-///   fork()/exec() inherits the bootstrap port, so the activation script
-///   sees `launchctl managername == "Aqua"` and the App Management check
-///   proceeds correctly.
-///
-///   The elevated command is this binary re-executed in root-activation
-///   mode (`privileged_helper::root_activation`): fixed Rust code with the
-///   same hardening rules as the helper daemon — no shell script, no
-///   sudoers rules, no EXIT traps, absolute programs, and a fixed root-owned
-///   environment.
+/// Run the activation step, by whichever of the two paths is allowed — the
+/// privileged helper, or one native authentication dialog (see
+/// [`password_activation`]).
 fn run_activate_step(
+    app: &AppHandle,
     system_store_path: &Path,
-    allow_helper: bool,
 ) -> Result<ActivateResult, anyhow::Error> {
     let activate_path = system_store_path.join("activate");
-    run_activate_with_path(&activate_path.to_string_lossy(), allow_helper)
+    run_activate_with_path(app, &activate_path.to_string_lossy())
 }
 
 /// Activate a specific nix store path directly
-fn activate_store_path(store_path: &str) -> Result<ActivateResult, anyhow::Error> {
+fn activate_store_path(app: &AppHandle, store_path: &str) -> Result<ActivateResult, anyhow::Error> {
     let activate_path = format!("{}/activate", store_path);
-    run_activate_with_path(&activate_path, true)
+    run_activate_with_path(app, &activate_path)
 }
 
 /// Classify an activation failure into (error_type, error_message).
 fn classify_activate_error(result: &ActivateResult) -> (&'static str, String) {
+    // A refusal is not a failed process: the sentence in stderr is the whole
+    // report, and there is no real exit code to headline.
+    if result.refused {
+        return ("activation_refused", result.stderr.clone());
+    }
     let output_lower = format!("{}\n{}", result.stderr, result.stdout).to_lowercase();
     if output_lower.contains("user canceled") {
         return ("user_cancelled", "Activation cancelled by user".to_string());
+    }
+    // The admin-password path's root executor refuses at the shared activation
+    // lock before mutating anything (`helper_runtime::acquire_activation_lock`),
+    // but that arrives here as a real process exit wrapped by osascript, so
+    // text is the only channel to recognize it by.
+    if output_lower.contains(
+        helper_runtime::ACTIVATION_ALREADY_RUNNING_MESSAGE
+            .to_lowercase()
+            .as_str(),
+    ) {
+        return (
+            "activation_refused",
+            activation_path::ACTIVATION_RUNNING_REPORT.to_string(),
+        );
     }
     const APP_MANAGEMENT_PHRASES: &[&str] = &[
         "permission denied when trying to update apps",
@@ -706,7 +721,7 @@ pub fn activate_store_path_stream(
             serde_json::json!({"chunk": "Activating previous nix store...\n"}),
         );
 
-        match activate_store_path(&store_path) {
+        match activate_store_path(&app_handle, &store_path) {
             Ok(result) => {
                 for line in result.stdout.lines() {
                     if !line.is_empty() {
@@ -761,8 +776,8 @@ pub fn activate_store_path_stream(
 }
 
 fn run_activate_with_path(
+    app: &AppHandle,
     activate_path: &str,
-    allow_helper: bool,
 ) -> Result<ActivateResult, anyhow::Error> {
     // Resolve the symlink to the real nix store path: the privileged step
     // only ever accepts canonical /nix/store activation paths.
@@ -770,19 +785,97 @@ fn run_activate_with_path(
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| activate_path.to_owned());
 
-    if allow_helper {
-        if let Some(result) = try_activate_with_helper(&real_activate) {
-            return result;
-        }
-    } else {
-        info!("[darwin] Skipping privileged helper for App Management-sensitive activation");
+    // Which path this apply may use is decided there, before any bytes reach
+    // the helper. Nothing in this module chooses between them.
+    activation_path::activate(&AppActivation { app }, &real_activate)
+}
+
+/// The observations and effects [`activation_path`] decides over. Nothing here
+/// decides anything; the two gates come from the replacement function's own, so
+/// Apply and reconciliation cannot disagree about where this copy runs from.
+struct AppActivation<'a> {
+    app: &'a AppHandle,
+}
+
+impl activation_path::ApplyEnvironment for AppActivation<'_> {
+    fn preference(&self) -> Result<crate::shared_types::HelperPreference, String> {
+        crate::state::preferences::read_helper_preference(self.app)
+            .map_err(|error| format!("{error:#}"))
     }
 
-    // Interactive fallback: one native admin prompt (Touch ID capable), then
-    // re-execute this binary in root-activation mode. The privileged step is
-    // fixed Rust code mirroring the helper daemon — direct exec of absolute
-    // programs with a fixed root-owned environment. No sudoers rules, EXIT
-    // traps, or requester-controlled PATH/HOME reach root.
+    fn displacement(&self) -> Option<String> {
+        reconcile::gates_live()
+            .err()
+            .map(|report| helper_permission::describe(&report))
+    }
+
+    fn registration_status(&self) -> Result<helper_service::RegistrationStatus, String> {
+        helper_service::registration_status().map_err(|error| format!("{error:#}"))
+    }
+
+    fn dispatch_activation(
+        &self,
+        activate_path: &str,
+    ) -> Result<helper_protocol::HelperReply, activation_path::DispatchFailure> {
+        let request =
+            helper_protocol::activation_request(Path::new(activate_path)).map_err(|error| {
+                activation_path::DispatchFailure::Unusable(
+                    error.context("failed to build helper activation request"),
+                )
+            })?;
+        // The result arrives on this connection when the activation completes,
+        // under the client's one generous bound rather than the short leashes
+        // the other exchanges use (`client::ACTIVATION_TIMEOUT`). An activation
+        // still running when that expires is reported as an unknown outcome and
+        // never compensated.
+        helper_client::activate_store_path(&request)
+            .map_err(activation_path::DispatchFailure::Exchange)
+    }
+
+    fn observe_listener(&self) -> helper_client::ListenerObservation {
+        helper_client::observe_listener()
+    }
+
+    fn password_activate(&self, activate_path: &str) -> Result<ActivateResult, anyhow::Error> {
+        // No record and no slot to consult here: the root executor this
+        // launches takes the shared activation lock itself, so a concurrent
+        // activation — helper-run or password-run — refuses it there, with
+        // the admin prompt's own error surface reporting why.
+        password_activation(activate_path)
+    }
+}
+
+/// The administrator-password path: one native macOS authentication dialog, then
+/// this binary re-executed in root-activation mode.
+///
+/// `osascript ... with administrator privileges` shows the legacy Security Agent
+/// dialog, which is password-only — macOS does not offer Touch ID there. Avoiding
+/// that prompt is what the privileged helper exists for.
+///
+/// Root cause of the "updating apps over SSH" error:
+///   `osascript do shell script ... with administrator privileges` spawns the
+///   privileged process in the *system* bootstrap domain (root context), not
+///   the user's Aqua GUI session domain.  The nix-darwin activation script
+///   calls `launchctl managername` and aborts with the "over SSH" error
+///   whenever the result is not "Aqua" — even when called from a GUI app.
+///
+/// Fix: the elevated step uses `launchctl asuser <uid>` to re-enter the
+///   user's Aqua bootstrap domain before exec'ing the activation script.
+///   fork()/exec() inherits the bootstrap port, so the activation script
+///   sees `launchctl managername == "Aqua"` and the App Management check
+///   proceeds correctly.
+///
+///   The elevated command is this binary re-executed in root-activation
+///   mode (`privileged_helper::root_activation`): fixed Rust code with the
+///   same hardening rules as the helper daemon — no shell script, no
+///   sudoers rules, no EXIT traps, absolute programs, and a fixed root-owned
+///   environment.
+///
+/// Reached only through [`activation_path::ApplyEnvironment::password_activate`],
+/// which records that a password activation is running for as long as this
+/// takes.
+fn password_activation(real_activate: &str) -> Result<ActivateResult, anyhow::Error> {
+    let real_activate = real_activate.to_owned();
     let root_args = root_activation::RootActivationArgs {
         // SAFETY: `getuid` is thread-safe, has no preconditions, and cannot fail.
         uid: unsafe { libc::getuid() },
@@ -823,108 +916,26 @@ fn run_activate_with_path(
         code,
         stdout: stdout_str,
         stderr: stderr_str,
+        refused: false,
     })
-}
-
-fn try_activate_with_helper(activate_path: &str) -> Option<Result<ActivateResult, anyhow::Error>> {
-    let status = helper_service::status();
-    if !status.authorized || !status.socket_available {
-        return None;
-    }
-    // `responding` is the authenticated status round-trip `helper_service`
-    // already performed. Requiring it here is what keeps a version-skewed
-    // daemon from failing the apply: a daemon predating this app's protocol
-    // cannot answer the probe, so the osascript path takes over instead of
-    // the activation request coming back as an unparseable request.
-    if !status.responding {
-        info!(
-            "[darwin] privileged helper did not answer an authenticated status probe; falling back to osascript: {}",
-            status.detail.unwrap_or_default()
-        );
-        return None;
-    }
-
-    let request = match helper_protocol::activation_request(Path::new(activate_path)) {
-        Ok(request) => request,
-        Err(error) => {
-            return Some(Err(
-                error.context("failed to build helper activation request")
-            ));
-        }
-    };
-
-    match helper_client::activate_store_path(&request) {
-        Ok(response) => {
-            // A live daemon that refuses this peer means the running build is
-            // not signed as an approved client (unsigned dev build, or a
-            // helper/app version skew). A daemon that does not speak this
-            // app's protocol version is the same situation with a different
-            // cause: an older helper still resident from a previous install.
-            // Falling back to the interactive prompt keeps the apply working
-            // in both cases until the installed helper is replaced by a
-            // current one.
-            if !response.ok
-                && (response.reports_protocol_skew() || response.reports_unauthorized_client())
-            {
-                info!(
-                    "[darwin] privileged helper rejected this client; falling back to osascript: {}",
-                    response.error.unwrap_or_default()
-                );
-                return None;
-            }
-
-            Some(Ok(ActivateResult {
-                success: response.ok,
-                code: response.code,
-                stdout: response.stdout,
-                // The response has no stderr: the activation log arrives
-                // merged into stdout, so only a helper-level error belongs
-                // in the stderr slot consumers show for failures.
-                stderr: response.error.unwrap_or_default(),
-            }))
-        }
-        Err(error) => {
-            let error_text = format!("{error:#}");
-            if error_text.contains("failed to connect to /var/run/nixmac/helper.sock") {
-                info!(
-                    "[darwin] privileged helper socket was stale; falling back to osascript: {error:#}"
-                );
-                return None;
-            }
-            if error_text.contains(crate::privileged_helper::peer_auth::HELPER_VALIDATION_FAILED) {
-                warn!(
-                    "[darwin] process at helper socket failed signature validation; falling back to osascript: {error:#}"
-                );
-                return None;
-            }
-            // The client rejects a response whose protocol version is
-            // missing or different before reading its fields, so version
-            // skew surfaces here as a classified error rather than a
-            // response. A skewed daemon cannot have run the activation — it
-            // could not have parsed the request — so falling back is safe
-            // until the installed helper is replaced by a current one.
-            if helper_protocol::is_protocol_skew(&error) {
-                info!(
-                    "[darwin] privileged helper speaks a different protocol version; falling back to osascript: {error:#}"
-                );
-                return None;
-            }
-
-            Some(Ok(ActivateResult {
-                success: false,
-                code: -1,
-                stdout: String::new(),
-                stderr: format!(
-                    "Privileged helper activation did not return a response: {error:#}. Activation may still be running; nixmac did not fall back to the password prompt."
-                ),
-            }))
-        }
-    }
 }
 
 /// Handle activation failures and determine the appropriate error response.
 fn handle_activation_error(result: &ActivateResult, log_path: &Path) -> serde_json::Value {
     let (error_type, friendly_error) = classify_activate_error(result);
+
+    // A refusal: no activation process ran and nothing was mutated. The
+    // sentence is the whole report — no exit-code headline and no log tail.
+    if error_type == "activation_refused" {
+        error!("[darwin] activation refused: {friendly_error}");
+        return serde_json::json!({
+            "ok": false,
+            "code": result.code,
+            "error_type": error_type,
+            "system_untouched": true,
+            "error": friendly_error,
+        });
+    }
 
     // AppleScript cancellation (-128)
     if error_type == "user_cancelled" {
@@ -1014,7 +1025,7 @@ fn handle_activation_error(result: &ActivateResult, log_path: &Path) -> serde_js
 }
 
 fn activation_failure_left_system_untouched(error_type: &str) -> bool {
-    matches!(error_type, "user_cancelled")
+    matches!(error_type, "user_cancelled" | "activation_refused")
 }
 
 /// Internal function to run darwin-rebuild with proper streaming.
@@ -1154,11 +1165,15 @@ fn run_darwin_rebuild(
     // =========================================================================
     // Step 1c: proactively detect App Management denial for Home Manager
     // copyApps. This mirrors Home Manager's own harmless `.DS_Store` update
-    // probe, but does it before the admin activation prompt. When existing app
-    // bundles are involved, avoid the unattended helper path so macOS attributes
-    // the TCC decision to the foreground app flow more consistently.
+    // probe, but does it before the admin activation prompt.
+    //
+    // A denial refuses the apply here. A pass says the bundle writes succeed,
+    // and the activation path is chosen the same way it is for every other
+    // apply: managed app bundles used to divert this flow to the password
+    // prompt, which was a silent substitution while an enabled registration
+    // could still admit a scheduled sync-agent activation of the same
+    // generation.
     // =========================================================================
-    let mut allow_activation_helper = true;
     match preflight_app_management(config_dir, host_attr) {
         Ok(result) if !result.ok => {
             log_and_emit!(
@@ -1169,7 +1184,6 @@ fn run_darwin_rebuild(
         }
         Ok(result) => {
             if result.checked > 0 {
-                allow_activation_helper = false;
                 log_and_emit!(format!(
                     "Preflight: App Management check passed for {} managed app bundle(s).",
                     result.checked
@@ -1202,17 +1216,16 @@ fn run_darwin_rebuild(
         }));
     };
 
-    let activate_result =
-        run_activate_step(system_store_path, allow_activation_helper).map_err(|e| {
-            serde_json::json!({
-                "ok": false,
-                "code": -1,
-                "log_file": log_path.to_string_lossy(),
-                "error_type": "generic_error",
-                "system_untouched": true,
-                "error": format!("Activation step failed to execute: {}", e),
-            })
-        })?;
+    let activate_result = run_activate_step(app, system_store_path).map_err(|e| {
+        serde_json::json!({
+            "ok": false,
+            "code": -1,
+            "log_file": log_path.to_string_lossy(),
+            "error_type": "generic_error",
+            "system_untouched": true,
+            "error": format!("Activation step failed to execute: {}", e),
+        })
+    })?;
 
     if !activate_result.success {
         summarizer.complete(false);
@@ -1370,7 +1383,21 @@ mod activation_safety_tests {
             code: 1,
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
+            refused: false,
         }
+    }
+
+    #[test]
+    fn a_refused_result_is_classified_from_its_flag_with_the_sentence_verbatim() {
+        let mut result = failed_activation("", "An activation is already running.");
+        result.refused = true;
+        result.code = -1;
+
+        let (error_type, message) = classify_activate_error(&result);
+
+        assert_eq!(error_type, "activation_refused");
+        // The sentence is the whole report: no exit-code headline around it.
+        assert_eq!(message, "An activation is already running.");
     }
 
     #[test]
@@ -1399,8 +1426,30 @@ mod activation_safety_tests {
     }
 
     #[test]
-    fn only_explicit_cancellation_is_known_untouched() {
+    fn a_password_path_lock_refusal_is_classified_as_refused() {
+        // The real shape: osascript wraps the root executor's pre-mutation
+        // bail into a process exit, so `refused` is false and only the text
+        // identifies it.
+        let result = failed_activation(
+            "",
+            "0:233: execution error: nixmac root activation failed: an activation is already running; try again once it finishes (1)",
+        );
+
+        let (error_type, message) = classify_activate_error(&result);
+
+        assert_eq!(error_type, "activation_refused");
+        assert_eq!(
+            message,
+            "An activation is already running, so nixmac did not start another."
+        );
+    }
+
+    #[test]
+    fn only_cancellations_and_refusals_are_known_untouched() {
         assert!(activation_failure_left_system_untouched("user_cancelled"));
+        assert!(activation_failure_left_system_untouched(
+            "activation_refused"
+        ));
         assert!(!activation_failure_left_system_untouched(
             "authorization_denied"
         ));

--- a/apps/native/src-tauri/src/rebuild/mod.rs
+++ b/apps/native/src-tauri/src/rebuild/mod.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 //! Darwin-rebuild pipeline: build, activate, finalize, and rollback.
 
+pub mod activation_path;
 pub mod darwin;
 pub mod finalize_apply;
 pub mod finalize_restore;

--- a/apps/native/src-tauri/src/shared_types/events.rs
+++ b/apps/native/src-tauri/src/shared_types/events.rs
@@ -101,6 +101,8 @@ pub enum RebuildErrorType {
     AuthorizationDenied,
     /// nix-darwin would overwrite unmanaged files in /etc.
     EtcClobber,
+    /// The apply refused to start the activation and made no changes.
+    ActivationRefused,
     /// Fallback for uncategorized failures.
     GenericError,
 }

--- a/apps/native/src-tauri/src/shared_types/prefs.rs
+++ b/apps/native/src-tauri/src/shared_types/prefs.rs
@@ -11,6 +11,47 @@ pub enum UpdateChannel {
     Develop,
 }
 
+/// The user's standing decision about the privileged helper.
+///
+/// Tri-state on purpose. `Unset` means the user never decided — a fresh install,
+/// or one predating the helper's install/replace/remove contract — and is what
+/// lets an existing registration be adopted as an earlier opt-in without
+/// overriding an explicit `Disabled`. It selects a goal and authorizes nothing
+/// else: every trust or termination decision is taken from live observation.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum HelperPreference {
+    #[default]
+    Unset,
+    Granted,
+    Disabled,
+}
+
+/// A helper decision that may be stored.
+///
+/// Deliberately not three-valued: `unset` says the user has not decided, so no
+/// *decision* may put it back — an install that fell back to `unset` would let
+/// an automatic path re-adopt a registration the user disabled. Every deliberate
+/// write of [`HelperPreference`] goes through this type. Two paths do still reach
+/// the stored value without deciding anything — a slice-wide reset and a reload
+/// as defaults — and `state::preferences::read_helper_preference` enumerates
+/// them.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum HelperDecision {
+    Granted,
+    Disabled,
+}
+
+impl From<HelperDecision> for HelperPreference {
+    fn from(decision: HelperDecision) -> Self {
+        match decision {
+            HelperDecision::Granted => HelperPreference::Granted,
+            HelperDecision::Disabled => HelperPreference::Disabled,
+        }
+    }
+}
+
 /// How nixmac handles updates available from the configuration Git repository.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Type)]
 #[serde(rename_all = "camelCase")]
@@ -223,6 +264,12 @@ pub struct GlobalPreferences {
     pub pending_import_dir: Option<String>,
     /// Whether or not to auto-format Nix files when making changes to the flakes.
     pub auto_format_nix_files: bool,
+    /// Standing decision about the privileged helper. Read by the helper
+    /// reconciliation and by apply; decided only by the grant and disable
+    /// actions, which is why it is not writable via `UiPrefsUpdate` and is held
+    /// out of settings export/import. `state::preferences` documents which
+    /// writers can reach it.
+    pub helper_preference: HelperPreference,
 }
 
 impl Default for GlobalPreferences {
@@ -259,6 +306,7 @@ impl Default for GlobalPreferences {
             feature_flag_overrides: None,
             pending_import_dir: None,
             auto_format_nix_files: false,
+            helper_preference: HelperPreference::Unset,
         }
     }
 }

--- a/apps/native/src-tauri/src/state/preferences.rs
+++ b/apps/native/src-tauri/src/state/preferences.rs
@@ -14,6 +14,7 @@ use tauri::{AppHandle, Manager, Runtime};
 
 use crate::observable::{AppDataJson, Observable, Persistence};
 pub use crate::shared_types::GlobalPreferences;
+use crate::shared_types::{HelperDecision, HelperPreference};
 
 pub(crate) const GLOBAL_PREFERENCES_PATH: &str = "global-preferences.json";
 
@@ -75,6 +76,73 @@ pub fn write<R: Runtime>(app: &AppHandle<R>, f: impl FnOnce(&mut GlobalPreferenc
     Ok(())
 }
 
+/// Reads the standing helper decision.
+///
+/// Three writers reach the stored value, and only the first one decides:
+///
+/// - this module's [`store_helper_decision`], which cannot express `unset`;
+/// - `commands::debug::developer_clear_tauri_state`, which resets the whole
+///   slice to defaults, so `unset`. Deliberate: that command exists to put a
+///   developer's install back to a fresh state, and a stale helper decision is
+///   part of what "fresh" means. Developer-mode gated, and the developer gets
+///   the decision back by clicking Grant or Disable;
+/// - [`load_or_default`], which flattens a **well-formed** JSON file whose values
+///   do not deserialize into the whole slice's defaults, so `unset` again. A file
+///   that is not well-formed JSON does not reach this: the parse error
+///   propagates and startup fails instead. This one is pre-existing behavior of
+///   the shared loader — it discards every field of every slice it loads, not
+///   just this one — and is fixed on its own terms rather than here.
+///
+/// The two paths that transfer a whole slice from somewhere else — a settings
+/// import (`commands::settings_io`) and the legacy-store migration
+/// ([`adopt_legacy_fields`]) — both leave it alone, because it is one of the
+/// [`DEVICE_LOCAL_KEYS`]. So a stored `disabled` survives an import, the legacy
+/// store, and the ordinary settings UI, and does not survive a schema-mismatched
+/// preferences file or the developer reset.
+///
+/// An unmanaged observable is an error rather than `unset`: "the user never
+/// decided" is a statement about the user, and inventing it would let an
+/// automatic path adopt or re-adopt a registration on the strength of a failed
+/// read. That only covers the observable being absent — the writers above have
+/// all already run by the time anything reads this.
+pub fn read_helper_preference<R: Runtime>(app: &AppHandle<R>) -> Result<HelperPreference> {
+    try_read(app)
+        .map(|prefs| prefs.helper_preference)
+        .ok_or_else(|| anyhow::anyhow!("GlobalPreferences observable is not managed"))
+}
+
+/// Stores a helper decision. Idempotent, and there is no counterpart that
+/// stores `unset` — see [`HelperDecision`].
+///
+/// `Ok` means the value is the one every later read in this process returns and
+/// that a flush was dispatched; like every other preference in this store, the
+/// flush itself is best-effort ([`crate::observable::Observable::persist_to`]
+/// logs its failures). A decision lost to a failed flush is recovered the way
+/// the user made it — by granting or disabling again — never by an automatic
+/// path inventing one.
+pub fn store_helper_decision<R: Runtime>(
+    app: &AppHandle<R>,
+    decision: HelperDecision,
+) -> Result<()> {
+    write(app, |prefs| prefs.helper_preference = decision.into())
+}
+
+/// Serialized field names of [`GlobalPreferences`] that describe *this device's*
+/// installation rather than a portable preference.
+///
+/// They are excluded from every wholesale transfer of the slice: settings export
+/// omits them and the legacy-store migration below does not adopt them, both by
+/// consulting this list, while settings import keeps the stored value field by
+/// field (`imported_over_device_local`) rather than by key — so a second entry
+/// added here needs that function extended to match. What they have in common is
+/// that their value is a decision about this machine which only an explicit
+/// action here may make — for the helper preference, Grant or Disable.
+pub(crate) const DEVICE_LOCAL_KEYS: &[&str] = &["helperPreference"];
+
+pub(crate) fn is_device_local_key(key: &str) -> bool {
+    DEVICE_LOCAL_KEYS.contains(&key)
+}
+
 /// One-shot copy of the legacy `settings.json` preference values into
 /// `prefs`. Returns whether `prefs` should be flushed (first run after the
 /// migration shipped). The legacy keys are left in place for reversibility;
@@ -94,23 +162,42 @@ fn migrate_from_legacy_store<R: Runtime>(
         return Ok(false);
     }
 
+    adopt_legacy_fields(prefs, |key| store.get(key))?;
+
+    store.set(LEGACY_MIGRATED_MARKER, serde_json::Value::Bool(true));
+    store.save()?;
+    Ok(true)
+}
+
+/// The copy itself, over a `legacy` lookup rather than the store, so the rules it
+/// applies are testable without one.
+///
+/// Every field of the slice takes the same-named legacy value if there is one —
+/// except [`DEVICE_LOCAL_KEYS`], which are left as loaded. Adopting those would
+/// let a key in the old store decide something about this installation that no
+/// action here decided; for the helper preference that means an automatic path
+/// granting or disabling a helper the user never ruled on.
+fn adopt_legacy_fields(
+    prefs: &mut GlobalPreferences,
+    legacy: impl Fn(&str) -> Option<serde_json::Value>,
+) -> Result<()> {
     let mut as_value = serde_json::to_value(&*prefs)?;
     let Some(fields) = as_value.as_object_mut() else {
-        return Ok(false);
+        return Ok(());
     };
     for key in fields.keys().cloned().collect::<Vec<_>>() {
-        if let Some(legacy) = store.get(&key) {
-            fields.insert(key, legacy.clone());
+        if is_device_local_key(&key) {
+            continue;
+        }
+        if let Some(legacy) = legacy(&key) {
+            fields.insert(key, legacy);
         }
     }
     // Unknown/garbage legacy values fall back to the loaded ones.
     if let Ok(migrated) = serde_json::from_value::<GlobalPreferences>(as_value) {
         *prefs = migrated;
     }
-
-    store.set(LEGACY_MIGRATED_MARKER, serde_json::Value::Bool(true));
-    store.save()?;
-    Ok(true)
+    Ok(())
 }
 
 /// One-shot flip to default-on diagnostics for installs that predate the
@@ -401,6 +488,149 @@ mod tests {
         });
         assert!(!prefs.evolve_models.contains_key("openai"));
         assert_eq!(prefs.current_evolve_model(), None);
+    }
+
+    fn mock_app_with_preferences(
+        initial: GlobalPreferences,
+    ) -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds");
+        app.manage(Observable::new(initial));
+        app
+    }
+
+    #[test]
+    fn a_helper_decision_round_trips_through_the_stored_preference() {
+        // Both decisions, in both orders, and idempotent: granting twice is one
+        // stored value, and a later disable replaces it.
+        let app = mock_app_with_preferences(GlobalPreferences::default());
+        let handle = app.handle();
+
+        assert_eq!(
+            read_helper_preference(handle).unwrap(),
+            HelperPreference::Unset,
+            "a fresh install has no decision"
+        );
+
+        for decision in [
+            HelperDecision::Granted,
+            HelperDecision::Granted,
+            HelperDecision::Disabled,
+            HelperDecision::Granted,
+        ] {
+            store_helper_decision(handle, decision).expect("store");
+
+            assert_eq!(
+                read_helper_preference(handle).unwrap(),
+                HelperPreference::from(decision)
+            );
+        }
+    }
+
+    #[test]
+    fn the_legacy_store_can_set_every_field_except_the_device_local_ones() {
+        // The migration matches on serialized field names, so the helper
+        // decision came into its reach the moment it joined this slice. A
+        // `helperPreference` key in the old store — a hand edit, or a frontend
+        // write, since that store is reachable from JavaScript — would otherwise
+        // grant or disable a helper the user never ruled on.
+        let legacy = serde_json::json!({
+            "hostAttr": "from-the-old-store",
+            "developerMode": true,
+            "helperPreference": "granted",
+        });
+        let mut prefs = GlobalPreferences {
+            helper_preference: HelperPreference::Disabled,
+            ..GlobalPreferences::default()
+        };
+
+        adopt_legacy_fields(&mut prefs, |key| legacy.get(key).cloned()).expect("adopt");
+
+        assert_eq!(prefs.helper_preference, HelperPreference::Disabled);
+        assert_eq!(prefs.host_attr.as_deref(), Some("from-the-old-store"));
+        assert!(prefs.developer_mode);
+    }
+
+    #[test]
+    fn the_legacy_store_cannot_reset_the_decision_by_omitting_it() {
+        // The same guarantee in the other direction: the copy leaves the field
+        // as loaded rather than defaulting it, so an old store that predates the
+        // key cannot turn a decision back into "never decided".
+        let legacy = serde_json::json!({ "hostAttr": "macbook" });
+        let mut prefs = GlobalPreferences {
+            helper_preference: HelperPreference::Disabled,
+            ..GlobalPreferences::default()
+        };
+
+        adopt_legacy_fields(&mut prefs, |key| legacy.get(key).cloned()).expect("adopt");
+
+        assert_eq!(prefs.helper_preference, HelperPreference::Disabled);
+    }
+
+    #[test]
+    fn a_stored_decision_is_never_unset() {
+        // The write API is two-valued, so this holds by construction; the test
+        // pins it because a third variant sneaking into `HelperDecision` would
+        // let an automatic path undo an explicit disable.
+        for decision in [HelperDecision::Granted, HelperDecision::Disabled] {
+            assert_ne!(HelperPreference::from(decision), HelperPreference::Unset);
+        }
+    }
+
+    #[test]
+    fn an_unreadable_store_is_an_error_rather_than_a_decision() {
+        // Without the observable there is no answer to give; reporting "unset"
+        // would be a claim about the user that nothing observed.
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds");
+
+        assert!(read_helper_preference(app.handle()).is_err());
+        assert!(store_helper_decision(app.handle(), HelperDecision::Granted).is_err());
+    }
+
+    #[test]
+    fn the_helper_preference_persists_and_defaults_to_unset() {
+        let stored = MemoryPersistence::with_value(json!({ "helperPreference": "disabled" }));
+        assert_eq!(
+            load_or_default::<GlobalPreferences>(&stored)
+                .unwrap()
+                .helper_preference,
+            HelperPreference::Disabled
+        );
+
+        let absent = MemoryPersistence::with_value(json!({}));
+        assert_eq!(
+            load_or_default::<GlobalPreferences>(&absent)
+                .unwrap()
+                .helper_preference,
+            HelperPreference::Unset
+        );
+
+        let serialized = serde_json::to_value(GlobalPreferences {
+            helper_preference: HelperPreference::Granted,
+            ..GlobalPreferences::default()
+        })
+        .unwrap();
+        assert_eq!(serialized.get("helperPreference").unwrap(), "granted");
+    }
+
+    #[test]
+    fn a_ui_preference_update_cannot_touch_the_helper_decision() {
+        // Grant and disable are their own actions; the settings surface must not
+        // be able to flip the stored value without them.
+        let mut prefs = GlobalPreferences {
+            helper_preference: HelperPreference::Granted,
+            ..GlobalPreferences::default()
+        };
+
+        prefs.apply_ui_update(&crate::shared_types::UiPrefsUpdate {
+            developer_mode: Some(true),
+            ..Default::default()
+        });
+
+        assert_eq!(prefs.helper_preference, HelperPreference::Granted);
     }
 
     #[test]

--- a/apps/native/src-tauri/src/system/helper_permission.rs
+++ b/apps/native/src-tauri/src/system/helper_permission.rs
@@ -1,0 +1,545 @@
+//! The unattended sync helper, as the app's permission surface sees it.
+//!
+//! One reconciliation function decides everything about the installed helper
+//! (`privileged_helper::reconcile`). This module is the only place the GUI calls
+//! it from, and it holds nothing but the wiring:
+//!
+//!   * [`observe`] for startup and status refreshes, [`grant`] and [`disable`]
+//!     for the two explicit user actions;
+//!   * [`describe`] and [`row`], which turn one run's report into the sentence
+//!     and the permission state the UI shows.
+//!
+//! Opening Login Items lives here too, and only in [`grant`]: startup and
+//! refreshes run the same reconciliation function, so no report opens System
+//! Settings except through the click whose run produced it — however pending the
+//! approval a report describes, a run no click is waiting on opens nothing.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tauri::{AppHandle, Runtime};
+
+use crate::privileged_helper::reconcile::{self, LiveEnvironment, Reconciled};
+use crate::privileged_helper::service::{self, RegistrationStatus};
+use crate::shared_types::PermissionStatus;
+use crate::state::permissions_state;
+use crate::system::permissions;
+
+const APPROVE_IN_LOGIN_ITEMS: &str = "Approve nixmac in System Settings → General → Login Items & Extensions to finish enabling the unattended sync helper.";
+
+/// Reconciles the installed helper with this build, and reports.
+///
+/// Cheap on its normal path (one `Status` exchange), so startup and every
+/// status refresh run it. It opens System Settings for nothing it observes: only
+/// [`grant`] does that, from what the click itself saw.
+///
+/// Must not run on the main thread: the register and replace calls it may make
+/// are issued *on* the main queue and awaited, so a main-thread caller would
+/// starve the queue that has to make them. Those two refuse up front rather than
+/// wait out the call window and misreport the silence. The other two,
+/// `registration_status` and `unregister`, are issued inline and would proceed —
+/// so a main-thread run that only has to read a status or remove a helper is not
+/// caught by that refusal.
+pub fn observe<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    reconcile::reconcile(&LiveEnvironment::new(app))
+}
+
+/// The explicit Grant action: record the decision, reconcile under it, and open
+/// Login Items when macOS is waiting on the user there.
+///
+/// This function is the only thing in nixmac that opens System Settings for the
+/// helper, which is what keeps startup and refreshes from ever doing it: they
+/// call [`observe`], and no report can open anything on its own account however
+/// pending the approval it describes.
+///
+/// It opens the pane in the two places a click can learn that macOS is waiting.
+/// At most one fires per click — the second is guarded on the first — and which
+/// one depends only on what this call saw, never on which pass happened to
+/// report first:
+///
+///   * **before the run**, when the registration is already waiting for
+///     approval. The row's button says "Open Settings" in that state, so opening
+///     it is the click's own action and does not depend on the run at all — the
+///     run may still report something else, and that is not a reason for the
+///     click to do nothing visible.
+///   * **after the run**, when this run is the one that registered and macOS now
+///     wants approval for it. That is the first-time Enable path, where nothing
+///     was waiting when the click landed.
+///
+/// A decision is never answered `Busy`: it waits out an in-flight pass and then
+/// makes its own (see `reconcile::decide`), so the report this returns is always
+/// the pass that carried the click out.
+///
+/// [`observe`]'s must-not-run-on-the-main-thread rule applies here with more
+/// force: a main-thread decision would block on the slot while the holder's
+/// pass may be awaiting a main-queue dispatch — a deadlock, where an
+/// observation merely misreports. Every current caller is an async handler.
+pub fn grant<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    // Read before the run, because the run is what changes it.
+    let awaiting_approval_already = matches!(
+        service::registration_status(),
+        Ok(RegistrationStatus::RequiresApproval)
+    );
+    if awaiting_approval_already {
+        service::open_login_items_settings();
+    }
+    let report = reconcile::grant(&LiveEnvironment::new(app));
+    if !awaiting_approval_already && matches!(report, Reconciled::PendingApproval) {
+        service::open_login_items_settings();
+    }
+    start_converging(app);
+    report
+}
+
+/// The explicit Disable action: record the decision, then reconcile under it —
+/// unregister the helper, deferring while an activation runs, done. Never on
+/// the main thread, for [`grant`]'s reason.
+pub fn disable<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    let report = reconcile::disable(&LiveEnvironment::new(app));
+    start_converging(app);
+    report
+}
+
+/// The permission row for one report: only a helper of this build, ready, is
+/// granted, and every report says what it found.
+pub fn row(report: &Reconciled) -> (PermissionStatus, String) {
+    let status = match report {
+        Reconciled::AtThisBuild => PermissionStatus::Granted,
+        _ => PermissionStatus::Pending,
+    };
+    (status, describe(report))
+}
+
+/// Whether a pane of System Settings is where the user finishes this report.
+///
+/// `PendingApproval` is the one report where it is: the registration exists and
+/// macOS is waiting for the user to approve it in Login Items, and nothing else
+/// makes it go. So the row offers the same "Open Settings" action as the other
+/// rows that deep-link into System Settings, rather than one more attempt or a
+/// way to hand the helper back. [`grant`] is still what the button calls — it
+/// records the decision and opens that pane, and does nothing to a registration
+/// already waiting there.
+///
+/// Not "can a later run change this": several reports are equally terminal
+/// without a run — a displaced copy has to be moved or restarted (see
+/// [`nothing_more_to_do`], which classifies those as final for that reason). What
+/// separates this one is *where* the remedy is. The others are answered by a run,
+/// or by the user doing something to the app itself, not in System Settings.
+pub fn can_request_programmatically(report: &Reconciled) -> bool {
+    !matches!(report, Reconciled::PendingApproval)
+}
+
+/// What one report says, in a sentence for the user.
+///
+/// The vocabulary is the report's own wherever the report carries text of its
+/// own (the displaced and stopped-short cases); the resting states have none, so
+/// they are phrased here.
+pub fn describe(report: &Reconciled) -> String {
+    match report {
+        Reconciled::AtThisBuild => {
+            "The unattended sync helper is installed and answering.".to_string()
+        }
+        Reconciled::PendingApproval => APPROVE_IN_LOGIN_ITEMS.to_string(),
+        Reconciled::NoHelper => {
+            "The unattended sync helper is not installed. Enable it to activate builds without a password prompt.".to_string()
+        }
+        Reconciled::Removed => {
+            "The unattended sync helper is disabled and has been removed.".to_string()
+        }
+        Reconciled::Busy => "nixmac is still reconciling the unattended sync helper.".to_string(),
+        // The one report that says why enabling or disabling is taking
+        // minutes: a running activation is never interrupted, and the loop
+        // re-observes until it ends.
+        Reconciled::WaitingOnActivation(Some(activation)) => format!(
+            "nixmac is waiting for a running activation to finish before updating the unattended sync helper ({} submitted by the {}).",
+            activation.script_path, activation.client_kind
+        ),
+        Reconciled::WaitingOnActivation(None) => {
+            "nixmac is waiting for a running activation to finish before updating the unattended sync helper.".to_string()
+        }
+        Reconciled::Displaced(displacement) => sentence(displacement),
+        Reconciled::ServiceDefinitionBroken => {
+            sentence(&"this app's helper service definition is broken")
+        }
+        Reconciled::Stopped(stopped) => sentence(stopped),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Converging on the stored decision.
+// ---------------------------------------------------------------------------
+//
+// One reconciliation run is often not enough, and nothing else re-runs it: the
+// platform refuses a register for about a second after any unregister, and
+// approving in Login Items neither starts the helper nor tells anyone. So a
+// launch, and each explicit user action, drives the function until the stored
+// decision is carried out. Measured on real hardware: one launch, one Login
+// Items toggle, ~30 s, no relaunch.
+
+/// Spacing between attempts, and how many working ones are made at the shorter
+/// one.
+///
+/// The short spacing covers the platform's refusal window — measured at about a
+/// second — and the settling that follows a replacement. These are counts of
+/// *working* attempts, not wall clock: a run that has to prove the socket absent
+/// costs about five seconds of its own, so thirty of them is minutes rather than
+/// half a minute.
+const FAST_INTERVAL: Duration = Duration::from_secs(1);
+const SLOW_INTERVAL: Duration = Duration::from_secs(60);
+const FAST_ATTEMPTS: u32 = 30;
+
+/// Spacing while nothing is being attempted. Not derived from the counters
+/// above, because a wait is not a streak of failures: it may last weeks, so it
+/// must not sit at the short spacing, and it should still notice an approval
+/// promptly once it comes.
+///
+/// Not free, either. Every pass runs the gates first, and those resolve the app
+/// bundle twice — `current_exe` and two `canonicalize` each — and parse
+/// `Info.plist` for the stamped build id, before the `SMAppService` read. All
+/// page-cached and cheap in absolute terms, but this is the app's steady state
+/// for as long as an approval is outstanding, so it is a poll rather than a
+/// glance.
+const WAITING_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Working attempts one loop makes before giving up and leaving repair to the
+/// next launch or the next click.
+///
+/// Only attempts that are *trying to change something* count. Waiting on a human
+/// is not failing at anything — see [`drive`] — so this bounds the repetition
+/// that could churn a registration, and nothing else.
+const MAX_ATTEMPTS: u32 = 100;
+
+/// Whether re-running could still change anything.
+fn nothing_more_to_do(report: &Reconciled) -> bool {
+    matches!(
+        report,
+        // The stored decision is carried out — one success state per goal.
+        Reconciled::AtThisBuild | Reconciled::Removed | Reconciled::NoHelper
+        // Or nothing this loop can do will change the answer. A displaced copy
+        // must be moved or restarted, and neither takes effect in a running
+        // process: `current_exe` reports the path the process was launched from,
+        // and the realistic route here is a quarantined copy, which macOS runs
+        // from a read-only mount that is never under /Applications. A broken
+        // service definition is a property of the bundle, read identically every
+        // time.
+            | Reconciled::Displaced(_)
+            | Reconciled::ServiceDefinitionBroken
+    )
+}
+
+/// The one loop, as a flag rather than a handle: nothing waits on it, cancels
+/// it, or asks it anything.
+static CONVERGING: AtomicBool = AtomicBool::new(false);
+
+/// Held for a loop's lifetime, and released by `Drop` on every way out
+/// including a panic — a leaked flag is permanent, since nothing else clears it.
+///
+/// A unit struct on purpose. An earlier version passed a value carrying the flag
+/// into `bool::then_some`, which evaluates its argument eagerly: the guard was
+/// built and dropped on the *refused* path too, releasing the running loop's
+/// flag, and loops doubled every tick until the process ran out of threads.
+/// There is nothing here for a claim to construct speculatively.
+struct Converging;
+
+impl Drop for Converging {
+    fn drop(&mut self) {
+        CONVERGING.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Starts a loop unless one is already running.
+///
+/// Startup calls this, and so does every explicit user action — a click has to
+/// keep trying if its first attempt stops short, not wait for the next launch.
+/// A loop already running needs no help: every pass re-reads the stored decision,
+/// so it picks up a Grant or a Disable by itself.
+pub fn start_converging<R: Runtime>(app: &AppHandle<R>) {
+    // A build that reports every permission granted without probing must not go
+    // and register a real helper behind that fiction. `replace_row` refuses too,
+    // but this is the one that keeps `SMAppService` untouched.
+    if permissions::skip_enabled() {
+        return;
+    }
+    if CONVERGING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    // Built only after the claim succeeded, and moved into the closure — so a
+    // `spawn` that fails drops it and gives the flag back.
+    let guard = Converging;
+    let app = app.clone();
+    // Off the calling thread for two reasons. It must not be the main thread:
+    // the ServiceManagement calls are issued *on* the main queue and awaited, so
+    // a main-thread caller would starve the queue it is waiting on, and the
+    // adapter refuses outright. And its own thread rather than the blocking
+    // pool, because this one sleeps for as long as an approval takes — a pool
+    // slot it would never give back.
+    std::thread::spawn(move || {
+        let _guard = guard;
+        drive(
+            || {
+                let report = observe(&app);
+                permissions_state::replace_row(&app, permissions::helper_row(&report));
+                report
+            },
+            std::thread::sleep,
+        );
+    });
+}
+
+/// Run, publish, stop when there is nothing left to do, otherwise wait and go
+/// again.
+fn drive(mut attempt: impl FnMut() -> Reconciled, mut wait: impl FnMut(Duration)) {
+    let mut working = 0;
+    loop {
+        let report = attempt();
+        if nothing_more_to_do(&report) {
+            return;
+        }
+        // None of these attempted anything. `PendingApproval` is macOS
+        // waiting on the user — which may be weeks. `Busy` is another run
+        // holding the single-flight slot, so this pass did not even begin.
+        // `WaitingOnActivation` is a running activation the pass deferred to —
+        // activations take minutes and are never interrupted, so the deferral
+        // lives here, in the loop's waiting cadence, rather than as a poll
+        // inside a pass. All are cheap, all can persist, and none changed what
+        // is registered, so they are neither counted nor hurried, and the loop
+        // watches for as long as the app runs. (A truly hung activation is
+        // therefore watched forever and reported, never force-killed; the
+        // recovery boundary is a reboot.)
+        //
+        // The subtlety, because the report alone does not carry it: a *mutating*
+        // pass can also end at `PendingApproval`, when `verify` finds the
+        // registration it just created parked at `requiresApproval`. What keeps
+        // that from recurring uncounted is the world, not the report — after it,
+        // the registration *is* at `requiresApproval`, so the next pass takes the
+        // status × goal table's row and touches nothing. Getting back to a
+        // mutating pass takes an external event: an approval, or a removal in
+        // Login Items. Every such cycle is therefore paced by a human.
+        if matches!(
+            report,
+            Reconciled::PendingApproval | Reconciled::Busy | Reconciled::WaitingOnActivation(_)
+        ) {
+            wait(WAITING_INTERVAL);
+            continue;
+        }
+        working += 1;
+        if working >= MAX_ATTEMPTS {
+            log::warn!(
+                "helper convergence: giving up after {working} attempts, last report {report:?}; \
+                 repair is left to the next launch or user action"
+            );
+            return;
+        }
+        wait(if working < FAST_ATTEMPTS {
+            FAST_INTERVAL
+        } else {
+            SLOW_INTERVAL
+        });
+    }
+}
+
+/// One report, terminated.
+///
+/// The reports are written as clauses and carry no full stop; several of them
+/// start with "nixmac", so the first letter is left exactly as the report wrote
+/// it rather than upper-cased into a different product name.
+fn sentence(report: &impl std::fmt::Display) -> String {
+    let report = report.to_string();
+    if report.ends_with(['.', '!', '?']) {
+        report
+    } else {
+        format!("{report}.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stopped(sentence: &str) -> Reconciled {
+        Reconciled::Stopped(sentence.to_string())
+    }
+
+    fn displaced() -> Reconciled {
+        Reconciled::Displaced(
+            "nixmac is not running from an app bundle in /Applications".to_string(),
+        )
+    }
+
+    #[test]
+    fn the_loop_stops_on_a_goal_and_on_nothing_else_it_can_fix() {
+        for done in [
+            Reconciled::AtThisBuild,
+            Reconciled::Removed,
+            Reconciled::NoHelper,
+            displaced(),
+            Reconciled::ServiceDefinitionBroken,
+        ] {
+            assert!(nothing_more_to_do(&done), "{done:?}");
+        }
+        // Everything else is worth another go — the refusal window, the
+        // approval wait, a caller turned away, a helper that has not answered
+        // yet, a running activation being waited out.
+        for keep_going in [
+            Reconciled::PendingApproval,
+            Reconciled::Busy,
+            Reconciled::WaitingOnActivation(None),
+            stopped("the helper could not be registered: not permitted"),
+            stopped("the registered helper never answered on its socket"),
+            stopped("the helper could not be unregistered: refused"),
+            stopped("the helper is no longer granted; it was being replaced"),
+        ] {
+            assert!(!nothing_more_to_do(&keep_going), "{keep_going:?}");
+        }
+    }
+
+    #[test]
+    fn only_a_pending_approval_hands_the_row_to_the_user() {
+        // The one report whose remedy is in System Settings, so the row offers
+        // the Login Items deep link rather than an action of nixmac's own.
+        assert!(!can_request_programmatically(&Reconciled::PendingApproval));
+        // Everything else is answered by a run, or by the user doing something to
+        // the app itself — including the reports that ask for a move or a restart,
+        // which no pane of System Settings can help with.
+        for ours in [
+            Reconciled::AtThisBuild,
+            Reconciled::NoHelper,
+            Reconciled::Removed,
+            Reconciled::Busy,
+            Reconciled::WaitingOnActivation(None),
+            displaced(),
+            Reconciled::ServiceDefinitionBroken,
+            stopped("the helper could not be registered: not permitted"),
+            stopped("the helper could not be unregistered: refused"),
+            stopped("the registered helper never answered on its socket"),
+        ] {
+            assert!(can_request_programmatically(&ours), "{ours:?}");
+        }
+    }
+
+    #[test]
+    fn it_stops_as_soon_as_the_decision_is_carried_out() {
+        let mut attempts = 0;
+        let mut waited = Vec::new();
+        drive(
+            || {
+                attempts += 1;
+                if attempts < 3 {
+                    stopped("the helper could not be registered: not permitted")
+                } else {
+                    Reconciled::AtThisBuild
+                }
+            },
+            |interval| waited.push(interval),
+        );
+        assert_eq!(attempts, 3);
+        // Waited between attempts, and not after the last one.
+        assert_eq!(waited, vec![FAST_INTERVAL; 2]);
+    }
+
+    #[test]
+    fn waiting_on_a_human_is_never_counted_against_the_bound() {
+        // §8.6 says the approval may arrive weeks later, and the poll that
+        // observes it registers nothing. So the loop must still be watching long
+        // after a bound on working attempts would have stopped it.
+        let mut attempts = 0;
+        let mut waited = Vec::new();
+        drive(
+            || {
+                attempts += 1;
+                if attempts <= MAX_ATTEMPTS * 10 {
+                    Reconciled::PendingApproval
+                } else {
+                    Reconciled::AtThisBuild
+                }
+            },
+            |interval| waited.push(interval),
+        );
+        assert_eq!(attempts, MAX_ATTEMPTS * 10 + 1, "the loop stopped watching");
+        // And it waits at the waiting spacing throughout — the working counter
+        // never moves, so it must not be what picks the interval.
+        assert!(waited.iter().all(|i| *i == WAITING_INTERVAL));
+    }
+
+    #[test]
+    fn a_wait_that_turns_into_work_is_still_bounded() {
+        // The pending polls are free, but the moment the approval lands and the
+        // repair starts failing, the bound applies to those attempts.
+        let mut attempts = 0;
+        let mut working = 0;
+        drive(
+            || {
+                attempts += 1;
+                if attempts <= 500 {
+                    Reconciled::PendingApproval
+                } else {
+                    working += 1;
+                    stopped("the helper could not be registered: not permitted")
+                }
+            },
+            |_| {},
+        );
+        assert_eq!(working, MAX_ATTEMPTS);
+    }
+
+    #[test]
+    fn it_gives_up_rather_than_running_for_ever() {
+        let mut attempts = 0;
+        let mut waited = Vec::new();
+        drive(
+            || {
+                attempts += 1;
+                stopped("the helper could not be registered: not permitted")
+            },
+            |interval| waited.push(interval),
+        );
+        assert_eq!(attempts, MAX_ATTEMPTS);
+        assert_eq!(waited.len(), (MAX_ATTEMPTS - 1) as usize);
+        // Quick while the platform might still be settling, patient afterwards.
+        assert!(
+            waited[..(FAST_ATTEMPTS - 1) as usize]
+                .iter()
+                .all(|i| *i == FAST_INTERVAL)
+        );
+        assert!(
+            waited[(FAST_ATTEMPTS - 1) as usize..]
+                .iter()
+                .all(|i| *i == SLOW_INTERVAL)
+        );
+    }
+
+    #[test]
+    fn the_claim_primitives_hold_one_loop_and_survive_a_panic() {
+        // Note this drives `CONVERGING` and `Converging` directly, not
+        // `start_converging` — the claim/spawn/guard *sequencing* in that
+        // function is what once had the doubling bug, and it is not covered
+        // here.
+        assert!(
+            CONVERGING
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+        );
+        assert!(
+            CONVERGING
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err(),
+            "a second loop claimed a taken flag"
+        );
+        // A refused claim must not release what the holder has — the bug that
+        // spawned loops until the process ran out of threads.
+        assert!(CONVERGING.load(Ordering::SeqCst));
+
+        let outcome = std::panic::catch_unwind(|| {
+            let _guard = Converging;
+            panic!("the run panicked");
+        });
+        assert!(outcome.is_err());
+        assert!(
+            !CONVERGING.load(Ordering::SeqCst),
+            "the flag was leaked by a panic"
+        );
+    }
+}

--- a/apps/native/src-tauri/src/system/mod.rs
+++ b/apps/native/src-tauri/src/system/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod app_management_preflight;
 pub mod etc_preflight;
+pub mod helper_permission;
 pub mod install_location;
 pub mod launchd_scanner;
 pub mod nix;

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1983,6 +1983,10 @@ export type RebuildErrorType =
  */
 "etc_clobber" | 
 /**
+ * The apply refused to start the activation and made no changes.
+ */
+"activation_refused" | 
+/**
  * Fallback for uncategorized failures.
  */
 "generic_error"

--- a/apps/native/src/lib/errors.ts
+++ b/apps/native/src/lib/errors.ts
@@ -24,6 +24,7 @@ export const REBUILD_ERROR_CODES = {
   USER_CANCELLED: "user_cancelled",
   AUTHORIZATION_DENIED: "authorization_denied",
   ETC_CLOBBER: "etc_clobber",
+  ACTIVATION_REFUSED: "activation_refused",
   GENERIC_ERROR: "generic_error",
 } as const;
 
@@ -50,6 +51,7 @@ const AI_UNFIXABLE_REBUILD_ERRORS = new Set<string>([
   REBUILD_ERROR_CODES.USER_CANCELLED,
   REBUILD_ERROR_CODES.AUTHORIZATION_DENIED,
   REBUILD_ERROR_CODES.ETC_CLOBBER,
+  REBUILD_ERROR_CODES.ACTIVATION_REFUSED,
 ]);
 
 /**
@@ -112,6 +114,10 @@ const REBUILD_ERROR_DETAILS = {
   [REBUILD_ERROR_CODES.ETC_CLOBBER]: {
     why: "Existing /etc files would be overwritten",
     fix: "nix-darwin found files in /etc it doesn't manage and won't overwrite. Back up anything important, then rename each listed file by adding .before-nix-darwin to the end and retry. No changes were made to your system.",
+  },
+  [REBUILD_ERROR_CODES.ACTIVATION_REFUSED]: {
+    why: "Activation did not start",
+    fix: "nixmac refused to start the activation. The message says why and what to do next.",
   },
   [REBUILD_ERROR_CODES.GENERIC_ERROR]: DEFAULT_REBUILD_ERROR_DETAILS,
 } satisfies Record<RebuildErrorCode, RebuildErrorDetails>;


### PR DESCRIPTION
## Summary

**Problem:** the GUI meets an installed helper of unknown build that may be running an activation, and must drive it toward the stored decision — adopt, replace, or remove — without ever interrupting a running activation. Every apply must pick between the helper and the administrator-password prompt, and a helper refusal must never silently become a password prompt. One pass is rarely enough: the platform refuses a register for about a second after an unregister, and approval waits on a human.

**Solution:** one idempotent reconciliation pass — a status-by-goal table with displacement gates re-checked before every mutation and a typed commitment token minted only by the register step's final checks — over a ServiceManagement adapter that registers only after the unregister completion confirms the old process is gone. A pass that finds an activation running ends with a `WaitingOnActivation` report; the convergence loop re-observes it on its waiting cadence, uncounted against the mutation bound. `activation_path` routes each apply from reconciled service state, totally over decision and status, and an attempted helper exchange never falls through to the prompt. The sync agent stays a fire-and-defer activation client. The helper preference is device-local: settings import cannot carry or reset it.

Stacked on #668.

## Test Plan

- [x] `cargo test` green: scripted-world reconciliation tests over the full status-by-goal table (adoption, replacement, deferral, verify branches, gate re-checks, mid-run Disable declining the register), the complete activation-routing table (every refusal proven never to reach the prompt), convergence-loop bounds, sync-agent dispatch outcomes

## Docs

- [x] No docs update needed

## Prior review

Carried over from Scott-approved PRs, byte-identical or nearly: `service.rs` (4 lines differ, a test string) from #620/#635, `preferences.rs`/`prefs.rs`/`settings_io.rs` from #620. `reconcile.rs` keeps #635's shape (status-by-goal table, scripted-world tests) but is substantially rewritten — no drain machinery, deferral instead — and `activation_path.rs`/`helper_permission.rs` differ by ~20% from the #636-era versions. Review effort belongs on those three.