### PR TITLE
feat(ui): surface helper state and actions

### DIFF
--- a/apps/native/src-tauri/src/commands/permissions.rs
+++ b/apps/native/src-tauri/src/commands/permissions.rs
@@ -26,8 +26,9 @@ pub async fn refresh_permissions(app: AppHandle) -> Result<(), String> {
 /// For manual permissions (full-disk), this opens System Settings.
 #[tauri::command]
 pub async fn permissions_request(
+    app: AppHandle,
     permission_id: String,
 ) -> Result<shared_types::Permission, String> {
-    permissions::request_permission(&permission_id)
+    permissions::request_permission(&app, &permission_id)
         .map_err(|e| capture_err("permissions_request", e))
 }

--- a/apps/native/src-tauri/src/orpc/darwin.rs
+++ b/apps/native/src-tauri/src/orpc/darwin.rs
@@ -3,14 +3,14 @@
 use super::{OrpcCtx, helpers::internal_err};
 use crate::commands::{apply, evolve, rollback};
 use crate::privileged_helper::{
-    protocol::{HelperServiceStatus, SyncAgentLaunchConfig},
-    service,
+    protocol::SyncAgentLaunchConfig,
     sync_agent::{self, SyncAgentStatus},
 };
 use crate::shared_types::{
     AppManagementCheckResult, BuildCheckResult, EtcClobberCheckResult, EvolveCancelResult,
     OkResult, RebuildStatus, RollbackResult,
 };
+use crate::system::helper_permission;
 use orpc::*;
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -66,6 +66,28 @@ struct RestoreTargetInput {
 #[serde(rename_all = "camelCase")]
 struct InstallSyncAgentInput {
     config: Option<SyncAgentLaunchConfig>,
+}
+
+/// What one reconciliation run found, for a client that only has to display it:
+/// whether the helper is installed and answering at this build, and the sentence
+/// that says what else is true.
+#[derive(Debug, Deserialize, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+struct HelperReport {
+    at_this_build: bool,
+    detail: String,
+}
+
+impl HelperReport {
+    fn of(report: &crate::privileged_helper::reconcile::Reconciled) -> Self {
+        Self {
+            at_this_build: matches!(
+                report,
+                crate::privileged_helper::reconcile::Reconciled::AtThisBuild
+            ),
+            detail: helper_permission::describe(report),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Type)]
@@ -193,16 +215,29 @@ async fn rebuild_status(ctx: OrpcCtx, _input: ()) -> Result<RebuildStatus, ORPCE
         .map_err(|error| internal_err("darwin.rebuildStatus", error))
 }
 
-async fn helper_status(_ctx: OrpcCtx, _input: ()) -> Result<HelperServiceStatus, ORPCError> {
-    Ok(service::status())
+/// One run of the reconciliation function, reported. It takes no decision of its
+/// own and opens nothing — only [`helper_grant`] opens Login Items. The one thing
+/// it may store is the adoption: a registration that already exists is recorded as
+/// the user's earlier opt-in before anything is mutated under it.
+///
+/// The same single run a status refresh makes, and no more than that: a refresh
+/// also starts the convergence loop, and this does not.
+async fn helper_status(ctx: OrpcCtx, _input: ()) -> Result<HelperReport, ORPCError> {
+    Ok(HelperReport::of(&helper_permission::observe(&ctx.app)))
 }
 
-async fn helper_register(_ctx: OrpcCtx, _input: ()) -> Result<HelperServiceStatus, ORPCError> {
-    service::register().map_err(|error| internal_err("darwin.helperRegister", error))
+/// The explicit Grant action. Grant is the only action that may open Login
+/// Items; `permissions.request("privileged-helper")` is the same action reached
+/// from the permission row.
+async fn helper_grant(ctx: OrpcCtx, _input: ()) -> Result<HelperReport, ORPCError> {
+    Ok(HelperReport::of(&helper_permission::grant(&ctx.app)))
 }
 
-async fn helper_unregister(_ctx: OrpcCtx, _input: ()) -> Result<HelperServiceStatus, ORPCError> {
-    service::unregister().map_err(|error| internal_err("darwin.helperUnregister", error))
+/// The explicit Disable action: unregister the helper (deferring while an
+/// activation runs) and
+/// register nothing. No later automatic run overrides it.
+async fn helper_disable(ctx: OrpcCtx, _input: ()) -> Result<HelperReport, ORPCError> {
+    Ok(HelperReport::of(&helper_permission::disable(&ctx.app)))
 }
 
 async fn sync_agent_status(_ctx: OrpcCtx, _input: ()) -> Result<SyncAgentStatus, ORPCError> {
@@ -278,14 +313,14 @@ pub fn routes() -> Router<OrpcCtx> {
             .output(orpc_specta::specta::<RebuildStatus>())
             .handler(rebuild_status),
         "helperStatus" => os::<OrpcCtx>()
-            .output(orpc_specta::specta::<HelperServiceStatus>())
+            .output(orpc_specta::specta::<HelperReport>())
             .handler(helper_status),
-        "helperRegister" => os::<OrpcCtx>()
-            .output(orpc_specta::specta::<HelperServiceStatus>())
-            .handler(helper_register),
-        "helperUnregister" => os::<OrpcCtx>()
-            .output(orpc_specta::specta::<HelperServiceStatus>())
-            .handler(helper_unregister),
+        "helperGrant" => os::<OrpcCtx>()
+            .output(orpc_specta::specta::<HelperReport>())
+            .handler(helper_grant),
+        "helperDisable" => os::<OrpcCtx>()
+            .output(orpc_specta::specta::<HelperReport>())
+            .handler(helper_disable),
         "syncAgentStatus" => os::<OrpcCtx>()
             .output(orpc_specta::specta::<SyncAgentStatus>())
             .handler(sync_agent_status),

--- a/apps/native/src-tauri/src/orpc/permissions.rs
+++ b/apps/native/src-tauri/src/orpc/permissions.rs
@@ -25,8 +25,8 @@ async fn refresh(ctx: OrpcCtx, _input: ()) -> Result<(), ORPCError> {
         .map_err(|e| internal_err("permissions.refresh", e))
 }
 
-async fn request(_ctx: OrpcCtx, input: RequestInput) -> Result<Permission, ORPCError> {
-    cmd::permissions_request(input.permission_id)
+async fn request(ctx: OrpcCtx, input: RequestInput) -> Result<Permission, ORPCError> {
+    cmd::permissions_request(ctx.app, input.permission_id)
         .await
         .map_err(|e| internal_err("permissions.request", e))
 }

--- a/apps/native/src-tauri/src/shared_types/system.rs
+++ b/apps/native/src-tauri/src/shared_types/system.rs
@@ -69,7 +69,14 @@ pub struct Permission {
     pub description: String,
     /// Whether onboarding requires this permission.
     pub required: bool,
-    /// Whether the app can trigger the system prompt directly.
+    /// Whether the app can trigger the system prompt directly. False means the
+    /// row's action can only deep-link into System Settings and wait for the
+    /// user, which is what the UI renders it as.
+    ///
+    /// Fixed per row for the TCC permissions, but not a capability in general:
+    /// the unattended sync helper reports it per observation, and it is false
+    /// only while macOS holds the registration pending approval in Login Items.
+    /// Read it as "is System Settings where the user finishes this, right now".
     pub can_request_programmatically: bool,
     /// Current permission status.
     pub status: PermissionStatus,

--- a/apps/native/src-tauri/src/state/permissions_state.rs
+++ b/apps/native/src-tauri/src/state/permissions_state.rs
@@ -8,7 +8,7 @@
 use tauri::{AppHandle, Manager, Runtime};
 
 use crate::observable::Observable;
-use crate::shared_types::PermissionsState;
+use crate::shared_types::{Permission, PermissionsState};
 use crate::system::permissions;
 
 pub const PERMISSIONS_CHANGED_EVENT: &str = "permissions_changed";
@@ -28,8 +28,38 @@ pub fn get<R: Runtime>(app: &AppHandle<R>) -> Option<PermissionsState> {
 /// Probe all permissions and record the result; the cell write emits
 /// `permissions_changed`.
 pub fn refresh<R: Runtime>(app: &AppHandle<R>) -> PermissionsState {
-    let state = permissions::check_all_permissions();
+    let state = permissions::check_all_permissions(app);
     let observable = app.state::<Observable<Option<PermissionsState>>>();
     *observable.write_sync() = Some(state.clone());
     state
+}
+
+/// Replace one permission's row in the last-known state and re-emit.
+///
+/// The convergence loop cannot use [`refresh`] to publish: that re-probes every
+/// permission, and its helper row runs a *second* reconciliation of its own. So
+/// the loop reconciles once, turns that report into a row, and drops it in here.
+///
+/// Does nothing when nothing has been probed yet — startup reconciles before any
+/// full probe has run, and inventing the other five rows here would be worse than
+/// waiting for the panel's own refresh.
+pub fn replace_row<R: Runtime>(app: &AppHandle<R>, row: Permission) {
+    // A build with the permission skip on reports every row Granted, and the
+    // onboarding gate depends on that fiction. A real helper row dropped in here
+    // would flip `all_required_granted` back to false and close the gate the
+    // flag exists to open.
+    if permissions::skip_enabled() {
+        return;
+    }
+    let observable = app.state::<Observable<Option<PermissionsState>>>();
+    let mut cell = observable.write_sync();
+    let Some(state) = cell.as_mut() else { return };
+    let Some(slot) = state.permissions.iter_mut().find(|p| p.id == row.id) else {
+        return;
+    };
+    *slot = row;
+    state.all_required_granted = state
+        .permissions
+        .iter()
+        .all(|p| !p.required || p.status == crate::shared_types::PermissionStatus::Granted);
 }

--- a/apps/native/src-tauri/src/system/permissions.rs
+++ b/apps/native/src-tauri/src/system/permissions.rs
@@ -10,12 +10,15 @@
 //! - App Management - recommended so activation can update managed apps
 //! - Administrator privileges (sudo access)
 
+use crate::privileged_helper::reconcile::Reconciled;
 pub(crate) use crate::shared_types::{Permission, PermissionStatus, PermissionsState};
+use crate::system::helper_permission;
 use anyhow::Result;
 use log::{debug, info, warn};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use tauri::{AppHandle, Runtime};
 
 impl Default for PermissionsState {
     fn default() -> Self {
@@ -82,6 +85,9 @@ fn get_default_permissions() -> Vec<Permission> {
         privileged_helper_permission(
             default_status,
             "Enable this once per device to allow nixmac to activate already-built system generations unattended.",
+            // No report yet, so nothing says macOS is waiting on the user. Every
+            // path that has one replaces this row whole (`helper_row`).
+            true,
         ),
     ]
 }
@@ -104,6 +110,11 @@ fn e2e_skip_permissions_enabled() -> bool {
 #[cfg(not(debug_assertions))]
 fn vite_skip_permissions_enabled() -> bool {
     false
+}
+
+/// Whether this build reports every permission granted without probing.
+pub(crate) fn skip_enabled() -> bool {
+    skip_permissions_enabled()
 }
 
 fn skip_permissions_enabled() -> bool {
@@ -140,7 +151,11 @@ fn granted_folder_permission(id: &str, name: &str, description: &str) -> Permiss
     }
 }
 
-fn privileged_helper_permission(status: PermissionStatus, instructions: &str) -> Permission {
+fn privileged_helper_permission(
+    status: PermissionStatus,
+    instructions: &str,
+    can_request_programmatically: bool,
+) -> Permission {
     Permission {
         id: "privileged-helper".to_string(),
         name: "Unattended Sync Helper".to_string(),
@@ -148,7 +163,7 @@ fn privileged_helper_permission(status: PermissionStatus, instructions: &str) ->
             "Required for unattended device sync to activate builds without a password prompt"
                 .to_string(),
         required: true,
-        can_request_programmatically: true,
+        can_request_programmatically,
         status,
         instructions: Some(instructions.to_string()),
     }
@@ -374,8 +389,12 @@ fn check_admin_privileges() -> PermissionStatus {
     }
 }
 
-/// Check all permissions and return the current state
-pub fn check_all_permissions() -> PermissionsState {
+/// Check all permissions and return the current state.
+///
+/// The helper row is one run of the reconciliation function, which is also how
+/// a routine refresh converges the installed helper on this build. It must not
+/// run on the main thread — see [`helper_permission::observe`].
+pub fn check_all_permissions<R: Runtime>(app: &AppHandle<R>) -> PermissionsState {
     // Debug/test environments may not have TCC permissions granted and cannot
     // obtain them programmatically, so the skip flags satisfy the whole gate.
     if skip_permissions_enabled() {
@@ -388,43 +407,43 @@ pub fn check_all_permissions() -> PermissionsState {
 
     // Fill in each permission status and update all_required_granted on the fly
     for perm in &mut permissions {
-        perm.status = match perm.id.as_str() {
-            "desktop" => check_desktop_access(),
-            "documents" => check_documents_access(),
-            "admin" => check_admin_privileges(),
-            "full-disk" => {
-                let (status, detail) = check_full_disk_access();
-                // Keep the default "how to grant it" text unless the probe has
-                // something more accurate to say.
-                if let Some(detail) = detail {
-                    perm.instructions = Some(detail);
+        // The helper row is the one row a report produces whole — its status, the
+        // sentence that tells the user what is true, and whether nixmac can still
+        // get anywhere on its own — so it is replaced rather than patched field by
+        // field, and `helper_row` stays the only place a report becomes a row.
+        if perm.id == "privileged-helper" {
+            *perm = helper_row(&check_privileged_helper(app));
+        } else {
+            perm.status = match perm.id.as_str() {
+                "desktop" => check_desktop_access(),
+                "documents" => check_documents_access(),
+                "admin" => check_admin_privileges(),
+                "full-disk" => {
+                    let (status, detail) = check_full_disk_access();
+                    // Keep the default "how to grant it" text unless the probe
+                    // has something more accurate to say.
+                    if let Some(detail) = detail {
+                        perm.instructions = Some(detail);
+                    }
+                    // A probe that could not decide must not keep the gate shut
+                    // — the same reasoning that makes app-management Recommended
+                    // rather than Required (see `app_management_permission`),
+                    // except discovered at runtime. Requiring access we cannot
+                    // verify shows a permissions banner to users who may well
+                    // have granted it. Only this row relaxes: every other
+                    // `Unknown` still blocks.
+                    if status == PermissionStatus::Unknown {
+                        perm.required = false;
+                    }
+                    status
                 }
-                // A probe that could not decide must not keep the gate shut —
-                // the same reasoning that makes app-management Recommended
-                // rather than Required (see `app_management_permission`), except
-                // discovered at runtime. Requiring access we cannot verify shows
-                // a permissions banner to users who may well have granted it.
-                // Only this row relaxes: every other `Unknown` still blocks.
-                if status == PermissionStatus::Unknown {
-                    perm.required = false;
+                "app-management" => check_app_management(),
+                other => {
+                    debug_assert!(false, "no probe for permission id {other:?}");
+                    PermissionStatus::Unknown
                 }
-                status
-            }
-            "app-management" => check_app_management(),
-            "privileged-helper" => {
-                let (status, detail) = check_privileged_helper();
-                // Keep the default instructions when healthy; surface what is
-                // actually wrong otherwise.
-                if let Some(detail) = detail {
-                    perm.instructions = Some(detail);
-                }
-                status
-            }
-            other => {
-                debug_assert!(false, "no probe for permission id {other:?}");
-                PermissionStatus::Unknown
-            }
-        };
+            };
+        }
 
         // If this permission is required and not granted, mark all_required_granted as false
         if perm.required && perm.status != PermissionStatus::Granted {
@@ -456,7 +475,10 @@ pub fn check_all_permissions() -> PermissionsState {
 /// Request a specific permission
 /// For programmatic permissions (desktop, documents), this triggers the OS prompt
 /// For manual permissions (FDA, admin), this returns instructions
-pub fn request_permission(permission_id: &str) -> Result<Permission> {
+pub fn request_permission<R: Runtime>(
+    app: &AppHandle<R>,
+    permission_id: &str,
+) -> Result<Permission> {
     info!("Requesting permission: {}", permission_id);
 
     match permission_id {
@@ -595,196 +617,44 @@ pub fn request_permission(permission_id: &str) -> Result<Permission> {
 
             Ok(app_management_permission(check_app_management()))
         }
-        "privileged-helper" => {
-            // SMAppService registration requires the helper binary and its
-            // LaunchDaemon plist to be embedded inside the .app bundle
-            // (Contents/MacOS/nixmac-helper and
-            // Contents/Library/LaunchDaemons/com.darkmatter.nixmac.helper.plist).
-            // Those assets are only staged by `bun run desktop:build[:local]`
-            // (externalBin in package.json). Under `tauri dev` the app runs as
-            // a bare binary from target/debug with no bundle, so
-            // registerAndReturnError: fails with an opaque "Operation not
-            // permitted". Detect that up front and surface a clear Pending
-            // state instead of propagating the OS error to the UI.
-            let install = crate::system::install_location::check_install_location();
-
-            const APPROVE_INSTRUCTIONS: &str = "Approve nixmac in System Settings → General → Login Items & Extensions if macOS asks for background item approval.";
-
-            let (status, instructions) = if install.bundle_path.is_none() {
-                warn!(
-                    "privileged helper registration skipped: nixmac is not running from a .app bundle"
-                );
-                (
-                    PermissionStatus::Pending,
-                    "Build a signed .app with `bun run desktop:build:local`, drag it into /Applications, and launch it from there to install the unattended sync helper. It cannot be installed from a dev build."
-                        .to_string(),
-                )
-            } else if cfg!(debug_assertions) && !install.in_applications_dir {
-                // Debug builds run out of the build tree, never /Applications.
-                // Registering from there would pin the LaunchDaemon to that
-                // bundle path, so only connect to a helper that an
-                // /Applications install already registered. Release builds
-                // keep the normal register flow regardless of location.
-                warn!(
-                    "privileged helper registration skipped: nixmac is running outside /Applications"
-                );
-                let (status, detail) = probe_installed_helper();
-                (
-                    status,
-                    detail.unwrap_or_else(|| APPROVE_INSTRUCTIONS.to_string()),
-                )
-            } else {
-                match crate::privileged_helper::service::register() {
-                    // Registration alone is not a working helper: wait briefly
-                    // for the freshly launched daemon to answer a status
-                    // round-trip before reporting Granted.
-                    Ok(status) if status.authorized => match await_helper_ready() {
-                        Ok(()) => (PermissionStatus::Granted, APPROVE_INSTRUCTIONS.to_string()),
-                        Err(error) => (
-                            PermissionStatus::Pending,
-                            format!(
-                                "The helper is registered but did not answer a status probe: {error:#}."
-                            ),
-                        ),
-                    },
-                    Ok(_) => {
-                        crate::privileged_helper::service::open_login_items_settings();
-                        (PermissionStatus::Pending, APPROVE_INSTRUCTIONS.to_string())
-                    }
-                    Err(error) => {
-                        warn!("privileged helper registration failed: {error:#}");
-                        crate::privileged_helper::service::open_login_items_settings();
-                        (PermissionStatus::Pending, APPROVE_INSTRUCTIONS.to_string())
-                    }
-                }
-            };
-            Ok(privileged_helper_permission(status, &instructions))
-        }
+        // Grant: record the decision, then reconcile under it. First-time
+        // registration and repairing a half-finished one are the same step, and
+        // the write is idempotent. Grant is the only action that may open Login
+        // Items; `darwin.helperGrant` is this same action.
+        "privileged-helper" => Ok(helper_row(&helper_permission::grant(app))),
         _ => Err(anyhow::anyhow!("Unknown permission: {}", permission_id)),
     }
 }
 
-/// Wait for a freshly registered helper daemon to come up and answer a
-/// status round-trip. launchd starts it asynchronously after approval, so the
-/// socket appears a moment after `register()` returns.
-fn await_helper_ready() -> Result<()> {
-    const ATTEMPTS: u32 = 10;
-    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
-
-    let mut last_error = anyhow::anyhow!("helper socket never appeared");
-    for attempt in 0..ATTEMPTS {
-        if attempt > 0 {
-            std::thread::sleep(RETRY_DELAY);
-        }
-        if !crate::privileged_helper::client::socket_available() {
-            continue;
-        }
-        match crate::privileged_helper::client::status() {
-            Ok(response) if response.ok => return Ok(()),
-            Ok(response) => {
-                last_error = anyhow::anyhow!(
-                    response
-                        .error
-                        .unwrap_or_else(|| "helper returned an error".to_string())
-                );
-            }
-            Err(error) => last_error = error,
-        }
-    }
-    Err(last_error)
-}
-
-/// One authenticated status round-trip to an already-installed helper
-/// daemon, bypassing SMAppService entirely. Used when the app is not running
-/// from /Applications: it must never install the helper from there (the
-/// LaunchDaemon would point at the wrong bundle path), but if a signed
-/// /Applications copy already installed one, mutual code-signature
-/// validation is what decides whether this copy may use it.
-fn probe_installed_helper() -> (PermissionStatus, Option<String>) {
-    const INSTALL_FROM_APPLICATIONS: &str = "nixmac is not running from /Applications, so it cannot install the unattended sync helper itself. Install it by launching a signed nixmac from /Applications; a correctly signed copy running elsewhere can then connect to it.";
-
-    if !crate::privileged_helper::client::socket_available() {
-        return (
-            PermissionStatus::Pending,
-            Some(INSTALL_FROM_APPLICATIONS.to_string()),
-        );
-    }
-    match crate::privileged_helper::client::status() {
-        Ok(response) if response.ok => (PermissionStatus::Granted, None),
-        Ok(response) => (
-            PermissionStatus::Pending,
-            Some(format!(
-                "The helper is running but refused this app: {}. {INSTALL_FROM_APPLICATIONS}",
-                response
-                    .error
-                    .unwrap_or_else(|| "unknown error".to_string())
-            )),
-        ),
-        Err(error) => (
-            PermissionStatus::Pending,
-            Some(format!(
-                "The helper did not answer a status probe: {error:#}. {INSTALL_FROM_APPLICATIONS}"
-            )),
-        ),
-    }
-}
-
-/// Status of the unattended sync helper, with a detail message when it is
-/// not fully working.
+/// Status of the unattended sync helper: one run of the reconciliation
+/// function, as a permission row.
 ///
-/// `SMAppService` registration alone is not proof of a working helper: the
-/// approval persists in the BackgroundTaskManagement database even after the
-/// helper binary is gone or replaced. Granted therefore additionally requires
-/// a live status round-trip through the socket, which also exercises both
-/// code-signature checks (client validates the daemon, daemon validates this
-/// client).
-fn check_privileged_helper() -> (PermissionStatus, Option<String>) {
-    // Debug builds run outside /Applications (bare dev binaries or a locally
-    // built .app), where SMAppService describes this bundle copy rather than
-    // the daemon that an /Applications install registered. Skip it there and
-    // rely on the authenticated socket round-trip alone: a correctly signed
-    // copy can talk to an installed helper from anywhere. Release builds
-    // always go through the full SMAppService check below.
-    if cfg!(debug_assertions)
-        && !crate::system::install_location::check_install_location().in_applications_dir
-    {
-        return probe_installed_helper();
-    }
+/// Only a helper of this build answering an authenticated `Status` is granted.
+/// An `SMAppService` registration alone proves nothing — the approval outlives
+/// the binary it was granted for — and neither does a socket. Everything else is
+/// a report, and the report is what tells the user what to do: approve in Login
+/// Items, move the app to /Applications, restart the app, or wait out a running
+/// activation.
+fn check_privileged_helper<R: Runtime>(app: &AppHandle<R>) -> Reconciled {
+    let report = helper_permission::observe(app);
+    // A refresh is how a user comes back to this — opening the panel, or
+    // pressing Check again — and one run is usually not enough: the platform
+    // refuses a register for about a second after any unregister, so the run
+    // that repairs a helper typically reports a failure and needs a successor.
+    // Starting the loop here means the visit converges instead of handing back a
+    // scary report. A loop already running ignores this.
+    helper_permission::start_converging(app);
+    report
+}
 
-    let status = crate::privileged_helper::service::status();
-    if !status.available {
-        return (PermissionStatus::Unknown, status.detail);
-    }
-    if !status.authorized {
-        return (PermissionStatus::Pending, None);
-    }
-    if !status.socket_available {
-        return (
-            PermissionStatus::Pending,
-            Some(
-                "The helper is approved in Login Items, but its daemon is not running (no socket). Use Grant to re-register it, or toggle nixmac off and on in System Settings → General → Login Items & Extensions."
-                    .to_string(),
-            ),
-        );
-    }
-    match crate::privileged_helper::client::status() {
-        Ok(response) if response.ok => (PermissionStatus::Granted, None),
-        Ok(response) => (
-            PermissionStatus::Pending,
-            Some(format!(
-                "The helper is running but refused this app: {}. Unattended sync will fall back to password prompts until a matching signed build talks to it.",
-                response
-                    .error
-                    .unwrap_or_else(|| "unknown error".to_string())
-            )),
-        ),
-        Err(error) => (
-            PermissionStatus::Pending,
-            Some(format!(
-                "The helper is registered but did not answer a status probe: {error:#}."
-            )),
-        ),
-    }
+/// One report as the permission row it produces.
+pub(crate) fn helper_row(report: &Reconciled) -> Permission {
+    let (status, detail) = helper_permission::row(report);
+    privileged_helper_permission(
+        status,
+        &detail,
+        helper_permission::can_request_programmatically(report),
+    )
 }
 
 /// Best-effort App Management status.
@@ -801,6 +671,29 @@ fn check_app_management() -> PermissionStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::privileged_helper::reconcile::Reconciled;
+
+    /// The row a report produces has to carry the report's own answer to "is
+    /// System Settings where the user finishes this", or the panel offers the
+    /// wrong action: an approval waiting in Login Items would get a button that
+    /// hands the helper back instead of one that opens the pane. Asserted through
+    /// `helper_row` rather than on the predicate alone, because the wiring between
+    /// them is what the UI actually reads and nothing else pins it.
+    #[test]
+    fn the_row_takes_its_deep_link_from_the_report() {
+        assert!(!helper_row(&Reconciled::PendingApproval).can_request_programmatically);
+        assert!(helper_row(&Reconciled::AtThisBuild).can_request_programmatically);
+        assert!(helper_row(&Reconciled::NoHelper).can_request_programmatically);
+    }
+
+    /// A bare app handle. The skip flags below short-circuit before anything
+    /// reads app state, which is what keeps these tests from probing the real
+    /// helper.
+    fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
+        tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds")
+    }
 
     #[cfg(debug_assertions)]
     #[test]
@@ -943,7 +836,8 @@ mod tests {
         unsafe { std::env::remove_var("NIXMAC_SKIP_PERMISSIONS") };
         unsafe { std::env::set_var("VITE_NIXMAC_SKIP_PERMISSIONS", "true") };
 
-        let state = check_all_permissions();
+        let app = mock_app();
+        let state = check_all_permissions(app.handle());
 
         assert!(state.all_required_granted);
         assert!(
@@ -966,7 +860,8 @@ mod tests {
         unsafe { std::env::set_var("NIXMAC_SKIP_PERMISSIONS", "true") };
         unsafe { std::env::remove_var("VITE_NIXMAC_SKIP_PERMISSIONS") };
 
-        let state = check_all_permissions();
+        let app = mock_app();
+        let state = check_all_permissions(app.handle());
 
         assert!(state.all_required_granted);
         assert!(

--- a/apps/native/src/components/widget/permissions/permissions-panel.test.tsx
+++ b/apps/native/src/components/widget/permissions/permissions-panel.test.tsx
@@ -1,0 +1,348 @@
+import type { Permission, PermissionStatus } from "@/ipc/types";
+import { HELPER_PERMISSION_ID } from "@/lib/permissions";
+import { APPROVE_IN_LOGIN_ITEMS } from "@/utils/test-fixtures";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The helper row is the one permission nixmac installs rather than asks macOS
+ * for, so it is the one row that can hand it back — as one button, a toggle of
+ * the standing decision. Everything else the row shows comes from the backend's
+ * reconciliation report: the status decides whether "Granted" is shown, and
+ * `instructions` is the sentence.
+ */
+
+const mockRefresh = vi.fn();
+const mockRequest = vi.fn();
+const mockDisableHelper = vi.fn();
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    permissions: {
+      refresh: (...args: unknown[]) => mockRefresh(...args),
+      request: (...args: unknown[]) => mockRequest(...args),
+      requestFullDiskAccess: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/orpc", () => ({
+  client: {
+    darwin: {
+      helperDisable: (...args: unknown[]) => mockDisableHelper(...args),
+    },
+    permissions: {
+      refresh: (...args: unknown[]) => mockRefresh(...args),
+    },
+  },
+  orpc: {
+    system: {
+      installLocation: {
+        queryOptions: () => ({
+          queryKey: ["installLocation"],
+          queryFn: async () => ({ bundlePath: null, inApplicationsDir: false }),
+        }),
+      },
+    },
+  },
+}));
+
+const permissionsState = vi.fn();
+const helperPreference = vi.fn();
+vi.mock("@nixmac/state", () => ({
+  useViewModel: (select: (state: { permissions: unknown; preferences: unknown }) => unknown) =>
+    select({
+      permissions: permissionsState(),
+      preferences: { helperPreference: helperPreference() },
+    }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: { bundlePath: null, inApplicationsDir: false } }),
+}));
+
+function helperPermission(overrides: Partial<Permission>) {
+  return {
+    id: HELPER_PERMISSION_ID,
+    name: "Unattended Sync Helper",
+    description: "Required for unattended device sync",
+    required: true,
+    canRequestProgrammatically: true,
+    status: "pending",
+    instructions: "a report",
+    ...overrides,
+  };
+}
+
+function helperRow(status: PermissionStatus, instructions: string, ...others: unknown[]) {
+  return {
+    permissions: [helperPermission({ status, instructions }), ...others],
+    allRequiredGranted: status === "granted",
+    checkedAt: null,
+  };
+}
+
+/**
+ * The row the backend sends while macOS holds the registration pending approval
+ * in Login Items: the sentence names the pane, and `canRequestProgrammatically`
+ * is false because no run nixmac makes can finish it — only the user can.
+ */
+function awaitingApprovalRow() {
+  return {
+    permissions: [
+      helperPermission({
+        instructions: APPROVE_IN_LOGIN_ITEMS,
+        canRequestProgrammatically: false,
+      }),
+    ],
+    allRequiredGranted: false,
+    checkedAt: null,
+  };
+}
+
+/**
+ * A second row, to check that one row's action leaves the other's alone.
+ *
+ * `admin` specifically: its grant takes `handleGrant`'s plain
+ * `permissions.request` branch, so the mocked request is what holds the action in
+ * flight. The `full-disk` and `app-management` branches wait out a `setTimeout`
+ * of their own, which would settle the row after the test body and take its
+ * running label with it.
+ */
+const adminRow = {
+  id: "admin",
+  name: "Administrator Privileges",
+  description: "Required to install system packages and modify system configurations",
+  required: true,
+  canRequestProgrammatically: false,
+  status: "pending",
+  instructions: "You will be prompted for your password when needed",
+};
+
+async function panel() {
+  const { PermissionsPanel } = await import("./permissions-panel");
+  const rendered = render(<PermissionsPanel />);
+  // The store is mocked as a bare selector call, so nothing re-renders on its
+  // own when a mocked value changes: a test that flips one mid-flight has to ask
+  // for the render itself, or it asserts against the pre-flip markup.
+  return { ...rendered, repaint: () => rendered.rerender(<PermissionsPanel />) };
+}
+
+describe("PermissionsPanel — the unattended sync helper row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefresh.mockResolvedValue(undefined);
+    helperPreference.mockReturnValue("unset");
+  });
+
+  it("offers Enable, and only Enable, while no helper is wanted", async () => {
+    for (const preference of ["unset", "disabled"]) {
+      helperPreference.mockReturnValue(preference);
+      permissionsState.mockReturnValue(
+        helperRow("pending", "The unattended sync helper is not installed."),
+      );
+
+      const { unmount } = await panel();
+
+      expect(screen.getByRole("button", { name: "Enable" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+      unmount();
+    }
+  });
+
+  it("offers Disable in every state the helper is wanted in, granted or not", async () => {
+    // A row that is not granted is still one nixmac keeps reconciling towards on
+    // its own, so the only thing left for the user to decide is whether they
+    // still want it — and offering Disable only on a granted row would leave a
+    // helper this build cannot use with no way out but Enable, which records the
+    // opposite. The reports that want the user to act say so in `instructions`.
+    // The one exception is approval pending, which has its own test below.
+    helperPreference.mockReturnValue("granted");
+    for (const status of ["granted", "pending", "denied", "unknown"] as const) {
+      permissionsState.mockReturnValue(helperRow(status, "a report"));
+
+      const { unmount } = await panel();
+
+      expect(screen.getByRole("button", { name: "Disable" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+      unmount();
+    }
+  });
+
+  it("offers the Login Items deep link, not Disable, while approval is pending", async () => {
+    // macOS is holding the registration and nothing nixmac does next makes that
+    // go, so the row offers the same "Open Settings" action as the other rows
+    // that send the user into System Settings — the pane the sentence names,
+    // which is where macOS asks for the approval. Disable would be answering a
+    // question the user has not been asked yet, and Enable would run a
+    // reconciliation that can only report the same thing again.
+    for (const preference of ["unset", "granted"]) {
+      helperPreference.mockReturnValue(preference);
+      permissionsState.mockReturnValue(awaitingApprovalRow());
+
+      const { unmount } = await panel();
+
+      expect(screen.getByRole("button", { name: /Open Settings/ })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+      expect(screen.getByText(APPROVE_IN_LOGIN_ITEMS)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it("opens Login Items through the same grant action the row always used", async () => {
+    // The deep link is not a new backend call: it is `permissions.request` for
+    // this row, which records the decision and reconciles, and is the only action
+    // allowed to open Login Items. In this state it opens them before it
+    // reconciles at all — the registration is already waiting for approval, so
+    // the pane does not depend on what the run goes on to report.
+    helperPreference.mockReturnValue("granted");
+    permissionsState.mockReturnValue(awaitingApprovalRow());
+    mockRequest.mockResolvedValue({ id: HELPER_PERMISSION_ID, status: "pending" });
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: /Open Settings/ }));
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(HELPER_PERMISSION_ID);
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+    expect(mockDisableHelper).not.toHaveBeenCalled();
+  });
+
+  it("offers Disable on a granted row whose decision was never recorded", async () => {
+    // An adopted registration: the reconciliation run records `granted` before
+    // it reports, so this is the window before the mirrored preference catches
+    // up. A granted row must never offer to enable what is already enabled.
+    helperPreference.mockReturnValue("unset");
+    permissionsState.mockReturnValue(helperRow("granted", "installed and answering"));
+
+    await panel();
+
+    expect(screen.getByRole("button", { name: "Disable" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+  });
+
+  it("renders every report the backend can send for a row that is not granted", async () => {
+    // The vocabulary: move the app, restart it, wait out a running activation
+    // (with and without the activation's details), and plain failures. Each
+    // arrives as the row's instructions and is shown verbatim — the UI never
+    // re-words a report. All of them are reachable with the helper wanted,
+    // which is what this row is. Approval pending comes with a row of its own
+    // and is asserted in the Login Items test above. The sentences mirror the
+    // backend's `helper_permission::describe` vocabulary.
+    helperPreference.mockReturnValue("granted");
+    for (const report of [
+      "nixmac runs from /Volumes/nixmac/nixmac.app — move it to /Applications.",
+      "this app was replaced while running (build a is running, b is installed) — restart nixmac.",
+      "nixmac is waiting for a running activation to finish before updating the unattended sync helper (/nix/store/abc/activate submitted by the sync agent).",
+      "nixmac is waiting for a running activation to finish before updating the unattended sync helper.",
+      "the helper could not be unregistered: SMAppService 1 refused.",
+    ]) {
+      permissionsState.mockReturnValue(helperRow("pending", report));
+
+      const { unmount } = await panel();
+
+      expect(screen.getByText(report)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it("keeps the clicked action's button until it finishes", async () => {
+    // Both actions record the decision before the run they start, so the
+    // preference this row picks its button from flips while the run is still
+    // going. The button must not: an Enable click that turned into "Disable"
+    // mid-run would offer to undo an action still in flight, and the row would
+    // be labelling the opposite of what was asked.
+    helperPreference.mockReturnValue("unset");
+    permissionsState.mockReturnValue(helperRow("pending", "a report"));
+    let finishGrant: () => void = () => {};
+    mockRequest.mockReturnValue(
+      new Promise((resolve) => {
+        finishGrant = () => resolve({ id: HELPER_PERMISSION_ID, status: "pending" });
+      }),
+    );
+
+    const { getByRole, repaint } = await panel();
+    fireEvent.click(getByRole("button", { name: "Enable" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    });
+    // The decision the click recorded, now mirrored back mid-run.
+    helperPreference.mockReturnValue("granted");
+    repaint();
+
+    expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+
+    finishGrant();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /Enabling/ })).toBeNull();
+    });
+  });
+
+  it("leaves another row's in-flight button alone", async () => {
+    // The in-flight action is keyed by row for this: only the row that owns an
+    // action is disabled, so a click on any other row is expected at any moment.
+    // With one slot for the whole panel it would evict this row's, and the row
+    // would fall back to the decision its own running Enable already recorded —
+    // offering to disable a helper it is still enabling.
+    helperPreference.mockReturnValue("unset");
+    permissionsState.mockReturnValue(helperRow("pending", "a report", adminRow));
+    mockRequest.mockReturnValue(new Promise(() => {}));
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: "Enable" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    });
+    helperPreference.mockReturnValue("granted");
+    // No `repaint` needed: this click starts the second row's action, and that
+    // state change is the render which reads the flipped preference back.
+    fireEvent.click(getByRole("button", { name: /Open Settings/ }));
+
+    expect(screen.getByRole("button", { name: /Enabling/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+    // And the row that was clicked second reports its own action, not the first.
+    expect(screen.getByRole("button", { name: /Waiting/ })).toBeTruthy();
+  });
+
+  it("keeps the label rendered while the action runs, and says the running word", async () => {
+    // What fixes the button's width is that the idle label stays in the layout,
+    // hidden, with the spinner over it. jsdom has no layout, so what is asserted
+    // here is the testable half — the label is still rendered, and the running
+    // word is the accessible name meanwhile, so the button is never nameless
+    // while its label is hidden.
+    helperPreference.mockReturnValue("granted");
+    permissionsState.mockReturnValue(helperRow("granted", "installed and answering"));
+    mockDisableHelper.mockReturnValue(new Promise(() => {}));
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: "Disable" }));
+
+    const running = await waitFor(() => screen.getByRole("button", { name: "Disabling…" }));
+    expect(screen.getByText("Disable")).toBeTruthy();
+    // The running label and `disabled` come from the same input, so a button
+    // that says it is working cannot still be taking clicks.
+    expect(running).toBeDisabled();
+  });
+
+  it("disabling reports what the run did and re-probes", async () => {
+    permissionsState.mockReturnValue(helperRow("granted", "installed and answering"));
+    mockDisableHelper.mockResolvedValue({
+      atThisBuild: false,
+      detail: "The unattended sync helper is disabled and has been removed.",
+    });
+
+    const { getByRole } = await panel();
+    fireEvent.click(getByRole("button", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(mockDisableHelper).toHaveBeenCalledTimes(1);
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+    expect(screen.getByText("The unattended sync helper is disabled and has been removed.")).toBeTruthy();
+  });
+});

--- a/apps/native/src/components/widget/permissions/permissions-panel.tsx
+++ b/apps/native/src/components/widget/permissions/permissions-panel.tsx
@@ -3,12 +3,76 @@
 import { Button } from "@/components/ui/button";
 import { tauriAPI } from "@/ipc/api";
 import type { Permission } from "@/ipc/types";
-import { orpc } from "@/lib/orpc";
+import { client, orpc } from "@/lib/orpc";
+import { HELPER_PERMISSION_ID } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
 import { useViewModel } from "@nixmac/state";
 import { useQuery } from "@tanstack/react-query";
 import { AppWindow, Check, ExternalLink, Folder, HardDrive, KeyRound, Loader2, ShieldCheck, Terminal } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type ComponentProps, type ReactNode, useEffect, useState } from "react";
+
+type ActionButtonProps = {
+  idle: ReactNode;
+  busy: string;
+  isBusy: boolean;
+  variant?: ComponentProps<typeof Button>["variant"];
+  onClick: () => void;
+};
+
+/**
+ * One row's action button. `isBusy` drives both the running label and
+ * `disabled`, so the two cannot disagree.
+ *
+ * The idle label keeps its box and the spinner is laid over it: swapping
+ * content would resize the button, and the design-system Button animates every
+ * resize. The spinner stays solid because here `disabled` means "running", and
+ * the base's pointer-events rule is what refuses the click. `aria-label`
+ * carries the running word while the label is hidden.
+ */
+function ActionButton({ idle, busy, isBusy, variant, onClick }: ActionButtonProps) {
+  return (
+    <Button
+      size="sm"
+      variant={variant}
+      onClick={onClick}
+      disabled={isBusy}
+      aria-label={isBusy ? busy : undefined}
+      aria-busy={isBusy}
+      className="relative disabled:opacity-100"
+    >
+      <span className={cn("inline-flex items-center gap-1.5", isBusy && "invisible")}>{idle}</span>
+      {isBusy ? (
+        <span className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        </span>
+      ) : null}
+    </Button>
+  );
+}
+
+/**
+ * What one row's grant button says. A row nixmac cannot advance on its own
+ * can only deep-link into System Settings; the helper is installed by nixmac
+ * rather than requested from macOS, hence "Enable".
+ */
+function grantLabel(perm: Permission): Pick<ActionButtonProps, "idle" | "busy" | "variant"> {
+  if (!perm.canRequestProgrammatically) {
+    return {
+      idle: (
+        <>
+          Open Settings
+          <ExternalLink className="size-3.5" aria-hidden="true" />
+        </>
+      ),
+      busy: "Waiting…",
+      variant: "secondary",
+    };
+  }
+  if (perm.id === HELPER_PERMISSION_ID) {
+    return { idle: "Enable", busy: "Enabling…" };
+  }
+  return { idle: "Request", busy: "Requesting…" };
+}
 
 /**
  * The macOS permission list: status rows plus grant/request actions. Real
@@ -19,8 +83,30 @@ import { useEffect, useState } from "react";
  */
 export function PermissionsPanel() {
   const permissionsState = useViewModel((s) => s.permissions);
-  const [requesting, setRequesting] = useState<string | null>(null);
+  // The standing helper decision picks the helper row's action. Both actions
+  // record the decision before their run finishes, so an action in flight pins
+  // its button rather than re-deriving it from here.
+  const helperPreference = useViewModel((s) => s.preferences?.helperPreference ?? null);
+  // The action in flight, per row. Per row because only the row that owns an
+  // action is disabled; a single panel-wide slot would let a click on one row
+  // evict another's entry while its action still runs.
+  const [requesting, setRequesting] = useState<ReadonlyMap<string, "grant" | "disable">>(
+    () => new Map(),
+  );
   const [notice, setNotice] = useState<{ tone: "info" | "error"; message: string } | null>(null);
+
+  // Updater form: two rows can start or settle in the same tick.
+  function startAction(id: string, action: "grant" | "disable") {
+    setRequesting((inFlight) => new Map(inFlight).set(id, action));
+  }
+
+  function finishAction(id: string) {
+    setRequesting((inFlight) => {
+      const next = new Map(inFlight);
+      next.delete(id);
+      return next;
+    });
+  }
 
   // Refresh permissions when the panel mounts.
   useEffect(() => {
@@ -30,18 +116,16 @@ export function PermissionsPanel() {
     });
   }, []);
 
-  // Detect whether nixmac is running from /Applications. macOS TCC services
-  // (Full Disk Access especially) key off the bundle's location, so an app
-  // launched from the mounted DMG or a download folder will not match the TCC
-  // entry and grants silently fail. Only warn when we are actually inside a
-  // bundle but misplaced — `bundlePath` is null under `tauri dev` / tests, and
-  // we must not surface a false warning there.
+  // macOS TCC grants key off the bundle's location, so an app launched from
+  // the DMG or a download folder silently fails to match its grants. Warn only
+  // when actually inside a bundle but misplaced — `bundlePath` is null under
+  // `tauri dev` and tests.
   const { data: installLocation } = useQuery(orpc.system.installLocation.queryOptions());
   const showMisplacedWarning =
     installLocation?.bundlePath != null && !installLocation.inApplicationsDir;
 
   async function handleGrant(permission: Permission) {
-    setRequesting(permission.id);
+    startAction(permission.id, "grant");
     setNotice(null);
     try {
       if (permission.id === "full-disk") {
@@ -49,11 +133,9 @@ export function PermissionsPanel() {
         // Give the user a beat to grant access in System Settings, then re-probe.
         await new Promise((resolve) => setTimeout(resolve, 1000));
       } else if (permission.id === "app-management") {
-        // Opens System Settings → Privacy & Security → App Management. macOS
-        // can't grant this programmatically and exposes no probe, so we can
-        // only deep-link and let the user toggle it. Give them a beat, then
-        // re-probe; the backend will keep this row pending rather than report
-        // a false grant.
+        // macOS cannot grant this programmatically and exposes no probe, so
+        // deep-link, give the user a beat, then re-probe; the backend keeps
+        // the row pending rather than report a false grant.
         await tauriAPI.permissions.request(permission.id);
         setNotice({
           tone: "info",
@@ -61,18 +143,20 @@ export function PermissionsPanel() {
             "nixmac opened System Settings → Privacy & Security → App Management. Enable nixmac there, then return here. macOS does not let nixmac verify this permission, so this recommended row may remain pending.",
         });
         await new Promise((resolve) => setTimeout(resolve, 1000));
-      } else if (permission.id === "privileged-helper") {
-        // Registers the bundled SMAppService LaunchDaemon. macOS may require
-        // one-time approval in Login Items & Extensions before status is granted.
+      } else if (permission.id === HELPER_PERMISSION_ID) {
+        // The backend records the decision and reconciles; it may open Login
+        // Items when approval is pending. Show this run's report only when it
+        // differs from the row's sentence — otherwise every click while
+        // approval is pending prints the same sentence twice.
         const result = await tauriAPI.permissions.request(permission.id);
-        if (result.status !== "granted") {
+        if (result.status !== "granted" && result.instructions !== permission.instructions) {
           setNotice({
             tone: "info",
             message:
-              "nixmac opened Login Items & Extensions. Enable nixmac there, then return here and click Enable again if this row is still pending.",
+              result.instructions ??
+              "nixmac could not finish enabling the unattended sync helper.",
           });
         }
-        await new Promise((resolve) => setTimeout(resolve, 1500));
       } else {
         // deprecated(orpc): replace with client/orpc from @/lib/orpc
         await tauriAPI.permissions.request(permission.id);
@@ -86,7 +170,30 @@ export function PermissionsPanel() {
         message: `Permission request failed: ${error instanceof Error ? error.message : String(error)}`,
       });
     } finally {
-      setRequesting(null);
+      finishAction(permission.id);
+    }
+  }
+
+  /**
+   * The backend records the decision, waits out a running activation, and
+   * unregisters. Not offered while macOS holds the registration pending
+   * approval — that row deep-links to Login Items instead.
+   */
+  async function handleDisableHelper() {
+    startAction(HELPER_PERMISSION_ID, "disable");
+    setNotice(null);
+    try {
+      const report = await client.darwin.helperDisable();
+      setNotice({ tone: "info", message: report.detail });
+      await client.permissions.refresh();
+    } catch (error) {
+      console.error("Failed to disable the unattended sync helper:", error);
+      setNotice({
+        tone: "error",
+        message: `Disabling the unattended sync helper failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    } finally {
+      finishAction(HELPER_PERMISSION_ID);
     }
   }
 
@@ -124,8 +231,31 @@ export function PermissionsPanel() {
       <ul className="flex flex-col gap-3">
         {permissions.map((perm) => {
           const isGranted = perm.status === "granted";
-          const isRequesting = requesting === perm.id;
-          const canRequest = perm.canRequestProgrammatically;
+          const pendingAction = requesting.get(perm.id) ?? null;
+          const isGranting = pendingAction === "grant";
+          const isDisabling = pendingAction === "disable";
+          // The one action this row offers. The helper is the one permission
+          // nixmac installs rather than asks macOS for, so its row can hand it
+          // back — a toggle of the standing decision, not of the row's status.
+          // While macOS holds the registration pending approval the backend
+          // clears `canRequestProgrammatically` and the row deep-links to Login
+          // Items instead. An action in flight keeps its own button: it has
+          // already recorded the opposite decision.
+          const offersDisable =
+            perm.id === HELPER_PERMISSION_ID &&
+            perm.canRequestProgrammatically &&
+            (helperPreference === "granted" || isGranted);
+          const action: "grant" | "disable" | null =
+            pendingAction ?? (offersDisable ? "disable" : isGranted ? null : "grant");
+          // A fresh DOM node whenever the button changes shape: the
+          // design-system Button animates a reused one, cross-fading fill and
+          // width between shapes.
+          const buttonKey =
+            action === "disable"
+              ? "disable"
+              : perm.canRequestProgrammatically
+                ? "grant"
+                : "open-settings";
           const icon = (() => {
             if (isGranted) {
               return <ShieldCheck className="size-5" />;
@@ -141,7 +271,7 @@ export function PermissionsPanel() {
                 return <HardDrive className="size-5" />;
               case "app-management":
                 return <AppWindow className="size-5" />;
-              case "privileged-helper":
+              case HELPER_PERMISSION_ID:
                 return <KeyRound className="size-5" />;
               default:
                 return <Loader2 className="size-5 animate-spin" aria-hidden="true" />;
@@ -156,7 +286,7 @@ export function PermissionsPanel() {
                 isGranted ? "border-success/30" : "border-border",
               )}
             >
-              <div className="flex items-start gap-3">
+              <div className="flex min-w-0 flex-1 items-start gap-3">
                 <span
                   className={cn(
                     "mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg",
@@ -183,44 +313,41 @@ export function PermissionsPanel() {
                   <p className="mt-1 text-muted-foreground text-sm leading-relaxed">
                     {perm.description}
                   </p>
+                  {/* These sentences quote unbreakable `/nix/store/…` paths
+                      wider than the row, so they must be allowed to break
+                      anywhere. */}
                   {perm.instructions ? (
-                    <p className="mt-2 rounded-md border border-border bg-secondary/50 p-2 font-mono text-muted-foreground text-xs">
+                    <p className="mt-2 wrap-anywhere rounded-md border border-border bg-secondary/50 p-2 font-mono text-muted-foreground text-xs">
                       {perm.instructions}
                     </p>
                   ) : null}
                 </div>
               </div>
 
-              <div className="shrink-0 self-start sm:self-center">
+              <div className="flex shrink-0 flex-col items-end gap-1.5 self-end sm:self-center">
                 {isGranted ? (
                   <span className="inline-flex items-center gap-1.5 font-medium text-success text-sm">
                     <Check className="size-4" aria-hidden="true" />
                     Granted
                   </span>
-                ) : (
-                  <Button
-                    size="sm"
-                    variant={canRequest ? "default" : "secondary"}
+                ) : null}
+                {action === "disable" ? (
+                  <ActionButton
+                    key={buttonKey}
+                    idle="Disable"
+                    busy="Disabling…"
+                    isBusy={isDisabling}
+                    variant="ghost"
+                    onClick={handleDisableHelper}
+                  />
+                ) : action === "grant" ? (
+                  <ActionButton
+                    key={buttonKey}
+                    {...grantLabel(perm)}
+                    isBusy={isGranting}
                     onClick={() => handleGrant(perm)}
-                    disabled={isRequesting}
-                  >
-                    {isRequesting ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                        {canRequest ? "Requesting…" : "Waiting…"}
-                      </>
-                    ) : perm.id === "privileged-helper" ? (
-                      "Enable"
-                    ) : canRequest ? (
-                      "Request"
-                    ) : (
-                      <>
-                        Open Settings
-                        <ExternalLink className="size-3.5" aria-hidden="true" />
-                      </>
-                    )}
-                  </Button>
-                )}
+                  />
+                ) : null}
               </div>
             </li>
           );

--- a/apps/native/src/components/widget/repair/lib.test.ts
+++ b/apps/native/src/components/widget/repair/lib.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { makeGrantedPermissions } from "@/utils/test-fixtures";
+import {
+  APPROVE_IN_LOGIN_ITEMS,
+  makeGrantedPermissions,
+  makeHelperRow,
+} from "@/utils/test-fixtures";
 import { computeRepairPlan, type RepairInputs } from "./lib";
 
 function makeInputs(overrides: Partial<RepairInputs> = {}): RepairInputs {
@@ -9,6 +13,9 @@ function makeInputs(overrides: Partial<RepairInputs> = {}): RepairInputs {
     flakeExists: true,
     nixInstalled: true,
     permissions: makeGrantedPermissions(),
+    helperRow: null,
+    helperPreference: "unset",
+    helperGraceElapsed: false,
     skipPermissions: false,
     nixInstalledOverride: false,
     ...overrides,
@@ -82,6 +89,103 @@ describe("computeRepairPlan", () => {
     ]);
   });
 
+  it("says nothing about a helper the user never asked for", () => {
+    for (const helperPreference of ["unset", "disabled"] as const) {
+      const plan = computeRepairPlan(
+        makeInputs({
+          helperPreference,
+          helperRow: makeHelperRow(),
+          helperGraceElapsed: true,
+        }),
+      );
+      expect(plan.banners).toEqual([]);
+    }
+  });
+
+  it("says nothing about a helper that is answering", () => {
+    const plan = computeRepairPlan(
+      makeInputs({
+        helperPreference: "granted",
+        helperRow: makeHelperRow({ status: "granted" }),
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([]);
+  });
+
+  it("waits for the grace period before naming the helper", () => {
+    const plan = computeRepairPlan(
+      makeInputs({
+        helperPreference: "granted",
+        helperRow: makeHelperRow(),
+        helperGraceElapsed: false,
+      }),
+    );
+    expect(plan.banners).toEqual([]);
+  });
+
+  it("banners the wanted-but-silent helper with the row's own sentence", () => {
+    const plan = computeRepairPlan(
+      makeInputs({
+        helperPreference: "granted",
+        helperRow: makeHelperRow(),
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
+  it("leaves the helper out of the revoked-permissions list", () => {
+    const helperRow = makeHelperRow();
+    const plan = computeRepairPlan(
+      makeInputs({
+        permissions: {
+          permissions: [
+            {
+              id: "full-disk",
+              name: "Full Disk Access",
+              description: "",
+              required: true,
+              canRequestProgrammatically: true,
+              status: "denied",
+            },
+            helperRow,
+          ],
+          allRequiredGranted: false,
+          checkedAt: 1,
+        },
+        helperPreference: "granted",
+        helperRow,
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([
+      { kind: "permissions-revoked", missing: [{ id: "full-disk", name: "Full Disk Access" }] },
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
+  it("produces exactly one banner when only the helper is missing", () => {
+    const helperRow = makeHelperRow();
+    const plan = computeRepairPlan(
+      makeInputs({
+        permissions: {
+          permissions: [helperRow],
+          allRequiredGranted: false,
+          checkedAt: 1,
+        },
+        helperPreference: "granted",
+        helperRow,
+        helperGraceElapsed: true,
+      }),
+    );
+    expect(plan.banners).toEqual([
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
   it("honors the dev-profile skip overrides", () => {
     const plan = computeRepairPlan(
       makeInputs({
@@ -93,6 +197,9 @@ describe("computeRepairPlan", () => {
           allRequiredGranted: false,
           checkedAt: 1,
         },
+        helperPreference: "granted",
+        helperRow: makeHelperRow(),
+        helperGraceElapsed: true,
       }),
     );
     expect(plan).toEqual({ blocking: null, banners: [] });

--- a/apps/native/src/components/widget/repair/lib.ts
+++ b/apps/native/src/components/widget/repair/lib.ts
@@ -1,10 +1,13 @@
-import type { PermissionsState } from "@/ipc/types";
+import type { HelperPreference, Permission, PermissionsState } from "@/ipc/types";
+import { HELPER_PERMISSION_ID } from "@/lib/permissions";
 
 /** A prerequisite that regressed after onboarding completed. */
 export type RepairIssue =
   | { kind: "config-missing"; configDir: string }
   | { kind: "nix-missing" }
-  | { kind: "permissions-revoked"; missing: { id: string; name: string }[] };
+  | { kind: "permissions-revoked"; missing: { id: string; name: string }[] }
+  /** The user asked for the unattended sync helper and it is not answering. */
+  | { kind: "helper-inactive"; instructions: string | null };
 
 export interface RepairInputs {
   /** Onboarding completion latch; repair is a post-completion concept. */
@@ -14,6 +17,16 @@ export interface RepairInputs {
   flakeExists: boolean | null;
   nixInstalled: boolean | null;
   permissions: PermissionsState | null;
+  /**
+   * The helper's row as it stands *now*, not as the snapshot in `permissions`
+   * had it; null before the first probe. See [`computeRepairPlan`] for why it
+   * is read live.
+   */
+  helperRow: Permission | null;
+  /** The user's standing decision about the helper; null before hydration. */
+  helperPreference: HelperPreference | null;
+  /** Whether the helper condition has held long enough to be worth saying. */
+  helperGraceElapsed: boolean;
   /** Dev-profile overrides; a skipped gate must not resurface as a repair. */
   skipPermissions: boolean;
   nixInstalledOverride: boolean;
@@ -28,13 +41,17 @@ export interface RepairPlan {
 
 /**
  * Classify post-completion prerequisite regressions (design decision D7 of
- * docs/2026-07-08-onboarding-state-ownership.md). Evaluated once at launch —
- * the window is never swapped mid-session by a background event — and
- * re-evaluated only through the explicit "Check again" action.
+ * docs/2026-07-08-onboarding-state-ownership.md).
  *
- * Only a missing configuration blocks: every main surface (evolve, git,
- * build) operates on it. A missing Nix install or a revoked permission
- * degrades specific actions but leaves the app browsable, so they banner.
+ * Only a missing configuration blocks: every main surface operates on it,
+ * while the other regressions degrade specific actions and banner instead.
+ *
+ * Every input except the three helper ones is snapshotted when the widget
+ * mounts and re-read only through "Check again", keeping the blocking card
+ * decided once per launch, as D7 requires. The helper's inputs are live: its
+ * row is expected to be wrong for the first seconds of a launch and to come
+ * right on its own, so a snapshot would banner a launch that is about to be
+ * fine — and a banner is the one surface D7 allows to change mid-session.
  */
 export function computeRepairPlan(inputs: RepairInputs): RepairPlan {
   // Pre-completion gating belongs to the onboarding wizard, not repair.
@@ -52,12 +69,37 @@ export function computeRepairPlan(inputs: RepairInputs): RepairPlan {
   }
 
   if (!inputs.skipPermissions && inputs.permissions && !inputs.permissions.allRequiredGranted) {
+    // The helper gets its own banner below: its list entry here would be a
+    // snapshot where its row is live, and "revoked" is wrong for a
+    // registration waiting on approval. The `missing.length > 0` guard keeps
+    // this banner from rendering empty.
     const missing = inputs.permissions.permissions
-      .filter((p) => p.required && p.status !== "granted")
+      .filter((p) => p.required && p.status !== "granted" && p.id !== HELPER_PERMISSION_ID)
       .map((p) => ({ id: p.id, name: p.name }));
     if (missing.length > 0) {
       banners.push({ kind: "permissions-revoked", missing });
     }
+  }
+
+  // The user asked for the helper and the helper is not answering. The row
+  // carries no marker for *why* (approval pending, a misplaced copy, a failed
+  // register), so one headline states the condition and the row's own
+  // `instructions` say what is true right now. For the same reason the button
+  // is the row's Grant action in every state: it opens Login Items when
+  // approval is pending, and in the states no run can fix it re-reports the
+  // same sentence — the accepted cost of having nothing to branch on, not a
+  // gap to close by inventing a marker.
+  if (
+    !inputs.skipPermissions &&
+    inputs.helperPreference === "granted" &&
+    inputs.helperRow !== null &&
+    inputs.helperRow.status !== "granted" &&
+    inputs.helperGraceElapsed
+  ) {
+    banners.push({
+      kind: "helper-inactive",
+      instructions: inputs.helperRow.instructions ?? null,
+    });
   }
 
   return { blocking, banners };

--- a/apps/native/src/components/widget/repair/repair.test.tsx
+++ b/apps/native/src/components/widget/repair/repair.test.tsx
@@ -1,0 +1,170 @@
+import type { HelperPreference, Permission } from "@/ipc/types";
+import {
+  APPROVE_IN_LOGIN_ITEMS,
+  makeCompletedOnboardingState,
+  makeGlobalPreferences,
+  makeHelperRow,
+  makeNixInstallState,
+} from "@/utils/test-fixtures";
+import { initialViewModelState, useViewModel } from "@nixmac/state";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HELPER_GRACE_MS, useRepair } from "./repair";
+
+/**
+ * The helper's banner is the one part of the repair plan that follows live state,
+ * so what is worth testing is the timing: it must stay quiet while the backend is
+ * still converging, speak once the condition has outlasted that, and go when the
+ * helper answers — without a churning report ever holding it back.
+ */
+
+vi.mock("@/ipc/api", () => ({
+  tauriAPI: {
+    permissions: { refresh: vi.fn(async () => {}) },
+  },
+}));
+
+vi.mock("@/lib/orpc", () => ({
+  client: {
+    flake: { exists: vi.fn(async () => true) },
+    permissions: { request: vi.fn(async () => {}) },
+  },
+}));
+
+vi.mock("@/lib/env", () => ({ settings: {} }));
+vi.mock("@/router", () => ({ nav: { openSettings: vi.fn() } }));
+vi.mock("@/components/widget/onboarding/restart-setup", () => ({
+  RestartSetupConfirmation: () => null,
+}));
+
+/** A completed profile whose only unsettled prerequisite is the helper row. */
+function seedStore(helperRow: Permission, helperPreference: HelperPreference) {
+  useViewModel.setState({
+    hydrated: true,
+    onboardingState: makeCompletedOnboardingState(),
+    preferences: makeGlobalPreferences({
+      configDir: "/Users/demo/.darwin",
+      helperPreference,
+    }),
+    nixInstall: makeNixInstallState(),
+    permissions: {
+      permissions: [helperRow],
+      allRequiredGranted: helperRow.status === "granted",
+      checkedAt: 1,
+    },
+  });
+}
+
+/** What the backend publishes on a later reconciliation pass. */
+function publishHelperRow(helperRow: Permission) {
+  useViewModel.setState({
+    permissions: {
+      permissions: [helperRow],
+      allRequiredGranted: helperRow.status === "granted",
+      checkedAt: 2,
+    },
+  });
+}
+
+describe("useRepair", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    useViewModel.setState(initialViewModelState);
+  });
+
+  /** Mount and let the launch snapshot (an async flake probe) settle. */
+  async function mount() {
+    const view = renderHook(() => useRepair());
+    await act(async () => {});
+    return view;
+  }
+
+  it("stays quiet until the condition has outlasted the grace period", async () => {
+    seedStore(makeHelperRow(), "granted");
+    const { result } = await mount();
+
+    expect(result.current.plan.banners).toEqual([]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+
+    expect(result.current.plan.banners).toEqual([
+      { kind: "helper-inactive", instructions: APPROVE_IN_LOGIN_ITEMS },
+    ]);
+  });
+
+  it("does not restart the clock when a still-failing report changes", async () => {
+    seedStore(makeHelperRow(), "granted");
+    const { result } = await mount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS * 0.6);
+      publishHelperRow(
+        makeHelperRow({
+          canRequestProgrammatically: true,
+          instructions: "nixmac could not register the unattended sync helper.",
+        }),
+      );
+    });
+    expect(result.current.plan.banners).toEqual([]);
+
+    // Past the grace period counted from the first report, not the second.
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS * 0.6);
+    });
+    expect(result.current.plan.banners).toEqual([
+      {
+        kind: "helper-inactive",
+        instructions: "nixmac could not register the unattended sync helper.",
+      },
+    ]);
+  });
+
+  it("clears the banner and the clock once the helper answers", async () => {
+    seedStore(makeHelperRow(), "granted");
+    const { result } = await mount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+    expect(result.current.plan.banners).toHaveLength(1);
+
+    await act(async () => {
+      publishHelperRow(
+        makeHelperRow({
+          status: "granted",
+          canRequestProgrammatically: true,
+          instructions: "The unattended sync helper is installed and answering.",
+        }),
+      );
+    });
+    expect(result.current.plan.banners).toEqual([]);
+
+    // The clock was cleared with the banner, so a later regression waits again.
+    await act(async () => {
+      publishHelperRow(makeHelperRow());
+    });
+    expect(result.current.plan.banners).toEqual([]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+    expect(result.current.plan.banners).toHaveLength(1);
+  });
+
+  it("says nothing about a helper the user did not ask for", async () => {
+    seedStore(makeHelperRow(), "unset");
+    const { result } = await mount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(HELPER_GRACE_MS);
+    });
+
+    expect(result.current.plan.banners).toEqual([]);
+  });
+});

--- a/apps/native/src/components/widget/repair/repair.tsx
+++ b/apps/native/src/components/widget/repair/repair.tsx
@@ -7,32 +7,75 @@ import { settings } from "@/lib/env";
 import { client } from "@/lib/orpc";
 import { nav } from "@/router";
 import { useViewModel } from "@nixmac/state";
-import { CircleAlert, FolderX, RotateCcw, X } from "lucide-react";
+import { CircleAlert, FolderX, Loader2, RotateCcw, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { computeRepairPlan, type RepairIssue, type RepairPlan } from "./lib";
+import { HELPER_PERMISSION_ID } from "@/lib/permissions";
+import {
+  computeRepairPlan,
+  type RepairInputs,
+  type RepairIssue,
+  type RepairPlan,
+} from "./lib";
+
+/** The inputs read once, when the (hydrated) widget mounts. */
+type LaunchSnapshot = Omit<
+  RepairInputs,
+  "helperRow" | "helperPreference" | "helperGraceElapsed"
+>;
 
 /**
- * Launch-time evaluation of post-completion prerequisite regressions.
- *
- * Runs once when the (hydrated) widget mounts and only again through the
- * returned `recheck` — mid-session backend events never add or swap a repair
- * surface, mirroring how the onboarding takeover is entered only at
- * well-defined moments.
+ * How long "the helper was asked for and is not answering" must hold before
+ * the banner shows. Not a cosmetic debounce: on any launch that re-registers
+ * the helper the condition is true at mount with the backend already working
+ * on it, and the grace lets those finish in silence.
  */
-export function useLaunchRepair(): {
+export const HELPER_GRACE_MS = 10_000;
+
+/**
+ * Post-completion prerequisite regressions: what to block on, what to banner.
+ *
+ * The plan is decided from a launch snapshot, re-taken only by the returned
+ * `recheck`, with one exception: the unattended sync helper's banner follows the
+ * live row and the live standing decision. `computeRepairPlan` documents why that
+ * one row is different and why a banner may change mid-session where the blocking
+ * card may not.
+ */
+export function useRepair(): {
   plan: RepairPlan;
   recheck: () => Promise<void>;
   dismissBanner: (kind: RepairIssue["kind"]) => void;
 } {
-  const [plan, setPlan] = useState<RepairPlan>({ blocking: null, banners: [] });
+  const [snapshot, setSnapshot] = useState<LaunchSnapshot | null>(null);
   const [dismissed, setDismissed] = useState<RepairIssue["kind"][]>([]);
   // The widget renders a neutral shell until hydration; the launch evaluation
   // must read post-hydration values (probes have run, latch is mirrored).
   const hydrated = useViewModel((s) => s.hydrated);
 
+  // The two live inputs.
+  const helperRow = useViewModel(
+    (s) => s.permissions?.permissions.find((p) => p.id === HELPER_PERMISSION_ID) ?? null,
+  );
+  const helperPreference = useViewModel((s) => s.preferences?.helperPreference ?? null);
+
+  // The grace clock keys on this boolean, not on the row: every publish is a
+  // fresh object, and a helper whose registration keeps failing publishes one
+  // per pass — restarting the clock each time would keep the banner off the
+  // screen for exactly as long as the failure lasts.
+  const helperWanted =
+    helperPreference === "granted" && helperRow !== null && helperRow.status !== "granted";
+  const [helperGraceElapsed, setHelperGraceElapsed] = useState(false);
+  useEffect(() => {
+    if (!helperWanted) {
+      setHelperGraceElapsed(false);
+      return;
+    }
+    const timer = setTimeout(() => setHelperGraceElapsed(true), HELPER_GRACE_MS);
+    return () => clearTimeout(timer);
+  }, [helperWanted]);
+
   const evaluate = useCallback(async () => {
-    // Snapshot the store rather than subscribing: repair is launch-scoped
-    // by design, not reactive.
+    // Snapshot the store rather than subscribing: everything here is
+    // launch-scoped by design (the helper's live inputs are read above).
     const vm = useViewModel.getState();
     const configDir = vm.preferences?.configDir ?? null;
 
@@ -46,17 +89,15 @@ export function useLaunchRepair(): {
       }
     }
 
-    setPlan(
-      computeRepairPlan({
-        completedAt: vm.onboardingState?.completedAt ?? null,
-        configDir,
-        flakeExists,
-        nixInstalled: vm.nixInstall?.installed ?? null,
-        permissions: vm.permissions,
-        skipPermissions: settings.skipPermissions === true,
-        nixInstalledOverride: settings.nixInstalledOverride === true,
-      }),
-    );
+    setSnapshot({
+      completedAt: vm.onboardingState?.completedAt ?? null,
+      configDir,
+      flakeExists,
+      nixInstalled: vm.nixInstall?.installed ?? null,
+      permissions: vm.permissions,
+      skipPermissions: settings.skipPermissions === true,
+      nixInstalledOverride: settings.nixInstalledOverride === true,
+    });
   }, []);
 
   useEffect(() => {
@@ -72,6 +113,10 @@ export function useLaunchRepair(): {
     await evaluate();
   }, [evaluate]);
 
+  const plan = snapshot
+    ? computeRepairPlan({ ...snapshot, helperRow, helperPreference, helperGraceElapsed })
+    : { blocking: null, banners: [] };
+
   return {
     plan: {
       blocking: plan.blocking,
@@ -80,6 +125,45 @@ export function useLaunchRepair(): {
     recheck,
     dismissBanner: (kind) => setDismissed((prev) => [...prev, kind]),
   };
+}
+
+/**
+ * The same Grant the helper's row in Settings → Permissions offers; it may
+ * open Login Items when macOS is waiting for approval there. No re-probe
+ * afterwards: this banner reads the row live, published on every
+ * reconciliation pass, so a failed call is logged rather than surfaced. The
+ * label keeps its box with the spinner laid over it so the running button
+ * never resizes (the design-system Button animates resizes).
+ */
+function HelperGrantButton() {
+  const [granting, setGranting] = useState(false);
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={granting}
+      aria-label={granting ? "Enabling…" : undefined}
+      aria-busy={granting}
+      className="relative disabled:opacity-100"
+      onClick={async () => {
+        setGranting(true);
+        try {
+          await client.permissions.request({ permissionId: HELPER_PERMISSION_ID });
+        } catch (error) {
+          console.error("Failed to enable the unattended sync helper:", error);
+        } finally {
+          setGranting(false);
+        }
+      }}
+    >
+      <span className={granting ? "invisible" : undefined}>Enable</span>
+      {granting ? (
+        <span className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        </span>
+      ) : null}
+    </Button>
+  );
 }
 
 /** Non-blocking repair notices, rendered above the main content. */
@@ -121,6 +205,16 @@ export function RepairBanners({
                   permissions in Settings → Permissions.
                 </p>
               </>
+            ) : issue.kind === "helper-inactive" ? (
+              <>
+                <p className="font-medium">Unattended sync helper is not active</p>
+                {/* The row's sentences quote unbreakable `/Volumes/…` paths
+                    wider than the banner, so they must be allowed to break
+                    anywhere. */}
+                {issue.instructions ? (
+                  <p className="mt-0.5 wrap-anywhere text-xs opacity-70">{issue.instructions}</p>
+                ) : null}
+              </>
             ) : null}
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -140,6 +234,7 @@ export function RepairBanners({
                 </Button>
               </>
             )}
+            {issue.kind === "helper-inactive" && <HelperGrantButton />}
             <button
               type="button"
               onClick={() => onDismiss(issue.kind)}

--- a/apps/native/src/components/widget/widget.tsx
+++ b/apps/native/src/components/widget/widget.tsx
@@ -18,7 +18,7 @@ import { useOnboardingFlow } from "@/components/widget/onboarding/use-onboarding
 import {
   RepairBanners,
   RepairBlockingCard,
-  useLaunchRepair,
+  useRepair,
 } from "@/components/widget/repair/repair";
 import { uiActions } from "@nixmac/state";
 import {
@@ -187,9 +187,11 @@ export function DarwinWidget() {
   // explicit "Restart setup", never because a preference fact regressed
   // mid-session. In-flow step routing still derives from durable facts.
   const { showFlow: showOnboarding } = useOnboardingFlow();
-  // Post-completion prerequisite regressions surface as repair cards/banners
-  // (evaluated once at launch), never by re-entering the wizard.
-  const repair = useLaunchRepair();
+  // Post-completion prerequisite regressions surface as repair cards/banners,
+  // never by re-entering the wizard. Evaluated from a launch snapshot; the
+  // unattended sync helper's banner is the one part that follows live state,
+  // because that row is expected to settle after the launch probe.
+  const repair = useRepair();
   // Suppress the boot flash: before the ViewModel hydrates, every gate input
   // is a default (null preferences/nixInstall), so both OnboardingFlow and the
   // main widget would render against stale state for a frame. Hold a neutral

--- a/apps/native/src/ipc/orpc-bindings.ts
+++ b/apps/native/src/ipc/orpc-bindings.ts
@@ -1193,14 +1193,33 @@ pendingImportDir: string | null;
 /**
  * Whether or not to auto-format Nix files when making changes to the flakes.
  */
-autoFormatNixFiles: boolean }
-
-export type HelperServiceStatus = { label: string; available: boolean; registered: boolean; authorized: boolean; socketAvailable: boolean; 
+autoFormatNixFiles: boolean; 
 /**
- * The daemon answered an authenticated status round-trip: the client
- * validated the daemon's signature and the daemon accepted this client.
+ * Standing decision about the privileged helper. Read by the helper
+ * reconciliation and by apply; decided only by the grant and disable
+ * actions, which is why it is not writable via `UiPrefsUpdate` and is held
+ * out of settings export/import. `state::preferences` documents which
+ * writers can reach it.
  */
-responding: boolean; detail: string | null }
+helperPreference: HelperPreference }
+
+/**
+ * The user's standing decision about the privileged helper.
+ * 
+ * Tri-state on purpose. `Unset` means the user never decided — a fresh install,
+ * or one predating the helper's install/replace/remove contract — and is what
+ * lets an existing registration be adopted as an earlier opt-in without
+ * overriding an explicit `Disabled`. It selects a goal and authorizes nothing
+ * else: every trust or termination decision is taken from live observation.
+ */
+export type HelperPreference = "unset" | "granted" | "disabled"
+
+/**
+ * What one reconciliation run found, for a client that only has to display it:
+ * whether the helper is installed and answering at this build, and the sentence
+ * that says what else is true.
+ */
+export type HelperReport = { atThisBuild: boolean; detail: string }
 
 /**
  * A commit entry combining git log data, tag-derived flags, optional DB metadata, and raw diff changes.
@@ -1583,7 +1602,14 @@ description: string;
  */
 required: boolean; 
 /**
- * Whether the app can trigger the system prompt directly.
+ * Whether the app can trigger the system prompt directly. False means the
+ * row's action can only deep-link into System Settings and wait for the
+ * user, which is what the UI renders it as.
+ * 
+ * Fixed per row for the TCC permissions, but not a capability in general:
+ * the unattended sync helper reports it per observation, and it is false
+ * only while macOS holds the registration pending approval in Login Items.
+ * Read it as "is System Settings where the user finishes this, right now".
  */
 canRequestProgrammatically: boolean; 
 /**
@@ -2037,9 +2063,9 @@ export type Procedures = {
     finalizeRestore: Client<Record<never, never>, RestoreTargetInput, void, Error>
     finalizeRollback: Client<Record<never, never>, FinalizeRollbackInput, void, Error>
     fixWithAi: Client<Record<never, never>, FixWithAiInput, void, Error>
-    helperRegister: Client<Record<never, never>, void, HelperServiceStatus, Error>
-    helperStatus: Client<Record<never, never>, void, HelperServiceStatus, Error>
-    helperUnregister: Client<Record<never, never>, void, HelperServiceStatus, Error>
+    helperDisable: Client<Record<never, never>, void, HelperReport, Error>
+    helperGrant: Client<Record<never, never>, void, HelperReport, Error>
+    helperStatus: Client<Record<never, never>, void, HelperReport, Error>
     prepareRestore: Client<Record<never, never>, RestoreTargetInput, void, Error>
     rebuildStatus: Client<Record<never, never>, void, RebuildStatus, Error>
     rollbackErase: Client<Record<never, never>, void, RollbackResult, Error>

--- a/apps/native/src/ipc/types.ts
+++ b/apps/native/src/ipc/types.ts
@@ -1418,7 +1418,26 @@ pendingImportDir: string | null;
 /**
  * Whether or not to auto-format Nix files when making changes to the flakes.
  */
-autoFormatNixFiles: boolean }
+autoFormatNixFiles: boolean; 
+/**
+ * Standing decision about the privileged helper. Read by the helper
+ * reconciliation and by apply; decided only by the grant and disable
+ * actions, which is why it is not writable via `UiPrefsUpdate` and is held
+ * out of settings export/import. `state::preferences` documents which
+ * writers can reach it.
+ */
+helperPreference: HelperPreference }
+
+/**
+ * The user's standing decision about the privileged helper.
+ * 
+ * Tri-state on purpose. `Unset` means the user never decided — a fresh install,
+ * or one predating the helper's install/replace/remove contract — and is what
+ * lets an existing registration be adopted as an earlier opt-in without
+ * overriding an explicit `Disabled`. It selects a goal and authorizes nothing
+ * else: every trust or termination decision is taken from live observation.
+ */
+export type HelperPreference = "unset" | "granted" | "disabled"
 
 /**
  * A commit entry combining git log data, tag-derived flags, optional DB metadata, and raw diff changes.
@@ -1854,7 +1873,14 @@ description: string;
  */
 required: boolean; 
 /**
- * Whether the app can trigger the system prompt directly.
+ * Whether the app can trigger the system prompt directly. False means the
+ * row's action can only deep-link into System Settings and wait for the
+ * user, which is what the UI renders it as.
+ * 
+ * Fixed per row for the TCC permissions, but not a capability in general:
+ * the unattended sync helper reports it per observation, and it is false
+ * only while macOS holds the registration pending approval in Login Items.
+ * Read it as "is System Settings where the user finishes this, right now".
  */
 canRequestProgrammatically: boolean; 
 /**

--- a/apps/native/src/lib/permissions.ts
+++ b/apps/native/src/lib/permissions.ts
@@ -1,0 +1,7 @@
+/**
+ * The one permission nixmac installs itself instead of asking macOS for, and so
+ * the one row whose state nixmac keeps working on after the probe returns.
+ * Mirrors the backend's permission id (`system::permissions`), the same way
+ * `lib/errors.ts` keeps the rebuild error codes' wire identifiers.
+ */
+export const HELPER_PERMISSION_ID = "privileged-helper";

--- a/apps/native/src/utils/test-fixtures.ts
+++ b/apps/native/src/utils/test-fixtures.ts
@@ -2,9 +2,11 @@ import type {
 	GlobalPreferences,
 	NixInstallState,
 	OnboardingState,
+	Permission,
 	PermissionsState,
 	RebuildStatus,
 } from "@/ipc/types";
+import { HELPER_PERMISSION_ID } from "@/lib/permissions";
 import { viewModelActions } from "@nixmac/state";
 
 /**
@@ -43,6 +45,7 @@ export function makeGlobalPreferences(
 		featureFlagOverrides: null,
 		pendingImportDir: null,
 		autoFormatNixFiles: false,
+		helperPreference: "unset",
 		...overrides,
 	};
 }
@@ -114,6 +117,31 @@ export function makeRebuildStatus(
 		errorType: null,
 		errorMessage: null,
 		systemUntouched: null,
+		...overrides,
+	};
+}
+
+/**
+ * What the backend reports while macOS holds the helper registration for
+ * approval in Login Items. Declared once so a copy change edits one fixture,
+ * not every test that mentions the sentence.
+ */
+export const APPROVE_IN_LOGIN_ITEMS =
+	"Approve nixmac in System Settings → General → Login Items & Extensions to finish enabling the unattended sync helper.";
+
+/**
+ * The helper permission row while macOS holds the registration for approval.
+ * Override the fields a scenario cares about.
+ */
+export function makeHelperRow(overrides: Partial<Permission> = {}): Permission {
+	return {
+		id: HELPER_PERMISSION_ID,
+		name: "Unattended Sync Helper",
+		description: "",
+		required: true,
+		canRequestProgrammatically: false,
+		status: "pending",
+		instructions: APPROVE_IN_LOGIN_ITEMS,
 		...overrides,
 	};
 }


### PR DESCRIPTION
## Summary

**Problem:** none of the helper machinery is visible or drivable — no way to grant or disable, no sign that macOS is waiting in Login Items or that an upgrade is waiting out a running activation — and the repair banner evaluates once per launch, so it keeps warning about a helper the convergence loop fixed seconds later.

**Solution:** orpc endpoints for status, grant, and disable; one permission row produced whole from each reconciliation report, with `replace_row` letting the convergence loop publish updates without running a second reconciliation; the repair banner follows live helper state instead of the launch snapshot. The UI never re-words or re-classifies a report — rows render the backend sentence verbatim, and the TS test fixtures mirror the backend vocabulary exactly.

Stacked on #669; completes the helper-redesign stack.

## Test Plan

- [x] `cargo test` green (row/report mapping, permissions state)
- [ ] `bunx tsc --noEmit && bun run test:unit` (panel + repair suites; fixtures assert the backend sentences verbatim)

## Docs

- [x] No docs update needed

## Prior review

Nearly all of this PR matches content from #636: `repair.tsx`/`lib.ts`/`types.ts`/`permissions_state.rs`/`orpc` byte-identical, `permissions-panel.tsx` differs by 2 lines, test fixtures updated to the new backend sentences. Caveat: Scott's #636 approval predates the convergence-loop and banner additions that landed on that branch afterwards, so those parts (mostly in #669's `helper_permission.rs`) were never formally approved.