### PR TITLE
chore: throwaway recheck smoke fixture (2)

### DIFF
--- a/smoke/recheck-smoke2.ts
+++ b/smoke/recheck-smoke2.ts
@@ -1,0 +1,8 @@
+/**
+ * Throwaway smoke fixture — reviewer-recheck-smoke2 branch only.
+ * Carries a real off-by-one so the first review lands request changes.
+ */
+export function clampLower(value: number, min: number): number {
+  // Off by one: excludes the minimum itself.
+  return value < min ? min + 1 : value;
+}

--- a/smoke/recheck-smoke2.ts
+++ b/smoke/recheck-smoke2.ts
@@ -1,8 +1,7 @@
 /**
- * Throwaway smoke fixture — reviewer-recheck-smoke2 branch only.
- * Carries a real off-by-one so the first review lands request changes.
+ * Throwaway smoke fixture — reviewer-recheck-smoke2 branch only. The bug was
+ * real and is fixed: the minimum is now inclusive.
  */
 export function clampLower(value: number, min: number): number {
-  // Off by one: excludes the minimum itself.
-  return value < min ? min + 1 : value;
+  return value < min ? min : value;
 }


### PR DESCRIPTION
Second throwaway with a real bug so review one lands request_changes; a fix push then verifies the recheck. Do not merge.