### PR TITLE
ci: bump actions/cache to v5

### DIFF
--- a/.depot/actions/setup/action.yml
+++ b/.depot/actions/setup/action.yml
@@ -89,7 +89,7 @@ runs:
     - name: Restore devenv profile pointer
       if: ${{ inputs.install-devenv == 'true' }}
       id: devenv-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .devenv-ci
         key: devenv-profile-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('devenv.nix', 'devenv.yaml', 'devenv.lock', 'flake.nix', 'flake.lock', 'treefmt.nix', 'nix/**') }}
@@ -222,7 +222,7 @@ runs:
 
     - name: Save devenv profile pointer
       if: ${{ inputs.install-devenv == 'true' && steps.devenv-push.outputs.ok == 'true' && steps.devenv-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: .devenv-ci
         key: ${{ steps.devenv-cache.outputs.cache-primary-key }}

--- a/.github/actions/setup-devenv/action.yml
+++ b/.github/actions/setup-devenv/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Restore devenv profile pointer
       if: ${{ inputs.install-devenv == 'true' && steps.devenv-existing.outputs.ok != 'true' }}
       id: devenv-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .devenv-ci
         key: devenv-profile-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('devenv.nix', 'devenv.yaml', 'devenv.lock', 'flake.nix', 'flake.lock', 'treefmt.nix', 'nix/**') }}
@@ -194,7 +194,7 @@ runs:
     # The cachix push is only needed for ephemeral (GitHub-hosted) runners.
     - name: Save devenv profile pointer
       if: ${{ inputs.install-devenv == 'true' && steps.devenv-existing.outputs.ok != 'true' && steps.devenv-realise.outputs.ok != 'true' && steps.devenv-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: .devenv-ci
         key: ${{ steps.devenv-cache.outputs.cache-primary-key }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -227,7 +227,7 @@ jobs:
           fi
 
       - name: Restore sccache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/sccache
           key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
@@ -326,7 +326,7 @@ jobs:
 
       - name: Save sccache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/sccache
           key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}


### PR DESCRIPTION
## Summary

Problem: v4 targets the Node 20 runtime, which is deprecated on GitHub Actions runners; runs emit a deprecation warning while the runner force-runs the action on Node 24.

Solution: v5 targets Node 24 natively; inputs and cache format are unchanged. Covers all four pins: build.yaml and the setup-devenv composite. Only requirement is runner >= 2.327.1; observed runners are at 2.336.0 (self-hosted macOS) and 2.335.1 (arc).

## Test Plan

- [x] No test plan needed

## Docs

- [ ] Docs updated (companion PR in darkmatter/nixmac-web: #\_\_\_)
- [x] No docs update needed
